### PR TITLE
fix: make ram_size and ram_ratio optional

### DIFF
--- a/gpustack/policies/utils.py
+++ b/gpustack/policies/utils.py
@@ -440,13 +440,15 @@ def get_model_ram_claim(model: Model) -> int:
     """
     Get the RAM requirement for the model in bytes.
     """
+    extended_kv_cache = model.extended_kv_cache
     if (
-        model.extended_kv_cache
-        and model.extended_kv_cache.enabled
-        and model.extended_kv_cache.ram_size > 0
+        extended_kv_cache
+        and extended_kv_cache.enabled
+        and extended_kv_cache.ram_size
+        and extended_kv_cache.ram_size > 0
     ):
         # When extended kv cache is enabled, reserve the ram for KV cache.
-        return model.extended_kv_cache.ram_size * 1024**3
+        return extended_kv_cache.ram_size * 1024**3
     return 0
 
 
@@ -459,16 +461,17 @@ def get_computed_ram_claim(model: Model, vram_claim: Dict[int, int]) -> Optional
     3. If neither is available, return None.
     """
 
-    if not model.extended_kv_cache or not model.extended_kv_cache.enabled:
+    extended_kv_cache = model.extended_kv_cache
+    if not extended_kv_cache or not extended_kv_cache.enabled:
         return None
 
-    if model.extended_kv_cache.ram_size > 0:
+    if extended_kv_cache.ram_size and extended_kv_cache.ram_size > 0:
         # static ram size
-        return model.extended_kv_cache.ram_size * 1024**3
+        return extended_kv_cache.ram_size * 1024**3
 
-    if model.extended_kv_cache.ram_ratio > 0 and vram_claim:
+    if extended_kv_cache.ram_ratio and extended_kv_cache.ram_ratio > 0 and vram_claim:
         # ram ratio to vram
         total_vram_claim = sum(vram_claim.values())
-        return int(total_vram_claim * model.extended_kv_cache.ram_ratio)
+        return int(total_vram_claim * extended_kv_cache.ram_ratio)
 
     return None

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -81,13 +81,13 @@ class ExtendedKVCacheConfig(BaseModel):
     enabled: bool = False
     """ Enable extended KV cache for the model."""
 
-    ram_ratio: float = 1.2
+    ram_ratio: Optional[float] = 1.2
     """ RAM-to-VRAM ratio for KV cache. For example, 2.0 means the RAM is twice the size of the VRAM. """
 
-    ram_size: int = 0
+    ram_size: Optional[int] = None
     """ Maximum size of the KV cache to be stored in local CPU memory (unit: GiB). Overrides ram_ratio if both are set. """
 
-    chunk_size: int = 0
+    chunk_size: Optional[int] = None
     """ Size for each KV cache chunk (unit: number of tokens). """
 
 

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -190,42 +190,32 @@ class SGLangServer(InferenceServer):
         """
         Get hierarchical KV cache arguments for SGLang.
         """
-        if not (
-            self._model.extended_kv_cache and self._model.extended_kv_cache.enabled
-        ):
+        extended_kv_cache = self._model.extended_kv_cache
+        if not (extended_kv_cache and extended_kv_cache.enabled):
             return []
 
         arguments = ["--enable-hierarchical-cache"]
-        if (
-            self._model.extended_kv_cache.chunk_size
-            and self._model.extended_kv_cache.chunk_size > 0
-        ):
+        if extended_kv_cache.chunk_size and extended_kv_cache.chunk_size > 0:
             arguments.extend(
                 [
                     "--page-size",
-                    str(self._model.extended_kv_cache.chunk_size),
+                    str(extended_kv_cache.chunk_size),
                 ]
             )
 
-        if (
-            self._model.extended_kv_cache.ram_size
-            and self._model.extended_kv_cache.ram_size > 0
-        ):
+        if extended_kv_cache.ram_size and extended_kv_cache.ram_size > 0:
             arguments.extend(
                 [
                     "--hicache-size",
-                    str(self._model.extended_kv_cache.ram_size),
+                    str(extended_kv_cache.ram_size),
                 ]
             )
 
-        if (
-            self._model.extended_kv_cache.ram_ratio
-            and self._model.extended_kv_cache.ram_ratio > 0
-        ):
+        if extended_kv_cache.ram_ratio and extended_kv_cache.ram_ratio > 0:
             arguments.extend(
                 [
                     "--hicache-ratio",
-                    str(self._model.extended_kv_cache.ram_ratio),
+                    str(extended_kv_cache.ram_ratio),
                 ]
             )
 

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -196,29 +196,17 @@ class VLLMServer(InferenceServer):
         """
         Set up LMCache environment variables if extended KV cache is enabled.
         """
-        if not (
-            self._model.extended_kv_cache and self._model.extended_kv_cache.enabled
-        ):
+        extended_kv_cache = self._model.extended_kv_cache
+        if not (extended_kv_cache and extended_kv_cache.enabled):
             return
 
-        if (
-            self._model.extended_kv_cache.chunk_size
-            and self._model.extended_kv_cache.chunk_size > 0
-        ):
-            env["LMCACHE_CHUNK_SIZE"] = str(self._model.extended_kv_cache.chunk_size)
+        if extended_kv_cache.chunk_size and extended_kv_cache.chunk_size > 0:
+            env["LMCACHE_CHUNK_SIZE"] = str(extended_kv_cache.chunk_size)
 
-        if (
-            self._model.extended_kv_cache.ram_size
-            and self._model.extended_kv_cache.ram_size > 0
-        ):
+        if extended_kv_cache.ram_size and extended_kv_cache.ram_size > 0:
             # Explicitly specified RAM size for KV cache
-            env["LMCACHE_MAX_LOCAL_CPU_SIZE"] = str(
-                self._model.extended_kv_cache.ram_size
-            )
-        elif (
-            self._model.extended_kv_cache.ram_ratio
-            and self._model.extended_kv_cache.ram_ratio > 0
-        ):
+            env["LMCACHE_MAX_LOCAL_CPU_SIZE"] = str(extended_kv_cache.ram_size)
+        elif extended_kv_cache.ram_ratio and extended_kv_cache.ram_ratio > 0:
             # Calculate RAM size based on ratio of total VRAM claim
             vram_claim = self._get_total_vram_claim()
             env["LMCACHE_MAX_LOCAL_CPU_SIZE"] = str(byte_to_gib(vram_claim))


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3103

Accepts null values and avoid returning 0 after creation by default.