### PR TITLE
ci: skip corex docker build

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -107,11 +107,13 @@ jobs:
           #
           # Iluvatar Corex
           #
-          - device: corex
-            dockerfile: "Dockerfile.corex"
-            platforms: "linux/amd64"
-            tag_suffix: "-corex"
-            build_args: []
+          # Skip until the base image is fixed.
+          # Ref: https://github.com/gpustack/gpustack/issues/2675
+          # - device: corex
+          #   dockerfile: "Dockerfile.corex"
+          #   platforms: "linux/amd64"
+          #   tag_suffix: "-corex"
+          #   build_args: []
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Skip corex docker ci to avoid breaking every PR check