### PR TITLE
ci(npu): avoid docker build cache invalid

### DIFF
--- a/Dockerfile.npu
+++ b/Dockerfile.npu
@@ -48,7 +48,7 @@ ARG PYTHON_VERSION=3.11
 #   docker build --tag=gpustack/gpustack:npu-base --file=Dockerfile.npu --target base --progress=plain .
 #
 
-FROM ubuntu:22.04 AS base
+FROM ubuntu:22.04@sha256:3c61d3759c2639d4b836d32a2d3c83fa0214e36f195a3421018dbaaf79cbe37f AS base
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
use hashed base image instead of tag