### PR TITLE
fix: set user's cluster_id/worker_id default to None

### DIFF
--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -50,10 +50,12 @@ class UserBase(SQLModel):
         default=None, description="Role of the user, e.g., worker or cluster"
     )
     cluster_id: Optional[int] = Field(
-        sa_column=Column(Integer, ForeignKey("clusters.id", ondelete="CASCADE"))
+        default=None,
+        sa_column=Column(Integer, ForeignKey("clusters.id", ondelete="CASCADE")),
     )
     worker_id: Optional[int] = Field(
-        sa_column=Column(Integer, ForeignKey("workers.id", ondelete="CASCADE"))
+        default=None,
+        sa_column=Column(Integer, ForeignKey("workers.id", ondelete="CASCADE")),
     )
 
 


### PR DESCRIPTION
Fix the issue when creating user
```
2 validation errors:\n  {'type': 'missing', 'loc': ('body', 'cluster_id'), 'msg': 'Field required', 'input': {'username': 'sdfs', 'full_name': 'sdfs', 'is_admin': False, 'password': 'Admin123!'}}\n  {'type': 'missing', 'loc': ('body', 'worker_id'), 'msg': 'Field required', 'input': {'username': 'sdfs', 'full_name': 'sdfs', 'is_admin': False, 'password': 'Admin123!'}}\n"
```