### PR TITLE
fix: wrong context length

### DIFF
--- a/gpustack/assets/model-catalog-modelscope.yaml
+++ b/gpustack/assets/model-catalog-modelscope.yaml
@@ -1220,7 +1220,7 @@
     - embedding
   capabilities:
     - dimensions/1024
-    - max_tokens/8192
+    - max_tokens/512
   licenses:
     - mit
   release_date: "2023-09-12"
@@ -1245,7 +1245,7 @@
     - embedding
   capabilities:
     - dimensions/1024
-    - max_tokens/8192
+    - max_tokens/512
   licenses:
     - mit
   release_date: "2023-09-12"

--- a/gpustack/assets/model-catalog.yaml
+++ b/gpustack/assets/model-catalog.yaml
@@ -1195,7 +1195,7 @@
     - embedding
   capabilities:
     - dimensions/1024
-    - max_tokens/8192
+    - max_tokens/512
   licenses:
     - mit
   release_date: "2023-09-12"
@@ -1220,7 +1220,7 @@
     - embedding
   capabilities:
     - dimensions/1024
-    - max_tokens/8192
+    - max_tokens/512
   licenses:
     - mit
   release_date: "2023-09-12"


### PR DESCRIPTION
The `bge-large-en-v1.5` and `bge-large-zh-v1.5` models have a maximum context length of only 512 tokens.