### PR TITLE
chore: Suppress warnings from transformers

### DIFF
--- a/gpustack/logging.py
+++ b/gpustack/logging.py
@@ -1,6 +1,14 @@
 from datetime import datetime, timezone
 import logging
+import os
 import sys
+
+
+# Suppress warnings from transformers
+# https://github.com/huggingface/transformers/issues/27214
+# Note: This should be set before importing transformers
+if "TRANSFORMERS_NO_ADVISORY_WARNINGS" not in os.environ:
+    os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 
 TRACE_LEVEL = 5
 


### PR DESCRIPTION
Supress repeated logs like the following
```
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
```