### PR TITLE
feat(config): Add GPUSTACK_DISABLE_DYNAMIC_LINK_LLAMA_BOX env var for llama-box deployment control

### DIFF
--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -5,13 +5,14 @@ import logging
 import multiprocessing
 import os
 import sys
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import yaml
 
 from gpustack import __version__, __git_commit__
 from gpustack.config.config import set_global_config
 from gpustack.logging import setup_logging
+from gpustack.utils.envs import get_gpustack_env, get_gpustack_env_bool
 from gpustack.worker.worker import Worker
 from gpustack.config import Config
 from gpustack.server.server import Server
@@ -492,19 +493,6 @@ def set_worker_options(args, config_data: dict):
 
     for option in options:
         set_config_option(args, config_data, option)
-
-
-def get_gpustack_env(env_var: str) -> Optional[str]:
-    env_name = "GPUSTACK_" + env_var
-    return os.getenv(env_name)
-
-
-def get_gpustack_env_bool(env_var: str) -> Optional[bool]:
-    env_name = "GPUSTACK_" + env_var
-    env_value = os.getenv(env_name)
-    if env_value is not None:
-        return env_value.lower() in ["true", "1"]
-    return None
 
 
 def debug_env_info():

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -141,15 +141,23 @@ class Config(BaseSettings):
         # common options
         if self.data_dir is None:
             self.data_dir = self.get_data_dir()
+        else:
+            self.data_dir = os.path.abspath(self.data_dir)
 
         if self.cache_dir is None:
             self.cache_dir = os.path.join(self.data_dir, "cache")
+        else:
+            self.cache_dir = os.path.abspath(self.cache_dir)
 
         if self.bin_dir is None:
             self.bin_dir = os.path.join(self.data_dir, "bin")
+        else:
+            self.bin_dir = os.path.abspath(self.bin_dir)
 
         if self.log_dir is None:
             self.log_dir = os.path.join(self.data_dir, "log")
+        else:
+            self.log_dir = os.path.abspath(self.log_dir)
 
         if not self._is_server() and not self.token:
             raise Exception("Token is required when running as a worker")

--- a/gpustack/utils/envs.py
+++ b/gpustack/utils/envs.py
@@ -4,7 +4,7 @@ import os
 import stat
 import subprocess
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 @functools.lru_cache
@@ -122,3 +122,16 @@ def extract_unix_vars_of_source(script_paths: List[Path]) -> Dict[str, str]:
         raise Exception(
             f"Failed to extract environment variables from [{script_paths}]: {e.stderr}"
         )
+
+
+def get_gpustack_env(env_var: str) -> Optional[str]:
+    env_name = "GPUSTACK_" + env_var
+    return os.getenv(env_name)
+
+
+def get_gpustack_env_bool(env_var: str) -> Optional[bool]:
+    env_name = "GPUSTACK_" + env_var
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        return env_value.lower() in ["true", "1"]
+    return None

--- a/gpustack/utils/platform.py
+++ b/gpustack/utils/platform.py
@@ -116,14 +116,16 @@ def device() -> str:
     ):
         return DeviceTypeEnum.MUSA.value
 
-    if is_command_available("npu-smi"):
-        return "npu"
+    if is_command_available("npu-smi") or os.path.exists(
+        "/usr/local/Ascend/ascend-toolkit"
+    ):
+        return DeviceTypeEnum.NPU.value
 
     if system() == "darwin" and arch() == "arm64":
         return DeviceTypeEnum.MPS.value
 
-    if is_command_available("hy-smi"):
-        return "dcu"
+    if is_command_available("hy-smi") or os.path.exists("/opt/dtk"):
+        return DeviceTypeEnum.DCU.value
 
     if is_command_available("rocm-smi") or os.path.exists(
         "C:\\Program Files\\AMD\\ROCm"
@@ -131,7 +133,7 @@ def device() -> str:
         return DeviceTypeEnum.ROCM.value
 
     if is_command_available("ixsmi"):
-        return "corex"
+        return DeviceTypeEnum.COREX.value
 
     if is_command_available("cnmon"):
         return DeviceTypeEnum.MLU.value

--- a/gpustack/worker/backends/llama_box.py
+++ b/gpustack/worker/backends/llama_box.py
@@ -19,7 +19,10 @@ from gpustack.schemas.models import (
 from gpustack.utils.command import find_parameter
 from gpustack.utils.compat_importlib import pkg_resources
 from gpustack.worker.backends.base import InferenceServer
-from gpustack.worker.tools_manager import get_llama_box_command
+from gpustack.worker.tools_manager import (
+    get_llama_box_command,
+    is_disabled_dynamic_link,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +39,13 @@ class LlamaBoxServer(InferenceServer):
             else (
                 os.path.join(
                     self._config.bin_dir,
-                    f'llama-box/llama-box-{self._model.backend_version}',
+                    'llama-box',
+                    f'{"static" if is_disabled_dynamic_link(self._model.backend_version, platform.device()) else ""}',
+                    f'llama-box-{self._model.backend_version}',
                 )
             )
         )
-        command_path = get_llama_box_command(base_path)
+        command_path = get_llama_box_command(base_path).absolute()
 
         layers = -1
         claim = self._model_instance.computed_resource_claim

--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -187,7 +187,13 @@ class ToolsManager:
         ):
             logger.debug(f"{file_name} already exists, skipping download")
         else:
-            self._download_llama_box(version, target_dir, file_name)
+            self._download_llama_box(
+                version,
+                target_dir,
+                file_name,
+                version < "v0.0.157"
+                or self._device == platform.DeviceTypeEnum.NPU.value,
+            )
             # Update versions.json
             self._update_versions_file(version_key, version)
 
@@ -240,7 +246,11 @@ class ToolsManager:
         self._download_acsend_mindie(version, target_dir)
 
     def install_versioned_llama_box(self, version: str):
-        target_dir = Path(self._bin_dir) / "llama-box" / f"llama-box-{version}"
+        disabled_dynamic_link = is_disabled_dynamic_link(version, self._device)
+        target_dir = Path(self._bin_dir) / "llama-box"
+        if disabled_dynamic_link:
+            target_dir = target_dir / "static"
+        target_dir = target_dir / f"llama-box-{version}"
         target_file = get_llama_box_command(target_dir)
         file_name = os.path.basename(target_file)
 
@@ -248,7 +258,7 @@ class ToolsManager:
             logger.debug(f"{file_name} already exists, skipping download")
             return
 
-        self._download_llama_box(version, target_dir, file_name)
+        self._download_llama_box(version, target_dir, file_name, disabled_dynamic_link)
 
     def install_versioned_vllm(self, version: str):
         system = platform.system()
@@ -440,7 +450,11 @@ class ToolsManager:
             shutil.rmtree(tmp_dir)
 
     def _download_llama_box(
-        self, version: str, target_dir: Path, target_file_name: str
+        self,
+        version: str,
+        target_dir: Path,
+        target_file_name: str,
+        disabled_dynamic_link: bool,
     ):
         llama_box_tmp_dir = target_dir.joinpath("tmp-llama-box")
 
@@ -449,10 +463,9 @@ class ToolsManager:
             shutil.rmtree(llama_box_tmp_dir)
         os.makedirs(llama_box_tmp_dir, exist_ok=True)
 
-        # Since v0.0.157: Use dynamic libraries instead of static linking
         platform_name = self._get_llama_box_platform_name(
             version,
-            version >= "v0.0.157" and self._device != platform.DeviceTypeEnum.NPU.value,
+            disabled_dynamic_link,
         )
         tmp_file = llama_box_tmp_dir / f"llama-box-{version}-{platform_name}.zip"
         url_path = f"gpustack/llama-box/releases/download/{version}/{platform_name}.zip"
@@ -544,7 +557,7 @@ class ToolsManager:
         logger.debug(f"Linked from {src_dir} to {dst_dir}")
 
     def _get_llama_box_platform_name(  # noqa C901
-        self, version: str, enable_dynmaic_link: bool
+        self, version: str, disabled_dynamic_link: bool
     ) -> str:
         """
         Get the platform name for llama-box based on the OS, architecture, and device type.
@@ -562,9 +575,9 @@ class ToolsManager:
         if self._device in device_toolkit_mapper:
             toolkit = device_toolkit_mapper[self._device]
         elif self._arch == "amd64":
-            toolkit = "cpu" if enable_dynmaic_link else "avx2"
+            toolkit = "avx2" if disabled_dynamic_link else "cpu"
         elif self._arch == "arm64":
-            toolkit = "cpu" if enable_dynmaic_link else "neon"
+            toolkit = "neon" if disabled_dynamic_link else "cpu"
         else:
             raise Exception(
                 f"unsupported platform, os: {self._os}, arch: {self._arch}, device: {self._device}"
@@ -630,9 +643,9 @@ class ToolsManager:
             segments.append(toolkit_version)
 
         return (
-            f"dl-llama-box-{'-'.join(segments)}"
-            if enable_dynmaic_link
-            else f"llama-box-{'-'.join(segments)}"
+            f"llama-box-{'-'.join(segments)}"
+            if disabled_dynamic_link
+            else f"dl-llama-box-{'-'.join(segments)}"
         )
 
     def download_gguf_parser(self):
@@ -963,3 +976,10 @@ def get_llama_box_version_dir_name(
     device = f'-{device}' if device else ''
     dir_name = os.path.join(f"llama-box-{version}-{system}-{arch}{device}")
     return dir_name
+
+
+def is_disabled_dynamic_link(version, device) -> Optional[bool]:
+    if version < "v0.0.157" or device == platform.DeviceTypeEnum.NPU.value:
+        return True
+
+    return envs.get_gpustack_env_bool("DISABLE_DYNAMIC_LINK_LLAMA_BOX")


### PR DESCRIPTION
issues address: https://github.com/gpustack/gpustack/issues/2322, https://github.com/gpustack/gpustack/issues/2297

Introduce environment variable to toggle between static/dynamic linking in llama-box:
- Set `GPUSTACK_DISABLE_DYNAMIC_LINK_LLAMA_BOX=true` to disable dynamic linking
- Static libraries stored in {$data_dir}/bin/llama-box/static with versioned subdirs
- Default behavior remains dynamic linking when env var not set