### PR TITLE
fix(vllm/ascend/ray): failed on picking several nodes from the whole group 2

### DIFF
--- a/Dockerfile.npu
+++ b/Dockerfile.npu
@@ -619,7 +619,7 @@ RUN --mount=type=bind,target=/workspace/gpustack,rw <<EOF
     # Patch vLLM
     for dir in lib lib64; do
         if [ -d "${PIPX_LOCAL_VENVS}/vllm/${dir}/python${PYTHON_VERSION}/site-packages/vllm" ]; then
-            cp /workspace/gpustack/gpustack/_sitecustomize.py ${PIPX_LOCAL_VENVS}/vllm/${dir}/python${PYTHON_VERSION}/site-packages/vllm/
+            cp /workspace/gpustack/gpustack/_sitecustomize.py ${PIPX_LOCAL_VENVS}/vllm/${dir}/python${PYTHON_VERSION}/site-packages/sitecustomize.py
         fi
     done
 EOF

--- a/docs/cli-reference/start.md
+++ b/docs/cli-reference/start.md
@@ -64,7 +64,7 @@ gpustack start [OPTIONS]
 | `--rpc-server-port-range` value     | `40064-40095`                          | Port range for llama-box RPC servers, specified as a string in the form 'N1-N2'. Both ends of the range are inclusive.                                                                                                                                           |
 | `--ray-node-manager-port` value     | `40098`                                | Port of Ray node manager. Used when Ray is enabled.                                                                                                                                                                                                              |
 | `--ray-object-manager-port` value   | `40099`                                | Port of Ray object manager. Used when Ray is enabled.                                                                                                                                                                                                            |
-| `--ray-worker-port-range` value     | `41000-42000`                          | Port range for Ray worker processes, specified as a string in the form 'N1-N2'. Both ends of the range are inclusive.                                                                                                                                            |
+| `--ray-worker-port-range` value     | `40100-40999`                          | Port range for Ray worker processes, specified as a string in the form 'N1-N2'. Both ends of the range are inclusive.                                                                                                                                            |
 | `--log-dir` value                   | (empty)                                | Directory to store logs.                                                                                                                                                                                                                                         |
 | `--rpc-server-args` value           | (empty)                                | Arguments to pass to the RPC servers. Use `=` to avoid the CLI recognizing rpc-server-args as a server argument. This can be used multiple times to pass a list of arguments. Example: `--rpc-server-args=--verbose --rpc-server-args=--log-colors --rpc-server-args="rpc-server-cache-dir /var/lib/gpustack/cache/rpc_server/"`              |
 | `--system-reserved` value           | `"{\"ram\": 2, \"vram\": 1}"`          | The system reserves resources for the worker during scheduling, measured in GiB. By default, 2 GiB of RAM and 1G of VRAM is reserved, Note: '{\"memory\": 2, \"gpu_memory\": 1}' is also supported, but it is deprecated and will be removed in future releases. |
@@ -132,7 +132,7 @@ service_port_range: 40000-40063
 rpc_server_port_range: 40064-40095
 ray_node_manager_port: 40098
 ray_object_manager_port: 40099
-ray_worker_port_range: 41000-42000
+ray_worker_port_range: 40100-40999
 log_dir: /path/to/log_dir
 rpc_server_args: ["--verbose"]
 system_reserved:

--- a/docs/installation/installation-requirements.md
+++ b/docs/installation/installation-requirements.md
@@ -164,4 +164,4 @@ The following ports are used on GPUStack worker when Ray is enabled for distribu
 | --------------- | ----------------------------------- |
 | TCP 40098       | Default port for Ray node manager   |
 | TCP 40099       | Default port for Ray object manager |
-| TCP 41000-42000 | Port range for Ray worker processes |
+| TCP 40100-40999 | Port range for Ray worker processes |

--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -249,7 +249,7 @@ def setup_start_cmd(subparsers: argparse._SubParsersAction):
     group.add_argument(
         "--ray-worker-port-range",
         type=str,
-        help="Port range for Ray worker processes, specified as a string in the form 'N1-N2'. Both ends of the range are inclusive. The default is '41000-42000'.",
+        help="Port range for Ray worker processes, specified as a string in the form 'N1-N2'. Both ends of the range are inclusive. The default is '40100-40999'.",
         default=get_gpustack_env("RAY_WORKER_PORT_RANGE"),
     )
     group.add_argument(

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -65,7 +65,7 @@ class Config(BaseSettings):
         rpc_server_port_range: Port range for RPC servers, specified as a string in the form 'N1-N2'. Both ends of the range are inclusive. Default is '40064-40095'.
         ray_node_manager_port: Raylet port for node manager. Used when Ray is enabled. Default is 40098.
         ray_object_manager_port: Raylet port for object manager. Used when Ray is enabled. Default is 40099.
-        ray_worker_port_range: Port range for Ray worker processes, specified as a string in the form 'N1-N2'. Both ends of the range are inclusive. Default is '41000-42000'.
+        ray_worker_port_range: Port range for Ray worker processes, specified as a string in the form 'N1-N2'. Both ends of the range are inclusive. Default is '40100-40999'.
         log_dir: Directory to store logs.
         bin_dir: Directory to store additional binaries, e.g., versioned backend executables.
         pipx_path: Path to the pipx executable, used to install versioned backends.
@@ -125,7 +125,7 @@ class Config(BaseSettings):
     metrics_port: int = 10151
     service_port_range: Optional[str] = "40000-40063"
     rpc_server_port_range: Optional[str] = "40064-40095"
-    ray_worker_port_range: Optional[str] = "41000-42000"
+    ray_worker_port_range: Optional[str] = "40100-40999"
     log_dir: Optional[str] = None
     resources: Optional[dict] = None
     bin_dir: Optional[str] = None

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -5,11 +5,13 @@ import subprocess
 import sys
 from typing import Dict, List, Optional
 from gpustack.schemas.models import ModelInstance, ModelInstanceStateEnum
+from gpustack.schemas.workers import VendorEnum
 from gpustack.utils.command import (
     find_parameter,
     get_versioned_command,
     get_command_path,
 )
+from gpustack.utils.gpu import all_gpu_match
 from gpustack.utils.hub import (
     get_hf_text_config,
     get_max_model_len,
@@ -121,6 +123,8 @@ class VLLMServer(InferenceServer):
             return
 
         device_str = "GPU"
+        if all_gpu_match(worker, lambda gpu: gpu.vendor == VendorEnum.Huawei.value):
+            device_str = "NPU"
 
         ray_placement_group_bundles: List[Dict[str, float]] = []
         bundle_indexes = []


### PR DESCRIPTION
address https://github.com/gpustack/gpustack/issues/2547, a continuous work for https://github.com/gpustack/gpustack/pull/2560.

- correct sitecustomize location
- narrow worker range port to 40100-40999
- correct ray request unit resource key