### PR TITLE
refactor: replace sysconfig with get_command_path

### DIFF
--- a/gpustack/ray/manager.py
+++ b/gpustack/ray/manager.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 import os
 import subprocess
-import sysconfig
 from urllib.parse import urlsplit
 from gpustack.config import Config
 from gpustack.utils.network import parse_port_range
+from gpustack.utils.command import get_command_path
 
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class RayManager:
     async def _start_ray(self):
         logger.info(f"Starting Ray {self._role}.")
 
-        command_path = os.path.join(sysconfig.get_path("scripts"), "ray")
+        command_path = get_command_path('ray')
         arguments = [
             "start",
             "--block",

--- a/gpustack/utils/command.py
+++ b/gpustack/utils/command.py
@@ -1,3 +1,6 @@
+import sys
+import sysconfig
+from os.path import dirname, abspath, join
 import shutil
 from typing import List, Optional
 
@@ -55,3 +58,15 @@ def get_versioned_command(command_name: str, version: str) -> str:
         return f"{command_name[:-4]}_{version}.exe"
 
     return f"{command_name}_{version}"
+
+
+def get_command_path(command_name: str) -> str:
+    """
+    Return the full path of sepcified command. Supports both frozen and python base environments.
+    """
+    base_path = (
+        dirname(sys.executable)
+        if getattr(sys, 'frozen', False)
+        else sysconfig.get_path("scripts")
+    )
+    return abspath(join(base_path, command_name))

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -3,10 +3,13 @@ import logging
 import os
 import subprocess
 import sys
-import sysconfig
 from typing import Dict, List, Optional
 from gpustack.schemas.models import ModelInstance, ModelInstanceStateEnum
-from gpustack.utils.command import find_parameter, get_versioned_command
+from gpustack.utils.command import (
+    find_parameter,
+    get_versioned_command,
+    get_command_path,
+)
 from gpustack.utils.hub import (
     get_hf_text_config,
     get_max_model_len,
@@ -20,7 +23,7 @@ logger = logging.getLogger(__name__)
 class VLLMServer(InferenceServer):
     def start(self):
         try:
-            command_path = os.path.join(sysconfig.get_path("scripts"), "vllm")
+            command_path = get_command_path("vllm")
             if self._model.backend_version:
                 command_path = os.path.join(
                     self._config.bin_dir,

--- a/gpustack/worker/backends/vox_box.py
+++ b/gpustack/worker/backends/vox_box.py
@@ -2,9 +2,8 @@ import logging
 import os
 import subprocess
 import sys
-import sysconfig
 from gpustack.schemas.models import ModelInstanceStateEnum
-from gpustack.utils.command import get_versioned_command
+from gpustack.utils.command import get_versioned_command, get_command_path
 from gpustack.worker.backends.base import InferenceServer
 
 logger = logging.getLogger(__name__)
@@ -13,7 +12,7 @@ logger = logging.getLogger(__name__)
 class VoxBoxServer(InferenceServer):
     def start(self):
         try:
-            command_path = os.path.join(sysconfig.get_path("scripts"), "vox-box")
+            command_path = get_command_path("vox-box")
             if self._model.backend_version:
                 command_path = os.path.join(
                     self._config.bin_dir,


### PR DESCRIPTION
Refer to https://github.com/gpustack/gpustack/issues/2211

When gpustack is built as binary, the sysconfig.get_path doesn't point to the proper location. In this case, we assume that the built-in binary is located in the same directory as the main program.