### PR TITLE
fix: mismatch parameters for get_inference_running_env

### DIFF
--- a/gpustack/worker/backends/vox_box.py
+++ b/gpustack/worker/backends/vox_box.py
@@ -54,7 +54,7 @@ class VoxBoxServer(InferenceServer):
                     f"Model environment variables: {', '.join(f'{key}={value}' for key, value in self._model.env.items())}"
                 )
 
-            env = self.get_inference_running_env(self._model_instance.gpu_indexes)
+            env = self.get_inference_running_env()
             result = subprocess.run(
                 [command_path] + arguments,
                 stdout=sys.stdout,


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1338

We probably need static checks like mypy to mitigate this.