### PR TITLE
Revert "fix: reset file lock on retry download"

### DIFF
--- a/gpustack/routes/model_files.py
+++ b/gpustack/routes/model_files.py
@@ -17,7 +17,6 @@ from gpustack.schemas.model_files import (
     ModelFileStateEnum,
     ModelFileUpdate,
     ModelFilesPublic,
-    RESET_DOWNLOAD_MESSAGE,
 )
 
 router = APIRouter()
@@ -200,7 +199,7 @@ async def reset_model_file(session: SessionDep, id: int):
     try:
         model_file.state = ModelFileStateEnum.DOWNLOADING
         model_file.download_progress = 0
-        model_file.state_message = RESET_DOWNLOAD_MESSAGE
+        model_file.state_message = ""
 
         await model_file.update(session)
     except Exception as e:

--- a/gpustack/schemas/model_files.py
+++ b/gpustack/schemas/model_files.py
@@ -9,9 +9,6 @@ from gpustack.schemas.links import ModelInstanceModelFileLink
 from gpustack.schemas.models import ModelSource, ModelInstance
 
 
-RESET_DOWNLOAD_MESSAGE = "Retrying download"
-
-
 class ModelFileStateEnum(str, Enum):
     ERROR = "error"
     DOWNLOADING = "downloading"

--- a/gpustack/worker/downloaders.py
+++ b/gpustack/worker/downloaders.py
@@ -72,22 +72,6 @@ def download_model(
         return file.get_sharded_file_paths(model.local_path)
 
 
-def reset_file_lock(
-    model: ModelSource,
-    cache_dir: Optional[str] = None,
-) -> List[str]:
-    if model.source == SourceEnum.HUGGING_FACE:
-        return HfDownloader.reset_lock(
-            repo_id=model.huggingface_repo_id,
-            cache_dir=os.path.join(cache_dir, "huggingface"),
-        )
-    elif model.source == SourceEnum.MODEL_SCOPE:
-        return ModelScopeDownloader.reset_lock(
-            model_id=model.model_scope_model_id,
-            cache_dir=os.path.join(cache_dir, "model_scope"),
-        )
-
-
 def get_model_file_info(
     model: Model,
     huggingface_token: Optional[str] = None,
@@ -246,20 +230,6 @@ class HfDownloader:
 
         logger.info(f"Downloaded model {repo_id}/{filename}")
         return sorted(downloaded_files)
-
-    @classmethod
-    def reset_lock(
-        cls, repo_id: str, cache_dir: Optional[Union[str, os.PathLike[str]]] = None
-    ):
-        """
-        Reset the lock file for a model.
-        """
-        group_or_owner, name = model_id_to_group_owner_name(repo_id)
-        lock_filename = os.path.join(cache_dir, group_or_owner, f"{name}.lock")
-
-        if os.path.exists(lock_filename):
-            logger.info(f"Resetting lock file: {lock_filename}")
-            os.remove(lock_filename)
 
     def __call__(self):
         return self.download()
@@ -631,17 +601,3 @@ class ModelScopeDownloader:
                 local_dir=local_dir,
             )
             return [local_dir]
-
-    @classmethod
-    def reset_lock(
-        cls, model_id: str, cache_dir: Optional[Union[str, os.PathLike[str]]] = None
-    ):
-        """
-        Reset the lock file for a model.
-        """
-        group_or_owner, name = model_id_to_group_owner_name(model_id)
-        lock_filename = os.path.join(cache_dir, group_or_owner, f"{name}.lock")
-
-        if os.path.exists(lock_filename):
-            logger.info(f"Resetting lock file: {lock_filename}")
-            os.remove(lock_filename)

--- a/gpustack/worker/model_file_manager.py
+++ b/gpustack/worker/model_file_manager.py
@@ -17,12 +17,7 @@ from huggingface_hub.utils import build_hf_headers
 from gpustack.api.exceptions import NotFoundException
 from gpustack.config.config import Config
 from gpustack.logging import setup_logging
-from gpustack.schemas.model_files import (
-    ModelFile,
-    ModelFileUpdate,
-    ModelFileStateEnum,
-    RESET_DOWNLOAD_MESSAGE,
-)
+from gpustack.schemas.model_files import ModelFile, ModelFileUpdate, ModelFileStateEnum
 from gpustack.client import ClientSet
 from gpustack.schemas.models import SourceEnum
 from gpustack.server.bus import Event, EventType
@@ -232,16 +227,8 @@ class ModelFileManager:
                 state_message=f"Deletion failed: {str(e)}",
             )
 
-    def _download_is_reset(self, model_file: ModelFile) -> bool:
-        return (
-            model_file.download_progress == 0
-            and model_file.state_message == RESET_DOWNLOAD_MESSAGE
-        )
-
     def _create_download_task(self, model_file: ModelFile):
         if model_file.id in self._active_downloads:
-            if self._download_is_reset(model_file):
-                downloaders.reset_file_lock(model_file, self._config.cache_dir)
             return
 
         cancel_flag = self._mp_manager.Event()
@@ -415,9 +402,7 @@ class ModelFileDownloadTask:
         )
 
     def _update_model_file_progress(self, model_file_id: int, progress: float):
-        self._update_model_file(
-            model_file_id, download_progress=progress, state_message=""
-        )
+        self._update_model_file(model_file_id, download_progress=progress)
 
     def _update_model_file(self, id: int, **kwargs):
         model_file_public = self._clientset.model_files.get(id=id)


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1621
It's not straitforward to users when resetting the lock on retrying download. It may cause issues hard to diagnose when using shared file system across workers.
