### PR TITLE
fix(dcu): crash with AWQ INT4 under high concurrency

### DIFF
--- a/Dockerfile.dcu
+++ b/Dockerfile.dcu
@@ -1,8 +1,11 @@
-ARG BASE_IMAGE=gpustack/dcu-base:dtk24.04.3_ubuntu22.04_py3.10_pytorch2.3.0_vllm0.6.2
-
-FROM $BASE_IMAGE
+FROM image.sourcefind.cn:5000/dcu/admin/base/pytorch:2.4.1-ubuntu22.04-dtk25.04-py3.10-fixpy AS base
 
 ARG TARGETPLATFORM
+
+# Install vllm
+RUN pip3 install https://download.sourcefind.cn:65024/file/4/lmslim/DAS1.5/lmslim-0.2.1+das.dtk2504-cp310-cp310-manylinux_2_28_x86_64.whl \
+    && pip3 install https://download.sourcefind.cn:65024/file/4/vllm/DAS1.5/vllm-0.6.2+das.opt3.dtk2504-cp310-cp310-manylinux_2_28_x86_64.whl
+
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     python3-venv \


### PR DESCRIPTION
### Summary

This PR addresses a kernel crash that occurs under high concurrency when using AWQ INT4 quantized models, particularly on systems running a CK-patched kernel.

### Fix

Upgraded `lmslim` from version `0.1.2` to `0.2.1`, which resolves the issue based on internal testing.

### Related Issue

Fixes https://github.com/gpustack/gpustack/issues/1726

### Environment

- Kernel: CK-patched Linux (6.x)
- Quantization: AWQ INT4
- Concurrency: High-load, multi-request scenario