### PR TITLE
deps: relaxing transformers version restrictions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -10161,4 +10161,4 @@ vllm = ["bitsandbytes", "mistral_common", "timm", "vllm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "0161f99f7a86b172a8835c027adca08289b863767b0801eab69155804d2f94d8"
+content-hash = "5adeb2c20421da13bdb0386bf2689180fc5406a5148cfac8ea818f9d410b941e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ ray = {version = "2.43.0", extras = ["default"]}
 vllm = {version = "0.9.2", optional = true}
 mistral_common = {version = "^1.4.3", optional = true, extras = ["opencv"]}
 uvicorn = "^0.32.0"
-transformers = "^4.53.1"
+transformers = "^4.51.3"
 fastapi-cdn-host = "^0.8.0"
 wmi = { version="^1.5.1", markers = "platform_system == 'Windows'" }
 pywin32 = { version="^308", markers = "platform_system == 'Windows'" }


### PR DESCRIPTION
Relaxing transformers version restrictions which allows installer to build gpustack with transformers 4.51.3.
Refer to issue: https://github.com/gpustack/gpustack/issues/2377,
and PR https://github.com/gpustack/gpustack/pull/2473