### PR TITLE
refactor(calculator): gguf-parser receive parameters 

### DIFF
--- a/gpustack/scheduler/calculator.py
+++ b/gpustack/scheduler/calculator.py
@@ -184,6 +184,7 @@ async def _gguf_parser_command(  # noqa: C901
         "168h0m0s",
         "--platform-footprint",
         "150,500",
+        "--no-mmap",
         "--json",
     ]
 

--- a/gpustack/worker/backends/llama_box.py
+++ b/gpustack/worker/backends/llama_box.py
@@ -68,6 +68,7 @@ class LlamaBoxServer(InferenceServer):
             self._model_path,
             "--alias",
             self._model.name,
+            "--no-mmap",
             "--no-warmup",
         ]
 


### PR DESCRIPTION
- revert the change introduced by https://github.com/gpustack/gpustack/pull/1767.
- enable calculator to recognize `--mmap` option.