### PR TITLE
docker: Fix libcuda.so.1 not found issue in running LLM model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ RUN apt-get update && apt-get install -y \
     wget \
     python3 \
     python3-pip \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install gpustack
+ENV LD_LIBRARY_PATH=/usr/local/cuda-12.5/compat:${LD_LIBRARY_PATH}
 
 ENTRYPOINT [ "gpustack", "start" ]


### PR DESCRIPTION
When testing GPUStack in a container, I found this issue. Simply setting `LD_LIBRARY_PATH` can fix it.