### PR TITLE
fix: correct compatibility check messages

### DIFF
--- a/gpustack/policies/candidate_selectors/ascend_mindie_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/ascend_mindie_resource_fit_selector.py
@@ -723,24 +723,24 @@ class AscendMindIEResourceFitSelector(ScheduleCandidatesSelector):
         # Validate and construct scheduling messages.
         if unsatisfied_workers:
             msg = (
-                f"{unsatisfied_workers[:2]}...(more {len(unsatisfied_workers) - 2})"
+                f"{str(unsatisfied_workers[:2]).rstrip("]")}...(more {len(unsatisfied_workers) - 2})]"
                 if len(unsatisfied_workers) > 2
                 else str(unsatisfied_workers)
             )
             self._scheduling_messages.append(
-                f"Worker {msg} fails to meet the required RAM."
+                f"Worker {msg} fail to meet the required RAM."
             )
 
         for worker_name, devices in unsatisfied_devices_idx.items():
             unsatisfied_devices = (
-                f"{devices[:3]}...(more {len(devices) - 3})"
+                f"{str(devices[:3]).rstrip("]")}...(more {len(devices) - 3})]"
                 if len(devices) > 3
                 else str(devices)
             )
             msg = f"Worker {worker_name} GPU indexes {unsatisfied_devices}"
             if len(unsatisfied_devices_idx) > 1:
-                msg += f" and other {len(unsatisfied_devices_idx) - 1} workers"
-            msg += f" fails to meet the {self._serving_params.npu_memory_fraction * 100}% allocatable VRAM ratio."
+                msg += f" and other {len(unsatisfied_devices_idx) - 1} {'workers' if len(unsatisfied_devices_idx) > 2 else 'worker'}"
+            msg += f" {'fail' if len(unsatisfied_devices_idx) > 2 else 'fails'} to meet the {self._serving_params.npu_memory_fraction * 100}% allocatable VRAM ratio."
             self._scheduling_messages.append(msg)
             break
 
@@ -1166,7 +1166,8 @@ class AscendMindIEResourceFitSelector(ScheduleCandidatesSelector):
             # Nothing can be return, construct scheduling message
             worker_names = [worker.name for worker in workers_combination]
             worker_names_msg = (
-                str(worker_names[:3]) + f"...more {len(worker_names) - 3}"
+                str(worker_names[:3]).rstrip("]")
+                + f"...(more {len(worker_names) - 3})]"
                 if len(worker_names) > 3
                 else str(worker_names)
             )
@@ -1197,7 +1198,7 @@ class AscendMindIEResourceFitSelector(ScheduleCandidatesSelector):
 
         # Set default scheduling message
         self._scheduling_messages.append(
-            f"The model requires approximately {byte_to_gib(request_usage.ram)} GiB RAM and {byte_to_gib(request_usage.vram)} GiB VRAM."
+            f"The model requires approximately {byte_to_gib(request_usage.vram)} GiB VRAM and {byte_to_gib(request_usage.ram)} GiB RAM."
         )
         if self._serving_params.npu_memory_fraction:
             self._scheduling_messages.append(

--- a/gpustack/policies/candidate_selectors/gguf_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/gguf_resource_fit_selector.py
@@ -411,7 +411,9 @@ class GGUFResourceFitSelector(ScheduleCandidatesSelector):
             if candidates is not None and len(candidates) > 0:
                 break
 
-        if not candidates or len(candidates) == 0:
+        if (not candidates or len(candidates) == 0) and len(
+            self._event_collector.events
+        ) == 0:
             msg = ListMessageBuilder(
                 f"The model requires approximately {byte_to_gib(self._non_uma_single_gpu_full_offload_vram)} GiB VRAM and {byte_to_gib(self._non_uma_single_gpu_full_offload_ram)} GiB RAM."
             )

--- a/gpustack/policies/candidate_selectors/vllm_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/vllm_resource_fit_selector.py
@@ -681,12 +681,12 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
                 )
                 if len(self._unsatisfied_gpu_messages[worker.name]) > 3:
                     unsatisfied_devices_msg = (
-                        str(self._unsatisfied_gpu_messages[worker.name][:3])
-                        + f"...(more {len(self._unsatisfied_gpu_messages[worker.name]) - 3})"
+                        str(self._unsatisfied_gpu_messages[worker.name][:3]).rstrip("]")
+                        + f"...(more {len(self._unsatisfied_gpu_messages[worker.name]) - 3})]"
                     )
                 scheduling_msg.extend(
                     [
-                        f"Worker {worker.name} GPU indexes {unsatisfied_devices_msg} fails to meet the {(self._gpu_memory_utilization * 100):.2f}% allocatable VRAM ratio.",
+                        f"Worker {worker.name} GPU indexes {unsatisfied_devices_msg} fail to meet the {(self._gpu_memory_utilization * 100):.2f}% allocatable VRAM ratio.",
                         f"Selected GPUs have {byte_to_gib(self._largest_multi_gpu_vram)} GiB allocatable VRAM, {self._largest_multi_gpu_utilization_satisfied_count}/{self._largest_multi_gpu_total} of GPUs meet the VRAM utilization ratio, providing {self._cal_effective_vram():.2f} GiB of allocatable VRAM.",
                     ]
                 )
@@ -805,7 +805,8 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
         elif workers_combination:
             worker_names = [worker.name for worker in workers_combination]
             worker_names_msg = (
-                str(worker_names[:3]) + f"...more {len(worker_names) - 3}"
+                str(worker_names[:3]).rstrip("]")
+                + f"...(more {len(worker_names) - 3})]"
                 if len(worker_names) > 3
                 else str(worker_names)
             )
@@ -893,14 +894,15 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
                 for worker_name, gpu_indexes in self._unsatisfied_gpu_messages.items():
                     # Some seleted gpu is not meet the utilization
                     devices_msg = (
-                        str(gpu_indexes[:3]) + f"...(more {len(gpu_indexes) - 3})"
+                        str(gpu_indexes[:3]).rstrip("]")
+                        + f"...(more {len(gpu_indexes) - 3})]"
                         if len(gpu_indexes) > 3
                         else str(gpu_indexes)
                     )
                     unsatisfied_msg = f"Worker {worker_name} GPU indexes {devices_msg}"
                     if len(self._unsatisfied_gpu_messages) > 1:
-                        unsatisfied_msg += f" and other {len(self._unsatisfied_gpu_messages) - 1} workers"
-                    unsatisfied_msg += f" fails to meet the {(self._gpu_memory_utilization * 100):.2f}% allocatable VRAM ratio."
+                        unsatisfied_msg += f" and other {len(self._unsatisfied_gpu_messages) - 1} {'workers' if len(self._unsatisfied_gpu_messages) > 2 else 'worker'}"
+                    unsatisfied_msg += f" {'fail' if len(self._unsatisfied_gpu_messages) > 1 else 'fails'} to meet the {(self._gpu_memory_utilization * 100):.2f}% allocatable VRAM ratio."
                     scheduling_msg.append(unsatisfied_msg)
                     break
 

--- a/tests/policies/candidate_selectors/ascend_mindie/test_ascend_mindie_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/ascend_mindie/test_ascend_mindie_resource_fit_selector.py
@@ -1349,7 +1349,7 @@ async def test_select_candidates_4x_64gx8(config, m, expected):
                 ],
             ),
             [
-                """- The model requires approximately 0.5 GiB RAM and 156.24 GiB VRAM.
+                """- The model requires approximately 156.24 GiB VRAM and 0.5 GiB RAM.
 - With --npu-memory-fraction=0.2, All GPUs combined need to provide at least 781.20 GiB of total VRAM.
 - The optimal combination ['ascend_0', 'ascend_1'] provides 102.4 GiB of allocatable VRAM.
 - Cannot find a suitable worker combination to run the model in distributed mode. If you are confident that the resources are sufficient, you may manually schedule the model by selecting the workers and devices."""
@@ -1370,7 +1370,7 @@ async def test_select_candidates_4x_64gx8(config, m, expected):
                 ],
             ),
             [
-                """- The model requires approximately 0.5 GiB RAM and 156.24 GiB VRAM.
+                """- The model requires approximately 156.24 GiB VRAM and 0.5 GiB RAM.
 - With --npu-memory-fraction=0.2, All GPUs combined need to provide at least 781.20 GiB of total VRAM.
 - The optimal combination ['ascend_2', 'ascend_3', 'ascend_1'] provides 76.8 GiB of allocatable VRAM. There are 1 worker that can provide 2 devices, as the workers in the combination, but some devices among them fail to meet requirements.
 - Cannot find a suitable worker combination to run the model in distributed mode. If you are confident that the resources are sufficient, you may manually schedule the model by selecting the workers and devices."""
@@ -1392,7 +1392,7 @@ async def test_select_candidates_4x_64gx8(config, m, expected):
                 distributed_inference_across_workers=False,
             ),
             [
-                """- The model requires approximately 0.5 GiB RAM and 156.24 GiB VRAM.
+                """- The model requires approximately 156.24 GiB VRAM and 0.5 GiB RAM.
 - With --npu-memory-fraction=0.2, All GPUs combined need to provide at least 781.20 GiB of total VRAM.
 - The largest available worker has 51.2 GiB allocatable VRAM, 4/4 of GPUs meet the VRAM utilization ratio, providing 10.24 GiB of allocatable VRAM."""
             ],
@@ -1493,9 +1493,9 @@ async def test_select_candidates_2x_64gx4_2x_64gx2_check_msg(
                 ),
             ),
             [
-                """- The model requires approximately 0.5 GiB RAM and 156.24 GiB VRAM.
+                """- The model requires approximately 156.24 GiB VRAM and 0.5 GiB RAM.
 - With --npu-memory-fraction=0.9, All GPUs combined need to provide at least 173.60 GiB of total VRAM.
-- Worker ascend_0 GPU indexes [0, 2] and other 3 workers fails to meet the 90.0% allocatable VRAM ratio."""
+- Worker ascend_0 GPU indexes [0, 2] and other 3 workers fail to meet the 90.0% allocatable VRAM ratio."""
             ],
         ),
         (
@@ -1525,7 +1525,7 @@ async def test_select_candidates_2x_64gx4_2x_64gx2_check_msg(
                 ),
             ),
             [
-                """- The model requires approximately 0.5 GiB RAM and 156.24 GiB VRAM.
+                """- The model requires approximately 156.24 GiB VRAM and 0.5 GiB RAM.
 - With --npu-memory-fraction=0.1, All GPUs combined need to provide at least 1562.40 GiB of total VRAM.
 - Selected GPUs have 51.2 GiB allocatable VRAM, 8/8 of GPUs meet the VRAM utilization ratio, providing 5.12 GiB of allocatable VRAM."""
             ],
@@ -1557,10 +1557,10 @@ async def test_select_candidates_2x_64gx4_2x_64gx2_check_msg(
                 ),
             ),
             [
-                """- The model requires approximately 0.5 GiB RAM and 156.24 GiB VRAM.
+                """- The model requires approximately 156.24 GiB VRAM and 0.5 GiB RAM.
 - With --npu-memory-fraction=0.9, All GPUs combined need to provide at least 173.60 GiB of total VRAM.
-- Worker ['ascend_0', 'ascend_1']...(more 2) fails to meet the required RAM.
-- Worker ascend_0 GPU indexes [0, 2] and other 3 workers fails to meet the 90.0% allocatable VRAM ratio."""
+- Worker ['ascend_0', 'ascend_1'...(more 2)] fail to meet the required RAM.
+- Worker ascend_0 GPU indexes [0, 2] and other 3 workers fail to meet the 90.0% allocatable VRAM ratio."""
             ],
         ),
     ],

--- a/tests/policies/candidate_selectors/vllm/test_vllm_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/vllm/test_vllm_resource_fit_selector.py
@@ -750,7 +750,7 @@ async def test_manual_schedule_multi_work_multi_gpu(config):
         expect_msg2 = [
             """- The model requires approximately 75.23 GiB of VRAM.
 - With --gpu-memory-utilization=0.9, All GPUs combined need to provide at least 83.59 GiB of total VRAM.
-- Worker host4090 GPU indexes [0] and other 1 workers fails to meet the 90.00% allocatable VRAM ratio.
+- Worker host4090 GPU indexes [0] and other 1 worker fail to meet the 90.00% allocatable VRAM ratio.
 - Selected GPUs have 25.87 GiB allocatable VRAM, 0/2 of GPUs meet the VRAM utilization ratio, providing 0.00 GiB of allocatable VRAM."""
         ]
 


### PR DESCRIPTION
1. Change `['ascend_0', 'ascend_1']...(more 2)` to `['ascend_0', 'ascend_1'...(more 2)]` in multi worker scenario, achieving better visual integration"
2. Correct the usage of singular and plural words in sentences.
3. Swap the order of RAM and VRAM in MindIE to align with llama-box.