### PR TITLE
fix: do not pass vendor specific device env to vox-box

### DIFF
--- a/gpustack/worker/backends/vox_box.py
+++ b/gpustack/worker/backends/vox_box.py
@@ -54,7 +54,9 @@ class VoxBoxServer(InferenceServer):
                     f"Model environment variables: {', '.join(f'{key}={value}' for key, value in self._model.env.items())}"
                 )
 
-            env = self.get_inference_running_env()
+            env = os.environ.copy()
+            env.update(self._model.env or {})
+
             result = subprocess.run(
                 [command_path] + arguments,
                 stdout=sys.stdout,


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1943

vox-box accepts device index via arguments. Passing the index via device env may cause conflicts.