### PR TITLE
fix: prevent users from updating privileged fields via /me endpoint

### DIFF
--- a/gpustack/routes/users.py
+++ b/gpustack/routes/users.py
@@ -15,6 +15,7 @@ from gpustack.schemas.users import (
     UserUpdate,
     UserPublic,
     UsersPublic,
+    UserSelfUpdate,
 )
 from gpustack.server.services import UserService
 
@@ -141,10 +142,10 @@ async def get_user_me(user: CurrentUserDep):
 
 @me_router.put("/me", response_model=UserPublic)
 async def update_user_me(
-    session: SessionDep, user: CurrentUserDep, user_in: UserUpdate
+    session: SessionDep, user: CurrentUserDep, user_in: UserSelfUpdate
 ):
     try:
-        update_data = user_in.model_dump()
+        update_data = user_in.model_dump(exclude_none=True)
         if "password" in update_data:
             hashed_password = get_secret_hash(update_data["password"])
             update_data["hashed_password"] = hashed_password

--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -82,6 +82,30 @@ class UserUpdate(UserBase):
     password: Optional[str] = None
 
 
+class UserSelfUpdate(SQLModel):
+    """Schema for users updating their own profile - excludes privileged fields"""
+
+    full_name: Optional[str] = None
+    avatar_url: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+    password: Optional[str] = None
+
+    @field_validator('password')
+    def validate_password(cls, value):
+        if value is None:
+            return value
+        if not re.search(r'[A-Z]', value):
+            raise ValueError('Password must contain at least one uppercase letter')
+        if not re.search(r'[a-z]', value):
+            raise ValueError('Password must contain at least one lowercase letter')
+        if not re.search(r'[0-9]', value):
+            raise ValueError('Password must contain at least one digit')
+        if not re.search(r'[!@#$%^&*_+]', value):
+            raise ValueError('Password must contain at least one special character')
+        return value
+
+
 class UpdatePassword(SQLModel):
     current_password: str
     new_password: str


### PR DESCRIPTION
## Pull Request: Fix Security Vulnerability - Prevent Privilege Escalation via User Self-Update Endpoint

### 🔒 Security Issue

**Severity**: High  
**Type**: Privilege Escalation Vulnerability

The `/me` endpoint (`PUT /me`) allowed regular users to update any field defined in the `UserUpdate` schema, including privileged fields that should only be modifiable by administrators. This created a security vulnerability where users could potentially:

- Grant themselves admin privileges (`is_admin: true`)
- Modify system-level flags (`is_system`, `role`)
- Change authentication source (`source`)
- Alter system associations (`cluster_id`, `worker_id`)

### 🛠️ Changes

#### 1. **New Schema: `UserSelfUpdate`** (users.py)
Created a restrictive schema specifically for user self-updates that only allows modification of safe, non-privileged fields:

**Allowed fields:**
- `full_name` - Display name
- `avatar_url` - Profile picture URL
- `password` - User password (with validation)

**Blocked fields:**
- `is_admin` - Admin privileges
- `is_system` - System user flag
- `username` - Edit username
- `role` - User role (Worker/Cluster)
- `source` - Authentication provider
- `cluster_id`, `worker_id` - System associations

#### 2. **Updated Endpoint: `update_user_me`** (users.py)
- Changed parameter type from `UserUpdate` to `UserSelfUpdate`
- Added `exclude_none=True` to only update explicitly provided fields
- Maintains existing password hashing logic
- Preserves all security validations

### ✅ Security Benefits

- **Prevents privilege escalation**: Users cannot make themselves administrators
- **Protects account status**: Users cannot reactivate deactivated accounts
- **Maintains system integrity**: System-level fields remain protected
- **Clear API contract**: The schema explicitly defines what users can modify

### 🔄 Backward Compatibility

- **Admin functionality preserved**: Admins can still modify all fields via `PUT /users/{id}`
- **User experience unchanged**: Regular users can still update their profile information
- **API structure maintained**: No breaking changes to the API structure

### 📝 Notes

This fix follows the principle of least privilege by creating a clear separation between:
- **User self-management** (`PUT /me`) - restricted to safe fields
- **Admin user management** (`PUT /users/{id}`) - full access to all fields

---

**Type**: Security Fix  
**Priority**: High  
**Breaking Changes**: None