### PR TITLE
refactor: adjust runtime devices detection configuration

### DIFF
--- a/pack/Dockerfile
+++ b/pack/Dockerfile
@@ -443,6 +443,11 @@ RUN --mount=type=cache,target=/root/.cache \
     # Download wasm-plugins
     python gpustack/gateway/pull_plugins.py
 
+    # Try to update PCI IDs
+    if ! update-pciids; then
+        curl -o /usr/share/misc/pci.ids https://pci-ids.ucw.cz/v2.2/pci.ids || true
+    fi
+
     # Cleanup
     rm -rf /var/tmp/* \
         && rm -rf /tmp/* \
@@ -458,10 +463,23 @@ COPY pack/s6-overlay /etc/s6-overlay
 ## Active all AMD devices detection,
 ## works with (default) ROCm container runtime and privileged mode.
 ## See https://rocm.docs.amd.com/projects/amdsmi/en/latest/reference/amdsmi-py-api.html.
-## Options:
-## - Mount /sys from the host to detect the correct devices' PCI info.
-## - Mount /opt/rocm from the host to detect the correct ROCm version, device architecture and compute_capability.
-## E.g. docker run --rm -it --privileged -v /var/run/docker.sock:/var/run/docker.sock gpustack/gpustack:main
+## Runs:
+## - With container runtime installed:
+##   + If installed AMD contaienr runtime as default runtime, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged ...
+##   + If there are mulitple container runtimes installed, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged --runtime amd ...
+##   + If failed to detect devices' name, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v /usr/share:/usr/share:ro ...
+##   + If want to detect the correct host ROCm version, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v /opt/rocm:/opt/rocm:ro ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock ...
+## - Without container runtime installed:
+##   + Allowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v /opt/rocm:/opt/rocm:ro ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --security-opt seccomp=unconfined -v /dev:/dev:ro --group-add video -v /opt/rocm:/opt/rocm:ro ...
 RUN --mount=type=bind,from=rocm-base,source=/opt/rocm/share,target=/opt/rocm/share,rw <<EOF
     # Reinstall amd-smi
 
@@ -471,18 +489,28 @@ RUN --mount=type=bind,from=rocm-base,source=/opt/rocm/share,target=/opt/rocm/sha
         /opt/rocm/share/amd_smi
     uv pip tree
 EOF
-ENV AMD_VISIBLE_DEVICES="0" \
+ENV AMD_VISIBLE_DEVICES="all" \
     GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT_IGNORE_VOLUMES="/opt/rocm"
 
 ## Active all Ascend devices detection,
 ## works with (default) Ascend container runtime and privileged mode.
 ## See https://gitcode.com/Ascend/mind-cluster/blob/master/component/ascend-common/devmanager/dcmi/dcmi_interface_api.h.
-## Options:
-## - Mount /sys from the host to detect the correct devices' PCI info.
-## - Mount /usr/local/Ascend/ascend-toolkit to detect the correct CANN version and SoC name.
-## E.g. docker run --rm -it --privileged -v /var/run/docker.sock:/var/run/docker.sock gpustack/gpustack:main
-ENV ASCEND_VISIBLE_DEVICES="0" \
-    ASCEND_HOME_PATH="/usr/local/Ascend/ascend-toolkit/latest" \
+## Runs:
+## - With container runtime installed:
+##   + If installed Ascend container runtime as default runtime, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged ...
+##   + If there are mulitple container runtimes installed, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged --runtime ascend ...
+##   + If want to detect the correct host CANN version and SoC name, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v /usr/local/Ascend/ascend-toolkit:/usr/local/Ascend/ascend-toolkit:ro ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -e ASCEND_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 ...
+## - Without container runtime installed:
+##   + Allowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v /usr/local/dcmi:/usr/local/dcmi:ro -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro -v /etc/hccn.conf:/etc/hccn.conf:ro -v /etc/ascend_install.info:/etc/ascend_install.info:ro ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --security-opt seccomp=unconfined -v /dev:/dev:ro -v /usr/local/dcmi:/usr/local/dcmi:ro -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro -v /etc/hccn.conf:/etc/hccn.conf:ro -v /etc/ascend_install.info:/etc/ascend_install.info:ro ...
+ENV ASCEND_HOME_PATH="/usr/local/Ascend/ascend-toolkit/latest" \
     LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/ascend-toolkit/latest/runtime/lib64:${LD_LIBRARY_PATH}" \
     GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT_IGNORE_VOLUMES="/usr/local/Ascend/ascend-toolkit;${GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT_IGNORE_VOLUMES}"
 
@@ -490,64 +518,85 @@ ENV ASCEND_VISIBLE_DEVICES="0" \
 ## works with (default) Cambricon container runtime and privileged mode.
 ## See https://github.com/Cambricon/cambricon-k8s-device-plugin/blob/master/device-plugin/pkg/cndev/include/cndev.h,
 ##     https://github.com/Cambricon/cambricon-k8s-device-plugin/blob/master/device-plugin/pkg/cntopo/include/cntopo.h.
-## Options:
-## - Mount /sys from the host to detect the correct devices' PCI info.
-## - Mount /usr/bin/cnmon to detect the correct devices. [TODO, TBD] maybe we can mount /usr/local/neuware to detect the correct Neuware version futher.
-## E.g. docker run --rm -it --privileged -v /var/run/docker.sock:/var/run/docker.sock gpustack/gpustack:main
-ENV CAMBRICON_VISIBLE_DEVICES="0"
+## Runs:
+## - With container runtime installed:
+##   [TODO, TBD]
+## - Without container runtime installed:
+##   [TODO, TBD]
+ENV CAMBRICON_VISIBLE_DEVICES="all"
 
 ## Active all Hygon devices detection,
 ## works with (default) Hygon container runtime and privileged mode.
 ## See https://github.com/Project-HAMi/dcu-dcgm/blob/master/pkg/dcgm/include/rocm_smi.h.
-## - Mount /opt/hyhal from the host to support device detecting.
-## - Mount /opt/dtk from the host to support device detecting.
-## - Configure ROCM_PATH environment variable to point to the mounted ROCm path.
-## Requireds:
-## Options:
-## - Mount /sys from the host to detect the correct devices' PCI info.
-## E.g. docker run --rm -it --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /opt/hyhal:/opt/hyhal:ro -v /opt/dtk:/opt/dtk -e ROCM_PATH=/opt/dtk gpustack/gpustack:main
-ENV HYGON_VISIBLE_DEVICES="0" \
+## Runs:
+## - With container runtime installed:
+##   [TODO, TBD]
+## - Without container runtime installed:
+##   + Allowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v /opt/hyhal:/opt/hyhal:ro -v /opt/dtk:/opt/dtk:ro -e ROCM_PATH=/opt/dtk ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --security-opt seccomp=unconfined -v /dev:/dev:ro --group-add video -v /opt/hyhal:/opt/hyhal:ro -v /opt/dtk:/opt/dtk:ro -e ROCM_PATH=/opt/dtk ...
+ENV HYGON_VISIBLE_DEVICES="all" \
     GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT_IGNORE_VOLUMES="/opt/dtk;${GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT_IGNORE_VOLUMES}"
 
 ## Active all Iluvatar devices detection,
 ## works with (default) Iluvatar container runtime and privileged mode.
 ## See https://gitee.com/deep-spark/ix-device-plugin/blob/master/vendor/gitee.com/deep-spark/go-ixml/pkg/ixml/api.h.
-## Options:
-## - Mount /sys from the host to detect the correct devices' PCI info.
-## - Mount /run/udev from the host to detect the correct devices' udev info.
-## - Mount /usr/bin/ixsmi to detect the correct devices. [TODO, TBD] maybe we can mount /usr/local/corex to detect the correct CoreX version futher.
-## E.g. docker run --rm -it --privileged -v /var/run/docker.sock:/var/run/docker.sock gpustack/gpustack:main
-ENV ILUVATAR_VISIBLE_DEVICES="0"
+## Runs:
+## - With container runtime installed:
+##   [TODO, TBD]
+## - Without container runtime installed:
+##   + Allowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v /run/udev:/run/udev:ro -v /usr/local/corex:/usr/local/corex:ro -v /usr/bin/ixsmi:/usr/bin/ixsmi ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --security-opt seccomp=unconfined -v /dev:/dev:ro -v /run/udev:/run/udev:ro -v /usr/local/corex:/usr/local/corex:ro -v /usr/bin/ixsmi:/usr/bin/ixsmi...
+ENV ILUVATAR_VISIBLE_DEVICES="all"
 
 ## Active all MetaX devices detection,
 ## works with (default) MetaX container runtime and privileged mode.
 ## See https://developer.metax-tech.com/api/client/document/preview/626/k8s/03_component.html#container-runtime.
-## Requireds:
-## - Mount /opt/mxdriver from the host to support device detecting.
-## - Mount /opt/maca from the host to support device detecting.
-## Options:
-## - Mount /sys from the host to detect the correct devices' PCI info.
-## E.g. docker run --rm -it --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /opt/mxdriver:/opt/mxdriver:ro -v /opt/maca:/opt/maca -e  gpustack/gpustack:main
+## Runs:
+## - With container runtime installed:
+##   [TODO, TBD]
+## - Without container runtime installed:
+##   + Allowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v /opt/mxdriver:/opt/mxdriver:ro -v /opt/maca:/opt/maca:ro ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --security-opt seccomp=unconfined -v /dev:/dev:ro -v /opt/mxdriver:/opt/mxdriver:ro -v /opt/maca:/opt/maca:ro ...
 ENV LD_LIBRARY_PATH="/opt/maca/lib:/opt/maca/ompi/lib:/opt/maca/ucx/lib:/opt/mxdriver/lib:${LD_LIBRARY_PATH}" \
     GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT_IGNORE_VOLUMES="/opt/maca;${GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT_IGNORE_VOLUMES}"
 
-## Active all MThread devices detection,
-## works with (default) MThread container runtime and privileged mode.
+## Active all MThreads devices detection,
+## works with (default) MThreads container runtime and privileged mode.
 ## See https://docs.mthreads.com/cloud-native/cloud-native-doc-online/install_guide.
-## Options:
-## - Mount /sys from the host to detect the correct devices' PCI info.
-## E.g. docker run --rm -it --privileged -v /var/run/docker.sock:/var/run/docker.sock gpustack/gpustack:main
-ENV MTHREADS_VISIBLE_DEVICES="0" \
+## Runs:
+## - With container runtime installed:
+##   + If installed MThreads container runtime as default runtime, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged ...
+##   + If there are mulitple container runtimes installed, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged --runtime methreads ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock ...
+## - Without container runtime installed:
+##   [TODO, TBD]
+ENV MTHREADS_VISIBLE_DEVICES="all" \
     MTHREADS_DRIVER_CAPABILITIES="compute,utility"
 
 ## Active all NVIDIA devices detection,
 ## works with (default) NVIDIA container runtime and privileged mode.
 ## See https://docs.nvidia.com/deploy/nvml-api/nvml-api-reference.html#nvml-api-reference.
-## Options:
-## - Mount /sys from the host to detect the correct devices' PCI info.
-## E.g. docker run --rm -it --privileged -v /var/run/docker.sock:/var/run/docker.sock gpustack/gpustack:main
+## Runs:
+## - With container runtime installed:
+##   + If installed NVIDIA container runtime as default runtime, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged ...
+##   + If there are mulitple container runtimes installed, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged --runtime nvidia ...
+##   + Disallowing privileged, try with:
+##     docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock ...
+## - Without container runtime installed:
+##   [TODO, TBD]
 ENV NVIDIA_DISABLE_REQUIRE="true" \
-    NVIDIA_VISIBLE_DEVICES="0" \
+    NVIDIA_VISIBLE_DEVICES="all" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility"
 
 COPY --chmod=755 pack/entrypoint.sh /usr/bin/entrypoint.sh

--- a/poetry.lock
+++ b/poetry.lock
@@ -2784,13 +2784,13 @@ dataclasses-json = ">=0.6.7"
 
 [[package]]
 name = "gpustack-runtime"
-version = "0.1.23"
+version = "0.1.24"
 description = "GPUStack Runtime is library for detecting GPU resources and launching GPU workloads."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "gpustack_runtime-0.1.23-py3-none-any.whl", hash = "sha256:03de8c522c709be37e47165620c6cf786d36739b0dbf828f4d45fe0a5f16584e"},
-    {file = "gpustack_runtime-0.1.23.tar.gz", hash = "sha256:edcd0b3a884e68d0565fef6ff044d94e600ceafc7aaad2309bfb8bee3474e5df"},
+    {file = "gpustack_runtime-0.1.24-py3-none-any.whl", hash = "sha256:e4f0bf156a28736bb295c7df79504fdda267409eb7df437922e34e5cb8c5d6e1"},
+    {file = "gpustack_runtime-0.1.24.tar.gz", hash = "sha256:966081089b5562beb48a8f0e951b7c561a1c255139bdaef06bad365beb10b220"},
 ]
 
 [package.dependencies]
@@ -10692,4 +10692,4 @@ vllm = ["bitsandbytes", "mistral_common", "timm", "vllm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "b55fec7d1919ed5b3871a5423a5f54f5a602051b452a1f28789dbf8ab53d274e"
+content-hash = "6b4ab1b21a57c732de03c4663d2609aa92fd59089cbf36fbc5ed5a7b6c0013f9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ kubernetes-asyncio = "^33.1.0"
 msgpack = "^1.1.2"
 
 gpustack-runner = ">=0.1.11"
-gpustack-runtime = ">=0.1.23"
+gpustack-runtime = ">=0.1.24"
 
 [tool.poetry.group.dev.dependencies]
 installer = "0.7.0"


### PR DESCRIPTION
- Always update PCI ids, so that we can query the latest devices's name if needed.
- Change configured ${RUNTIME}_VISIBLE_DEVICES env to "all", allow related container runtime inject devices and libs.
- Since we don't know if there are Cambricon/Hygon/Iluvatar container runtime, we keep the corresponding env to "all" at present.
- Remove ASCEND_VISIBLE_DEVICES to avoid launching failure at non-zero initial device checks caused by virtual machine device pass-through.
- Update gpustack-runtime to help configure the right device indexes list when needs all devices injection.