### PR TITLE
fix: avoid worker name in user name

### DIFF
--- a/gpustack/worker/worker.py
+++ b/gpustack/worker/worker.py
@@ -70,7 +70,7 @@ class Worker:
 
         self._clientset = ClientSet(
             base_url=cfg.server_url,
-            username=f"system/worker/{self._worker_name}",
+            username=f"system/worker/{self._worker_ip}",
             password=cfg.token,
         )
         self._worker_manager = WorkerManager(


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1300

Ensure the system username is ASCII-decoded to maintain compatibility.

Context: https://github.com/fastapi/fastapi/blob/b0215699137c41a96c57f650640cb9db1c25314a/fastapi/security/http.py#L211