### PR TITLE
fix: proxy request fail when no reposnse within 300s

### DIFF
--- a/gpustack/routes/openai.py
+++ b/gpustack/routes/openai.py
@@ -316,7 +316,7 @@ async def handle_streaming_request(
     form_data: Optional[aiohttp.FormData],
     extra_headers: Optional[dict] = None,
 ):
-    timeout = aiohttp.ClientTimeout(total=300)
+    timeout = aiohttp.ClientTimeout(total=PROXY_TIMEOUT)
     headers = filter_headers(request.headers)
     if extra_headers:
         headers.update(extra_headers)


### PR DESCRIPTION
issues address: https://github.com/gpustack/gpustack/issues/621

Unify proxy request timeouts to use the `GPUSTACK_PROXY_TIMEOUT_SECONDS` environment variable, with a default value of 1800 seconds.