### PR TITLE
fix: lint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -69,7 +69,7 @@ class ToolsManager:
             test_url = f"{url}{test_path}"
             try:
                 start_time = time.time()
-                headers = {"Range": f"bytes=0-{test_size-1}"}
+                headers = {"Range": f"bytes=0-{test_size - 1}"}
                 response = requests.get(
                     test_url, headers=headers, timeout=5, stream=True
                 )


### PR DESCRIPTION
Catched when running with py3.12. Update python version in PR CI given it seems to be more comprehensive.