### PR TITLE
When a timeout error occurs due to the absence of a configured HF_TOKEN, the log does not contain clear error step information, only printing "Error evaluating model xxx:".

### DIFF
--- a/gpustack/scheduler/evaluator.py
+++ b/gpustack/scheduler/evaluator.py
@@ -147,7 +147,7 @@ async def evaluate_model_with_cache(
             result = await evaluate_model(config, session, model, workers)
             evaluate_cache[cache_key] = result
     except Exception as e:
-        logger.error(
+        logger.exception(
             f"Error evaluating model {model.name or model.readable_source}: {e}"
         )
         result = ModelEvaluationResult(


### PR DESCRIPTION
Users are unaware of where the failure occurred.