### PR TITLE
fix: mysql migration

### DIFF
--- a/gpustack/migrations/versions/2025_10_28_1548-912d04e0d1d0_support_speculative_config.py
+++ b/gpustack/migrations/versions/2025_10_28_1548-912d04e0d1d0_support_speculative_config.py
@@ -35,8 +35,8 @@ def upgrade() -> None:
         op.create_table('modelinstancedraftmodelfilelink',
         sa.Column('model_instance_id', sa.Integer(), nullable=False),
         sa.Column('model_file_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['model_file_id'], ['model_files.id'], name='fk_model_instance_model_file_link_model_files', ondelete='RESTRICT'),
-        sa.ForeignKeyConstraint(['model_instance_id'], ['model_instances.id'], name='fk_model_instance_model_file_link_model_instances', ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['model_file_id'], ['model_files.id'], name='fk_model_instance_draft_model_file_link_model_files', ondelete='RESTRICT'),
+        sa.ForeignKeyConstraint(['model_instance_id'], ['model_instances.id'], name='fk_model_instance_draft_model_file_link_model_instances', ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('model_instance_id', 'model_file_id')
         )
 

--- a/gpustack/migrations/versions/2025_11_01_0034-2ea2c247a117_gateway_followup.py
+++ b/gpustack/migrations/versions/2025_11_01_0034-2ea2c247a117_gateway_followup.py
@@ -22,8 +22,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     with op.batch_alter_table("model_usages", schema=None) as batch_op:
-        batch_op.alter_column('operation', nullable=True)
-        batch_op.alter_column('user_id', nullable=True)
+        batch_op.alter_column('operation',existing_type=sa.VARCHAR(length=16), nullable=True)
+        batch_op.alter_column('user_id', existing_type=sa.Integer(), nullable=True)
         batch_op.add_column(sa.Column('access_key', sqlmodel.sql.sqltypes.AutoString(), nullable=True))
     with op.batch_alter_table("models", schema=None) as batch_op:
         batch_op.add_column(sa.Column('generic_proxy', sa.Boolean(), nullable=True, server_default=sa.sql.expression.false()))
@@ -34,7 +34,7 @@ def downgrade() -> None:
     )
     with op.batch_alter_table("model_usages", schema=None) as batch_op:
         batch_op.drop_column('access_key')
-        batch_op.alter_column('user_id', nullable=False)
-        batch_op.alter_column('operation', nullable=False)
+        batch_op.alter_column('user_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.alter_column('operation', existing_type=sa.VARCHAR(length=16), nullable=False)
     with op.batch_alter_table("models", schema=None) as batch_op:
         batch_op.drop_column('generic_proxy')


### PR DESCRIPTION
Two errors occur on fresh mysql migration:

1. pymysql.err.OperationalError) (1826, "Duplicate foreign key constraint name 'fk_model_instance_model_file_link_model_files'"
Rename FK constraint name.
3. 'Database migration failed: All MySQL CHANGE/MODIFY COLUMN operations require the existing type.'
Specify existing type for alter_column.