### PR TITLE
fix: add watch timeout

### DIFF
--- a/gpustack/client/generated_model_client.py
+++ b/gpustack/client/generated_model_client.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Callable, Dict, Optional
 
+import httpx
 from pydantic import BaseModel
 from gpustack.api.exceptions import raise_if_response_error
 from gpustack.server.bus import Event
@@ -34,7 +35,7 @@ class ModelClient:
             stop_condition = lambda event: False
 
         with self._client.get_httpx_client().stream(
-            "GET", self._url, params=params, timeout=None
+            "GET", self._url, params=params, timeout=httpx.Timeout(45)
         ) as response:
             raise_if_response_error(response)
             for line in response.iter_lines():

--- a/gpustack/client/generated_model_instance_client.py
+++ b/gpustack/client/generated_model_instance_client.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Callable, Dict, Optional
 
+import httpx
 from pydantic import BaseModel
 from gpustack.api.exceptions import raise_if_response_error
 from gpustack.server.bus import Event
@@ -34,7 +35,7 @@ class ModelInstanceClient:
             stop_condition = lambda event: False
 
         with self._client.get_httpx_client().stream(
-            "GET", self._url, params=params, timeout=None
+            "GET", self._url, params=params, timeout=httpx.Timeout(45)
         ) as response:
             raise_if_response_error(response)
             for line in response.iter_lines():

--- a/gpustack/client/generated_user_client.py
+++ b/gpustack/client/generated_user_client.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Callable, Dict, Optional
 
+import httpx
 from pydantic import BaseModel
 from gpustack.api.exceptions import raise_if_response_error
 from gpustack.server.bus import Event
@@ -34,7 +35,7 @@ class UserClient:
             stop_condition = lambda event: False
 
         with self._client.get_httpx_client().stream(
-            "GET", self._url, params=params, timeout=None
+            "GET", self._url, params=params, timeout=httpx.Timeout(45)
         ) as response:
             raise_if_response_error(response)
             for line in response.iter_lines():

--- a/gpustack/client/generated_worker_client.py
+++ b/gpustack/client/generated_worker_client.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Callable, Dict, Optional
 
+import httpx
 from pydantic import BaseModel
 from gpustack.api.exceptions import raise_if_response_error
 from gpustack.server.bus import Event
@@ -34,7 +35,7 @@ class WorkerClient:
             stop_condition = lambda event: False
 
         with self._client.get_httpx_client().stream(
-            "GET", self._url, params=params, timeout=None
+            "GET", self._url, params=params, timeout=httpx.Timeout(45)
         ) as response:
             raise_if_response_error(response)
             for line in response.iter_lines():

--- a/gpustack/codegen/templates/client.py.jinja
+++ b/gpustack/codegen/templates/client.py.jinja
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Callable, Dict, Optional
 
+import httpx
 from pydantic import BaseModel
 from gpustack.api.exceptions import raise_if_response_error
 from gpustack.server.bus import Event
@@ -34,7 +35,7 @@ class {{ class_name }}Client:
             stop_condition = lambda event: False
 
         with self._client.get_httpx_client().stream(
-            "GET", self._url, params=params, timeout=None
+            "GET", self._url, params=params, timeout=httpx.Timeout(45)
         ) as response:
             raise_if_response_error(response)
             for line in response.iter_lines():

--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -343,7 +343,7 @@ class ActiveRecordMixin:
     @overload
     @classmethod
     async def subscribe(
-        cls, session_or_engine: AsyncEngine
+        cls, session_or_engine: AsyncSession
     ) -> AsyncGenerator[Event, None]: ...
 
     @overload

--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone
+import asyncio
+from datetime import datetime, timedelta, timezone
 import importlib
 import json
 import logging
@@ -369,11 +370,23 @@ class ActiveRecordMixin:
             raise ValueError("Invalid session or engine.")
 
         subscriber = event_bus.subscribe(cls.__name__.lower())
+        heartbeat_interval = timedelta(seconds=30)
+        last_event_time = datetime.now(timezone.utc)
 
         try:
             while True:
-                event = await subscriber.receive()
-                yield event
+                try:
+                    event = await asyncio.wait_for(
+                        subscriber.receive(), timeout=heartbeat_interval.total_seconds()
+                    )
+                    yield event
+                except asyncio.TimeoutError:
+                    if (
+                        datetime.now(timezone.utc) - last_event_time
+                        >= heartbeat_interval
+                    ):
+                        yield Event(type=EventType.HEARTBEAT, data=None)
+                        last_event_time = datetime.now(timezone.utc)
         finally:
             event_bus.unsubscribe(cls.__name__.lower(), subscriber)
 
@@ -385,33 +398,48 @@ class ActiveRecordMixin:
         fuzzy_fields: Optional[dict] = None,
         filter_func: Optional[Callable[[Any], bool]] = None,
     ) -> AsyncGenerator[str, None]:
+        """Stream events matching the given criteria as JSON strings."""
         async for event in cls.subscribe(session):
-            skip_event = False
-
-            # Check fields using AND condition
-            for key, value in (fields or {}).items():
-                if getattr(event.data, key) != value:
-                    skip_event = True
-                    break
-            if skip_event:
+            if event.type == EventType.HEARTBEAT:
+                yield "\n\n"
                 continue
 
-            # Check fuzzy_fields using OR condition
-            fuzzy_match = False
-            for key, value in (fuzzy_fields or {}).items():
-                if value in str(getattr(event.data, key, "")):
-                    fuzzy_match = True
-                    break
-            if fuzzy_fields and not fuzzy_match:
+            if not cls._match_fields(event, fields):
+                continue
+
+            if not cls._match_fuzzy_fields(event, fuzzy_fields):
                 continue
 
             if filter_func and not filter_func(event.data):
                 continue
 
-            # Convert the current instance to the corresponding Public class if exists
-            class_module = importlib.import_module(cls.__module__)
-            public_class = getattr(class_module, f"{cls.__name__}Public", None)
-            if public_class:
-                event.data = public_class.model_validate(event.data)
+            event.data = cls._convert_to_public_class(event.data)
+            yield cls._format_event(event)
 
-            yield json.dumps(jsonable_encoder(event), separators=(",", ":")) + "\n\n"
+    @classmethod
+    def _match_fields(cls, event: Any, fields: Optional[dict]) -> bool:
+        """Match fields using AND condition."""
+        for key, value in (fields or {}).items():
+            if getattr(event.data, key, None) != value:
+                return False
+        return True
+
+    @classmethod
+    def _match_fuzzy_fields(cls, event: Any, fuzzy_fields: Optional[dict]) -> bool:
+        """Match fuzzy fields using OR condition."""
+        for key, value in (fuzzy_fields or {}).items():
+            if value in str(getattr(event.data, key, "")):
+                return True
+        return not fuzzy_fields
+
+    @classmethod
+    def _convert_to_public_class(cls, data: Any) -> Any:
+        """Convert the instance to the corresponding Public class if it exists."""
+        class_module = importlib.import_module(cls.__module__)
+        public_class = getattr(class_module, f"{cls.__name__}Public", None)
+        return public_class.model_validate(data) if public_class else data
+
+    @staticmethod
+    def _format_event(event: Any) -> str:
+        """Format the event as a JSON string."""
+        return json.dumps(jsonable_encoder(event), separators=(",", ":")) + "\n\n"

--- a/gpustack/schemas/workers.py
+++ b/gpustack/schemas/workers.py
@@ -171,7 +171,7 @@ WorkersPublic = PaginatedList[WorkerPublic]
 
 
 def compute_state(
-    unreachable: bool, heartbeat_time: Optional[datetime], worker_offline_timeout=180
+    unreachable: bool, heartbeat_time: Optional[datetime], worker_offline_timeout=60
 ) -> Tuple[WorkerStateEnum, Optional[str]]:
     now = int(datetime.now(timezone.utc).timestamp())
     heartbeat_timestamp = heartbeat_time.timestamp() if heartbeat_time else None

--- a/gpustack/server/bus.py
+++ b/gpustack/server/bus.py
@@ -10,6 +10,7 @@ class EventType(Enum):
     UPDATED = 2
     DELETED = 3
     UNKNOWN = 4
+    HEARTBEAT = 5
 
 
 @dataclass

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -38,6 +38,9 @@ class ModelController:
         """
 
         async for event in Model.subscribe(self._engine):
+            if event.type == EventType.HEARTBEAT:
+                continue
+
             await self._reconcile(event)
 
     async def _reconcile(self, event: Event):
@@ -67,6 +70,9 @@ class ModelInstanceController:
         """
 
         async for event in ModelInstance.subscribe(self._engine):
+            if event.type == EventType.HEARTBEAT:
+                continue
+
             await self._reconcile(event)
 
     async def _reconcile(self, event: Event):

--- a/gpustack/server/worker_syncer.py
+++ b/gpustack/server/worker_syncer.py
@@ -14,7 +14,7 @@ class WorkerSyncer:
     """
 
     def __init__(
-        self, interval=60, worker_offline_timeout=180, worker_unreachable_timeout=10
+        self, interval=15, worker_offline_timeout=60, worker_unreachable_timeout=10
     ):
         self._engine = get_engine()
         self._interval = interval


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/268
https://github.com/gpustack/gpustack/issues/871

Problem:
The client does not detect connection interruption during system sleep and the watch request hangs.

Solution:
Add stream heartbeats and client timeout

Also, reduce the worker sync interval to make it more responsive.