### PR TITLE
refactor: Llama box multi version directory structure changes

### DIFF
--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -529,7 +529,6 @@ def set_ulimit(target_soft_limit=65535):
     if sys.platform.startswith('win'):
         logger.info("Windows detected, skipping ulimit adjustment.")
         return
-
     import resource
 
     resource_type = resource.RLIMIT_NOFILE

--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -94,7 +94,7 @@ class InferenceServer(ABC):
         if event.data["state"] == ModelInstanceStateEnum.ERROR:
             raise ModelInstanceStateError()
         elif event.data["state"] == ModelInstanceStateEnum.STARTING:
-            self._model_path = event.data["resolved_path"]
+            self._model_path = str(Path(event.data["resolved_path"]).absolute())
             return True
 
         return False

--- a/gpustack/worker/rpc_server.py
+++ b/gpustack/worker/rpc_server.py
@@ -55,7 +55,7 @@ class RPCServer:
         args: Optional[List[str]] = None,
     ):
         command_path = pkg_resources.files(
-            "gpustack.third_party.bin.llama-box"
+            "gpustack.third_party.bin.llama-box.llama-box-default"
         ).joinpath(RPCServer.get_llama_box_rpc_server_command())
 
         arguments = [
@@ -98,6 +98,7 @@ class RPCServer:
                 stdout=sys.stdout,
                 stderr=sys.stderr,
                 env=env,
+                cwd=command_path.cwd(),
             )
         except Exception as e:
             error_message = f"Failed to run the llama-box rpc server: {e}"


### PR DESCRIPTION
issue address: https://github.com/gpustack/gpustack/issues/1722
Adjust multi-version directory structure to support dynamic library
﻿
Since llama-box v0.0.157 introduced dynamic library support, we now:
1. Reorganized versioned directories to accommodate dynamic loading
2. Priority use dynamic library

### old directory structure
```
# download tools
.../third_party/bin/llama-box/llama-box-$(os)-$(arch)-$(variant)
.../third_party/bin/llama-box/llama-box-rpc-server (linked)
 
# running specified version
$(data_dir)/bin/llama-box/llama-box_v0.0.156
$(data_dir)/bin/llama-box/llama-box_v0.0.157
```

### new directory structure
```
# download tools
.../third_party/bin/llama-box/llama-box-$(version)-$(os)-$(arch)-$(variant)/llama-box
.../third_party/bin/llama-box/llama-box-default/llama-box (linked)
 
# running specified version
$(data_dir)/bin/llama-box/llama-box-v0.0.156/llama-box
$(data_dir)/bin/llama-box/llama-box-v0.0.157/llama-box
```