### PR TITLE
fix: avoid mutating workers argument

### DIFF
--- a/gpustack/policies/utils.py
+++ b/gpustack/policies/utils.py
@@ -582,7 +582,7 @@ async def sort_selected_workers_by_resource(
         ]
 
         # Create a copy of the worker with sorted GPUs
-        w = worker.model_copy()
+        w = worker.model_copy(deep=True)
         w.status.gpu_devices = sorted_gpus
         selected_workers.append(w)
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2990

Problem:
Manual scheduling may miss expected candidates. The cause is that `workers[].status.gpu_devices` is cleared unexpectedly in `sort_selected_workers_by_resource()`.


Solution:
Use deep copy. Add correlated test case.

Chore:
Add test case names to help diagnose on test failures.