### PR TITLE
fix: avoid rpc server and inference server use same name

### DIFF
--- a/gpustack/worker/rpc_server.py
+++ b/gpustack/worker/rpc_server.py
@@ -8,10 +8,11 @@ from typing import List, Optional
 
 import setproctitle
 
+from gpustack.utils import platform
 from gpustack.utils.compat_importlib import pkg_resources
 from gpustack.utils.process import add_signal_handlers
 from gpustack.worker.backends.base import get_env_name_by_vendor
-from gpustack.worker.backends.llama_box import get_llama_box_command
+
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class RPCServer:
     ):
         command_path = pkg_resources.files(
             "gpustack.third_party.bin.llama-box"
-        ).joinpath(get_llama_box_command())
+        ).joinpath(RPCServer.get_llama_box_rpc_server_command())
 
         arguments = [
             "--rpc-server-host",
@@ -86,3 +87,10 @@ class RPCServer:
             error_message = f"Failed to run the llama-box rpc server: {e}"
             logger.error(error_message)
             raise error_message
+
+    @staticmethod
+    def get_llama_box_rpc_server_command() -> str:
+        command = "llama-box-rpc-server"
+        if platform.system() == "windows":
+            command += ".exe"
+        return command

--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -306,12 +306,24 @@ class ToolsManager:
 
         file_name = "llama-box.exe" if self._os == "windows" else "llama-box"
         target_file = target_dir / target_file_name
+        if self._os == "windows":
+            target_rpc_server_file = target_dir / "llama-box-rpc-server.exe"
+        else:
+            target_rpc_server_file = target_dir / "llama-box-rpc-server"
         shutil.copy(llama_box_tmp_dir / file_name, target_file)
 
         # Make the file executable (non-Windows only)
         if self._os != "windows":
             st = os.stat(target_file)
             os.chmod(target_file, st.st_mode | stat.S_IEXEC)
+
+        # To avoid same name for the RPC server and the inference service
+        if self._os != "windows" and not os.path.exists(target_rpc_server_file):
+            os.symlink(target_file, target_dir / target_rpc_server_file)
+        elif self._os == "windows" and not os.path.exists(target_rpc_server_file):
+            os.link(target_file, target_dir / target_rpc_server_file)
+        else:
+            logger.info(f"{target_rpc_server_file} already exists")
 
         # Clean up temporary directory
         shutil.rmtree(llama_box_tmp_dir)


### PR DESCRIPTION
Mac / Linux: use symlink for rpc server
windows: copy llama-box to a new file