### PR TITLE
fix: SGLang scheduling

### DIFF
--- a/gpustack/policies/candidate_selectors/sglang_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/sglang_resource_fit_selector.py
@@ -170,19 +170,9 @@ class SGLangResourceFitSelector(ScheduleCandidatesSelector):
                 raise ValueError(f"tp-size {world_size} must be divisible by nnodes")
 
         if pp_size and int(pp_size) > 1:
-            disable_overlap_schedule_param = find_parameter(
-                model.backend_parameters, ["disable-overlap-schedule"]
-            )
-            disable_overlap_schedule = (
-                strtobool(disable_overlap_schedule_param)
-                if disable_overlap_schedule_param is not None
-                else False
-            )
-            if (
-                not disable_overlap_schedule
-                or speculative_algorithm is not None
-                or enable_mixed_chunk
-            ):
+            if speculative_algorithm is not None or enable_mixed_chunk:
+                # We don't need to check overlap schedule. SGLang ignore this conflict and proceed.
+                # Ref: https://github.com/sgl-project/sglang/blob/64480ec7124b8c23d9560746ca20415bfaf97a8e/python/sglang/srt/server_args.py#L1548-L1553
                 raise ValueError(
                     "Pipeline parallelism is not compatible with overlap schedule, speculative decoding, mixed chunked prefill."
                 )

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -534,7 +534,14 @@ def get_auto_parallelism_arguments(
 
     parallelism = find_parameter(
         backend_parameters,
-        ["tp-size", "tp", "pp-size", "pp", "data-parallel-size", "dp-size"],
+        [
+            "tensor-parallel-size",
+            "tp-size",
+            "pipeline-parallel-size",
+            "pp-size",
+            "data-parallel-size",
+            "dp-size",
+        ],
     )
 
     if parallelism is not None:

--- a/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
@@ -76,6 +76,32 @@ def expected_candidate(
             ],
             0,
         ),
+        # Auto schedule two GPUs from 1 worker with PP2 parameter.
+        # Check point:
+        # - Candidate selection correctness.
+        # - pp-size parameter handling.
+        (
+            "auto_select_2_gpus_1_worker_pp2",
+            new_model(
+                1,
+                "test_name",
+                1,
+                huggingface_repo_id="Qwen/Qwen3-0.6B",
+                backend_parameters=["--pipeline-parallel-size=2"],
+            ),
+            [
+                linux_nvidia_2_4080_16gx2(),
+            ],
+            [
+                expected_candidate(
+                    3,
+                    "host4080",
+                    [0, 1],
+                    {0: 15454332518, 1: 15454332518},
+                )
+            ],
+            0,
+        ),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
Partially(SGlang part) address https://github.com/gpustack/gpustack/issues/2501#issuecomment-3556098187


Case 1. Setting dp2 parameter results in single-GPU schedule candidate.
Case 2. GPUStack validation blocks PP while SGLang works.
Case 3. Parallelism does not match expected SGLang parameters and causes unexpected results