### PR TITLE
feat: extended kvcache for SGLang

### DIFF
--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -71,14 +71,14 @@ class ExtendedKVCacheConfig(BaseModel):
     enabled: bool = False
     """ Enable extended KV cache for the model."""
 
-    chunk_size: Optional[int] = None
-    """ Chunk size for each KV cache chunk (unit: number of tokens). """
+    ram_ratio: float = 1.2
+    """ RAM-to-VRAM ratio for KV cache. For example, 2.0 means the RAM is twice the size of the VRAM. """
 
-    max_local_cpu_size: Optional[float] = None
-    """ Maximum size of the KV cache to be stored in local CPU memory (unit: GiB). """
+    ram_size: int = 0
+    """ Maximum size of the KV cache to be stored in local CPU memory (unit: GiB). Overrides ram_ratio if both are set. """
 
-    remote_url: Optional[str] = None
-    """ Remote storage URL for offloading KV cache. Format: "protocol://host:port". """
+    chunk_size: int = 0
+    """ Size for each KV cache chunk (unit: number of tokens). """
 
 
 class ModelSource(BaseModel):

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -162,6 +162,10 @@ class SGLangServer(InferenceServer):
             multinode_arguments = self._get_multinode_arguments()
             arguments.extend(multinode_arguments)
 
+        # Add hierarchical cache arguments if needed
+        hicache_arguments = self._get_hicache_arguments()
+        arguments.extend(hicache_arguments)
+
         # Add user-defined backend parameters
         if self._model.backend_parameters:
             arguments.extend(self._model.backend_parameters)
@@ -175,6 +179,51 @@ class SGLangServer(InferenceServer):
                 str(port),
             ]
         )
+
+        return arguments
+
+    def _get_hicache_arguments(self) -> List[str]:
+        """
+        Get hierarchical KV cache arguments for SGLang.
+        """
+        if not (
+            self._model.extended_kv_cache and self._model.extended_kv_cache.enabled
+        ):
+            return []
+
+        arguments = ["--enable-hierarchical-cache"]
+        if (
+            self._model.extended_kv_cache.chunk_size
+            and self._model.extended_kv_cache.chunk_size > 0
+        ):
+            arguments.extend(
+                [
+                    "--page-size",
+                    str(self._model.extended_kv_cache.chunk_size),
+                ]
+            )
+
+        if (
+            self._model.extended_kv_cache.ram_size
+            and self._model.extended_kv_cache.ram_size > 0
+        ):
+            arguments.extend(
+                [
+                    "--hicache-size",
+                    str(self._model.extended_kv_cache.ram_size),
+                ]
+            )
+
+        if (
+            self._model.extended_kv_cache.ram_ratio
+            and self._model.extended_kv_cache.ram_ratio > 0
+        ):
+            arguments.extend(
+                [
+                    "--hicache-ratio",
+                    str(self._model.extended_kv_cache.ram_ratio),
+                ]
+            )
 
         return arguments
 

--- a/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
@@ -8,6 +8,7 @@ from gpustack.scheduler import scheduler
 from gpustack.schemas.models import (
     CategoryEnum,
     ComputedResourceClaim,
+    ExtendedKVCacheConfig,
     GPUSelector,
     ModelInstanceStateEnum,
     ModelInstanceSubordinateWorker,
@@ -867,3 +868,117 @@ async def test_sglang_memory_fraction_static(config):
 
         # Should handle custom memory fraction
         assert len(candidates) >= 0
+
+
+@pytest.mark.asyncio
+async def test_auto_schedule_extended_kv_cache_ram_size(config):
+    workers = [
+        linux_nvidia_1_4090_24gx1(),
+    ]
+
+    m = new_model(
+        1,
+        "test_name",
+        1,
+        huggingface_repo_id="Qwen/Qwen3-0.6B",
+        cpu_offloading=False,
+        extended_kv_cache=ExtendedKVCacheConfig(
+            enabled=True,
+            ram_size=8.0,  # 8GiB
+        ),
+    )
+
+    resource_fit_selector = SGLangResourceFitSelector(config, m)
+    placement_scorer = PlacementScorer(m)
+
+    with (
+        patch(
+            'gpustack.policies.utils.get_worker_model_instances',
+            return_value=[],
+        ),
+        patch(
+            'gpustack.policies.scorers.placement_scorer.get_model_instances',
+            return_value=[],
+        ),
+        patch('sqlmodel.ext.asyncio.session.AsyncSession', AsyncMock()),
+        patch(
+            'gpustack.schemas.workers.Worker.all',
+            return_value=workers,
+        ),
+    ):
+
+        candidates = await resource_fit_selector.select_candidates(workers)
+        candidates = await placement_scorer.score(candidates)
+
+        expected_candidates = [
+            {
+                "worker_id": 2,
+                "worker_name": "host4090",
+                "gpu_indexes": [0],
+                "is_unified_memory": False,
+                "vram": {
+                    0: 23413653504,
+                },
+                "ram": 8589934592,
+            },
+        ]
+
+        assert len(candidates) == 1
+        compare_candidates(candidates, expected_candidates)
+
+
+@pytest.mark.asyncio
+async def test_auto_schedule_extended_kv_cache_ram_ratio(config):
+    workers = [
+        linux_nvidia_1_4090_24gx1(),
+    ]
+
+    m = new_model(
+        1,
+        "test_name",
+        1,
+        huggingface_repo_id="Qwen/Qwen3-0.6B",
+        cpu_offloading=False,
+        extended_kv_cache=ExtendedKVCacheConfig(
+            enabled=True,
+            ram_ratio=2.0,  # 2x of VRAM
+        ),
+    )
+
+    resource_fit_selector = SGLangResourceFitSelector(config, m)
+    placement_scorer = PlacementScorer(m)
+
+    with (
+        patch(
+            'gpustack.policies.utils.get_worker_model_instances',
+            return_value=[],
+        ),
+        patch(
+            'gpustack.policies.scorers.placement_scorer.get_model_instances',
+            return_value=[],
+        ),
+        patch('sqlmodel.ext.asyncio.session.AsyncSession', AsyncMock()),
+        patch(
+            'gpustack.schemas.workers.Worker.all',
+            return_value=workers,
+        ),
+    ):
+
+        candidates = await resource_fit_selector.select_candidates(workers)
+        candidates = await placement_scorer.score(candidates)
+
+        expected_candidates = [
+            {
+                "worker_id": 2,
+                "worker_name": "host4090",
+                "gpu_indexes": [0],
+                "is_unified_memory": False,
+                "vram": {
+                    0: 23413653504,
+                },
+                "ram": 46827307008,
+            },
+        ]
+
+        assert len(candidates) == 1
+        compare_candidates(candidates, expected_candidates)


### PR DESCRIPTION
Context:
  1.  LMCache with SGLang is not well maintained. The practical approach is to use SGLang’s built-in Hicache support.
  2.  Therefore, extended_kv_cache integrates with vLLM+LMCache and SGLang+Hicache under the hood.
  3.  We aim to provide a unified interface to smooth out differences, although the two implementations still differ in the following ways:

Differences:
  1.  RAM cache:
  • SGLang requires the RAM cache to be larger than VRAM. A static default RAM size is impractical due to differences in deployment environments. LMCache in vLLM does not have this limitation.
  • SGLang provides both size and ratio configurations for RAM, whereas LMCache in vLLM only supports size configuration.
  2.  Storage backend:
  • SGLang supports Mooncake and HF3FS. LMCache provides more options.
  • Each backend has different configuration requirements, and UX can be poor without proper control.
  • The plan is to define an API for each storage backend to simplify configuration.

Changes in this PR:
  1.  Use RAM ratio by default. The default value (1.2) is more conservative than SGLang’s default (2), improving deployment success rates.
  2.  For LMCache, which does not support ratio configuration, RAM size is computed from the claimed VRAM.
  3.  ~~Add Redis as a storage backend and~~ Remove the previously arbitrary backend. Remote storage backend like Mooncake can be added in future releases depending on effort and community requests.