### PR TITLE
feat: seperate configuration into mixins

### DIFF
--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -11,6 +11,11 @@ import yaml
 
 from gpustack import __version__, __git_commit__
 from gpustack.config.config import set_global_config
+from gpustack.config.config_mixin import (
+    set_common_options,
+    set_server_options,
+    set_worker_options,
+)
 from gpustack.logging import setup_logging
 from gpustack.utils.envs import get_gpustack_env, get_gpustack_env_bool
 from gpustack.worker.worker import Worker
@@ -416,83 +421,6 @@ def parse_args(args: argparse.Namespace) -> Config:
 
     set_global_config(cfg)
     return cfg
-
-
-def set_config_option(args, config_data: dict, option_name: str):
-    option_value = getattr(args, option_name, None)
-    if option_value is not None:
-        config_data[option_name] = option_value
-
-
-def set_common_options(args, config_data: dict):
-    options = [
-        "debug",
-        "data_dir",
-        "cache_dir",
-        "bin_dir",
-        "pipx_path",
-        "token",
-        "huggingface_token",
-        "enable_ray",
-        "ray_args",
-        "ray_node_manager_port",
-        "ray_object_manager_port",
-    ]
-
-    for option in options:
-        set_config_option(args, config_data, option)
-
-
-def set_server_options(args, config_data: dict):
-    options = [
-        "host",
-        "port",
-        "database_url",
-        "disable_worker",
-        "bootstrap_password",
-        "ssl_keyfile",
-        "ssl_certfile",
-        "force_auth_localhost",
-        "ollama_library_base_url",
-        "disable_update_check",
-        "disable_openapi_docs",
-        "update_check_url",
-        "model_catalog_file",
-        "ray_port",
-        "ray_client_server_port",
-        "enable_cors",
-        "allow_origins",
-        "allow_credentials",
-        "allow_methods",
-        "allow_headers",
-    ]
-
-    for option in options:
-        set_config_option(args, config_data, option)
-
-
-def set_worker_options(args, config_data: dict):
-    options = [
-        "server_url",
-        "worker_ip",
-        "worker_name",
-        "worker_port",
-        "disable_metrics",
-        "disable_rpc_servers",
-        "metrics_port",
-        "service_port_range",
-        "rpc_server_port_range",
-        "log_dir",
-        "rpc_server_args",
-        "system_reserved",
-        "tools_download_base_url",
-        "ray_worker_port_range",
-        "enable_hf_transfer",
-        "enable_hf_xet",
-    ]
-
-    for option in options:
-        set_config_option(args, config_data, option)
 
 
 def debug_env_info():

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -1,6 +1,5 @@
 import os
 import secrets
-from typing import List, Optional
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
 from gpustack.utils import validators
@@ -21,11 +20,21 @@ from gpustack.schemas.workers import (
 )
 from gpustack.utils import platform
 from gpustack.utils.platform import DeviceTypeEnum, device_type_from_vendor
+from gpustack.config.config_mixin import (
+    CommonConfigMixin,
+    ServerConfigMixin,
+    WorkerConfigMixin,
+)
 
 _config = None
 
 
-class Config(BaseSettings):
+class Config(
+    CommonConfigMixin,
+    ServerConfigMixin,
+    WorkerConfigMixin,
+    BaseSettings,
+):
     """A class used to define GPUStack configuration.
 
     Attributes:
@@ -79,61 +88,6 @@ class Config(BaseSettings):
         allow_methods: A list of HTTP methods that should be allowed for cross-origin requests.
         allow_headers: A list of HTTP request headers that should be supported for cross-origin requests.
     """
-
-    # Common options
-    debug: bool = False
-    data_dir: Optional[str] = None
-    cache_dir: Optional[str] = None
-    token: Optional[str] = None
-    huggingface_token: Optional[str] = None
-    enable_ray: bool = False
-    ray_args: Optional[List[str]] = None
-    ray_node_manager_port: int = 40098
-    ray_object_manager_port: int = 40099
-
-    # Server options
-    host: Optional[str] = "0.0.0.0"
-    port: Optional[int] = None
-    database_url: Optional[str] = None
-    disable_worker: bool = False
-    bootstrap_password: Optional[str] = None
-    jwt_secret_key: Optional[str] = None
-    system_reserved: Optional[dict] = None
-    ssl_keyfile: Optional[str] = None
-    ssl_certfile: Optional[str] = None
-    force_auth_localhost: bool = False
-    ollama_library_base_url: Optional[str] = "https://registry.ollama.ai"
-    disable_update_check: bool = False
-    disable_openapi_docs: bool = False
-    update_check_url: Optional[str] = None
-    model_catalog_file: Optional[str] = None
-    ray_port: int = 40096
-    ray_client_server_port: int = 40097
-    enable_cors: bool = False
-    allow_origins: Optional[List[str]] = ['*']
-    allow_credentials: bool = False
-    allow_methods: Optional[List[str]] = ['GET', 'POST']
-    allow_headers: Optional[List[str]] = ['Authorization', 'Content-Type']
-
-    # Worker options
-    server_url: Optional[str] = None
-    worker_ip: Optional[str] = None
-    worker_name: Optional[str] = None
-    disable_metrics: bool = False
-    disable_rpc_servers: bool = False
-    worker_port: int = 10150
-    metrics_port: int = 10151
-    service_port_range: Optional[str] = "40000-40063"
-    rpc_server_port_range: Optional[str] = "40064-40095"
-    ray_worker_port_range: Optional[str] = "40100-40131"
-    log_dir: Optional[str] = None
-    resources: Optional[dict] = None
-    bin_dir: Optional[str] = None
-    pipx_path: Optional[str] = None
-    tools_download_base_url: Optional[str] = None
-    rpc_server_args: Optional[List[str]] = None
-    enable_hf_transfer: bool = False
-    enable_hf_xet: bool = False
 
     def __init__(self, **values):
         super().__init__(**values)

--- a/gpustack/config/config_mixin.py
+++ b/gpustack/config/config_mixin.py
@@ -1,0 +1,99 @@
+from typing import Optional, List
+
+
+class CommonConfigMixin:
+    # Common options
+    debug: bool = False
+    data_dir: Optional[str] = None
+    cache_dir: Optional[str] = None
+    bin_dir: Optional[str] = None
+    pipx_path: Optional[str] = None
+    token: Optional[str] = None
+    huggingface_token: Optional[str] = None
+    enable_ray: bool = False
+    ray_args: Optional[List[str]] = None
+    ray_node_manager_port: int = 40098
+    ray_object_manager_port: int = 40099
+
+
+class ServerConfigCLIMixin:
+    # Server options
+    host: Optional[str] = "0.0.0.0"
+    port: Optional[int] = None
+    database_url: Optional[str] = None
+    disable_worker: bool = False
+    bootstrap_password: Optional[str] = None
+    ssl_keyfile: Optional[str] = None
+    ssl_certfile: Optional[str] = None
+    force_auth_localhost: bool = False
+    ollama_library_base_url: Optional[str] = "https://registry.ollama.ai"
+    disable_update_check: bool = False
+    disable_openapi_docs: bool = False
+    update_check_url: Optional[str] = None
+    model_catalog_file: Optional[str] = None
+    ray_port: int = 40096
+    ray_client_server_port: int = 40097
+    enable_cors: bool = False
+    allow_origins: Optional[List[str]] = ['*']
+    allow_credentials: bool = False
+    allow_methods: Optional[List[str]] = ['GET', 'POST']
+    allow_headers: Optional[List[str]] = ['Authorization', 'Content-Type']
+
+
+class ServerConfigMixin(ServerConfigCLIMixin):
+    # not supported in args
+    jwt_secret_key: Optional[str] = None
+
+
+class WorkerConfigCLIMixin:
+    # Worker options
+    server_url: Optional[str] = None
+    worker_ip: Optional[str] = None
+    worker_name: Optional[str] = None
+    worker_port: int = 10150
+    disable_metrics: bool = False
+    disable_rpc_servers: bool = False
+    metrics_port: int = 10151
+    service_port_range: Optional[str] = "40000-40063"
+    rpc_server_port_range: Optional[str] = "40064-40095"
+    log_dir: Optional[str] = None
+    rpc_server_args: Optional[List[str]] = None
+    system_reserved: Optional[dict] = None
+    tools_download_base_url: Optional[str] = None
+    ray_worker_port_range: Optional[str] = "40100-40131"
+    enable_hf_transfer: bool = False
+    enable_hf_xet: bool = False
+
+
+class WorkerConfigMixin(WorkerConfigCLIMixin):
+    # not supported in args
+    resources: Optional[dict] = None
+
+
+def list_config_attributes(config_class: object) -> List[str]:
+    return [
+        name
+        for name, value in config_class.__dict__.items()
+        if not name.startswith('__')
+        and not callable(value)
+        and not isinstance(value, (classmethod, staticmethod))
+    ]
+
+
+def set_config_option_from_class(config_mixin, args, config_data: dict):
+    for option in list_config_attributes(config_mixin):
+        option_value = getattr(args, option, None)
+        if option_value is not None:
+            config_data[option] = option_value
+
+
+def set_common_options(args, config_data: dict):
+    set_config_option_from_class(CommonConfigMixin, args, config_data)
+
+
+def set_server_options(args, config_data: dict):
+    set_config_option_from_class(ServerConfigCLIMixin, args, config_data)
+
+
+def set_worker_options(args, config_data: dict):
+    set_config_option_from_class(WorkerConfigCLIMixin, args, config_data)


### PR DESCRIPTION
The class Config is split into CommonConfigMixin, ServerConfigMixin and WorkerConfigMixin. With these mixins, we can set options from args based on the class attributes.