### PR TITLE
feat: Include host in run_command template

### DIFF
--- a/gpustack/schemas/inference_backend.py
+++ b/gpustack/schemas/inference_backend.py
@@ -124,6 +124,7 @@ class InferenceBackendBase(SQLModel):
         version: Optional[str],
         model_path: Optional[str],
         port: Optional[int],
+        worker_ip: Optional[str] = None,
         model_name: Optional[str] = None,
         command: Optional[str] = None,
     ) -> str:
@@ -134,6 +135,7 @@ class InferenceBackendBase(SQLModel):
 
         command = command.replace("{{model_path}}", model_path)
         command = command.replace("{{port}}", str(port))
+        command = command.replace("{{worker_ip}}", str(worker_ip))
         command = command.replace("{{model_name}}", model_name)
         return command
 

--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -76,6 +76,8 @@ class InferenceServer(ABC):
             self._model_instance = mi
             self._config = cfg
             self._worker = self._clientset.workers.get(worker_id)
+            if not self._worker:
+                raise KeyError(f"Worker {worker_id} not found")
 
             self.get_model()
             self.inference_backend = inference_backend
@@ -494,11 +496,12 @@ class InferenceServer(ABC):
             resolved_model_name = self._model_instance.model_name
 
             command = self.inference_backend.replace_command_param(
-                version,
-                resolved_model_path,
-                resolved_port,
-                resolved_model_name,
-                version_config.run_command,
+                version=version,
+                model_path=resolved_model_path,
+                port=resolved_port,
+                worker_ip=self._worker.ip,
+                model_name=resolved_model_name,
+                command=version_config.run_command,
             )
             if command:
                 return command.split()

--- a/gpustack/worker/backends/custom.py
+++ b/gpustack/worker/backends/custom.py
@@ -54,6 +54,7 @@ class CustomServer(InferenceServer):
             version=self._model.backend_version,
             model_path=self._model_path,
             port=self._get_serving_port(),
+            worker_ip=self._worker.ip,
             model_name=self._model.name,
             command=self._model.run_command,
         )


### PR DESCRIPTION
While addressing this issue https://github.com/gpustack/gpustack/issues/3224, we adjusted the host IP selection for backends(https://github.com/gpustack/gpustack/pull/3229). This adjustment also needs to be applied to custom backends, supporting the replacement of {{host}} in run_command with work_ip.