### PR TITLE
fix: bump gpustack-token-usage plugin version

### DIFF
--- a/gpustack/gateway/plugins.py
+++ b/gpustack/gateway/plugins.py
@@ -57,7 +57,7 @@ supported_plugins: List[HigressPlugin] = [
     HigressPlugin(
         name="gpustack-token-usage",
         version="1.0.0",
-        digest="sha256:d2228e4db0f5600c932ec92e2e121aba61ee175f20444c2a3666c29a5831a1f0",
+        digest="sha256:708c71b15707c16682dfc4c08b3573c0c6a94d3514e669cf12e4d6c4d27388fd",
         registry_prefix="oci://docker.io/gpustack/higress-plugin-",
     ),
 ]


### PR DESCRIPTION
To fix incomplete response for non-streaming chat request.
Related commits: https://github.com/gpustack/gpustack-higress-plugin/commit/968b5620d3ec4d1ca81e192c40964eb4d8e54e2c

Refer to issue:
- #3371 