### PR TITLE
chore: validator return self

### DIFF
--- a/gpustack/chat/manager.py
+++ b/gpustack/chat/manager.py
@@ -44,6 +44,7 @@ class ChatConfig(BaseSettings):
             raise Exception("API key is required. Please set GPUSTACK_API_KEY env var.")
         elif parsed_url.hostname in ["127.0.0.1", "localhost"] and not self.api_key:
             self.api_key = "local"
+        return self
 
 
 def parse_arguments(args) -> ChatConfig:


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/276
model_validator should return self.(https://docs.pydantic.dev/latest/concepts/validators/#model-validators)
It prints warning in py3.12