### PR TITLE
fix: improve error handling for missing pretrained configuration files

### DIFF
--- a/gpustack/policies/candidate_selectors/ascend_mindie_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/ascend_mindie_resource_fit_selector.py
@@ -79,7 +79,8 @@ class ModelParameters:
         # Parse
         pretrained_config = get_pretrained_config(model, trust_remote_code=True)
         pretrained_config = get_hf_text_config(pretrained_config)
-        if not pretrained_config:
+        if pretrained_config is None:
+            # Exclude empty dict cases, as they indicate the locally-sourced model is not local to the server node.
             raise ValueError(f"Failed to get model {model.name} pretrained config")
         for attr_name in [attr.name for attr in dataclasses.fields(self.__class__)]:
             try:

--- a/gpustack/policies/candidate_selectors/vllm_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/vllm_resource_fit_selector.py
@@ -231,6 +231,7 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
                 self._vram_claim = 0
 
         self._set_pretrained_config()
+        # _pretrained_config may be None or an empty dictionary, but subsequent methods are designed to handle this case.
         self._set_gpu_memory_utilization()
         self._set_num_attention_heads()
 

--- a/gpustack/utils/hub.py
+++ b/gpustack/utils/hub.py
@@ -313,6 +313,13 @@ def get_pretrained_config(model: Model, **kwargs):
                 local_files_only=local_files_only,
             )
     elif model.source == SourceEnum.LOCAL_PATH:
+        if not os.path.exists(model.local_path):
+            logger.warning(
+                f"Local Path: {model.readable_source} is not local to the server node and may reside on a worker node."
+            )
+            # Return an empty dict here to facilitate special handling by upstream methods.
+            return {}
+
         from transformers import AutoConfig
 
         pretrained_config = AutoConfig.from_pretrained(
@@ -320,6 +327,7 @@ def get_pretrained_config(model: Model, **kwargs):
             trust_remote_code=trust_remote_code,
             local_files_only=True,
         )
+
     else:
         raise ValueError(f"Unsupported model source: {model.source}")
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2548

Support specifying model paths located outside the server, with existence verification performed on worker nodes.

