### PR TITLE
ci: pin action-gh-release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           retention-days: 5
 
       - name: Release GitHub Assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.11' && matrix.os == 'linux'
         with:
           # Draft for official releases to prepare and review release notes before publishing


### PR DESCRIPTION
v0.6 release CI [fails](https://github.com/gpustack/gpustack/actions/runs/15554792388) because the new release of softprops/action-gh-release is broken. Ref: https://github.com/softprops/action-gh-release/issues/627