### PR TITLE
fix: Supports image name with overrided registry

### DIFF
--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -592,17 +592,14 @@ class Config(BaseSettings):
     def _is_server(self):
         return self.server_url is None
 
-    def get_image_name(self) -> str:
+    def get_image_name(self, override: Optional[str]) -> str:
         if self.image_name_override:
             return self.image_name_override
         version = __version__
         if version.removeprefix("v") == "0.0.0":
             version = "main"
-        prefix = (
-            f"{self.system_default_container_registry}/"
-            if self.system_default_container_registry
-            else ""
-        )
+        registry = override or self.system_default_container_registry
+        prefix = f"{registry}/" if registry else ""
         return f"{prefix}{self.image_repo}:{version}"
 
     def higress_base_dir(self) -> str:

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -222,7 +222,7 @@ async def get_registration_token(request: Request, session: SessionDep, id: int)
         raise NotFoundException(message=f"cluster {id} not found")
     url = get_server_url(request)
     cfg = get_global_config()
-    container_registry = ""
+    container_registry = None
     if cfg.system_default_container_registry:
         container_registry = cfg.system_default_container_registry
     elif not registration.dockerhub_reachable:
@@ -231,8 +231,9 @@ async def get_registration_token(request: Request, session: SessionDep, id: int)
     return ClusterRegistrationTokenPublic(
         token=cluster.registration_token,
         server_url=url,
-        image=get_global_config().get_image_name(),  # Default image, can be customized
-        container_registry=container_registry,
+        image=get_global_config().get_image_name(
+            container_registry
+        ),  # Default image, can be customized
     )
 
 

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -348,7 +348,6 @@ class ClusterRegistrationTokenPublic(BaseModel):
     token: str
     server_url: str
     image: str
-    container_registry: Optional[str] = None
 
 
 class CredentialType(str, Enum):


### PR DESCRIPTION
When using quay.io overrides default registry
Refer to issue: #3417 