### PR TITLE
Fix error "Error fetching serving logs" when worker is installed using custom worker port other than 10150

### DIFF
--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -82,7 +82,7 @@ async def get_serving_logs(
     server_config: Config = request.app.state.server_config
 
     model_instance_log_url = (
-        f"http://{worker.ip}:{server_config.worker_port}/serveLogs"
+        f"http://{worker.ip}:{worker.port}/serveLogs"
         f"/{model_instance.id}?{log_options.url_encode()}"
     )
 

--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -79,8 +79,6 @@ async def get_serving_logs(
     if not worker:
         raise NotFoundException(message="Model instance's worker not found")
 
-    server_config: Config = request.app.state.server_config
-
     model_instance_log_url = (
         f"http://{worker.ip}:{worker.port}/serveLogs"
         f"/{model_instance.id}?{log_options.url_encode()}"

--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -3,7 +3,6 @@ import aiohttp
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import PlainTextResponse, StreamingResponse
 
-from gpustack.config.config import Config
 from gpustack.worker.logs import LogOptionsDep
 from gpustack.api.exceptions import (
     InternalServerErrorException,


### PR DESCRIPTION
When worker is installed using custom worker port other than 10150, by using '--worker-port' worker options, GpuStack can not fetch log from worker. And it will throw following error on gpustack serevr:

```text
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 177, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.10/dist-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 180, in __call__
    await response(scope, wrapped_receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 215, in __call__
    async for chunk in self.body_iterator:
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 169, in body_stream
    raise app_exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 141, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 177, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.10/dist-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 180, in __call__
    await response(scope, wrapped_receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 215, in __call__
    async for chunk in self.body_iterator:
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 169, in body_stream
    raise app_exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 141, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/base.py", line 177, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.10/dist-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/responses.py", line 264, in wrap
    await func()
  File "/usr/local/lib/python3.10/dist-packages/starlette/responses.py", line 245, in stream_response
    async for chunk in self.body_iterator:
  File "/usr/local/lib/python3.10/dist-packages/gpustack/routes/model_instances.py", line 97, in proxy_stream
    raise HTTPException(
fastapi.exceptions.HTTPException: 500: Error fetching serving logs
```text