### PR TITLE
Prevent CI/CD from running on issue template updates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
       - main
       - "v*-dev"
     paths-ignore:
+      - ".github/ISSUE_TEMPLATE/**"
       - "mkdocs.yml"
       - "docs/**"
       - "**.md"


### PR DESCRIPTION
### Background

Currently, CI/CD workflows are triggered on every pull request, including changes to issue templates.  
This is unnecessary because updating issue templates does not affect the codebase.

### Changes

- Updated `paths-ignore` in the PR workflow:
  - Ignore `.github/ISSUE_TEMPLATE/**` directory
  - Retain existing ignores (docs, images, mkdocs.yml, etc.)

### Effect

- PRs that only modify issue templates will no longer trigger CI/CD runs.
- Reduces unnecessary CI/CD usage and speeds up workflow.

### Notes

This change only affects CI/CD triggers, no functional code changes.
