### PR TITLE
refactor(mindie): optimize docker build

### DIFF
--- a/Dockerfile.npu
+++ b/Dockerfile.npu
@@ -1,26 +1,58 @@
-# NB(thxCode): According to Ascend Extension Installation,
-# torch-npu has the mapping requirements for the CANN version,
-# please check https://www.hiascend.com/document/detail/zh/Pytorch/600/configandinstg/instg/insg_0001.html for details.
+# Packaging logic:
+# 1. base target:
+#   - Install tools, including Python, GCC, CMake, Make, SCCache and dependencies.
+#   - Install specific version Ascend CANN according to the chip, including Toolkit and Kernels.
+# 2. mindie-install target:
+#   - Install specific version Ascend CANN NNAL.
+#   - Copy and intsall the ATB models from a fixed image.
+#   - Install required dependencies.
+#   - Install specific version MindIE.
+# 3. gpustack target (final):
+#   - Install GPUStack, and override the required dependencies after installed.
+#   - Set up the environment for CANN, NNAL and ATB models.
+#   - Set up the entrypoint to start GPUStack.
+
+# Arguments description:
+# - CANN_VERSION is the version of Ascend CANN,
+#   which is used to install the Ascend CANN Toolkit, Kernels and NNAL.
+# - CANN_CHIP is the chip version of Ascend CANN,
+#   which is used to install the Ascend CANN Kernels.
+# - MINDIE_VERSION is the version of Ascend MindIE,
+#   which is used to install the Ascend MindIE,
+#   please check https://www.hiascend.com/developer/download/community/result?module=ie%2Bpt%2Bcann for details.
+# - According to Ascend Extension Installation,
+#   TORCH_VERSION and TORCH_NPU_VERSION have the mapping requirements for the CANN_VERSION,
+#   please check https://www.hiascend.com/document/detail/zh/Pytorch/600/configandinstg/instg/insg_0001.html for details.
+# - PYTHON_VERSION is the version of Python,
+#   which should be properly set, it must be 3.x.
 
 ARG CANN_VERSION=8.0.0.beta1
 ARG CANN_CHIP=910b
+ARG MINDIE_VERSION=1.0.0
 ARG TORCH_VERSION=2.1.0
 ARG TORCH_NPU_VERSION=2.1.0.post8
-ARG MINDIE_VERSION=1.0.0
+ARG PYTHON_VERSION=3.11
 
-FROM ubuntu:20.04
+#
+# Stage Base
+#
+# Example build command:
+#   docker build --tag=gpustack/gpustack:npu-base --file=Dockerfile.npu --target base --progress=plain .
+#
+
+FROM ubuntu:20.04 AS base
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-#
-# Install tools
-#
+## Install tools
+
+ARG PYTHON_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONPATH="/usr/lib/python3.10/site-packages:/usr/lib64/python3.10/site-packages"
+    PYTHON_VERSION=${PYTHON_VERSION}
 
 RUN <<EOF
     # Refresh
@@ -42,11 +74,12 @@ RUN <<EOF
         tini vim jq bc tree
 
     # Update python
+    PYTHON="python${PYTHON_VERSION}"
     apt-get install -y --no-install-recommends \
-        python3.10 python3.10-dev python3.10-distutils python3.10-venv
-    if [ -f /etc/alternatives/python ]; then update-alternatives --remove-all python; fi; update-alternatives --install /usr/bin/python python /usr/bin/python3.10 10
-    if [ -f /etc/alternatives/python3 ]; then update-alternatives --remove-all python3; fi; update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 10
-    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+        ${PYTHON} ${PYTHON}-dev ${PYTHON}-distutils ${PYTHON}-venv ${PYTHON}-lib2to3
+    if [ -f /etc/alternatives/python ]; then update-alternatives --remove-all python; fi; update-alternatives --install /usr/bin/python python /usr/bin/${PYTHON} 10
+    if [ -f /etc/alternatives/python3 ]; then update-alternatives --remove-all python3; fi; update-alternatives --install /usr/bin/python3 python3 /usr/bin/${PYTHON} 10
+    curl -sS https://bootstrap.pypa.io/get-pip.py | ${PYTHON}
 
     # Update locale
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
@@ -62,9 +95,7 @@ ENV LANG='en_US.UTF-8' \
     LANGUAGE='en_US:en' \
     LC_ALL='en_US.UTF-8'
 
-#
-# Install GCC
-#
+## Install GCC
 
 RUN <<EOF
     # GCC
@@ -92,9 +123,7 @@ RUN <<EOF
         && rm -rf /var/cache/apt
 EOF
 
-#
-# Install CMake/Make/SCCache
-#
+## Install CMake/Make/SCCache
 
 RUN <<EOF
     # CMake/Make/SCCache
@@ -111,9 +140,7 @@ RUN <<EOF
         && rm -rf /var/cache/apt
 EOF
 
-#
-# Install Dependencies
-#
+## Install Dependencies
 
 RUN <<EOF
     # Dependencies
@@ -130,16 +157,14 @@ RUN <<EOF
         && rm -rf /var/cache/apt
 EOF
 
-#
-# Install CANN
-#
-
 ARG CANN_VERSION
 ARG CANN_CHIP
 
 ENV CANN_VERSION=${CANN_VERSION} \
     CANN_CHIP=${CANN_CHIP} \
     CANN_HOME="/usr/local/Ascend"
+
+## Install CANN Toolkit
 
 RUN <<EOF
     # CANN Toolkit
@@ -157,7 +182,7 @@ RUN <<EOF
     TOOLKIT_FILE="Ascend-cann-toolkit_${DOWNLOAD_VERSION}_${OS}-${ARCH}.run"
     TOOLKIT_PATH="/tmp/${TOOLKIT_FILE}"
     TOOLKIT_URL="${URL_PREFIX}/${TOOLKIT_FILE}?${URL_SUFFIX}"
-    curl -H 'Referer: https://www.hiascend.com/' -fL -o "${TOOLKIT_PATH}" "${TOOLKIT_URL}"
+    curl -H 'Referer: https://www.hiascend.com/' --retry 3 --retry-connrefused -fL -o "${TOOLKIT_PATH}" "${TOOLKIT_URL}"
     chmod a+x "${TOOLKIT_PATH}"
     printf "Y\n" | "${TOOLKIT_PATH}" --install --install-for-all --install-path="${CANN_HOME}"
 
@@ -167,6 +192,8 @@ RUN <<EOF
         && rm -rf /var/log/ascend_seclog \
         && pip cache purge
 EOF
+
+## Install CANN Kernels
 
 RUN <<EOF
     # CANN Kernels
@@ -182,13 +209,13 @@ RUN <<EOF
 
     # Install kernels
     KERNELS_FILE="Ascend-cann-kernels-${CANN_CHIP}_${DOWNLOAD_VERSION}_${OS}-${ARCH}.run"
-    if ! curl -H 'Referer: https://www.hiascend.com/' -fsSIL "${URL_PREFIX}/${KERNELS_FILE}?${URL_SUFFIX}" >/dev/null 2>&1; then
+    if ! curl -H 'Referer: https://www.hiascend.com/' --retry 3 --retry-connrefused -fsSIL "${URL_PREFIX}/${KERNELS_FILE}?${URL_SUFFIX}" >/dev/null 2>&1; then
         # Fallback to generic kernels
         KERNELS_FILE="Ascend-cann-kernels-${CANN_CHIP}_${DOWNLOAD_VERSION}_${OS}.run"
     fi
     KERNELS_PATH="/tmp/${KERNELS_FILE}"
     KERNELS_URL="${URL_PREFIX}/${KERNELS_FILE}?${URL_SUFFIX}"
-    curl -H 'Referer: https://www.hiascend.com/' -fL -o "${KERNELS_PATH}" "${KERNELS_URL}"
+    curl -H 'Referer: https://www.hiascend.com/' --retry 3 --retry-connrefused -fL -o "${KERNELS_PATH}" "${KERNELS_URL}"
     chmod a+x "${KERNELS_PATH}"
     printf "Y\n" |"${KERNELS_PATH}" --install --install-for-all --install-path="${CANN_HOME}"
 
@@ -198,6 +225,17 @@ RUN <<EOF
         && rm -rf /var/log/ascend_seclog \
         && pip cache purge
 EOF
+
+#
+# Stage MindIE Install
+#
+# Example build command:
+#   docker build --tag=gpustack/gpustack:npu-mindie-install --file=Dockerfile.npu --target mindie-install --progress=plain .
+#
+
+FROM base AS mindie-install
+
+## Install NNAL
 
 RUN <<EOF
     # CANN NNAL
@@ -215,7 +253,7 @@ RUN <<EOF
     NNAL_FILE="Ascend-cann-nnal_${DOWNLOAD_VERSION}_${OS}-${ARCH}.run"
     NNAL_PATH="/tmp/${NNAL_FILE}"
     NNAL_URL="${URL_PREFIX}/${NNAL_FILE}?${URL_SUFFIX}"
-    curl -H 'Referer: https://www.hiascend.com/' -fL -o "${NNAL_PATH}" "${NNAL_URL}"
+    curl -H 'Referer: https://www.hiascend.com/' --retry 3 --retry-connrefused -fL -o "${NNAL_PATH}" "${NNAL_URL}"
     chmod a+x "${NNAL_PATH}"
     printf "Y\n" | "${NNAL_PATH}" --install --install-path="${CANN_HOME}"
 
@@ -240,9 +278,7 @@ RUN <<EOF
         && pip cache purge
 EOF
 
-#
-# Install MindIE
-#
+## Install MindIE
 
 ARG TORCH_VERSION
 ARG TORCH_NPU_VERSION
@@ -275,14 +311,17 @@ RUN <<EOF
         ;;
     esac
     pip install torch-npu==${TORCH_NPU_VERSION}
+    pip install torchvision==0.16.0
 
     # Install MindIE
     MINDIE_FILE="Ascend-mindie_${DOWNLOAD_VERSION}_${OS}-${ARCH}.run"
     MINDIE_PATH="/tmp/${MINDIE_FILE}"
     MINDIE_URL="${URL_PREFIX}/${MINDIE_FILE}?${URL_SUFFIX}"
-    curl -H 'Referer: https://www.hiascend.com/' -fL -o "${MINDIE_PATH}" "${MINDIE_URL}"
+    curl -H 'Referer: https://www.hiascend.com/' --retry 3 --retry-connrefused -fL -o "${MINDIE_PATH}" "${MINDIE_URL}"
     chmod a+x "${MINDIE_PATH}"
     printf "Y\n" | "${MINDIE_PATH}" --install --install-path="${CANN_HOME}"
+
+    # Post process
     chmod +w "${CANN_HOME}/mindie/latest/mindie-service/conf"
 
     # Cleanup
@@ -293,38 +332,43 @@ RUN <<EOF
 EOF
 
 #
-# Install GPUStack
+# Stage GPUStack
 #
+# Example build command:
+#   docker build --tag=gpustack/gpustack:npu --file=Dockerfile.npu --progress=plain .
+#
+
+FROM mindie-install AS gpustack
+
+## Install GPUStack
 
 RUN --mount=type=bind,target=/workspace/gpustack,rw <<EOF
     # Build
-    cd /workspace/gpustack && \
-        make build
+    cd /workspace/gpustack \
+        && make build
 
     # Install
     WHEEL_PACKAGE="$(ls /workspace/gpustack/dist/*.whl)[mindie]"
     pip install $WHEEL_PACKAGE
 
-    # Post-install
-    pip install transformers==4.46.3 pillow==11.0.0 && \
-        pip list && \
-        python -m site
-
     # Download tools
     gpustack download-tools --device npu
 
+    # Post process
+    pip install transformers==4.46.3 pillow==11.0.0 \
+        && pip list \
+        && python -m site
+
     # Set up environment
-    mkdir -p /var/lib/gpustack && \
-        chmod -R 0755 /var/lib/gpustack
+    mkdir -p /var/lib/gpustack \
+        && chmod -R 0755 /var/lib/gpustack
 
     # Cleanup
     rm -rf /workspace/gpustack/dist \
         && pip cache purge
 EOF
 
-#
-# Setup environment
-#
+## Setup environment
 
 RUN <<EOF
     # Export CANN driver lib


### PR DESCRIPTION
- bump python 3.11
- split into multiple stages for reusing,
  for example, you can use `docker build --tag=gpustack/gpustack:npu-base --file=Dockerfile.npu --target base --progress=plain .` to prepare the npu-base.
- fix https://github.com/gpustack/gpustack/issues/1779