### PR TITLE
fix: Allow users to customize CORS-related parameters.

### DIFF
--- a/docs/cli-reference/start.md
+++ b/docs/cli-reference/start.md
@@ -30,7 +30,7 @@ gpustack start [OPTIONS]
 ### Server Options
 
 | <div style="width:180px">Flag</div> | <div style="width:100px">Default</div> | Description                                                                                                                                         |
-| ----------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------------------|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--host` value                      | `0.0.0.0`                              | Host to bind the server to.                                                                                                                         |
 | `--port` value                      | `80`                                   | Port to bind the server to.                                                                                                                         |
 | `--disable-worker`                  | `False`                                | Disable embedded worker.                                                                                                                            |
@@ -43,6 +43,11 @@ gpustack start [OPTIONS]
 | `--model-catalog-file` value        | (empty)                                | Path or URL to the model catalog file.                                                                                                              |
 | `--ray-port` value                  | `40096`                                | Port of Ray (GCS server). Used when Ray is enabled.                                                                                                 |
 | `--ray-client-server-port` value    | `40097`                                | Port of Ray Client Server. Used when Ray is enabled.                                                                                                |
+| `--enable_cors`                     | `False`                                | Enable CORS in server.                                                                                                                              |
+| `--allow-origins` value             | `["*"]`                                | A list of origins that should be permitted to make cross-origin requests.                                                                           |
+| `--allow-credentials`               | `False`                                | Indicate that cookies should be supported for cross-origin requests.                                                                                |
+| `--allow-methods` value             | `["*"]`                                | A list of HTTP methods that should be allowed for cross-origin requests.                                                                            |
+| `--allow-headers` value             | `["*"]`                                | A list of HTTP request headers that should be supported for cross-origin requests.                                                                  |
 
 ### Worker Options
 
@@ -102,6 +107,11 @@ disable_update_check: false
 model_catalog_file: /path_or_url/to/model_catalog_file
 ray_port: 40096
 ray_client_server_port: 40097
+enable_cors: false
+allow_origins: ["*"]
+allow_credentials: false
+allow_methods: ["*"]
+allow_headers: ["*"]
 
 # Worker Options
 server_url: http://myserver

--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -292,6 +292,33 @@ def setup_start_cmd(subparsers: argparse._SubParsersAction):
         help="Base URL to download dependency tools.",
         default=get_gpustack_env("TOOLS_DOWNLOAD_BASE_URL"),
     )
+    group.add_argument(
+        "--enable-cors",
+        action=OptionalBoolAction,
+        help="Enable CORS in server.",
+        default=get_gpustack_env_bool("ENABLE_CORS"),
+    )
+    group.add_argument(
+        "--allow-origins",
+        action='append',
+        help="A list of origins that should be permitted to make cross-origin requests.",
+    )
+    group.add_argument(
+        "--allow-credentials",
+        action=OptionalBoolAction,
+        help="Indicate that cookies should be supported for cross-origin requests.",
+        default=get_gpustack_env_bool("ALLOW_CREDENTIALS"),
+    )
+    group.add_argument(
+        "--allow-methods",
+        action='append',
+        help="A list of HTTP methods that should be allowed for cross-origin requests.",
+    )
+    group.add_argument(
+        "--allow-headers",
+        action='append',
+        help="A list of HTTP request headers that should be supported for cross-origin requests.",
+    )
 
     parser_server.set_defaults(func=run)
 
@@ -406,6 +433,11 @@ def set_server_options(args, config_data: dict):
         "model_catalog_file",
         "ray_port",
         "ray_client_server_port",
+        "enable_cors",
+        "allow_origins",
+        "allow_credentials",
+        "allow_methods",
+        "allow_headers",
     ]
 
     for option in options:

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -70,6 +70,11 @@ class Config(BaseSettings):
         pipx_path: Path to the pipx executable, used to install versioned backends.
         system_reserved: Reserved system resources.
         tools_download_base_url: Base URL to download dependency tools.
+        enable_cors: Enable CORS in server.
+        allow_origins: A list of origins that should be permitted to make cross-origin requests.
+        allow_credentials: Indicate that cookies should be supported for cross-origin requests.
+        allow_methods: A list of HTTP methods that should be allowed for cross-origin requests.
+        allow_headers: A list of HTTP request headers that should be supported for cross-origin requests.
     """
 
     # Common options
@@ -98,6 +103,11 @@ class Config(BaseSettings):
     model_catalog_file: Optional[str] = None
     ray_port: int = 40096
     ray_client_server_port: int = 40097
+    enable_cors: bool = False
+    allow_origins: Optional[List[str]] = ['*']
+    allow_credentials: bool = False
+    allow_methods: Optional[List[str]] = ['*']
+    allow_headers: Optional[List[str]] = ['*']
 
     # Worker options
     server_url: Optional[str] = None

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -4,6 +4,7 @@ import os
 from typing import List
 import uvicorn
 import logging
+from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel.ext.asyncio.session import AsyncSession
 from gpustack.logging import setup_logging
 from gpustack.schemas.users import User
@@ -78,6 +79,14 @@ class Server:
         # Start FastAPI server
         app.state.server_config = self._config
         app.state.jwt_manager = jwt_manager
+        if self._config.enable_cors:
+            app.add_middleware(
+                CORSMiddleware,
+                allow_origins=self._config.allow_origins,
+                allow_credentials=self._config.allow_credentials,
+                allow_methods=self._config.allow_methods,
+                allow_headers=self._config.allow_headers,
+            )
         config = uvicorn.Config(
             app,
             host=host,


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1271

Start with default parameters when no parameters are specified:
<img width="626" alt="image" src="https://github.com/user-attachments/assets/647a2bcf-98c5-44e1-a6ff-efe9578d3b2c" />

When more precise control is required, modify the configuration file as shown in the figure below, ensuring that the parameters comply with the specifications of FastAPI's CORSMiddleware.
https://fastapi.tiangolo.com/tutorial/cors/#use-corsmiddleware
<img width="513" alt="image" src="https://github.com/user-attachments/assets/d6d4c563-f1a9-479a-8eb4-d7244798fe0a" />
