### PR TITLE
refactor: lock postgres port

### DIFF
--- a/pack/Dockerfile
+++ b/pack/Dockerfile
@@ -338,7 +338,8 @@ RUN <<EOF
         && gosu postgres sed -i "s/^#logging_collector = off/logging_collector = on/" "$PGCONFIG_FILE" \
         && gosu postgres sed -i 's/^#log_directory = '\''log'\''/log_directory = '\''\/var\/lib\/gpustack\/log\/postgresql'\''/g' "$PGCONFIG_FILE" \
         && gosu postgres sed -i "s/^#log_filename/log_filename/" "$PGCONFIG_FILE" \
-        && gosu postgres sed -i "s/^#log_rotation_size/log_rotation_size/" "$PGCONFIG_FILE"
+        && gosu postgres sed -i "s/^#log_rotation_size/log_rotation_size/" "$PGCONFIG_FILE" \
+        && gosu postgres sed -i "s/^port[[:space:]]*=[[:space:]]*[0-9]\+/port = 5432/" "$PGCONFIG_FILE"
 
     # Cleanup
     rm -rf /var/tmp/* \


### PR DESCRIPTION
When install PostgreSQL, it's typical set port to 5432 in config file. If it isn't available, it will change the config file to use next free port, we correcting the port to 5432. Since we may use overlay network in feature instead of host network, the port will not be occupied.