### PR TITLE
fix: respect vram utilization for qwen3 embedding

### DIFF
--- a/gpustack/assets/model-catalog-modelscope.yaml
+++ b/gpustack/assets/model-catalog-modelscope.yaml
@@ -2203,9 +2203,12 @@
       categories:
         - reranker
       replicas: 1
+      env:
+        GPUSTACK_APPLY_QWEN3_RERANKER_TEMPLATES: "true"
       backend: vllm
       backend_parameters:
         - '--hf_overrides={"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}'
+        - --task=score
 # Image models
 - name: Stable Diffusion V3.5 Large
   description: Stable Diffusion 3.5 Large is a Multimodal Diffusion Transformer (MMDiT) text-to-image model that features improved performance in image quality, typography, complex prompt understanding, and resource-efficiency.

--- a/gpustack/assets/model-catalog.yaml
+++ b/gpustack/assets/model-catalog.yaml
@@ -2189,9 +2189,12 @@
       categories:
         - reranker
       replicas: 1
+      env:
+        GPUSTACK_APPLY_QWEN3_RERANKER_TEMPLATES: "true"
       backend: vllm
       backend_parameters:
         - '--hf_overrides={"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}'
+        - --task=score
 # Image models
 - name: Stable Diffusion V3.5 Large
   description: Stable Diffusion 3.5 Large is a Multimodal Diffusion Transformer (MMDiT) text-to-image model that features improved performance in image quality, typography, complex prompt understanding, and resource-efficiency.


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2462

Unlike other embedding/reranker models, current vLLM implementation allocates vram according to --gpu-memory-utilization for the Qwen3 Embedding series. Obey this behavior in GPUStack scheduling/evaluation.

https://github.com/gpustack/gpustack/issues/2244

Apply Qwen3 Reranker official template so that it works for clients out of the box.