### PR TITLE
refactor: relax validation for audio models

### DIFF
--- a/gpustack/scheduler/evaluator.py
+++ b/gpustack/scheduler/evaluator.py
@@ -27,7 +27,6 @@ from gpustack.schemas.models import (
     CategoryEnum,
     SourceEnum,
     get_backend,
-    is_audio_model,
     is_gguf_model,
 )
 from gpustack.schemas.workers import Worker, WorkerStateEnum
@@ -327,8 +326,8 @@ async def evaluate_model_metadata(
 
         if is_gguf_model(model):
             await scheduler.evaluate_gguf_model(config, model)
-        elif is_audio_model(model):
-            await scheduler.evaluate_audio_model(config, model)
+        elif model.backend == BackendEnum.VOX_BOX:
+            await scheduler.evaluate_vox_box_model(config, model)
         else:
             await scheduler.evaluate_pretrained_config(model)
 

--- a/gpustack/scheduler/scheduler.py
+++ b/gpustack/scheduler/scheduler.py
@@ -51,7 +51,6 @@ from gpustack.schemas.models import (
     SourceEnum,
     get_backend,
     is_gguf_model,
-    is_audio_model,
     DistributedServerCoordinateModeEnum,
 )
 from gpustack.server.bus import EventType
@@ -176,8 +175,8 @@ class Scheduler:
                             session, model, instance
                         ):
                             return
-                    elif is_audio_model(model):
-                        should_update_model = await evaluate_audio_model(
+                    elif model.backend == BackendEnum.VOX_BOX:
+                        should_update_model = await evaluate_vox_box_model(
                             self._config, model
                         )
                     else:
@@ -384,7 +383,7 @@ async def find_candidate(
     try:
         if is_gguf_model(model):
             candidates_selector = GGUFResourceFitSelector(model, config.cache_dir)
-        elif is_audio_model(model):
+        elif model.backend == BackendEnum.VOX_BOX:
             candidates_selector = VoxBoxResourceFitSelector(
                 config, model, config.cache_dir
             )
@@ -492,7 +491,7 @@ async def evaluate_gguf_model(
     return should_update
 
 
-async def evaluate_audio_model(
+async def evaluate_vox_box_model(
     config: Config,
     model: Model,
 ) -> bool:


### PR DESCRIPTION
Now audio models are considered to work with the vox-box backend only. With custom backend support, we should remove this assumption and relax some of the validations.