### PR TITLE
refactor: enhance mirrored deployment self container detection

### DIFF
--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -146,6 +146,20 @@ jobs:
           echo "DEBUG: GITHUB_REF=${GITHUB_REF}"
           echo "DEBUG: CACHE_FROM_REF=${CACHE_FROM_REF}"
           echo "DEBUG: CACHE_TO_REF=${CACHE_TO_REF}"
+      - name: Get Image Labels
+        run: |
+          #!/usr/bin/env bash
+
+          set -eo pipefail
+
+          LABELS=(
+            "org.opencontainers.image.source=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.source'] }}"
+            "org.opencontainers.image.version=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.version'] }}"
+            "org.opencontainers.image.revision=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.revision'] }}"
+            "org.opencontainers.image.created=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.created'] }}"
+          )
+          INPUT_DOCKER_MIRRORED_NAME_FILTER_LABELS=$(printf "%s;" "${LABELS[@]}")
+          echo "INPUT_DOCKER_MIRRORED_NAME_FILTER_LABELS=${INPUT_DOCKER_MIRRORED_NAME_FILTER_LABELS}" >> $GITHUB_ENV
       - name: Package
         uses: docker/build-push-action@v6
         with:
@@ -163,6 +177,7 @@ jobs:
           platforms: "linux/amd64,linux/arm64"
           build-args: |
             PYTHON_VERSION=${{ env.INPUT_PYTHON_VERSION }}
+            GPUSTACK_RUNTIME_DOCKER_MIRRORED_NAME_FILTER_LABELS=${{ env.INPUT_DOCKER_MIRRORED_NAME_FILTER_LABELS }}
           tags: |
             ${{ steps.metadata.outputs.tags }}
           labels: |

--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -264,6 +264,7 @@ class InferenceServer(ABC):
                             "_DISABLE_REQUIRE",
                             "_DRIVER_CAPABILITIES",
                             "_PATH",
+                            "_HOME",
                         )
                     )
                     or (

--- a/hack/package.sh
+++ b/hack/package.sh
@@ -32,6 +32,7 @@ function pack() {
             --bootstrap
     fi
 
+    LABELS=("org.opencontainers.image.source=https://github.com/gpustack/gpustack" "org.opencontainers.image.version=main" "org.opencontainers.image.revision=$(git rev-parse HEAD 2>/dev/null || echo "unknown")" "org.opencontainers.image.created=$(date +"%Y-%m-%dT%H:%M:%S.%s")");
     TAG="${PACKAGE_NAMESPACE}/${PACKAGE_REPOSITORY}:${PACKAGE_TAG}"
     EXTRA_ARGS=()
 	if [[ "${PACKAGE_WITH_CACHE}" == "true" ]]; then
@@ -53,6 +54,7 @@ function pack() {
         --ulimit nofile=65536:65536 \
         --shm-size 16G \
         --progress plain \
+        --build-arg "GPUSTACK_RUNTIME_DOCKER_MIRRORED_NAME_FILTER_LABELS=$(printf "%s;" "${LABELS[@]}")" \
         "${EXTRA_ARGS[@]}" \
         "${ROOT_DIR}"
     set +x

--- a/pack/Dockerfile
+++ b/pack/Dockerfile
@@ -17,11 +17,13 @@
 # - PYTHON_VERSION: Version of Python to use.
 # - GPUSTACK_BASE_IMAGE: Base image for the gpustack stage.
 # - GPUSTACK_RUNTIME_ROCM_VERSION: Version of ROCm detection library for gpustack-runtime, update this if project dependencies has changed.
+# - GPUSTACK_RUNTIME_DOCKER_MIRRORED_NAME_FILTER_LABELS: Semicolon-separated list of labels to filter mirrored images when deploying mirrored deployment.
 # - HIGRESS_VERSION: Version of Higress to use.
 # - HIGRESS_APISERVER_VERSION: Version of Higress API server to use.
 ARG PYTHON_VERSION=3.11
 ARG GPUSTACK_BASE_IMAGE=base
 ARG GPUSTACK_RUNTIME_ROCM_VERSION=6.2.4
+ARG GPUSTACK_RUNTIME_DOCKER_MIRRORED_NAME_FILTER_LABELS
 ARG HIGRESS_VERSION=2.1.8
 ARG HIGRESS_APISERVER_VERSION=0.0.25
 
@@ -660,6 +662,15 @@ ENV MTHREADS_VISIBLE_DEVICES="all" \
 ENV NVIDIA_DISABLE_REQUIRE="true" \
     NVIDIA_VISIBLE_DEVICES="all" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility"
+
+## Active GPUStack runtime mirrored deployment mode,
+## if getting an error like, "Found multiple Containers with the same hostname ...",
+## please use `--env GPUSTACK_RUNTIME_DEPLOY_MIRRORED_NAME=...` to specify the exact container name.
+##
+ARG GPUSTACK_RUNTIME_DOCKER_MIRRORED_NAME_FILTER_LABELS
+
+ENV GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT="true" \
+    GPUSTACK_RUNTIME_DOCKER_MIRRORED_NAME_FILTER_LABELS="${GPUSTACK_RUNTIME_DOCKER_MIRRORED_NAME_FILTER_LABELS}"
 
 COPY --chmod=755 pack/entrypoint.sh /usr/bin/entrypoint.sh
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2785,13 +2785,13 @@ dataclasses-json = ">=0.6.7"
 
 [[package]]
 name = "gpustack-runtime"
-version = "0.1.29"
+version = "0.1.30"
 description = "GPUStack Runtime is library for detecting GPU resources and launching GPU workloads."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "gpustack_runtime-0.1.29-py3-none-any.whl", hash = "sha256:ba795cc9ec043a7cb3299f9809c8eddda5dabc39e4e40b1eb565f952cd37c7e1"},
-    {file = "gpustack_runtime-0.1.29.tar.gz", hash = "sha256:4ba133c084b9f44aaac5b60a5afad26f89442bc795d61b1c76b08d5fd922b3e1"},
+    {file = "gpustack_runtime-0.1.30-py3-none-any.whl", hash = "sha256:36399128835607e9af7163d1583781aedc7d13034b46f764faba54106deaef81"},
+    {file = "gpustack_runtime-0.1.30.tar.gz", hash = "sha256:476fa8ded24bc1f015ff0652351ef4bf69b2880baa5e46b414c6d3cfbd5c9dcf"},
 ]
 
 [package.dependencies]
@@ -10694,4 +10694,4 @@ vllm = ["bitsandbytes", "mistral_common", "timm", "vllm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "39735da53bed8e5dc88a9492f3272acf313313405c6c1ae8f17865bb9530b0f4"
+content-hash = "e2e657ba35236f647524f820fad0c5a88f2a649c714b852fa8aecb71eb701732"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ kubernetes-asyncio = "^33.1.0"
 msgpack = "^1.1.2"
 
 gpustack-runner = ">=0.1.19"
-gpustack-runtime = "0.1.29"
+gpustack-runtime = "0.1.30"
 
 [tool.poetry.group.dev.dependencies]
 installer = "0.7.0"


### PR DESCRIPTION
Now, we turn `--env GPUSTACK_RUNTIME_DEPLOY_MIRRORED_NAME=...` to be optional.

We previously discussed this in https://github.com/gpustack/gpustack/issues/3099, and the current commands for adding workers to Docker nodes are somewhat complex. To improve the setup experience, this PR attempts to use CI-injected image labels to filter worker containers within the container and achieve runtime mirrored deployment.

This does not fundamentally solve the problem: Without a given name, it can deterministically find itself within the container under host networking or customized hostname. 

This PR should work if: 
1. When host networking is used, only one worker with a specific version(as we filter by the CI-injected labels, which include a timestamp label)
2. When bridge networking is used, don't configure `--hostname`.