### PR TITLE
fix: match worker by name in serve manager

### DIFF
--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -3,7 +3,6 @@ import psutil
 import setproctitle
 import os
 import signal
-import socket
 import time
 from typing import Dict
 import logging
@@ -30,10 +29,11 @@ logger = logging.getLogger(__name__)
 class ServeManager:
     def __init__(
         self,
+        worker_name: str,
         clientset: ClientSet,
         cfg: Config,
     ):
-        self._hostname = socket.gethostname()
+        self._worker_name = worker_name
         self._config = cfg
         self._serve_log_dir = f"{cfg.log_dir}/serve"
         self._serving_model_instances: Dict[str, multiprocessing.Process] = {}
@@ -50,7 +50,7 @@ class ServeManager:
                 logger.debug(f"Failed to get workers: {e}")
 
             for worker in workers.items:
-                if worker.hostname == self._hostname:
+                if worker.name == self._worker_name:
                     self._worker_id = worker.id
                     break
             time.sleep(1)

--- a/gpustack/worker/worker.py
+++ b/gpustack/worker/worker.py
@@ -66,6 +66,7 @@ class Worker:
         )
         self._serve_manager = ServeManager(
             clientset=self._clientset,
+            worker_name=self._worker_name,
             cfg=cfg,
         )
         self._exporter = MetricExporter(


### PR DESCRIPTION
Problem:
Previously, serve-manager matches worker by hostname and may miss the worker with updated name.

https://github.com/gpustack/gpustack/issues/191