### PR TITLE
remove error instance to make it possible to re-create

### DIFF
--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -76,6 +76,13 @@ class ModelInstanceController:
         model_instance: ModelInstance = event.data
         try:
             async with AsyncSession(self._engine) as session:
+                if model_instance.state == ModelInstanceStateEnum.ERROR:
+                    # remove error instance, will recreate later automatically.
+                    instance = await ModelInstance.one_by_id(session, model_instance.id)
+                    if not instance:
+                        return
+                    await instance.delete(session)
+                    
                 model = await Model.one_by_id(session, model_instance.model_id)
                 if not model:
                     return


### PR DESCRIPTION
this PR remove state="error" instance in ModelInstanceController::_reconcile
to make it possible to re-create