### PR TITLE
fix: uninstall permissions and ignore errors

### DIFF
--- a/docs/installation/uninstallation.md
+++ b/docs/installation/uninstallation.md
@@ -13,7 +13,7 @@ If you installed GPUStack using the installation script, a script to uninstall G
 Run the following command to uninstall GPUStack:
 
 ```bash
-/var/lib/gpustack/uninstall.sh
+sudo /var/lib/gpustack/uninstall.sh
 ```
 
 ### Windows

--- a/install.sh
+++ b/install.sh
@@ -262,21 +262,20 @@ create_uninstall_script() {
   $SUDO mkdir -p /var/lib/gpustack
   $SUDO tee /var/lib/gpustack/uninstall.sh > /dev/null <<EOF
 #!/bin/bash
-set -e
 export PYTHONPATH="$PYTHONPATH"
 export PIPX_HOME=$(pipx environment --value PIPX_HOME)
 export PIPX_BIN_DIR=$(pipx environment --value PIPX_BIN_DIR)
 $(which pipx) uninstall gpustack > /dev/null
 if [ "$OS" = "macos" ]; then
   launchctl bootout system /Library/LaunchDaemons/ai.gpustack.plist
-  rm /Library/LaunchDaemons/ai.gpustack.plist
+  rm -f /Library/LaunchDaemons/ai.gpustack.plist
 else
   systemctl stop gpustack.service
   systemctl disable gpustack.service
-  rm /etc/systemd/system/gpustack.service
+  rm -f /etc/systemd/system/gpustack.service
   systemctl daemon-reload
 fi
-rm -rf /var/lib/gpustack
+rm -rf /var/lib/gpustack /var/log/gpustack.log
 echo "GPUStack has been uninstalled."
 EOF
   $SUDO chmod +x /var/lib/gpustack/uninstall.sh

--- a/install.sh.sha256sum
+++ b/install.sh.sha256sum
@@ -1,1 +1,1 @@
-40f9b4a546763f3869b15ce41ddf5aeccf2f375d45e609a48abab2c4e6bcdbbf  install.sh
+ba37faf7cfa936a774ba619d1acad0fefd3ac6142c0d6dc4de4f9839ff4d78b1  install.sh


### PR DESCRIPTION
Fix the following issues:
- The /var/lib/gpustack directory requires sudo permissions to be removed.
- The /var/log/gpustack.log file is not removed.
- The uninstall script exits if a command encounters an error.