### PR TITLE
docs: hide MkDocs footer in generated pages

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -11,3 +11,7 @@
 .md-typeset .center-table :is(td,th):not([align]) {
   text-align: initial; /* Reset alignment for table cells */
 }
+
+.md-footer {
+  display: none;
+}


### PR DESCRIPTION
<img width="3839" height="1952" alt="image" src="https://github.com/user-attachments/assets/4c37b580-d0e0-4103-b09c-3ebb0c83af59" />
