### PR TITLE
chore(tool): bump version

### DIFF
--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -22,8 +22,8 @@ from gpustack.config.config import get_global_config
 logger = logging.getLogger(__name__)
 
 
-BUILTIN_LLAMA_BOX_VERSION = "v0.0.147"
-BUILTIN_GGUF_PARSER_VERSION = "v0.17.6"
+BUILTIN_LLAMA_BOX_VERSION = "v0.0.149"
+BUILTIN_GGUF_PARSER_VERSION = "v0.18.1"
 BUILTIN_RAY_VERSION = "2.43.0"
 
 


### PR DESCRIPTION
this pr also refactors the receiving parameter list of the parser.

llama-box introduces new params as below: cc @hibig 

| Parameter | Default | Description|
| --- | --- | --- |
| `--visual-max-image-cache` |  0 |  0: disabled max visual image cache, works from v0.0.148 |
