### PR TITLE
ci: free space for docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,11 @@ jobs:
       - name: Run CI build
         run: |
           make ci
+      - name: Free Space
+        run: |
+          # Get more space for docker build.
+          poetry cache clear _default_cache --all
+          rm -rf $(poetry env info --path)
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
         with:


### PR DESCRIPTION
It frees up the space from 11GiB to 19GiB.
Help resolve https://github.com/gpustack/gpustack/actions/runs/11323631579/attempts/2
