### PR TITLE
refactor(mindie): bump to 2.0.rc1

### DIFF
--- a/Dockerfile.npu
+++ b/Dockerfile.npu
@@ -26,11 +26,11 @@
 # - PYTHON_VERSION is the version of Python,
 #   which should be properly set, it must be 3.x.
 
-ARG CANN_VERSION=8.0.0.beta1
+ARG CANN_VERSION=8.1.rc1.beta1
 ARG CANN_CHIP=910b
-ARG MINDIE_VERSION=1.0.0
+ARG MINDIE_VERSION=2.0.rc1
 ARG TORCH_VERSION=2.1.0
-ARG TORCH_NPU_VERSION=2.1.0.post8
+ARG TORCH_NPU_VERSION=2.1.0.post12
 ARG PYTHON_VERSION=3.11
 
 #
@@ -176,7 +176,9 @@ RUN <<EOF
     URL_SUFFIX="response-content-type=application/octet-stream"
 
     # Install dependencies
-    pip install attrs cython numpy==1.26.4 decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py
+    python3 -m pip install --no-cache-dir --root-user-action ignore --upgrade pip
+    pip install --no-cache-dir --root-user-action ignore \
+      attrs cython numpy==1.26.4 decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py
 
     # Install toolkit
     TOOLKIT_FILE="Ascend-cann-toolkit_${DOWNLOAD_VERSION}_${OS}-${ARCH}.run"
@@ -264,12 +266,12 @@ RUN <<EOF
         && pip cache purge
 EOF
 
-COPY --from=thxcode/mindie:1.0.0-800I-A2-py311-openeuler24.03-lts --chown=root:root ${CANN_HOME}/atb-models ${CANN_HOME}/atb-models
+COPY --from=thxcode/mindie:2.0.RC1-800I-A2-py311-openeuler24.03-lts --chown=root:root ${CANN_HOME}/atb-models ${CANN_HOME}/atb-models
 RUN <<EOF
     # ATB Models
 
     # Install
-    pip install ${CANN_HOME}/atb-models/*.whl
+    pip install --no-cache-dir --root-user-action ignore ${CANN_HOME}/atb-models/*.whl
 
     # Cleanup
     rm -f "${NNAL_PATH}" \
@@ -283,6 +285,10 @@ EOF
 ARG TORCH_VERSION
 ARG TORCH_NPU_VERSION
 ARG MINDIE_VERSION
+
+ENV TORCH_VERSION=${TORCH_VERSION} \
+    TORCH_NPU_VERSION=${TORCH_NPU_VERSION} \
+    MINDIE_VERSION=${MINDIE_VERSION}
 
 RUN <<EOF
     # MindIE
@@ -301,35 +307,52 @@ RUN <<EOF
     cat <<EOT >/tmp/requirements.txt
 absl-py==2.2.2
 attrs==24.3.0
-certifi==2019.11.28
-charset-normalizer==3.4.1
-click==8.1.8
-decorator==5.2.1
-filelock==3.18.0
-fsspec==2025.3.2
-greenlet==3.2.0
+certifi==2024.8.30
+cloudpickle==3.0.0
+einops==0.8.1
+easydict==1.13
+frozenlist==1.6.0
+gevent==24.2.1
+geventhttpclient==2.3.1
+greenlet==3.2.1
 grpcio==1.71.0
+icetk==0.0.4
 idna==2.8
+jsonlines==4.0.0
+jsonschema==4.23.0
+jsonschema-specifications==2025.4.1
 Jinja2==3.1.6
-MarkupSafe==3.0.2
-networkx==3.4.2
-pillow==11.0.0
-packaging==24.2
-RapidFuzz==3.13.0
-regex==2024.11.6
-safetensors==0.5.3
-scipy==1.15.2
-six==1.17.0
-torchvision==0.16.0
-tqdm==4.67.1
-typing_extensions==4.13.2
-urllib3==2.4.0
+loguru==0.7.2
+matplotlib==3.9.2
+ml_dtypes==0.5.0
+multidict==6.4.3
+nltk==3.9.1
+numba==0.61.2
+numpy==1.26.4
+pandas==2.2.3
+pillow==11.2.1
+prettytable==3.11.0
+pyarrow==19.0.1
+pydantic==2.9.2
+pydantic_core==2.23.4
+python-rapidjson==1.20
+requests==2.32.3
+sacrebleu==2.4.3
+tornado==6.4.2
 torch==${TORCH_VERSION}
 torch-npu==${TORCH_NPU_VERSION}
+torchvision==0.16.0
+transformers==4.46.3
+tiktoken==0.7.0
+typing_extensions==4.13.2
+tzdata==2024.2
+tqdm==4.67.1
+thefuzz==0.22.1
+urllib3==2.4.0
+zope.event==5.0
+zope.interface==7.0.3
 EOT
-    pip install --no-cache-dir -r /tmp/requirements.txt \
-        && pip freeze \
-        && python -m site
+    pip install --no-cache-dir --root-user-action ignore -r /tmp/requirements.txt
 
     # Install MindIE
     MINDIE_FILE="Ascend-mindie_${DOWNLOAD_VERSION}_${OS}-${ARCH}.run"
@@ -341,6 +364,10 @@ EOT
 
     # Post process
     chmod +w "${CANN_HOME}/mindie/latest/mindie-service/conf"
+
+    # Review
+    pip freeze \
+        && python -m site
 
     # Cleanup
     rm -f "${MINDIE_PATH}" \
@@ -366,9 +393,10 @@ RUN --mount=type=bind,target=/workspace/gpustack,rw <<EOF
     cd /workspace/gpustack \
         && make build
 
-    # Install
-    WHEEL_PACKAGE="$(ls /workspace/gpustack/dist/*.whl)[audio]"
-    pip install $WHEEL_PACKAGE
+    # Install,
+    # vox-box relies on PyTorch 2.7, which is not compatible with MindIE.
+    WHEEL_PACKAGE="$(ls /workspace/gpustack/dist/*.whl)"
+    pip install --no-cache-dir --root-user-action ignore $WHEEL_PACKAGE
 
     # Download tools
     gpustack download-tools --device npu
@@ -376,16 +404,17 @@ RUN --mount=type=bind,target=/workspace/gpustack,rw <<EOF
     # Post-process,
     # override the required dependencies after installed.
     cat <<EOT >/tmp/requirements.txt
-transformers==4.46.3
 pipx==1.7.1
 EOT
-    pip install --no-cache-dir -r /tmp/requirements.txt \
-        && pip freeze \
-        && python -m site
+    pip install --no-cache-dir --root-user-action ignore -r /tmp/requirements.txt
 
     # Set up environment
     mkdir -p /var/lib/gpustack \
         && chmod -R 0755 /var/lib/gpustack
+
+    # Review
+    pip freeze \
+        && python -m site
 
     # Cleanup
     rm -rf /workspace/gpustack/dist \
@@ -415,6 +444,11 @@ RUN <<EOF
     SOURCE_ATB_MODEL_ENV="source ${CANN_HOME}/atb-models/set_env.sh"
     echo "${SOURCE_ATB_MODEL_ENV}" >> /etc/profile
     echo "${SOURCE_ATB_MODEL_ENV}" >> ~/.bashrc
+
+    # Export Driver Tools
+    EXPORT_DRIVER_TOOLS="export PATH=${CANN_HOME}/driver/tools:\${PATH}"
+    echo "${EXPORT_DRIVER_TOOLS}" >> /etc/profile
+    echo "${EXPORT_DRIVER_TOOLS}" >> ~/.bashrc
 
     # NB(thxCode): For specific MindIE version supporting,
     # we need to process environment setting up during GPUStack deployment.

--- a/docs/user-guide/inference-backends.md
+++ b/docs/user-guide/inference-backends.md
@@ -171,32 +171,32 @@ The Ascend MindIE backend works on Linux platforms only, including ARM64 and x86
 ### Supported Models
 
 Ascend MindIE supports various models
-listed [here](https://www.hiascend.com/document/detail/zh/mindie/100/whatismindie/mindie_what_0003.html).
+listed [here](https://www.hiascend.com/document/detail/zh/mindie/20RC1/modellist/mindie_modellist_0001.html).
 
 Within GPUStack, support
-[large language models (LLMs)](https://www.hiascend.com/document/detail/zh/mindie/100/whatismindie/mindie_what_0003.html)
+[large language models (LLMs)](https://www.hiascend.com/document/detail/zh/mindie/20RC1/modellist/mindie_modellist_0001.html)
 and
-[multimodal language models (VLMs)](https://www.hiascend.com/document/detail/zh/mindie/100/whatismindie/mindie_what_0004.html)
+[multimodal language models (VLMs)](https://www.hiascend.com/document/detail/zh/mindie/20RC1/modellist/mindie_modellist_0002.html)
 . However, _embedding models_ and _multimodal generation models_ are not supported yet.
 
 ### Supported Features
 
 Ascend MindIE owns a variety of features
-outlined [here](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0001.html).
+outlined [here](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0001.html).
 
 At present, GPUStack supports a subset of these capabilities, including
-[Quantization](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0288.html),
-[Extending Context Size](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0295.html),
-[Mixture of Experts(MoE)](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0297.html),
-[Prefix Caching](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0302.html),
-[Function Calling](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0303.html),
-[Multimodal Understanding](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0304.html),
-[Multi-head Latent Attention(MLA)](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0305.html).
+[Quantization](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0288.html),
+[Extending Context Size](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0295.html),
+[Mixture of Experts(MoE)](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0297.html),
+[Prefix Caching](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0302.html),
+[Function Calling](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0303.html),
+[Multimodal Understanding](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0304.html),
+[Multi-head Latent Attention(MLA)](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0305.html).
 
 !!! Note
 
     1. Quantization needs specific weight, and must adjust the model's `config.json`,
-       please follow the [reference(guide)](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0288.html) to prepare the correct weight.
+       please follow the [reference(guide)](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0288.html) to prepare the correct weight.
     2. For Multimodal Understanding feature, some versions of Ascend MindIE's API are incompatible with OpenAI,
        please track this [issue](https://github.com/gpustack/gpustack/issues/1803) for more support.
     3. Some features are mutually exclusive, so be careful when using them.
@@ -204,16 +204,18 @@ At present, GPUStack supports a subset of these capabilities, including
 ### Parameters Reference
 
 Ascend MindIE has
-configurable [parameters](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0004.html)
-and [environment variables](https://www.hiascend.com/document/detail/zh/mindie/100/mindiellm/llmdev/mindie_llm0416.html).
+configurable [parameters](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0004.html)
+and [environment variables](https://www.hiascend.com/document/detail/zh/mindie/20RC1/mindiellm/llmdev/mindie_llm0416.html).
 
 To avoid directly configuring JSON, GPUStack provides a set of command line parameters as below.
 
 | Parameter                        | Default | Description                                                                                                                                                                                            |
-| -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|----------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--trust-remote-code`            |         | Trust remote code (for model loading).                                                                                                                                                                 |
 | `--npu-memory-fraction`          | 0.9     | Fraction of NPU memory to be used for the model executor (0 to 1). For example: `0.5` means 50% memory utilization.                                                                                    |
 | `--max-link-num`                 | 1000    | Maximum number of parallel requests.                                                                                                                                                                   |
+| `--token-timeout`                | 60      | Timeout for a token generation in seconds.                                                                                                                                                             |
+| `--e2e-timeout`                  | 60      | E2E (from request accepted to inference stopped) timeout in seconds.                                                                                                                                   |
 | `--max-seq-len`                  | 8192    | Model context length. If unspecified, it will be derived from the model config.                                                                                                                        |
 | `--max-input-token-len`          |         | Maximum input token length. If unspecified, it will be derived from `--max-seq-len`.                                                                                                                   |
 | `--truncation`                   |         | Truncate the input token length when it exceeds the minimum of `--max-input-token-len` and `--max-seq-len` - 1.                                                                                        |


### PR DESCRIPTION
- update dockerfile
  + bump CANN to 8.1.rc1.beta1
- adjust instance parameters
- compatible mindie 1.0.0 and 2.0.rc1
- revert the vox-box installation introduced by https://github.com/gpustack/gpustack/pull/1919

fix https://github.com/gpustack/gpustack/issues/1997