### PR TITLE
fix: improve exit error message

### DIFF
--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -199,7 +199,9 @@ class Server:
             await User.create(session, user)
 
     def at_exit(self):
-        logger.info("Stopping GPUStack server.")
+        logger.debug("GPUStack server exiting.")
         for process in self._sub_processes:
-            process.terminate()
-        logger.info("Stopped all processes.")
+            if process.is_alive():
+                process.terminate()
+                process.join()
+        logger.debug("Stopped all subprocesses.")


### PR DESCRIPTION
When server exit before embedded worker is alive, the clean up results in 
```
self._popen.terminate()
^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'terminate'
```

Also do join to avoid orphan process.