### PR TITLE
ci: publish rcs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           files: dist/*.whl
 
       - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.11' && !contains(github.ref, 'rc')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.11'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.CI_PYPI_API_TOKEN }}
@@ -115,7 +115,7 @@ jobs:
           files: dist/*.whl
 
       - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.11' && !contains(github.ref, 'rc')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.11'
         shell: powershell
         env:
           TWINE_USERNAME: __token__

--- a/hack/publish-pypi.sh
+++ b/hack/publish-pypi.sh
@@ -12,4 +12,4 @@ fi
 # shellcheck disable=SC2086
 poetry run twine check $DIST
 # shellcheck disable=SC2086
-poetry run twine upload $DIST || true # proceed if upload fails, useful for github action rerun.
+poetry run twine upload $DIST

--- a/hack/windows/publish-pypi.ps1
+++ b/hack/windows/publish-pypi.ps1
@@ -11,7 +11,7 @@ function Publish-Pypi {
     poetry run twine check dist/*.whl
     poetry run twine upload dist/*.whl
     if ($LASTEXITCODE -ne 0) {
-        GPUStack.Log.Warn "twine upload failed." # proceed if upload fails, useful for github action rerun.
+        GPUStack.Log.Fatal "twine upload failed."
     }
 }
 


### PR DESCRIPTION
We've refactored to reduce the package size to twenty-ish. Now it should be safe to publish rcs to pypi.
Remove workarounds to address publish issues. We can verify ci on publishing RCs in future releases.