### PR TITLE
fix: zombie processes being generated when stopping models inside containers.

### DIFF
--- a/gpustack/utils/process.py
+++ b/gpustack/utils/process.py
@@ -117,5 +117,12 @@ def terminate_process(process):
         except psutil.TimeoutExpired:
             try:
                 process.kill()
+                process.wait(timeout=3)
             except psutil.NoSuchProcess:
                 pass
+            except psutil.TimeoutExpired:
+                logger.warning(f"Process {process.pid} failed to terminate after kill.")
+            except Exception as e:
+                logger.error(f"Error killing process {process.pid}: {e}")
+        except Exception as e:
+            logger.error(f"Error terminating process {process.pid}: {e}")


### PR DESCRIPTION
In the terminate_process method, adding wait after a failed kill operation helps reclaim the child process and prevents the creation of zombie processes