### PR TITLE
feat: Refactor Docker Hub reachability checks and update configuration handling

### DIFF
--- a/gpustack/config/registration.py
+++ b/gpustack/config/registration.py
@@ -11,6 +11,8 @@ from gpustack.utils.uuid import get_legacy_uuid, get_system_uuid
 registration_token_filename = "token"
 worker_token_filename = "worker_token"
 
+dockerhub_reachable: Optional[bool] = None
+
 
 def read_token(data_dir: str, filename) -> Optional[str]:
     token_path = os.path.join(data_dir, filename)

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -339,6 +339,7 @@ class ClusterRegistrationTokenPublic(BaseModel):
     token: str
     server_url: str
     image: str
+    container_registry: Optional[str] = None
 
 
 class CredentialType(str, Enum):

--- a/gpustack/utils/network.py
+++ b/gpustack/utils/network.py
@@ -9,6 +9,8 @@ import psutil
 from datetime import datetime, timezone
 import ipaddress
 
+import requests
+
 
 def normalize_route_path(path: str) -> str:
     """
@@ -192,3 +194,19 @@ def is_offline(
     is_offline_flag = (now_ts - last_update_ts) > timeout_seconds
     last_update_str = last_update.strftime("%Y-%m-%d %H:%M:%S UTC")
     return is_offline_flag, last_update_str
+
+
+async def check_docker_hub_reachable() -> bool:
+    """
+    Check if Docker Hub is reachable.
+    To avoid frequent checks, cache the result for a short period via global lock.
+
+    Returns:
+        bool: True if Docker Hub is reachable, False otherwise.
+    """
+    try:
+        resp = requests.get("https://registry-1.docker.io/v2/", timeout=3)
+        reachable = resp.status_code < 500
+    except Exception:
+        reachable = False
+    return reachable

--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -20,6 +20,7 @@ from gpustack_runtime.detector.ascend import get_ascend_cann_variant
 from gpustack_runtime import envs as runtime_envs
 from gpustack_runtime.envs import to_bool
 from gpustack_runtime.logging import setup_logging as setup_runtime_logging
+from gpustack.config import registration as registration
 
 from gpustack.client.generated_clientset import ClientSet
 from gpustack.config.config import Config, set_global_config
@@ -45,8 +46,6 @@ from gpustack.utils import platform
 
 logger = logging.getLogger(__name__)
 lock = threading.Lock()
-
-_is_docker_hub_reachable: Optional[bool] = None
 
 
 class ModelInstanceStateError(Exception):
@@ -840,7 +839,7 @@ $@
         # 4) Otherwise, check if Docker Hub is reachable.
         #    If it is, prefix the image with "docker.io".
         #    Otherwise, prefix it with "quay.io".
-        if get_dockerhub_reachable():
+        if registration.dockerhub_reachable:
             logger.info(
                 f"Docker Hub reachable; using Docker Hub for gpustack image: {image}"
             )
@@ -893,12 +892,3 @@ def cal_distributed_parallelism_arguments(
             f"The number of GPUs selected for each worker is not equal: {num_gpus} != {tp}, fallback to using pipeline parallelism."
         )
     return tp, pp
-
-
-def set_dockerhub_reachable(reachable: bool):
-    global _is_docker_hub_reachable
-    _is_docker_hub_reachable = reachable
-
-
-def get_dockerhub_reachable() -> Optional[bool]:
-    return _is_docker_hub_reachable

--- a/gpustack/worker/inference_backend_manager.py
+++ b/gpustack/worker/inference_backend_manager.py
@@ -3,12 +3,11 @@ import logging
 import threading
 from typing import Dict, Optional
 
-import requests
 
 from gpustack.client import ClientSet
 from gpustack.schemas.inference_backend import InferenceBackend
 from gpustack.server.bus import EventType, Event
-from gpustack.worker.backends.base import set_dockerhub_reachable
+
 
 logger = logging.getLogger(__name__)
 
@@ -122,18 +121,3 @@ class InferenceBackendManager:
 
         except Exception as e:
             logger.error(f"Error handling InferenceBackend event: {e}")
-
-    async def check_docker_hub_reachable(self):
-        """
-        Check if Docker Hub is reachable.
-        To avoid frequent checks, cache the result for a short period via global lock.
-
-        Returns:
-            bool: True if Docker Hub is reachable, False otherwise.
-        """
-        try:
-            resp = requests.get("https://registry-1.docker.io/v2/", timeout=3)
-            _is_docker_hub_reachable = resp.status_code < 500
-        except Exception:
-            _is_docker_hub_reachable = False
-        set_dockerhub_reachable(_is_docker_hub_reachable)

--- a/gpustack/worker/worker.py
+++ b/gpustack/worker/worker.py
@@ -23,6 +23,7 @@ from gpustack.server import catalog
 from gpustack.utils.network import (
     get_first_non_loopback_ip,
     get_ifname_by_ip_hostname,
+    check_docker_hub_reachable,
 )
 from gpustack.client import ClientSet
 from gpustack.logging import setup_logging
@@ -38,6 +39,7 @@ from gpustack.worker.tools_manager import ToolsManager
 from gpustack.worker.worker_manager import WorkerManager
 from gpustack.worker.collector import WorkerStatusCollector
 from gpustack.config.registration import read_worker_token
+from gpustack.config import registration
 from gpustack.worker.worker_gateway import WorkerGatewayController
 from gpustack.gateway.plugins import register as register_gateway_plugins
 
@@ -223,7 +225,8 @@ class Worker:
         inference_backend_manager = InferenceBackendManager(self._clientset)
         # Start InferenceBackend listener to cache backend data
         self._create_async_task(inference_backend_manager.start_listener())
-        self._create_async_task(inference_backend_manager.check_docker_hub_reachable())
+        reachable = await check_docker_hub_reachable()
+        registration.dockerhub_reachable = reachable
 
         serve_manager = ServeManager(
             worker_id=self._worker_id,

--- a/tests/worker/backends/test_backend.py
+++ b/tests/worker/backends/test_backend.py
@@ -2,6 +2,7 @@ import types
 
 import pytest
 
+from gpustack.config import registration
 from gpustack.worker.backends.custom import CustomServer
 
 
@@ -58,10 +59,7 @@ async def test_apply_registry_override(
     backend._config = types.SimpleNamespace(
         system_default_container_registry=container_registry
     )
-    monkeypatch.setattr(
-        "gpustack.worker.backends.base.get_dockerhub_reachable",
-        lambda: can_connet_dockerhub,
-    )
+    registration.dockerhub_reachable = can_connet_dockerhub
     assert backend._apply_registry_override(image_name) == expect_image_name
 
     if container_registry:


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3159#issuecomment-3535439920

Perform DockerHub connectivity checks during both server and worker startup, record the results in the global `Config` for use in subsequent processes. Add a `registry_url` field to the response parameters of the /v1/clusters/{id}/registration-token API, enabling the frontend to modify worker addition instructions accordingly.