### PR TITLE
fix: infer max model len

### DIFF
--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 from abc import ABC, abstractmethod
 
 from gpustack.client.generated_clientset import ClientSet
-from gpustack.config.config import Config
+from gpustack.config.config import Config, set_global_config
 from gpustack.logging import setup_logging
 from gpustack.schemas.models import (
     BackendEnum,
@@ -147,6 +147,7 @@ class InferenceServer(ABC):
         cfg: Config,
     ):
         setup_logging(debug=cfg.debug)
+        set_global_config(cfg)
 
         try:
             self._clientset = clientset

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -6,7 +6,11 @@ import sysconfig
 from typing import Optional
 from gpustack.schemas.models import ModelInstanceStateEnum
 from gpustack.utils.command import find_parameter, get_versioned_command
-from gpustack.utils.hub import get_max_model_len, get_pretrained_config
+from gpustack.utils.hub import (
+    get_hf_text_config,
+    get_max_model_len,
+    get_pretrained_config,
+)
 from gpustack.worker.backends.base import InferenceServer
 
 logger = logging.getLogger(__name__)
@@ -98,7 +102,8 @@ class VLLMServer(InferenceServer):
         """
         try:
             pretrained_config = get_pretrained_config(self._model)
-            return get_max_model_len(pretrained_config)
+            pretrained_or_hf_text_config = get_hf_text_config(pretrained_config)
+            return get_max_model_len(pretrained_or_hf_text_config)
         except Exception as e:
             logger.error(f"Failed to derive max model length: {e}")
 

--- a/tests/pretrained_config/test_pretrained_config.py
+++ b/tests/pretrained_config/test_pretrained_config.py
@@ -1,4 +1,4 @@
-from gpustack.worker.backends.vllm import get_max_model_len
+from gpustack.worker.backends.vllm import get_hf_text_config, get_max_model_len
 from transformers import AutoConfig
 
 
@@ -8,11 +8,14 @@ def test_get_max_model_len():
         "Qwen/Qwen2-VL-7B-Instruct": 32768,
         "tiiuae/falcon-7b": 2048,
         "microsoft/Phi-3.5-mini-instruct": 131072,
-        "liuhaotian/llava-v1.6-34b": 4096,
+        "llava-hf/llava-v1.6-mistral-7b-hf": 32768,
+        "unsloth/Llama-3.2-11B-Vision-Instruct": 131072,
+        "THUDM/glm-4-9b-chat-1m": 1048576,
     }
 
     for model_name, expected_max_model_len in hf_model_lengths.items():
         config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+        pretrained_or_hf_text_config = get_hf_text_config(config)
         assert (
-            get_max_model_len(config) == expected_max_model_len
+            get_max_model_len(pretrained_or_hf_text_config) == expected_max_model_len
         ), f"max_model_len mismatch for {model_name}"


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1408
https://github.com/gpustack/gpustack/issues/1342

1.  Fix None global config as it's not initialized in serving process.
2. Support getting context size from text_config.
3. Update new keys acccording to current vLLM implementation.