### PR TITLE
fix: remove only binary limit since some packages only provide source packages

### DIFF
--- a/docs/installation/air-gapped-installation.md
+++ b/docs/installation/air-gapped-installation.md
@@ -37,7 +37,7 @@ Run the following commands in an online environment:
 PACKAGE_SPEC="gpustack"
 
 # Download all required packages
-pip download $PACKAGE_SPEC --only-binary=:all: -d gpustack_offline_packages
+pip download $PACKAGE_SPEC -d gpustack_offline_packages
 
 # Install GPUStack to access its CLI
 pip install gpustack


### PR DESCRIPTION
#722 

Remove only-binary limit since some packages just provide source packages.
Examples:
https://pypi.org/project/aliyun-python-sdk-core/#files
https://pypi.org/project/antlr3-python-runtime/3.4/#files

Others:
crcmod-1.7.tar.gz
jaconv-0.4.0.tar.gz
jieba-0.42.1.tar.gz
openai-whisper-20240930.tar.gz
oss2-2.19.1.tar.gz

