### PR TITLE
fix: TPOT calculates more accurately

### DIFF
--- a/gpustack/api/middlewares.py
+++ b/gpustack/api/middlewares.py
@@ -280,7 +280,8 @@ def add_metrics(response_dict, request, response_chunk):
     tokens_after_first = max(response_chunk.usage.completion_tokens - 1, 1)
     time_per_output_token_ms = (
         (now - request.state.first_token_time).total_seconds()
-        * 1000 / tokens_after_first
+        * 1000
+        / tokens_after_first
     )
 
     tokens_per_second = (


### PR DESCRIPTION
## What does this PR do?
> This PR makes TPOT calculations more accurate.

## GPUStack version
>main 

### Implementation Overview
>TPOT Calculation: Exclude the generation time of the first token and focus on the generation speed of subsequent tokens, which more accurately reflects the model's sustained generation capability.

### Before
```
    time_per_output_token_ms = (
        (now - request.state.first_token_time).total_seconds()
        * 1000
        / max(response_chunk.usage.completion_tokens, 1)
    )
```

### After
```
    tokens_after_first = max(response_chunk.usage.completion_tokens - 1, 1)
    time_per_output_token_ms = (
        (now - request.state.first_token_time).total_seconds()
        * 1000 / tokens_after_first
    )
```
