### PR TITLE
fix(mindie): failed on default launch

### DIFF
--- a/gpustack/worker/backends/ascend_mindie.py
+++ b/gpustack/worker/backends/ascend_mindie.py
@@ -316,8 +316,6 @@ class AscendMindIEServer(InferenceServer):
         # - Global config
         # -- Pin installation path, which helps to locate other resources.
         env["MIES_INSTALL_PATH"] = str(install_path)
-        # -- Disable exposing metrics.
-        env["MIES_SERVICE_MONITOR_MODE"] = "0"
         # -- Enable high performance swapper.
         # env["MIES_USE_MB_SWAPPER"] = "1"  # Atlas 300I Duo needs to unset this.
         env["MIES_RECOMPUTE_THRESHOLD"] = "0.5"
@@ -391,6 +389,7 @@ class AscendMindIEServer(InferenceServer):
 
         # - Listening config
         server_config["ipAddress"] = "0.0.0.0"
+        server_config.pop("managementIpAddress", None)
         server_config["allowAllZeroIpListening"] = True
         server_config["maxLinkNum"] = 1000
         server_config["port"] = self._model_instance.port
@@ -472,7 +471,8 @@ class AscendMindIEServer(InferenceServer):
                     }
                 )
             # --- Exposing metrics.
-            env["MIES_SERVICE_MONITOR_MODE"] = "1" if params.metrics else "0"
+            if params.metrics:
+                env["MIES_SERVICE_MONITOR_MODE"] = "1"
             # --- Emitting operators in synchronous way.
             env["TASK_QUEUE_ENABLE"] = "0" if params.enforce_eager else "1"
 

--- a/gpustack/worker/backends/ascend_mindie.py
+++ b/gpustack/worker/backends/ascend_mindie.py
@@ -407,6 +407,10 @@ class AscendMindIEServer(InferenceServer):
 
         # - Model config
         max_seq_len = self._get_model_max_seq_len()
+        # -- Mutate default max sequence length (aka. context length),
+        #    but allow to change it with below advanced parameters.
+        if max_seq_len > 8192:
+            max_seq_len = 8192
         model_deploy_config["maxSeqLen"] = max_seq_len
         model_deploy_config["maxInputTokenLen"] = max_seq_len
         model_deploy_config["truncation"] = False


### PR DESCRIPTION
- fix failed on default launch
- fix failed on exposing metrics, https://github.com/gpustack/gpustack/issues/1785
- align default context length to 8192, https://github.com/gpustack/gpustack/issues/1805