### PR TITLE
fix: get config attr

### DIFF
--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -496,7 +496,7 @@ def debug_env_info():
 
 
 def set_third_party_env(cfg: Config):
-    if cfg.get("enable_hf_transfer"):
+    if cfg.enable_hf_transfer:
         # https://huggingface.co/docs/huggingface_hub/guides/download#faster-downloads
         os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
         logger.debug("set env HF_HUB_ENABLE_HF_TRANSFER=1")


### PR DESCRIPTION
Fix the error
```
2025-03-25T17:27:21+08:00 - gpustack.cmd.start - CRITICAL - 'Config' object has no attribute 'get'
```