### PR TITLE
fix: missing third-party tools in NPU docker images

### DIFF
--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -623,7 +623,7 @@ class ToolsManager:
                 major, minor = map(int, match.groups())
                 if major == 8 and minor >= 2 and version > "v0.0.168":
                     toolkit_version = "8.2"
-                if major == 8 and minor >= 1 and version > "v0.0.144":
+                elif major == 8 and minor >= 1 and version > "v0.0.144":
                     toolkit_version = "8.1"
             # Currently, llama-box only supports release candidate version of CANN 8.1/8.2.
             if toolkit_version in ["8.1", "8.2"]:

--- a/pack/Dockerfile.npu
+++ b/pack/Dockerfile.npu
@@ -689,7 +689,8 @@ RUN --mount=type=bind,target=/workspace/gpustack,rw <<EOF
     export PATH="$(pipx environment --value PIPX_BIN_DIR):${PATH}"
     cd /workspace/gpustack \
         && git config --global --add safe.directory /workspace/gpustack \
-        && make build
+        && make build \
+        && cd /
 
     # Pre process
     # - Create virtual environment to place gpustack


### PR DESCRIPTION
issue address: https://github.com/gpustack/gpustack/issues/2711

Because the directory structure when downloading tools meets `gpustack.third_party`,the program selected the wrong storage path.