### PR TITLE
fix: invalid empty issue title

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -1,6 +1,5 @@
 name: 🐞 Bug Report
 description: Report a problem to help us improve
-title: ""
 type: "Bug"
 assignees: [ ]
 

--- a/.github/ISSUE_TEMPLATE/2_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2_enhancement.yml
@@ -1,6 +1,5 @@
 name: 💡 Enhancement Request
 description: Suggest an improvement or enhancement to existing functionality
-title: ""
 type: "Enhancement"
 assignees: [ ]
 

--- a/.github/ISSUE_TEMPLATE/3_question.yml
+++ b/.github/ISSUE_TEMPLATE/3_question.yml
@@ -1,6 +1,5 @@
 name: ❓ Question
 description: Ask a question about GPUStack
-title: ""
 type: "Question"
 assignees: [ ]
 

--- a/.github/ISSUE_TEMPLATE/4_doc.yml
+++ b/.github/ISSUE_TEMPLATE/4_doc.yml
@@ -1,6 +1,5 @@
 name: 📚 Documentation Update
 description: Request an update or improvement to GPUStack documentation
-title: ""
 type: "Documentation"
 assignees: [ ]
 

--- a/.github/ISSUE_TEMPLATE/5_other.yml
+++ b/.github/ISSUE_TEMPLATE/5_other.yml
@@ -1,6 +1,5 @@
 name: ⚡ Other
 description: Anything else not covered by other issue types
-title: ""
 assignees: [ ]
 
 body:


### PR DESCRIPTION
The title is optional, but cannot be empty once provided. Remove them instead.

<img width="898" height="1012" alt="image" src="https://github.com/user-attachments/assets/5e626edf-cbec-41c9-97cf-093742475e82" />

<img width="1298" height="274" alt="image" src="https://github.com/user-attachments/assets/2b5d05a4-ba2b-4851-b719-55283af1b754" />
