### PR TITLE
fix: Prevent retention of quick config parameters after backend modifications.

### DIFF
--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -393,12 +393,11 @@ class ActiveRecordMixin:
         session: AsyncSession,
         source: Union[dict, SQLModel, None] = None,
         auto_commit=True,
-        exclude_unset=True,
     ):
         """Update the object with the source and save to the database."""
 
         if isinstance(source, SQLModel):
-            source = source.model_dump(exclude_unset=exclude_unset)
+            source = source.model_dump(exclude_unset=True)
         elif source is None:
             source = {}
 

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -253,13 +253,8 @@ class ModelService:
             return None
         return model.access_policy, cluster.registration_token
 
-    async def update(
-        self,
-        model: Model,
-        source: Union[dict, SQLModel, None] = None,
-        exclude_unset: bool = True,
-    ):
-        result = await model.update(self.session, source, exclude_unset=exclude_unset)
+    async def update(self, model: Model, source: Union[dict, SQLModel, None] = None):
+        result = await model.update(self.session, source)
         await delete_cache_by_key(self.get_by_id, model.id)
         await delete_cache_by_key(self.get_by_name, model.name)
         await delete_cache_by_key(self.get_model_auth_info_by_name, model.name)


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3188
https://github.com/gpustack/gpustack/issues/3277

In a previous commit, we addressed the exclude_unset issue (https://github.com/gpustack/gpustack/pull/3167#discussion_r2497914118). I found that setting it directly to True affects too many functionalities (as evidenced by the two issues mentioned above, both caused by unexpected nullification during updates). Therefore, we need to return to the original discussion about how to properly clear `run_command` and `image_name` when switching from `quick config` to a `built-in backend`.

I attempted to handle this as a special case in parameter validation, narrowing the scope of impact to resolve the origin issue.
