### PR TITLE
fix: Repair the exception when the directory specified for a local source model does not exist.

### DIFF
--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -148,7 +148,7 @@ class ModelInstanceController:
 
         model_instance: ModelInstance = event.data
         try:
-            async with AsyncSession(self._engine) as session:
+            async with AsyncSession(self._engine, expire_on_commit=False) as session:
                 model = await Model.one_by_id(session, model_instance.model_id)
                 if not model:
                     return


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3198

Error handling and parameter safety:

* Updated the assignment of `d_head` in `_estimate_usage` to default to `0` if `head_dim` is `None`, preventing potential errors from undefined values.

Database session management:

* Modified the creation of `AsyncSession` in `_reconcile` to use `expire_on_commit=False`, ensuring that objects remain accessible after committing and reducing unnecessary database refreshes.
    - Although we previously addressed this issue (https://github.com/gpustack/gpustack/pull/3085), the `session.commit()` call during the retry operation caused associated objects to expire, subsequent `sync_instance_files_state()` still require extensive reading of model_instance and model_files, which will cause problems. 
    - As mentioned in the relevant section of [SQLAchemy's docs](https://docs.sqlalchemy.org/en/20/orm/session_basics.html#committing), setting `expire_on_commit=False` is the minimal change required to resolve this issue. This change does not affect transaction, commit, or rollback behaviors, it only impacts whether objects are marked as expired after commit(). Since we have added `session.refresh()` before `sync_ready_replicas`, there won't be issues with reading outdated values.
