### PR TITLE
Make password's special character list consistent

### DIFF
--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -26,7 +26,7 @@ class UserCreate(UserBase):
             raise ValueError('Password must contain at least one lowercase letter')
         if not re.search(r'[0-9]', value):
             raise ValueError('Password must contain at least one digit')
-        if not re.search(r'[!@#$%^&*(),.?":{}|<>]', value):
+        if not re.search(r'[!@#$%^&*_+]', value):
             raise ValueError('Password must contain at least one special character')
         return value
 
@@ -47,7 +47,7 @@ class UpdatePassword(SQLModel):
             raise ValueError('Password must contain at least one lowercase letter')
         if not re.search(r'[0-9]', value):
             raise ValueError('Password must contain at least one digit')
-        if not re.search(r'[!@#$%^&*(),.?":{}|<>]', value):
+        if not re.search(r'[!@#$%^&*_+]', value):
             raise ValueError('Password must contain at least one special character')
         return value
 


### PR DESCRIPTION
Currently password's special character list has two version: `[!@#$%^&*(),.?":{}|<>]` and `[!@#$%^&*_+]`. 
It should be consistent.

* `[!@#$%^&*(),.?":{}|<>]`
    - https://github.com/gpustack/gpustack/blob/v0.5.1/gpustack/schemas/users.py#L29
    - https://github.com/gpustack/gpustack/blob/v0.5.1/gpustack/schemas/users.py#L50
* `[!@#$%^&*_+]`
    - https://github.com/gpustack/gpustack/blob/v0.5.1/gpustack/security.py#L29
    - https://github.com/gpustack/gpustack-ui/blob/0.3.2/src/config/index.ts#L51