### PR TITLE
fix: should not reset log config

### DIFF
--- a/gpustack/cmd/db_migration.py
+++ b/gpustack/cmd/db_migration.py
@@ -19,7 +19,6 @@ from sqlalchemy.ext.asyncio import (
 from gpustack.cmd.start import get_gpustack_env
 from gpustack.config.envs import DB_ECHO, DB_MAX_OVERFLOW, DB_POOL_SIZE, DB_POOL_TIMEOUT
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 revision = "d19176de3b74"  # 0.7.1


### PR DESCRIPTION
reset log config makes server log lack of timestamp.

```
INFO:gpustack.cmd.start:GPUStack version: 0.0.0 (HEAD)
INFO:gpustack.server.server:Starting GPUStack server.
INFO:gpustack.server.server:Running database migration.
INFO:gpustack.server.server:Database migration completed.
INFO:gpustack.server.server:Default cluster token already exists.
INFO:gpustack.server.catalog:Cannot access https://huggingface.co, using ModelScope model catalog.
INFO:gpustack.server.server:Serving on 0.0.0.0:8084.
INFO:gpustack.scheduler.scheduler:Scheduler started.
INFO:gpustack.server.controllers:Reconcile cluster Default Cluster with event EventType.CREATED
INFO:gpustack.policies.candidate_selectors.vllm_resource_fit_selector:Calculated resource claim for model Qwen/Qwen3-0.6B, VRAM claim: 3951444041.6, RAM claim: 0
INFO:gpustack.policies.candidate_selectors.vllm_resource_fit_selector:Action: default_scheduling_msg, - The model requires approximately 3.68 GiB of VRAM.
- With --gpu-memory-utilization=0.15, all GPUs combined need to provide at least 24.53 GiB of total VRAM and each GPU needs 15% of allocatable VRAM., {}, model: Qwen/Qwen3-0.6B
2025-10-27 14:27:11.497594+08:00 - gpustack.worker.tools_manager - DEBUG - Preparing dependency tools
2025-10-27 14:27:11.498008+08:00 - gpustack.worker.tools_manager - DEBUG - OS: darwin, Arch: arm64
2025-10-27 14:27:11.498185+08:00 - gpustack.worker.tools_manager - DEBUG - gguf-parser already exists, skipping download
2025-10-27 14:27:11.498290+08:00 - gpustack.worker.tools_manager - DEBUG - fastfetch already exists, skipping download
2025-10-27 14:27:11.501326+08:00 - gpustack.worker.worker - INFO - Starting GPUStack worker.
2025-10-27 14:27:11.501454+08:00 - gpustack.utils.process - DEBUG - Adding signal handler for 2
2025-10-27 14:27:11.501660+08:00 - gpustack.utils.process - DEBUG - Adding signal handler for 15
```