### PR TITLE
fix: dashboard token ordering

### DIFF
--- a/gpustack/routes/dashboard.py
+++ b/gpustack/routes/dashboard.py
@@ -318,7 +318,7 @@ def active_model_statement() -> select:
             resource_claim_query.c.total_ram_claim,
             resource_claim_query.c.total_vram_claim,
         )
-        .order_by(usage_sum_query.c.total_token_count.desc())
+        .order_by(func.coalesce(usage_sum_query.c.total_token_count, 0).desc())
         .limit(10)
     )
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1062

Happends when using pg and token count query result is null