### PR TITLE
chore: bump runtime

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2784,13 +2784,13 @@ dataclasses-json = ">=0.6.7"
 
 [[package]]
 name = "gpustack-runtime"
-version = "0.1.22"
+version = "0.1.23"
 description = "GPUStack Runtime is library for detecting GPU resources and launching GPU workloads."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "gpustack_runtime-0.1.22-py3-none-any.whl", hash = "sha256:0fe5bfb7d19b9caf3a67ba456ef1f7f82d443c35eb77f607358df300915a2614"},
-    {file = "gpustack_runtime-0.1.22.tar.gz", hash = "sha256:b466f165f38b74579ffa28c2b682185206e59953c4522c4c2b570af45360dcc5"},
+    {file = "gpustack_runtime-0.1.23-py3-none-any.whl", hash = "sha256:03de8c522c709be37e47165620c6cf786d36739b0dbf828f4d45fe0a5f16584e"},
+    {file = "gpustack_runtime-0.1.23.tar.gz", hash = "sha256:edcd0b3a884e68d0565fef6ff044d94e600ceafc7aaad2309bfb8bee3474e5df"},
 ]
 
 [package.dependencies]
@@ -10692,4 +10692,4 @@ vllm = ["bitsandbytes", "mistral_common", "timm", "vllm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "aebf5b753669a3e6b494e4382f41f6eeb66273595b5ad5d99528151b83ed1b1a"
+content-hash = "b55fec7d1919ed5b3871a5423a5f54f5a602051b452a1f28789dbf8ab53d274e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ kubernetes-asyncio = "^33.1.0"
 msgpack = "^1.1.2"
 
 gpustack-runner = ">=0.1.11"
-gpustack-runtime = ">=0.1.22"
+gpustack-runtime = ">=0.1.23"
 
 [tool.poetry.group.dev.dependencies]
 installer = "0.7.0"


### PR DESCRIPTION
address https://github.com/gpustack/gpustack/issues/3086 https://github.com/gpustack/gpustack/issues/2960

gpustack-runtime introduces a command to display the available deployer and detector: 
```bash
$ gpustack-runtime --profile
Available Deployers: [docker]
Available Detectors: [amd, nvidia]
```

see https://github.com/gpustack/runtime/compare/v0.1.22...v0.1.23.