### PR TITLE
fix: log partial offload info for image model cause stuck in analyzing

### DIFF
--- a/gpustack/scheduler/calculator.py
+++ b/gpustack/scheduler/calculator.py
@@ -364,7 +364,7 @@ async def calculate_model_resource_claim(
         elif offload == GPUOffloadEnum.Partial:
             logger.trace(
                 f"Finished running parser for partial offloading model instance {model_instance.name}, latency: {latency:.2f}, at least: "
-                f"{claim.estimate.items[1].to_log_string()}"
+                f"{claim.estimate.items[1].to_log_string() if len(claim.estimate.items) > 1 else claim.estimate.items[0].to_log_string()}"
             )
         elif offload == GPUOffloadEnum.Disable:
             logger.trace(

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -80,7 +80,7 @@ class ServeManager:
                     self._get_current_worker_id()
 
                 await asyncio.sleep(5)
-                logger.debug("Started watching model instances.")
+                logger.info("Started watching model instances.")
                 await self._clientset.model_instances.awatch(
                     callback=self._handle_model_instance_event
                 )
@@ -94,7 +94,7 @@ class ServeManager:
             # Ignore model instances that are not assigned to this worker node.
             return
 
-        logger.debug(
+        logger.trace(
             f"Received model instance event: {event.type} {mi.name} {mi.state}"
         )
 

--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -396,7 +396,7 @@ class ToolsManager:
         return platform_name
 
     def download_gguf_parser(self):
-        version = "v0.13.16"
+        version = "v0.13.18"
         gguf_parser_dir = self.third_party_bin_path.joinpath("gguf-parser")
         os.makedirs(gguf_parser_dir, exist_ok=True)
 


### PR DESCRIPTION
- Issue: #1240 
- Problem: image models just have one item in parser's result, so log item[1] will cause out of index
```json
{
  "estimate": {
    "items": [
      {
        "fullOffloaded": true,
        "ram": {
          "remote": false,
          "position": 0,
          "uma": 349696800,
          "nonuma": 506983200
        },
        "vrams": [
          {
            "remote": false,
            "position": 0,
            "uma": 9019848372,
            "nonuma": 13216492079
          }
        ]
      }
    ],
    "type": "model",
    "architecture": "stable_diffusion_3_x",
    "flashAttention": false,
    "noMMap": true,
    "imageOnly": true,
    "distributable": true
  }
}
``` 