### PR TITLE
fix: no termination on disabled user site

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -239,7 +239,7 @@ check_python_tools() {
     fi
   fi
 
-  USER_BASE_BIN=$(python3 -m site --user-base)/bin
+  USER_BASE_BIN=$(python3 -m site --user-base || true)/bin
   export PATH="$USER_BASE_BIN:$PATH"
 
   if ! command -v pipx > /dev/null 2>&1; then

--- a/install.sh.sha256sum
+++ b/install.sh.sha256sum
@@ -1,1 +1,1 @@
-26fa972b875f28c62d0c8fb63b4a87debdf66dfc1acab9204a979e5a5ae633a3  install.sh
+9e2ebead33ecef90eacd9776c93037d04efb8e6cfccaf8f7eb1aecbff5c5ac31  install.sh


### PR DESCRIPTION
address https://github.com/gpustack/gpustack/issues/1207

When user site is disabled, `python3 -m site --user-base` exits with none-zero code and halts the installation script.

Ref: https://github.com/python/cpython/blob/9e23e0ad2cc4267829388bc29688ac0c2bfb3604/Lib/site.py#L720-L725