### PR TITLE
fix: Broken pipe on high concurrency

### DIFF
--- a/gpustack/server/app.py
+++ b/gpustack/server/app.py
@@ -19,6 +19,7 @@ def create_app(cfg: Config) -> FastAPI:
     async def lifespan(app: FastAPI):
         connector = aiohttp.TCPConnector(
             limit=TCP_CONNECTOR_LIMIT,
+            force_close=True,
         )
         app.state.http_client = aiohttp.ClientSession(connector=connector)
         yield

--- a/gpustack/worker/worker.py
+++ b/gpustack/worker/worker.py
@@ -247,6 +247,7 @@ class Worker:
         async def lifespan(app: FastAPI):
             connector = aiohttp.TCPConnector(
                 limit=TCP_CONNECTOR_LIMIT,
+                force_close=True,
             )
             app.state.http_client = aiohttp.ClientSession(connector=connector)
             yield


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1842

use force close to avoid `[Errno 32] Broken pipe` errors on high concurrency requests.