### PR TITLE
llama-box: bump version

### DIFF
--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -21,7 +21,7 @@ from gpustack.utils import platform, envs
 logger = logging.getLogger(__name__)
 
 
-BUILTIN_LLAMA_BOX_VERSION = "v0.0.164"
+BUILTIN_LLAMA_BOX_VERSION = "v0.0.167"
 BUILTIN_GGUF_PARSER_VERSION = "v0.21.4"
 
 


### PR DESCRIPTION
Bump `llama-box` to `v0.0.167` due to inference fallback to CPU using `gpustack/gpustack:main-musa` with MTGPU.