### PR TITLE
fix: model instance logs not show via higress

### DIFF
--- a/gpustack/routes/worker/logs.py
+++ b/gpustack/routes/worker/logs.py
@@ -227,5 +227,5 @@ async def get_serve_logs(
             model_instance_name,
             file_log_exists,
         ),
-        media_type="text/plain",
+        media_type="application/octet-stream",
     )


### PR DESCRIPTION
Use the same `media-type` as model instance logging API.
Refer to issue: https://github.com/gpustack/gpustack/issues/3090