### PR TITLE
fix: failed on mindie pick subordinate worker info

### DIFF
--- a/gpustack/worker/backends/ascend_mindie.py
+++ b/gpustack/worker/backends/ascend_mindie.py
@@ -957,11 +957,7 @@ class AscendMindIEServer(InferenceServer):
 
         # - Device config
         backend_config["interNodeTLSEnabled"] = False
-        backend_config["npuDeviceIds"] = [
-            # Since we can reassemble the IDs of all visible devices through runtime,
-            # we can simply provide the count ID.
-            list(range(len(self._model_instance.gpu_indexes)))
-        ]
+        backend_config["npuDeviceIds"] = [self._model_instance.gpu_indexes]
         model_config["worldSize"] = len(self._model_instance.gpu_indexes)
         backend_config["multiNodesInferEnabled"] = False
         if is_distributed:
@@ -979,11 +975,7 @@ class AscendMindIEServer(InferenceServer):
                 None,
             )
             # Override device config if is a subordinate worker.
-            backend_config["npuDeviceIds"] = [
-                # Since we can reassemble the IDs of all visible devices through runtime,
-                # we can simply provide the count ID.
-                list(range(len(subworker.gpu_indexes)))
-            ]
+            backend_config["npuDeviceIds"] = [subworker.gpu_indexes]
             model_config["worldSize"] = len(subworker.gpu_indexes)
 
         # - Model config
@@ -1339,7 +1331,7 @@ class AscendMindIEServer(InferenceServer):
         if not image:
             raise ValueError("Failed to get Ascend MindIE backend image")
 
-        resources = self._get_configured_resources()
+        resources = self._get_configured_resources(mount_all_devices=True)
 
         mounts = self._get_configured_mounts()
 


### PR DESCRIPTION
Address https://github.com/gpustack/gpustack/issues/3225.

Revert the changed introduce by https://github.com/gpustack/gpustack/pull/3130.

Since MindIE can use `npuDevicesIds` field to pick the right devices,
so we mount all devices to containers, then let MindIE do selection.
