### PR TITLE
ci: update docker tag latest flavor

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -70,9 +70,10 @@ jobs:
             type=pep440,pattern=v{{major}}.{{minor}}
             type=ref,event=branch
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ matrix.device == 'cuda' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
           # set no tag suffix for cuda as the default, set -{device} suffix for others
           flavor: |
+            latest=false
             suffix=${{ matrix.device != 'cuda' && format('-{0}', matrix.device) || '' }}
       - name: Package
         uses: docker/build-push-action@v5


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/991

Problem:
Previously, non-CUDA images are published to `latest`. [PR 762](https://github.com/gpustack/gpustack/pull/762) tends to resolve it but resulting in `latest-<device>` tags missing.

Solution:
Set `latest=false` in docker metadata flavor. It controls auto-generated latest tag.

Ref:
https://github.com/docker/metadata-action?tab=readme-ov-file#flavor-input

Test Result:
https://github.com/gitlawr/test/actions/runs/12801567432/job/35691246938