### PR TITLE
fix: huggingface accesses cache only after requesting remote data fails

### DIFF
--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -15,6 +15,9 @@ async def test_evaluate_pretrained_config(config):
         backend_parameters=[],
     )
 
+    # First run,will cache all file and automatic carry --trust-remote-code.
+    await evaluate_pretrained_config(Phi_4_multimodal)
+
     # Custom code without --trust-remote-code, should raise ValueError
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
issue comment address: https://github.com/gpustack/gpustack/issues/2519#issuecomment-3100509103
now huggingface model uses cache first