### PR TITLE
fix: avoid publishing non-cuda images to the latest tag

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -64,7 +64,7 @@ jobs:
             type=pep440,pattern=v{{major}}.{{minor}}
             type=ref,event=branch
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
+            type=raw,value=latest,enable=${{ matrix.device == 'cuda' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
           # set no tag suffix for cuda as the default, set -{device} suffix for others
           flavor: |
             suffix=${{ matrix.device != 'cuda' && format('-{0}', matrix.device) || '' }}


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/741