### PR TITLE
fix(catalog): evaluation model failure in air-gapped environment

### DIFF
--- a/gpustack/utils/hub.py
+++ b/gpustack/utils/hub.py
@@ -16,7 +16,7 @@ from requests.exceptions import HTTPError
 
 from gpustack.config.config import get_global_config
 from gpustack.schemas.models import Model, SourceEnum, get_mmproj_filename
-from gpustack.utils.cache import load_cache, save_cache
+from gpustack.utils.cache import is_cached, load_cache, save_cache
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +156,13 @@ def match_hugging_face_files(
         matching_files.append(extra_file)
 
     return matching_files
+
+
+def is_repo_cached(repo_id: str, source: str) -> bool:
+    if not repo_id or not source:
+        return False
+    cache_key = f"{source}:{repo_id}"
+    return is_cached(LIST_REPO_CACHE_DIR, cache_key)
 
 
 def list_repo(


### PR DESCRIPTION
issue address: https://github.com/gpustack/gpustack/issues/2565  

When evaluating a model in the catalog, an auth_check is performed,the operation can't run in air-gapped environments. This behavior has now been modified to first check the cache.