### PR TITLE
fix: skip watch loop if fail to get worker

### DIFF
--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -35,6 +35,10 @@ from gpustack.server.bus import Event, EventType
 logger = logging.getLogger(__name__)
 
 
+class WorkerNotFoundError(Exception):
+    pass
+
+
 class ServeManager:
     def __init__(
         self,
@@ -71,7 +75,7 @@ class ServeManager:
                     logger.debug(f"Successfully found worker ID: {worker.id}")
                     return
 
-        raise Exception(f"Worker {self._worker_name} not found.")
+        raise WorkerNotFoundError(f"Worker {self._worker_name} not found.")
 
     async def watch_model_instances(self):
         while True:
@@ -86,6 +90,8 @@ class ServeManager:
                 )
             except asyncio.CancelledError:
                 break
+            except WorkerNotFoundError:
+                raise
             except Exception as e:
                 logger.error(f"Failed watching model instances: {e}")
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1215

We've gathered async tasks to detect coroutine exceptions. The missing part is that it may enter infinity loop in watch_model_instances when registration fails. Raise the error in this case so that external manager like systemd/container runtime can restart the failed worker.