### PR TITLE
fix: container logs is ready even if it returns spaces or newline

### DIFF
--- a/gpustack/routes/worker/logs.py
+++ b/gpustack/routes/worker/logs.py
@@ -25,14 +25,12 @@ logger = logging.getLogger(__name__)
 def is_container_logs_ready(model_instance_name: str) -> bool:
     """Probe whether container logs have any content available to output."""
     try:
-        probe_stream = logs_workload(
+        logs_workload(
             name=model_instance_name,
             tail=1,
             follow=False,
         )
-        if isinstance(probe_stream, bytes):
-            return bool(probe_stream.strip())
-        return bool(str(probe_stream).strip())
+        return True
     except Exception:
         return False
 


### PR DESCRIPTION
Run logs_workload without exception means logs is ready
Refer to issue: #3320 