### PR TITLE
fix: simplify llama-box download logic

### DIFF
--- a/gpustack/utils/platform.py
+++ b/gpustack/utils/platform.py
@@ -218,7 +218,3 @@ def get_cann_chip() -> str:
     # TODO(thxCode): figure out a way to discover the CANN chip version
 
     return os.getenv("CANN_CHIP", "")
-
-
-def get_executable_suffix() -> str:
-    return '.exe' if system() == 'windows' else ''

--- a/gpustack/worker/backends/llama_box.py
+++ b/gpustack/worker/backends/llama_box.py
@@ -26,16 +26,21 @@ logger = logging.getLogger(__name__)
 
 class LlamaBoxServer(InferenceServer):
     def start(self):  # noqa: C901
-        base_path = pkg_resources.files("gpustack.third_party.bin").joinpath(
-            'llama-box/llama-box-default'
-        )
-        command_path = get_llama_box_command(str(base_path))
-        if self._model.backend_version:
-            command_path = os.path.join(
-                self._config.bin_dir,
-                f'llama-box/llama-box-{self._model.backend_version}',
+        base_path = (
+            str(
+                pkg_resources.files("gpustack.third_party.bin").joinpath(
+                    'llama-box/llama-box-default'
+                )
             )
-            command_path = get_llama_box_command(str(base_path))
+            if (self._config.bin_dir is None or not self._model.backend_version)
+            else (
+                os.path.join(
+                    self._config.bin_dir,
+                    f'llama-box/llama-box-{self._model.backend_version}',
+                )
+            )
+        )
+        command_path = get_llama_box_command(base_path)
 
         layers = -1
         claim = self._model_instance.computed_resource_claim


### PR DESCRIPTION
Revert some of the logic from 03cd217 as it has been implemented with bec76ba.
Multiple versions of llama-box support meet the needs of differentiating multiple devices.

Refer to 
- https://github.com/gpustack/gpustack/issues/2145
