### PR TITLE
fix: pagination in model sets and draft models

### DIFF
--- a/gpustack/routes/draft_models.py
+++ b/gpustack/routes/draft_models.py
@@ -31,6 +31,18 @@ async def get_draft_models(
         ]
 
     count = len(draft_models)
+
+    if params.page < 1 or params.perPage < 1:
+        # Return all items.
+        pagination = Pagination(
+            page=1,
+            perPage=count,
+            total=count,
+            totalPage=1,
+        )
+        return PaginatedList[DraftModel](items=draft_models, pagination=pagination)
+
+    # Paginate results.
     total_page = math.ceil(count / params.perPage)
 
     start_index = (params.page - 1) * params.perPage

--- a/gpustack/routes/model_sets.py
+++ b/gpustack/routes/model_sets.py
@@ -40,6 +40,18 @@ async def get_model_sets(
         ]
 
     count = len(model_sets)
+
+    if params.page < 1 or params.perPage < 1:
+        # Return all items.
+        pagination = Pagination(
+            page=1,
+            perPage=count,
+            total=count,
+            totalPage=1,
+        )
+        return PaginatedList[ModelSetPublic](items=model_sets, pagination=pagination)
+
+    # Paginate results.
     total_page = math.ceil(count / params.perPage)
 
     start_index = (params.page - 1) * params.perPage


### PR DESCRIPTION
Problem:
Now UI query using /v1/draft-models?page=-1 and API returns empty result.

Solution:
Support return all items by page/perPage<1 for draft-models and model-sets.