### PR TITLE
fix: optional top_n in rerank

### DIFF
--- a/gpustack/routes/rerank.py
+++ b/gpustack/routes/rerank.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Body, Request
 from pydantic import BaseModel
@@ -15,8 +15,9 @@ logger = logging.getLogger(__name__)
 class RerankRequest(BaseModel):
     model: str
     query: str
-    top_n: int
     documents: List[str]
+    top_n: Optional[int] = None
+    return_documents: Optional[bool] = True
 
 
 class RerankUsage(BaseModel):


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/214#issuecomment-2409896557

top_n is optional per https://api.jina.ai/redoc#tag/rerank/operation/rank_v1_rerank_post