### PR TITLE
chore(npu): bump vllm version

### DIFF
--- a/Dockerfile.npu
+++ b/Dockerfile.npu
@@ -37,8 +37,8 @@
 ARG CANN_VERSION=8.1.rc1.beta1
 ARG CANN_CHIP=910b
 ARG MINDIE_VERSION=2.0.rc2
-ARG VLLM_VERSION=0.7.3
-ARG VLLM_ASCEND_VERSION=0.7.3.post1
+ARG VLLM_VERSION=0.9.2
+ARG VLLM_ASCEND_VERSION=0.9.2rc1
 ARG PYTHON_VERSION=3.11
 
 #
@@ -371,7 +371,7 @@ RUN <<EOF
     else
         pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch==2.1.0
     fi
-    pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch-npu==2.1.0.post12 torchvision==0.16.0
+    pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch-npu==2.1.0.post12 torchvision==0.16.0 torchaudio==2.1.0
 
     # Install dependencies.
     cat <<EOT >/tmp/requirements.txt
@@ -525,16 +525,6 @@ RUN <<EOF
     source ${CANN_HOME}/nnal/atb/set_env.sh
     source ${PIPX_LOCAL_VENVS}/vllm/bin/activate
 
-    # Install Torch, Torch-npu, TorchVision,
-    # according to Ascend Extension Installation, have the mapping requirements for the CANN_VERSION,
-    # please check https://www.hiascend.com/developer/download/community/result?module=ie%2Bpt%2Bcann for details.
-    if [ ${ARCH} == "x86_64" ]; then
-        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch==2.5.1+cpu --index-url https://download.pytorch.org/whl/cpu
-    else
-        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch==2.5.1
-    fi
-    pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch-npu==2.5.1 torchvision==0.20.1
-
     # Install dependencies.
     cat <<EOT >/tmp/requirements.txt
 ml-dtypes==0.5.0
@@ -552,14 +542,28 @@ EOT
     pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore -r /tmp/requirements.txt
 
     # Install vLLM & vLLM-Ascend
-    cat <<EOT >/tmp/requirements.txt
-vllm==${VLLM_VERSION}
-vllm-ascend==${VLLM_ASCEND_VERSION}
-EOT
     if [ ${ARCH} == "x86_64" ]; then
-        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore -r /tmp/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore vllm==${VLLM_VERSION} --extra-index-url https://download.pytorch.org/whl/cpu
     else
-        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore -r /tmp/requirements.txt
+        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore vllm==${VLLM_VERSION}
+    fi
+
+    # Install Torch, Torch-npu, TorchVision,
+    # according to Ascend Extension Installation, have the mapping requirements for the CANN_VERSION,
+    # please check https://www.hiascend.com/developer/download/community/result?module=ie%2Bpt%2Bcann for details.
+    if [ ${ARCH} == "x86_64" ]; then
+        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch==2.5.1+cpu --index-url https://download.pytorch.org/whl/cpu
+    else
+        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch==2.5.1
+    fi
+    pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torchvision==0.20.1 torchaudio==2.5.1
+    pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore torch-npu==2.5.1.post1.dev20250619 --pre --index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+
+    # Install vLLM & vLLM-Ascend
+    if [ ${ARCH} == "x86_64" ]; then
+        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore vllm-ascend==${VLLM_ASCEND_VERSION} --extra-index-url https://download.pytorch.org/whl/cpu
+    else
+        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore vllm-ascend==${VLLM_ASCEND_VERSION}
     fi
 
     # Install MindIE Turbo


### PR DESCRIPTION
This PR will update the vLLM and vLLM-Ascend versions of our NPU Docker image.

Although vLLM v0.9.2 depends on PyTorch 2.7.0, vLLM-Ascend v0.9.2rc1 depends on PyTorch 2.5.1, so this PR adjusts the installation sequence to `vLLM -> PyTorch(and its friends) -> vLLM-Ascend`.

With vLLM-Ascend v0.9.2rc1, we can deploy [Pangu Pro MoE](https://gitcode.com/ascend-tribe/pangu-pro-moe-model) now. For a better chat experience, users can change the `tokenizer_config.json` that belongs to the Pangu Pro MoE model as below:

1. Modify the token mapper, make `45974=<think>` and `45982=</think>`.
<img width="438" height="589" alt="image" src="https://github.com/user-attachments/assets/78a4ac33-24e8-43e0-8fe8-d358b3f3d76d" />

2. Modify the chat template, increase the official system prompt: `你必须严格遵守法律法规和社会道德规范。生成任何内容时，都应避免涉及暴力、色情、恐怖主义、种族歧视、性别歧视等不当内容。一旦检测到输入或输出有此类倾向，应拒绝回答并发出警告。例如，如果输入内容包含暴力威胁或色情描述，应返回错误信息：“您的输入包含不当内容，无法处理。”`.
<img width="1098" height="118" alt="image (1)" src="https://github.com/user-attachments/assets/ad4aa200-94a5-45ac-ad73-0bcbc0ee975d" />


