### PR TITLE
fix: Replace hardcoded timeout with configurable PROXY_TIMEOUT

### DIFF
--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -3,6 +3,7 @@ import aiohttp
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from gpustack.api.responses import StreamingResponseWithStatusCode
+from gpustack.config.envs import PROXY_TIMEOUT
 
 from gpustack.server.services import ModelInstanceService
 from gpustack.worker.logs import LogOptionsDep
@@ -105,7 +106,7 @@ async def get_serving_logs(  # noqa: C901
         # Get model file ID for injected download logs if instance is downloading
         model_instance_log_url += f"&model_file_id={model_instance.model_files[0].id}"
 
-    timeout = aiohttp.ClientTimeout(total=5 * 60, sock_connect=5)
+    timeout = aiohttp.ClientTimeout(total=PROXY_TIMEOUT, sock_connect=5)
 
     client: aiohttp.ClientSession = request.app.state.http_client
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2753

The connection remains active beyond five minutes
<img width="3256" height="906" alt="image" src="https://github.com/user-attachments/assets/deda78e0-e49a-44b7-87e1-c6119227b2f3" />
