### PR TITLE
feat(config): Add GPUSTACK_DISABLE_DYNAMIC_LINK_LLAMA_BOX env var for llama-box deployment control

### DIFF
--- a/gpustack/utils/platform.py
+++ b/gpustack/utils/platform.py
@@ -116,14 +116,16 @@ def device() -> str:
     ):
         return DeviceTypeEnum.MUSA.value
 
-    if is_command_available("npu-smi"):
-        return "npu"
+    if is_command_available("npu-smi") or os.path.exists(
+        "/usr/local/Ascend/ascend-toolkit"
+    ):
+        return DeviceTypeEnum.NPU.value
 
     if system() == "darwin" and arch() == "arm64":
         return DeviceTypeEnum.MPS.value
 
-    if is_command_available("hy-smi"):
-        return "dcu"
+    if is_command_available("hy-smi") or os.path.exists("/opt/dtk"):
+        return DeviceTypeEnum.DCU.value
 
     if is_command_available("rocm-smi") or os.path.exists(
         "C:\\Program Files\\AMD\\ROCm"
@@ -131,7 +133,7 @@ def device() -> str:
         return DeviceTypeEnum.ROCM.value
 
     if is_command_available("ixsmi"):
-        return "corex"
+        return DeviceTypeEnum.COREX.value
 
     if is_command_available("cnmon"):
         return DeviceTypeEnum.MLU.value

--- a/gpustack/worker/backends/llama_box.py
+++ b/gpustack/worker/backends/llama_box.py
@@ -19,7 +19,7 @@ from gpustack.schemas.models import (
 from gpustack.utils.command import find_parameter
 from gpustack.utils.compat_importlib import pkg_resources
 from gpustack.worker.backends.base import InferenceServer
-from gpustack.worker.tools_manager import get_llama_box_command
+from gpustack.worker.tools_manager import get_enable_dynamic_link, get_llama_box_command
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +36,13 @@ class LlamaBoxServer(InferenceServer):
             else (
                 os.path.join(
                     self._config.bin_dir,
-                    f'llama-box/llama-box-{self._model.backend_version}',
+                    'llama-box',
+                    f'{"" if get_enable_dynamic_link(self._model.backend_version,platform.device()) else "static"}',
+                    f'llama-box-{self._model.backend_version}',
                 )
             )
         )
-        command_path = get_llama_box_command(base_path)
+        command_path = get_llama_box_command(base_path).absolute()
 
         layers = -1
         claim = self._model_instance.computed_resource_claim

--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -187,7 +187,13 @@ class ToolsManager:
         ):
             logger.debug(f"{file_name} already exists, skipping download")
         else:
-            self._download_llama_box(version, target_dir, file_name)
+            self._download_llama_box(
+                version,
+                target_dir,
+                file_name,
+                version >= "v0.0.157"
+                and self._device != platform.DeviceTypeEnum.NPU.value,
+            )
             # Update versions.json
             self._update_versions_file(version_key, version)
 
@@ -240,7 +246,11 @@ class ToolsManager:
         self._download_acsend_mindie(version, target_dir)
 
     def install_versioned_llama_box(self, version: str):
-        target_dir = Path(self._bin_dir) / "llama-box" / f"llama-box-{version}"
+        enable_dynamic_link = get_enable_dynamic_link(version, self._device)
+        target_dir = Path(self._bin_dir) / "llama-box"
+        if not enable_dynamic_link:
+            target_dir = target_dir / "static"
+        target_dir = target_dir / f"llama-box-{version}"
         target_file = get_llama_box_command(target_dir)
         file_name = os.path.basename(target_file)
 
@@ -248,7 +258,7 @@ class ToolsManager:
             logger.debug(f"{file_name} already exists, skipping download")
             return
 
-        self._download_llama_box(version, target_dir, file_name)
+        self._download_llama_box(version, target_dir, file_name, enable_dynamic_link)
 
     def install_versioned_vllm(self, version: str):
         system = platform.system()
@@ -440,7 +450,11 @@ class ToolsManager:
             shutil.rmtree(tmp_dir)
 
     def _download_llama_box(
-        self, version: str, target_dir: Path, target_file_name: str
+        self,
+        version: str,
+        target_dir: Path,
+        target_file_name: str,
+        enable_dynamic_link: bool,
     ):
         llama_box_tmp_dir = target_dir.joinpath("tmp-llama-box")
 
@@ -449,10 +463,9 @@ class ToolsManager:
             shutil.rmtree(llama_box_tmp_dir)
         os.makedirs(llama_box_tmp_dir, exist_ok=True)
 
-        # Since v0.0.157: Use dynamic libraries instead of static linking
         platform_name = self._get_llama_box_platform_name(
             version,
-            version >= "v0.0.157" and self._device != platform.DeviceTypeEnum.NPU.value,
+            enable_dynamic_link,
         )
         tmp_file = llama_box_tmp_dir / f"llama-box-{version}-{platform_name}.zip"
         url_path = f"gpustack/llama-box/releases/download/{version}/{platform_name}.zip"
@@ -544,7 +557,7 @@ class ToolsManager:
         logger.debug(f"Linked from {src_dir} to {dst_dir}")
 
     def _get_llama_box_platform_name(  # noqa C901
-        self, version: str, enable_dynmaic_link: bool
+        self, version: str, enable_dynamic_link: bool
     ) -> str:
         """
         Get the platform name for llama-box based on the OS, architecture, and device type.
@@ -562,9 +575,9 @@ class ToolsManager:
         if self._device in device_toolkit_mapper:
             toolkit = device_toolkit_mapper[self._device]
         elif self._arch == "amd64":
-            toolkit = "cpu" if enable_dynmaic_link else "avx2"
+            toolkit = "cpu" if enable_dynamic_link else "avx2"
         elif self._arch == "arm64":
-            toolkit = "cpu" if enable_dynmaic_link else "neon"
+            toolkit = "cpu" if enable_dynamic_link else "neon"
         else:
             raise Exception(
                 f"unsupported platform, os: {self._os}, arch: {self._arch}, device: {self._device}"
@@ -631,7 +644,7 @@ class ToolsManager:
 
         return (
             f"dl-llama-box-{'-'.join(segments)}"
-            if enable_dynmaic_link
+            if enable_dynamic_link
             else f"llama-box-{'-'.join(segments)}"
         )
 
@@ -963,3 +976,19 @@ def get_llama_box_version_dir_name(
     device = f'-{device}' if device else ''
     dir_name = os.path.join(f"llama-box-{version}-{system}-{arch}{device}")
     return dir_name
+
+
+def get_enable_dynamic_link(version, device) -> Optional[bool]:
+    if version < "v0.0.157":
+        return False
+
+    default = device != platform.DeviceTypeEnum.NPU.value
+
+    env_name = "GPUSTACK_ENABLE_DYNAMIC_LINK"
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        if env_value.lower() in ["false", "0"]:
+            return False
+        if env_value.lower() in ["true", "1"]:
+            return True
+    return default

--- a/gpustack/worker/worker_manager.py
+++ b/gpustack/worker/worker_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import random
 from datetime import datetime, timezone
+from pathlib import Path
 import multiprocessing
 import os
 import logging
@@ -46,7 +47,9 @@ class WorkerManager:
         self._system_reserved = system_reserved
         self._rpc_servers: Dict[int, RPCServerProcessInfo] = {}
         self._rpc_server_log_dir = f"{cfg.log_dir}/rpc_server"
-        self._rpc_server_cache_dir = f"{cfg.cache_dir}/rpc_server/"
+        self._rpc_server_cache_dir = str(
+            Path(f"{cfg.cache_dir}/rpc_server/").absolute()
+        )
         self._rpc_server_args = cfg.rpc_server_args
         self._gpu_devices = cfg.get_gpu_devices()
         self._system_info = cfg.get_system_info()


### PR DESCRIPTION
issues address: https://github.com/gpustack/gpustack/issues/2322

Introduce environment variable to toggle between static/dynamic linking in llama-box:
- Set `GPUSTACK_DISABLE_DYNAMIC_LINK_LLAMA_BOX=true` to disable dynamic linking
- Static libraries stored in {$data_dir}/bin/llama-box/static with versioned subdirs
- Default behavior remains dynamic linking when env var not set