### PR TITLE
fix: exception on log file not ready

### DIFF
--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -105,10 +105,10 @@ async def get_serving_logs(
             try:
                 async with client.get(model_instance_log_url, timeout=timeout) as resp:
                     if resp.status != 200:
-                        raise HTTPException(
-                            status_code=resp.status,
-                            detail=f"Error fetching serving logs: {resp.reason}",
-                        )
+                        body = await resp.read()
+                        yield body, resp.headers, resp.status
+                        return
+
                     async for chunk in resp.content.iter_any():
                         yield chunk, resp.headers, resp.status
             except Exception as e:

--- a/gpustack/utils/file.py
+++ b/gpustack/utils/file.py
@@ -32,7 +32,7 @@ def copy_owner_recursively(src, dst):
                 os.chown(os.path.join(dirpath, filename), st.st_uid, st.st_gid)
 
 
-@retry(stop=stop_after_attempt(5), wait=wait_fixed(0.5))
+@retry(stop=stop_after_attempt(10), wait=wait_fixed(1))
 def check_file_with_retries(path: Path):
     if not os.path.exists(path):
         raise FileNotFoundError(f"Log file not found: {path}")


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2157

Problem: Current retry period is short and the log file may not be ready when the model instance status turns to starting.
Solution: Increase retry and improve exception handling.