### PR TITLE
refactor: only set image-no-text-encoder-model-offload to fp16

### DIFF
--- a/gpustack/assets/model-catalog-modelscope.yaml
+++ b/gpustack/assets/model-catalog-modelscope.yaml
@@ -1438,16 +1438,26 @@
     - stabilityai-ai-community
   release_date: "2024-10-22"
   templates:
-    - quantizations: &image_quantizations
+    - quantizations:
         - Q4_0
         - Q4_1
         - Q8_0
+      source: model_scope
+      model_scope_model_id: gpustack/stable-diffusion-v3-5-large-GGUF
+      model_scope_file_path: "*large-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
         - FP16
       source: model_scope
       model_scope_model_id: gpustack/stable-diffusion-v3-5-large-GGUF
       model_scope_file_path: "*large-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
+      # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
+      backend_parameters:
+        - --image-no-text-encoder-model-offload
 - name: Stable Diffusion V3.5 Large Turbo
   description: Stable Diffusion 3.5 Large Turbo is a Multimodal Diffusion Transformer (MMDiT) text-to-image model with Adversarial Diffusion Distillation (ADD) that features improved performance in image quality, typography, complex prompt understanding, and resource-efficiency, with a focus on fewer inference steps.
   home: https://stability.ai
@@ -1458,12 +1468,26 @@
     - stabilityai-ai-community
   release_date: "2024-10-22"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
       source: model_scope
       model_scope_model_id: gpustack/stable-diffusion-v3-5-large-turbo-GGUF
       model_scope_file_path: "*turbo-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
+    - quantizations:
+        - FP16
+      source: model_scope
+      model_scope_model_id: gpustack/stable-diffusion-v3-5-large-turbo-GGUF
+      model_scope_file_path: "*turbo-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+      # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
+      backend_parameters:
+        - --image-no-text-encoder-model-offload
 - name: Stable Diffusion V3.5 Medium
   description: Stable Diffusion 3.5 Medium is a Multimodal Diffusion Transformer with improvements (MMDiT-X) text-to-image model that features improved performance in image quality, typography, complex prompt understanding, and resource-efficiency.
   home: https://stability.ai
@@ -1504,12 +1528,26 @@
     - stabilityai-ai-community
   release_date: "2024-06-12"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
       source: model_scope
       model_scope_model_id: gpustack/stable-diffusion-v3-medium-GGUF
       model_scope_file_path: "*medium-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
+    - quantizations:
+        - FP16
+      source: model_scope
+      model_scope_model_id: gpustack/stable-diffusion-v3-medium-GGUF
+      model_scope_file_path: "*medium-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+      # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
+      backend_parameters:
+        - --image-no-text-encoder-model-offload
 - name: Stable Diffusion XL
   description: SDXL is a model that can be used to generate and modify images based on text prompts. It is a Latent Diffusion Model that uses two fixed, pretrained text encoders (OpenCLIP-ViT/G and CLIP-ViT/L).
   home: https://stability.ai
@@ -1520,7 +1558,11 @@
     - openrail++
   release_date: "2023-07-26"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations: &image_quantizations
+        - Q4_0
+        - Q4_1
+        - Q8_0
+        - FP16
       source: model_scope
       model_scope_model_id: gpustack/stable-diffusion-xl-base-1.0-GGUF
       model_scope_file_path: "*-{quantization}*.gguf"
@@ -1632,12 +1674,26 @@
     - flux-1-dev-non-commercial-license
   release_date: "2024-08-02"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
       source: model_scope
       model_scope_model_id: gpustack/FLUX.1-dev-GGUF
       model_scope_file_path: "*dev-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
+    - quantizations:
+        - FP16
+      source: model_scope
+      model_scope_model_id: gpustack/FLUX.1-dev-GGUF
+      model_scope_file_path: "*dev-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+      # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
+      backend_parameters:
+        - --image-no-text-encoder-model-offload
 - name: FLUX.1 Schnell
   description: FLUX.1 [schnell] is a 12 billion parameter rectified flow transformer capable of generating images from text descriptions.
   home: https://blackforestlabs.ai
@@ -1648,12 +1704,26 @@
     - apache-2.0
   release_date: "2024-08-02"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
       source: model_scope
       model_scope_model_id: gpustack/FLUX.1-schnell-GGUF
       model_scope_file_path: "*schnell-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
+    - quantizations:
+        - FP16
+      source: model_scope
+      model_scope_model_id: gpustack/FLUX.1-schnell-GGUF
+      model_scope_file_path: "*schnell-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+      # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
+      backend_parameters:
+        - --image-no-text-encoder-model-offload
 - name: FLUX.1 Fill Dev
   description: FLUX.1 Fill [dev] is a 12 billion parameter rectified flow transformer capable of filling areas in existing images based on a text description.
   home: https://blackforestlabs.ai
@@ -1664,12 +1734,26 @@
     - flux-1-dev-non-commercial-license
   release_date: "2024-11-25"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
       source: model_scope
       model_scope_model_id: gpustack/FLUX.1-Fill-dev-GGUF
       model_scope_file_path: "*dev-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
+    - quantizations:
+        - FP16
+      source: model_scope
+      model_scope_model_id: gpustack/FLUX.1-Fill-dev-GGUF
+      model_scope_file_path: "*dev-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+      # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
+      backend_parameters:
+        - --image-no-text-encoder-model-offload
 - name: FLUX.1 Lite
   description: Flux.1 Lite is an 8B parameter transformer model distilled from the FLUX.1-dev model. This version uses 7 GB less RAM and runs 23% faster while maintaining the same precision (bfloat16) as the original model.
   home: https://huggingface.co/Freepik/flux.1-lite-8B-alpha
@@ -1680,12 +1764,26 @@
     - flux-1-dev-non-commercial-license
   release_date: "2024-10-23"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
       source: model_scope
       model_scope_model_id: gpustack/FLUX.1-lite-GGUF
       model_scope_file_path: "*lite-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
+    - quantizations:
+        - FP16
+      source: model_scope
+      model_scope_model_id: gpustack/FLUX.1-lite-GGUF
+      model_scope_file_path: "*lite-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+      # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
+      backend_parameters:
+        - --image-no-text-encoder-model-offload
 # Audio models
 - name: Faster Whisper Large V3
   description: Whisper is a state-of-the-art model for automatic speech recognition (ASR) and speech translation, proposed in the paper Robust Speech Recognition via Large-Scale Weak Supervision by Alec Radford et al. from OpenAI. Trained on >5M hours of labeled data, Whisper demonstrates a strong ability to generalise to many datasets and domains in a zero-shot setting. This is the conversion of openai/whisper-large-v3 to the CTranslate2 model format.

--- a/gpustack/assets/model-catalog.yaml
+++ b/gpustack/assets/model-catalog.yaml
@@ -1446,10 +1446,16 @@
     - stabilityai-ai-community
   release_date: "2024-10-22"
   templates:
-    - quantizations: &image_quantizations
+    - quantizations:
         - Q4_0
         - Q4_1
         - Q8_0
+      source: huggingface
+      huggingface_repo_id: gpustack/stable-diffusion-v3-5-large-GGUF
+      huggingface_filename: "*large-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
         - FP16
       source: huggingface
       huggingface_repo_id: gpustack/stable-diffusion-v3-5-large-GGUF
@@ -1457,6 +1463,7 @@
       replicas: 1
       backend: llama-box
       # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
       backend_parameters:
         - --image-no-text-encoder-model-offload
 - name: Stable Diffusion V3.5 Large Turbo
@@ -1469,13 +1476,24 @@
     - stabilityai-ai-community
   release_date: "2024-10-22"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
+      source: huggingface
+      huggingface_repo_id: gpustack/stable-diffusion-v3-5-large-turbo-GGUF
+      huggingface_filename: "*turbo-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
+        - FP16
       source: huggingface
       huggingface_repo_id: gpustack/stable-diffusion-v3-5-large-turbo-GGUF
       huggingface_filename: "*turbo-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
       # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
       backend_parameters:
         - --image-no-text-encoder-model-offload
 - name: Stable Diffusion V3.5 Medium
@@ -1488,13 +1506,24 @@
     - stabilityai-ai-community
   release_date: "2024-10-22"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
+      source: huggingface
+      huggingface_repo_id: gpustack/stable-diffusion-v3-5-medium-GGUF
+      huggingface_filename: "*medium-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
+        - FP16
       source: huggingface
       huggingface_repo_id: gpustack/stable-diffusion-v3-5-medium-GGUF
       huggingface_filename: "*medium-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
       # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
       backend_parameters:
         - --image-no-text-encoder-model-offload
 - name: Stable Diffusion V3 Medium
@@ -1507,13 +1536,24 @@
     - stabilityai-ai-community
   release_date: "2024-06-12"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
+      source: huggingface
+      huggingface_repo_id: gpustack/stable-diffusion-v3-medium-GGUF
+      huggingface_filename: "*medium-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
+        - FP16
       source: huggingface
       huggingface_repo_id: gpustack/stable-diffusion-v3-medium-GGUF
       huggingface_filename: "*medium-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
       # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
       backend_parameters:
         - --image-no-text-encoder-model-offload
 - name: Stable Diffusion XL
@@ -1526,7 +1566,11 @@
     - openrail++
   release_date: "2023-07-26"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations: &image_quantizations
+        - Q4_0
+        - Q4_1
+        - Q8_0
+        - FP16
       source: huggingface
       huggingface_repo_id: gpustack/stable-diffusion-xl-base-1.0-GGUF
       huggingface_filename: "*-{quantization}*.gguf"
@@ -1638,13 +1682,24 @@
     - flux-1-dev-non-commercial-license
   release_date: "2024-08-02"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
+      source: huggingface
+      huggingface_repo_id: gpustack/FLUX.1-dev-GGUF
+      huggingface_filename: "*dev-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
+        - FP16
       source: huggingface
       huggingface_repo_id: gpustack/FLUX.1-dev-GGUF
       huggingface_filename: "*dev-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
       # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
       backend_parameters:
         - --image-no-text-encoder-model-offload
 - name: FLUX.1 Schnell
@@ -1657,13 +1712,24 @@
     - apache-2.0
   release_date: "2024-08-02"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
+      source: huggingface
+      huggingface_repo_id: gpustack/FLUX.1-schnell-GGUF
+      huggingface_filename: "*schnell-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
+        - FP16
       source: huggingface
       huggingface_repo_id: gpustack/FLUX.1-schnell-GGUF
       huggingface_filename: "*schnell-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
       # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
       backend_parameters:
         - --image-no-text-encoder-model-offload
 - name: FLUX.1 Fill Dev
@@ -1676,13 +1742,24 @@
     - flux-1-dev-non-commercial-license
   release_date: "2024-11-25"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
+      source: huggingface
+      huggingface_repo_id: gpustack/FLUX.1-Fill-dev-GGUF
+      huggingface_filename: "*dev-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
+        - FP16
       source: huggingface
       huggingface_repo_id: gpustack/FLUX.1-Fill-dev-GGUF
       huggingface_filename: "*dev-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
       # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
       backend_parameters:
         - --image-no-text-encoder-model-offload
 - name: FLUX.1 Lite
@@ -1695,13 +1772,24 @@
     - flux-1-dev-non-commercial-license
   release_date: "2024-10-23"
   templates:
-    - quantizations: *image_quantizations
+    - quantizations:
+        - Q4_0
+        - Q4_1
+        - Q8_0
+      source: huggingface
+      huggingface_repo_id: gpustack/FLUX.1-lite-GGUF
+      huggingface_filename: "*lite-{quantization}*.gguf"
+      replicas: 1
+      backend: llama-box
+    - quantizations:
+        - FP16
       source: huggingface
       huggingface_repo_id: gpustack/FLUX.1-lite-GGUF
       huggingface_filename: "*lite-{quantization}*.gguf"
       replicas: 1
       backend: llama-box
       # This is a workaround for https://github.com/gpustack/gpustack/issues/1036
+      # After the issue is fixed, merge the FP16 quantization with the other quantizations
       backend_parameters:
         - --image-no-text-encoder-model-offload
 # Audio models


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1036

The workaround affects ~21% generation performance. Only apply it to the broken fp16 quant.