### PR TITLE
fix: should use inner join instead of left join for non_admin_user_mo…

### DIFF
--- a/gpustack/schemas/stmt.py
+++ b/gpustack/schemas/stmt.py
@@ -112,7 +112,7 @@ SELECT
     m.*
 FROM
     users u
-LEFT JOIN models m
+INNER JOIN models m
     ON m.public = {sql_true}
     OR EXISTS (
         SELECT 1 FROM modeluserlink mul


### PR DESCRIPTION
…dels view

Fix the problem that accessing `/v1/my-models` will failed if user doesn't have access to any models.