### PR TITLE
fix: Specify the Triton version only for platform amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -493,11 +493,16 @@ RUN <<EOF
     # We also lock the transformers version here to fix https://github.com/gpustack/gpustack/pull/2473.
     cat <<EOT >/tmp/requirements.txt
 transformers==4.51.3
-triton==3.3.1
 vox-box==${VERSION}
 EOT
     pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore --force-reinstall --no-dependencies -r /tmp/requirements.txt \
         && ln -vsf ${PIPX_LOCAL_VENVS}/vox-box/bin/vox-box /usr/local/bin/vox-box
+
+    if [[ "${TARGETARCH}" == "amd64" ]]; then
+        # Since no compatible version exists for arm64, triton installation is restricted to amd64 architectures,
+        # aligning with pyproject.toml constraints.
+        pip install --disable-pip-version-check --no-cache-dir --root-user-action ignore --force-reinstall --no-dependencies triton==3.3.1
+    fi
 
     # Download tools
     # - Download dac weights used by audio models like Dia.


### PR DESCRIPTION
Avoid specifying triton 3.31 installation on arm64 platforms since no compatible version exists, aligning with pyproject.toml constraints.