### PR TITLE
fix: put token usage plugin in front of ext-auth

### DIFF
--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -228,6 +228,7 @@ def ext_auth_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
             "http_service": {
                 "authorization_request": {
                     "allowed_headers": [
+                        {"exact": "X-GPUStack-Real-IP"},
                         {"exact": "x-higress-llm-model"},
                         {"exact": "cookie"},
                     ]
@@ -349,8 +350,8 @@ def token_usage_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         failStrategy="FAIL_OPEN",
         imagePullPolicy="UNSPECIFIED_POLICY",
         matchRules=[],
-        phase="UNSPECIFIED_PHASE",
-        priority=920,
+        phase="AUTHN",
+        priority=900,
         url=get_plugin_url_with_name_and_version(
             name="gpustack-token-usage", version="1.0.0", cfg=cfg
         ),


### PR DESCRIPTION
Then ext-auth can use X-GPUStack-Real-IP to determine whether the request is from 127.0.0.1

Refer to issue:
- #3196 