### PR TITLE
fix: Enhance attention heads validation

### DIFF
--- a/gpustack/policies/utils.py
+++ b/gpustack/policies/utils.py
@@ -125,7 +125,7 @@ class ListMessageBuilder:
 def get_model_num_attention_heads(pretrained_config) -> Optional[int]:
     """
     Get the number of attention heads in the model.
-    Priority: llm_config > text_config > root-level settings
+    Priority: llm_config > text_config > root-level setting > thinker_config.text_config
     """
 
     num_attention_heads = None
@@ -137,11 +137,16 @@ def get_model_num_attention_heads(pretrained_config) -> Optional[int]:
                 return value
             return None
 
-        # Check in priority order: llm_config > text_config > root-level
+        thinker_config = getattr(pretrained_config, "thinker_config", None)
+        thinker_text_config = (
+            getattr(thinker_config, "text_config", None) if thinker_config else None
+        )
+
         configs_by_priority = [
             getattr(pretrained_config, "llm_config", None),
             getattr(pretrained_config, "text_config", None),
             pretrained_config,
+            thinker_text_config,
         ]
 
         for config in configs_by_priority:

--- a/gpustack/scheduler/scheduler.py
+++ b/gpustack/scheduler/scheduler.py
@@ -364,7 +364,9 @@ async def find_candidate(
 
     worker_filter_chain = WorkerFilterChain(filters)
     workers, filter_messages = await worker_filter_chain.filter(workers)
-    messages = [str(ListMessageBuilder(filter_messages))]
+    messages = []
+    if filter_messages:
+        messages.append(str(ListMessageBuilder(filter_messages)) + "\n")
 
     try:
         if is_gguf_model(model):


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2646#issuecomment-3149768495

- Repaired the issue where GPU allocations that don't meet VRAM requirements could still pass compatibility checks when a specific GPU count is specified.
- Add support for retrieving num_attention_heads from thinker_config.
- Improve the scheduling test case.