### PR TITLE
Enhance log record

### DIFF
--- a/gpustack/routes/worker/logs.py
+++ b/gpustack/routes/worker/logs.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 from pathlib import Path
 from tenacity import RetryError
+from datetime import datetime
+import os
+import glob
 
 from gpustack.api.exceptions import NotFoundException
 from gpustack.worker.logs import LogOptionsDep
@@ -14,11 +17,51 @@ router = APIRouter()
 @router.get("/serveLogs/{id}")
 async def get_serve_logs(request: Request, id: int, log_options: LogOptionsDep):
     log_dir = request.app.state.config.log_dir
-    path = Path(log_dir) / "serve" / f"{id}.log"
-
-    try:
-        file.check_file_with_retries(path)
-    except (FileNotFoundError, RetryError):
-        raise NotFoundException(message="Log file not found")
-
-    return StreamingResponse(log_generator(path, log_options), media_type="text/plain")
+    serve_log_dir = Path(log_dir) / "serve"
+    
+    # 首先尝试查找旧格式的日志文件（向后兼容）
+    old_path = serve_log_dir / f"{id}.log"
+    if old_path.exists():
+        try:
+            file.check_file_with_retries(old_path)
+            return StreamingResponse(log_generator(old_path, log_options), media_type="text/plain")
+        except (FileNotFoundError, RetryError):
+            pass
+    
+    # 尝试通过映射文件查找对应的日志目录
+    mapping_file = serve_log_dir / "instance_mapping.txt"
+    if mapping_file.exists():
+        try:
+            with open(mapping_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line and ':' in line:
+                        inst_id, log_dir_path = line.split(':', 1)
+                        if int(inst_id) == id:
+                            log_dir_path = Path(log_dir_path)
+                            if log_dir_path.exists():
+                                log_files = glob.glob(str(log_dir_path / "*.log"))
+                                if log_files:
+                                    # 优先选择最新日期的文件 (YYYY-MM-DD.log 格式)
+                                    date_files = [(os.path.basename(f), f) for f in log_files 
+                                                 if os.path.basename(f).endswith('.log') and 
+                                                    len(os.path.basename(f)) == 14 and  # YYYY-MM-DD.log = 14 chars
+                                                    os.path.basename(f)[:10].count('-') == 2]  # 确保是日期格式
+                                    if date_files:
+                                        date_files.sort(reverse=True)
+                                        try:
+                                            file.check_file_with_retries(Path(date_files[0][1]))
+                                            return StreamingResponse(log_generator(Path(date_files[0][1]), log_options), media_type="text/plain")
+                                        except (FileNotFoundError, RetryError):
+                                            pass
+                                    # 回退到最新修改的文件
+                                    log_files.sort(key=os.path.getmtime, reverse=True)
+                                    try:
+                                        file.check_file_with_retries(Path(log_files[0]))
+                                        return StreamingResponse(log_generator(Path(log_files[0]), log_options), media_type="text/plain")
+                                    except (FileNotFoundError, RetryError):
+                                        pass
+        except Exception:
+            pass
+    
+    raise NotFoundException(message="Log file not found")

--- a/gpustack/routes/worker/logs.py
+++ b/gpustack/routes/worker/logs.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from tenacity import RetryError
 from datetime import datetime
 import os
-import glob
 
 from gpustack.api.exceptions import NotFoundException
 from gpustack.worker.logs import LogOptionsDep
@@ -19,15 +18,6 @@ async def get_serve_logs(request: Request, id: int, log_options: LogOptionsDep):
     log_dir = request.app.state.config.log_dir
     serve_log_dir = Path(log_dir) / "serve"
     
-    # 首先尝试查找旧格式的日志文件（向后兼容）
-    old_path = serve_log_dir / f"{id}.log"
-    if old_path.exists():
-        try:
-            file.check_file_with_retries(old_path)
-            return StreamingResponse(log_generator(old_path, log_options), media_type="text/plain")
-        except (FileNotFoundError, RetryError):
-            pass
-    
     # 尝试通过映射文件查找对应的日志目录
     mapping_file = serve_log_dir / "instance_mapping.txt"
     if mapping_file.exists():
@@ -40,28 +30,35 @@ async def get_serve_logs(request: Request, id: int, log_options: LogOptionsDep):
                         if int(inst_id) == id:
                             log_dir_path = Path(log_dir_path)
                             if log_dir_path.exists():
-                                log_files = glob.glob(str(log_dir_path / "*.log"))
-                                if log_files:
-                                    # 优先选择最新日期的文件 (YYYY-MM-DD.log 格式)
-                                    date_files = [(os.path.basename(f), f) for f in log_files 
-                                                 if os.path.basename(f).endswith('.log') and 
-                                                    len(os.path.basename(f)) == 14 and  # YYYY-MM-DD.log = 14 chars
-                                                    os.path.basename(f)[:10].count('-') == 2]  # 确保是日期格式
-                                    if date_files:
-                                        date_files.sort(reverse=True)
-                                        try:
-                                            file.check_file_with_retries(Path(date_files[0][1]))
-                                            return StreamingResponse(log_generator(Path(date_files[0][1]), log_options), media_type="text/plain")
-                                        except (FileNotFoundError, RetryError):
-                                            pass
-                                    # 回退到最新修改的文件
-                                    log_files.sort(key=os.path.getmtime, reverse=True)
+                                # 优先查找今天的日志文件
+                                today = datetime.now().strftime("%Y-%m-%d")
+                                today_log = log_dir_path / f"{today}.log"
+                                if today_log.exists():
                                     try:
-                                        file.check_file_with_retries(Path(log_files[0]))
-                                        return StreamingResponse(log_generator(Path(log_files[0]), log_options), media_type="text/plain")
+                                        file.check_file_with_retries(today_log)
+                                        return StreamingResponse(log_generator(today_log, log_options), media_type="text/plain")
+                                    except (FileNotFoundError, RetryError):
+                                        pass
+                                
+                                # 如果今天的文件不存在，查找最新的日志文件
+                                log_files = list(log_dir_path.glob("*.log"))
+                                if log_files:
+                                    log_files.sort(key=lambda x: x.stat().st_mtime, reverse=True)
+                                    try:
+                                        file.check_file_with_retries(log_files[0])
+                                        return StreamingResponse(log_generator(log_files[0], log_options), media_type="text/plain")
                                     except (FileNotFoundError, RetryError):
                                         pass
         except Exception:
+            pass
+    
+    # 向后兼容：查找旧格式的日志文件
+    old_path = serve_log_dir / f"{id}.log"
+    if old_path.exists():
+        try:
+            file.check_file_with_retries(old_path)
+            return StreamingResponse(log_generator(old_path, log_options), media_type="text/plain")
+        except (FileNotFoundError, RetryError):
             pass
     
     raise NotFoundException(message="Log file not found")

--- a/gpustack/worker/daily_rotating_logger.py
+++ b/gpustack/worker/daily_rotating_logger.py
@@ -1,0 +1,72 @@
+import os
+import sys
+from datetime import datetime
+from threading import Lock
+from typing import TextIO
+
+
+class DailyRotatingLogFile:
+    """日志文件包装器，支持按日期自动轮转"""
+    
+    def __init__(self, log_dir: str, encoding: str = "utf-8"):
+        self.log_dir = log_dir
+        self.encoding = encoding
+        self._current_file = None
+        self._current_date = None
+        self._lock = Lock()
+        
+        # 确保日志目录存在
+        os.makedirs(log_dir, exist_ok=True)
+        
+        # 立即初始化第一个日志文件
+        self._rotate_if_needed()
+    
+    def _get_current_date(self):
+        return datetime.now().strftime("%Y-%m-%d")
+    
+    def _get_log_filename(self, date: str):
+        return os.path.join(self.log_dir, f"{date}.log")
+    
+    def _rotate_if_needed(self):
+        """如果日期变化，轮转日志文件"""
+        current_date = self._get_current_date()
+        
+        if self._current_date != current_date:
+            if self._current_file and not self._current_file.closed:
+                try:
+                    self._current_file.close()
+                except Exception:
+                    pass  # 忽略关闭文件时的错误
+            
+            log_filename = self._get_log_filename(current_date)
+            try:
+                self._current_file = open(log_filename, "a", buffering=1, encoding=self.encoding)
+                self._current_date = current_date
+            except Exception as e:
+                # 如果无法打开新文件，保持旧文件不变
+                pass
+    
+    def write(self, data: str):
+        with self._lock:
+            self._rotate_if_needed()
+            if self._current_file:
+                self._current_file.write(data)
+                self._current_file.flush()  # 立即刷新，确保实时写入
+            return len(data)  # 返回写入的字符数，模拟标准文件行为
+    
+    def flush(self):
+        with self._lock:
+            if self._current_file:
+                self._current_file.flush()
+    
+    def close(self):
+        with self._lock:
+            if self._current_file and not self._current_file.closed:
+                self._current_file.close()
+    
+    def fileno(self):
+        with self._lock:
+            self._rotate_if_needed()
+            if self._current_file:
+                return self._current_file.fileno()
+            return None

--- a/gpustack/worker/daily_rotating_logger.py
+++ b/gpustack/worker/daily_rotating_logger.py
@@ -50,8 +50,9 @@ class DailyRotatingLogFile:
         with self._lock:
             self._rotate_if_needed()
             if self._current_file:
-                self._current_file.write(data)
+                result = self._current_file.write(data)
                 self._current_file.flush()  # 立即刷新，确保实时写入
+                return result
             return len(data)  # 返回写入的字符数，模拟标准文件行为
     
     def flush(self):
@@ -63,10 +64,31 @@ class DailyRotatingLogFile:
         with self._lock:
             if self._current_file and not self._current_file.closed:
                 self._current_file.close()
+                self._current_file = None
     
     def fileno(self):
         with self._lock:
             self._rotate_if_needed()
             if self._current_file:
                 return self._current_file.fileno()
+            return None
+    
+    def readable(self):
+        return False
+    
+    def writable(self):
+        return True
+    
+    def seekable(self):
+        return False
+    
+    def isatty(self):
+        return False
+    
+    def get_current_log_file(self):
+        """获取当前日志文件路径，用于调试"""
+        with self._lock:
+            self._rotate_if_needed()
+            if self._current_file:
+                return self._current_file.name
             return None

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -335,6 +335,10 @@ class ServeManager:
         # 使用按日期轮转的日志文件
         rotating_log = DailyRotatingLogFile(log_dir_path)
         
+        # 确保日志文件立即创建并可写入
+        test_msg = f"Model instance {mi.name} (ID: {mi.id}) started at {datetime.now()}\n"
+        rotating_log.write(test_msg)
+        
         try:
             with RedirectStdoutStderr(rotating_log):
                 if backend == BackendEnum.LLAMA_BOX:


### PR DESCRIPTION
The original log storage format was log/serve/**.log, which was not conducive to back-end maintenance and differentiation, and had low recognizability. Now, the log storage format has been changed to /log/serve/model instance name/replica name/YYYY-MM-DD.log (according to data rotation).

Such as:
<img width="1740" height="122" alt="image" src="https://github.com/user-attachments/assets/fe40f7c9-4b4f-4ad5-9e2d-53bedb663e8b" />
<img width="2028" height="82" alt="image" src="https://github.com/user-attachments/assets/0a9780f0-2878-4a94-9ea0-1ca785bcab44" />
