### PR TITLE
ci(docker/cuda): fix failed on llama-box starting

### DIFF
--- a/pack/Dockerfile
+++ b/pack/Dockerfile
@@ -729,4 +729,6 @@ EOT
         && rm -rf /tmp/*
 EOF
 
+ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+
 ENTRYPOINT [ "tini", "--", "gpustack", "start" ]


### PR DESCRIPTION
address https://github.com/gpustack/gpustack/issues/2704