### PR TITLE
feat: add usage query apis

### DIFF
--- a/gpustack/schemas/common.py
+++ b/gpustack/schemas/common.py
@@ -24,8 +24,11 @@ class ListParams(BaseModel):
     watch: bool = Query(default=False)
 
 
-class PaginatedList(BaseModel, Generic[T]):
+class ItemList(BaseModel, Generic[T]):
     items: list[T]
+
+
+class PaginatedList(ItemList[T]):
     pagination: Pagination
 
 

--- a/gpustack/schemas/dashboard.py
+++ b/gpustack/schemas/dashboard.py
@@ -33,11 +33,14 @@ class ModelUsageUserSummary(BaseModel):
     completion_token_count: int
 
 
-class ModelUsageSummary(BaseModel):
+class ModelUsageStats(BaseModel):
     api_request_history: List[TimeSeriesData]
     completion_token_history: List[TimeSeriesData]
     prompt_token_history: List[TimeSeriesData]
-    top_users: List[ModelUsageUserSummary]
+
+
+class ModelUsageSummary(ModelUsageStats):
+    top_users: Optional[List[ModelUsageUserSummary]] = None
 
 
 class ResourceClaim(BaseModel):


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1837

Add `/v1/dashboard/usage/stats` API. Examples:

`/v1/dashboard/usage/stats?start_date=2025-06-20&end_date=2025-06-22&model_ids=1&model_ids=2&user_ids=1`
(Same structure as the model_usage in existing /v1/dashboard)
```
{
    "api_request_history":
    [
        {
            "timestamp": 1750348800,
            "value": 1.0
        },
        {
            "timestamp": 1750608000,
            "value": 1.0
        }
    ],
    "completion_token_history":
    [
        {
            "timestamp": 1750348800,
            "value": 78.0
        },
        {
            "timestamp": 1750608000,
            "value": 69.0
        }
    ],
    "prompt_token_history":
    [
        {
            "timestamp": 1750348800,
            "value": 9.0
        },
        {
            "timestamp": 1750608000,
            "value": 9.0
        }
    ]
}
```

`/v1/dashboard/usage?start_date=2025-06-20&end_date=2025-06-22&model_ids=1&model_ids=2&user_ids=1`
```
{
    "items":
    [
        {
            "user_id": 1,
            "id": 1,
            "request_count": 1,
            "model_id": 1,
            "date": "2025-06-20",
            "prompt_token_count": 9,
            "completion_token_count": 78,
            "operation": "chat_completion"
        },
        {
            "user_id": 1,
            "id": 2,
            "request_count": 1,
            "model_id": 2,
            "date": "2025-06-23",
            "prompt_token_count": 9,
            "completion_token_count": 69,
            "operation": "chat_completion"
        }
    ]
}
```
