### PR TITLE
fix: skip profile and execution policy on powershell make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(eval $(rest_args):;@:)
 
 # List targets based on script extension and directory
 ifeq ($(OS),Windows_NT)
-    targets := $(shell powershell -Command "Get-ChildItem -Path $(curr_dir)/$(SCRIPT_DIR) | Select-Object -ExpandProperty BaseName")
+    targets := $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-ChildItem -Path $(curr_dir)/$(SCRIPT_DIR) | Select-Object -ExpandProperty BaseName")
 else
 	targets := $(shell ls $(curr_dir)/$(SCRIPT_DIR) | grep $(SCRIPT_EXT) | sed 's/$(SCRIPT_EXT)$$//')
 endif
@@ -29,7 +29,7 @@ $(targets):
 ifeq ($(PLATFORM_SHELL),/bin/bash)
 	$(curr_dir)/$(SCRIPT_DIR)/$(TARGET_NAME)$(SCRIPT_EXT) $(rest_args)
 else
-	powershell "$(curr_dir)/$(SCRIPT_DIR)/$(TARGET_NAME)$(SCRIPT_EXT) $(rest_args)"
+	powershell -NoProfile -ExecutionPolicy Bypass "$(curr_dir)/$(SCRIPT_DIR)/$(TARGET_NAME)$(SCRIPT_EXT) $(rest_args)"
 endif
 
 help:


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1287

Problem:
Running make on windows may result in error due to execution policy. The make targets include error messages and available script list, making the error opaque.

Under the hood:
```
. : File C:\Users\alice\Documents\WindowsPowerShell\profile.ps1 cannot be loaded because running scripts is disabled on this system.
For more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.
At line:1 char:3
```