### PR TITLE
[v0.6] fix: disallow abbrev parsing backend parameters

### DIFF
--- a/gpustack/scheduler/calculator.py
+++ b/gpustack/scheduler/calculator.py
@@ -170,7 +170,7 @@ class GGUFParserCommandMutableParameters:
     skip_tls_verify: Optional[bool] = None
 
     def from_args(self, args: List[str]):
-        parser = argparse.ArgumentParser(exit_on_error=False)
+        parser = argparse.ArgumentParser(exit_on_error=False, allow_abbrev=False)
 
         # Estimate
         parser.add_argument(

--- a/gpustack/worker/backends/ascend_mindie.py
+++ b/gpustack/worker/backends/ascend_mindie.py
@@ -54,7 +54,7 @@ class AscendMindIEParameters:
     override_generation_config_parsed: Optional[any] = None  # store JSON parsed result
 
     def from_args(self, args: List[str]):
-        parser = argparse.ArgumentParser(exit_on_error=False)
+        parser = argparse.ArgumentParser(exit_on_error=False, allow_abbrev=False)
         #
         # Log config
         #


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2183