### PR TITLE
feat: Isolate virtual environments for vox-box and gpustack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ FROM nvidia/cuda:${CUDA_VERSION}${CUDA_TAG_SUFFIX}
 ARG TARGETPLATFORM
 ENV DEBIAN_FRONTEND=noninteractive
 
+## Preset this to simplify configuration,
+## it is the output of $(pipx environment --value PIPX_LOCAL_VENVS).
+ENV PIPX_LOCAL_VENVS=/root/.local/share/pipx/venvs
+
 RUN apt-get update && apt-get install -y \
     git \
     curl \
@@ -18,6 +22,26 @@ RUN apt-get update && apt-get install -y \
     tini \
     && rm -rf /var/lib/apt/lists/*
 
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+RUN python3 -m pip install --no-cache-dir pipx
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+ARG VOXBOX_VERSION=0.0.18
+ARG TRANSFORMERS_VERSION=4.51.3
+
+ENV VOXBOX_VERSION=${VOXBOX_VERSION}
+ENV TRANSFORMERS_VERSION=${TRANSFORMERS_VERSION}
+
+RUN <<EOF
+    pipx install vox-box==${VOXBOX_VERSION} --pip-args="transformers==${TRANSFORMERS_VERSION}"
+    # Download dac weights used by audio models like Dia
+    ${PIPX_LOCAL_VENVS}/vox-box/bin/python -m dac download
+EOF
+
+
+
 COPY . /workspace/gpustack
 RUN cd /workspace/gpustack && \
     make build
@@ -29,15 +53,12 @@ RUN <<EOF
     else
         WHEEL_PACKAGE="$(ls /workspace/gpustack/dist/*.whl)[audio]";
     fi
-    pip install pipx
-    pip install $WHEEL_PACKAGE
-    pip cache purge
+    pipx install ${WHEEL_PACKAGE} \
+        && ln -vsf ${PIPX_LOCAL_VENVS}/gpustack/bin/gpustack /usr/local/bin/gpustack \
+        && ln -vsf ${PIPX_LOCAL_VENVS}/vox-box/bin/vox-box ${PIPX_LOCAL_VENVS}/gpustack/bin/vox-box
     rm -rf /workspace/gpustack
 EOF
 
 RUN gpustack download-tools
-
-# Download dac weights used by audio models like Dia
-RUN python3 -m dac download
 
 ENTRYPOINT [ "tini", "--", "gpustack", "start" ]


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2377

CosyVoice in vox-box requires transformer==4.51.3, while gpustack's dependencies already use transformer==4.53.1. The newer version causes abnormal audio output from CosyVoice. Isolate the environments to prevent future conflicts.