### PR TITLE
feat: add installation of flashinfer-python JIT for vllm on linux/amd…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ FROM nvidia/cuda:${CUDA_VERSION}${CUDA_TAG_SUFFIX}
 ARG TARGETPLATFORM
 ENV DEBIAN_FRONTEND=noninteractive
 
-## Preset this to simplify configuration,
-## it is the output of $(pipx environment --value PIPX_LOCAL_VENVS).
-ENV PIPX_LOCAL_VENVS=/root/.local/share/pipx/venvs
-
 RUN apt-get update && apt-get install -y \
     git \
     curl \
@@ -26,25 +22,12 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 RUN python3 -m pip install --no-cache-dir pipx
 
-ENV PATH="/root/.local/bin:${PATH}"
-
-ARG VOXBOX_VERSION=0.0.18
-ARG TRANSFORMERS_VERSION=4.51.3
-
-ENV VOXBOX_VERSION=${VOXBOX_VERSION}
-ENV TRANSFORMERS_VERSION=${TRANSFORMERS_VERSION}
-
-RUN <<EOF
-    pipx install vox-box==${VOXBOX_VERSION} --pip-args="transformers==${TRANSFORMERS_VERSION}"
-    # Download dac weights used by audio models like Dia
-    ${PIPX_LOCAL_VENVS}/vox-box/bin/python -m dac download
-EOF
-
-
-
 COPY . /workspace/gpustack
 RUN cd /workspace/gpustack && \
     make build
+
+# Keep same FlashInfer version as vLLM https://github.com/vllm-project/vllm/blob/v0.9.2/docker/Dockerfile#L382
+ARG FLASHINFER_GIT_REF=0.2.6.post1
 
 RUN <<EOF
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
@@ -53,12 +36,31 @@ RUN <<EOF
     else
         WHEEL_PACKAGE="$(ls /workspace/gpustack/dist/*.whl)[audio]";
     fi
-    pipx install ${WHEEL_PACKAGE} \
-        && ln -vsf ${PIPX_LOCAL_VENVS}/gpustack/bin/gpustack /usr/local/bin/gpustack \
-        && ln -vsf ${PIPX_LOCAL_VENVS}/vox-box/bin/vox-box ${PIPX_LOCAL_VENVS}/gpustack/bin/vox-box
+    pip install ${WHEEL_PACKAGE}
+
+    if [ "$TARGETPLATFORM" = "linux/amd64" ] && command -v nvcc &> /dev/null; then
+        # Install flashinfer-python JIT for vllm
+        pip install flashinfer-python==${FLASHINFER_GIT_REF}
+    fi
     rm -rf /workspace/gpustack
 EOF
 
 RUN gpustack download-tools
+
+# Prepara variables for vox-box installation.
+ENV PATH="/root/.local/bin:${PATH}"
+ENV PIPX_LOCAL_VENVS=/root/.local/share/pipx/venvs
+ARG VOXBOX_VERSION=0.0.18
+ARG TRANSFORMERS_VERSION=4.51.3
+
+RUN <<EOF
+    pipx install vox-box==${VOXBOX_VERSION} --pip-args="transformers==${TRANSFORMERS_VERSION}"
+    # Download dac weights used by audio models like Dia
+    ${PIPX_LOCAL_VENVS}/vox-box/bin/python -m dac download
+
+    # Create a symbolic link for vox-box to prevent version conflicts.
+    GPUSTACK_PATH=$(dirname $(which gpustack))
+    ln -vsf ${PIPX_LOCAL_VENVS}/vox-box/bin/vox-box ${GPUSTACK_PATH}/vox-box
+EOF
 
 ENTRYPOINT [ "tini", "--", "gpustack", "start" ]


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1955

The prebuilt version of FlashInfer does not support torch 2.7, but we can install FlashInfer via JIT compilation to avoid dependency conflicts.