### PR TITLE
[Security] Prevent users from updating privileged fields via `PUT /me endpoint`

### DIFF
--- a/gpustack/routes/users.py
+++ b/gpustack/routes/users.py
@@ -15,6 +15,7 @@ from gpustack.schemas.users import (
     UserUpdate,
     UserPublic,
     UsersPublic,
+    UserSelfUpdate,
 )
 from gpustack.server.services import UserService
 
@@ -141,10 +142,10 @@ async def get_user_me(user: CurrentUserDep):
 
 @me_router.put("/me", response_model=UserPublic)
 async def update_user_me(
-    session: SessionDep, user: CurrentUserDep, user_in: UserUpdate
+    session: SessionDep, user: CurrentUserDep, user_in: UserSelfUpdate
 ):
     try:
-        update_data = user_in.model_dump()
+        update_data = user_in.model_dump(exclude_none=True)
         if "password" in update_data:
             hashed_password = get_secret_hash(update_data["password"])
             update_data["hashed_password"] = hashed_password

--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -82,6 +82,30 @@ class UserUpdate(UserBase):
     password: Optional[str] = None
 
 
+class UserSelfUpdate(SQLModel):
+    """Schema for users updating their own profile - excludes privileged fields"""
+
+    full_name: Optional[str] = None
+    avatar_url: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+    password: Optional[str] = None
+
+    @field_validator('password')
+    def validate_password(cls, value):
+        if value is None:
+            return value
+        if not re.search(r'[A-Z]', value):
+            raise ValueError('Password must contain at least one uppercase letter')
+        if not re.search(r'[a-z]', value):
+            raise ValueError('Password must contain at least one lowercase letter')
+        if not re.search(r'[0-9]', value):
+            raise ValueError('Password must contain at least one digit')
+        if not re.search(r'[!@#$%^&*_+]', value):
+            raise ValueError('Password must contain at least one special character')
+        return value
+
+
 class UpdatePassword(SQLModel):
     current_password: str
     new_password: str


### PR DESCRIPTION
## Issue description

An unprivileged user (i.e. not `admin`) can issue the following HTTP request through the API:

```
PUT /v1/users/me
Content-Type: application/json
Authorization: Bearer <token>

{
  "password": "new_password",
  "username": "test",
  "is_admin": true
}
```

This request will succeed and the user `test` will be updated and become `admin`.

## The cause

When we look at the content of the file `routes/users.py`, the model that the user can send is `UserUpdate`:
https://github.com/gpustack/gpustack/blob/c7485c50aff51f27f362a1d6bf209e8d2702dc7a/gpustack/routes/users.py#L142-L145

And when we check what fields contains `UserUpdate` (which extends `UserBase`):
https://github.com/gpustack/gpustack/blob/c7485c50aff51f27f362a1d6bf209e8d2702dc7a/gpustack/schemas/users.py#L38-L42

So we can see that any user can modify its own data, including sensitive fields, including `username`, `is_admin`, `is_active`, `source`, `require_password_change`, `is_system`, `role`, `cluster_id`, `worker_id`.

## Proposed fix (this PR)

Introduce a new schema `UserSelfUpdate` that exposes only allowed fields (`full_name`, `avatar_url`, `password`) for the self-update endpoint.

Update function `update_user_me` to use the new `UserSelfUpdate` schema instead of `UserUpdate`.

This change modifies the behavior of the `PUT /v1/users/me` endpoint by allowing only changes on unprivileged fields, even for administrators. The privileged endpoint will become only `PUT /v1/users/{id}` and allow only admin users to edit privileged fields.