### PR TITLE
feat: check for both quay.io and dockerhub for fallback registry

### DIFF
--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -222,11 +222,9 @@ async def get_registration_token(request: Request, session: SessionDep, id: int)
         raise NotFoundException(message=f"cluster {id} not found")
     url = get_server_url(request)
     cfg = get_global_config()
-    container_registry = None
-    if cfg.system_default_container_registry:
-        container_registry = cfg.system_default_container_registry
-    elif not registration.dockerhub_reachable:
-        container_registry = "quay.io"
+    container_registry = registration.determine_default_registry(
+        cfg.system_default_container_registry
+    )
 
     return ClusterRegistrationTokenPublic(
         token=cluster.registration_token,

--- a/gpustack/utils/network.py
+++ b/gpustack/utils/network.py
@@ -196,16 +196,17 @@ def is_offline(
     return is_offline_flag, last_update_str
 
 
-async def check_docker_hub_reachable() -> bool:
+def check_registry_reachable(address: str) -> bool:
     """
-    Check if Docker Hub is reachable.
+    Check if the registry is reachable.
     To avoid frequent checks, cache the result for a short period via global lock.
 
     Returns:
-        bool: True if Docker Hub is reachable, False otherwise.
+        bool: True if the registry is reachable, False otherwise.
     """
+    url = f"{address}/v2/"
     try:
-        resp = requests.get("https://registry-1.docker.io/v2/", timeout=3)
+        resp = requests.get(url, timeout=3)
         reachable = resp.status_code < 500
     except Exception:
         reachable = False

--- a/gpustack/worker/backends/ascend_mindie.py
+++ b/gpustack/worker/backends/ascend_mindie.py
@@ -1498,7 +1498,8 @@ class AscendMindIEServer(InferenceServer):
             shm_size=10 * 1 << 30,  # 10 GiB
             containers=[run_container],
         )
-        create_workload(workload_plan)
+
+        create_workload(self._transform_workload_plan(workload_plan))
 
         logger.info(f"Created Ascend MindIE container workload {self._workload_name}")
 

--- a/gpustack/worker/backends/custom.py
+++ b/gpustack/worker/backends/custom.py
@@ -122,6 +122,6 @@ class CustomServer(InferenceServer):
             shm_size=10 * 1 << 30,  # 10 GiB
             containers=[run_container],
         )
-        create_workload(workload_plan)
+        create_workload(self._transform_workload_plan(workload_plan))
 
         logger.info(f"Created container workload {self._workload_name}")

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -164,7 +164,7 @@ class SGLangServer(InferenceServer):
             f"envs(inconsistent input items mean unchangeable):{os.linesep}"
             f"{os.linesep.join(f'{k}={v}' for k, v in sorted(sanitize_env(env).items()))}"
         )
-        create_workload(workload_plan)
+        create_workload(self._transform_workload_plan(workload_plan))
 
         logger.info(
             f"SGLang container workload {self._workload_name} created successfully"

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -178,7 +178,7 @@ class VLLMServer(InferenceServer):
                 else [run_container, sidecar_container]
             ),
         )
-        create_workload(workload_plan)
+        create_workload(self._transform_workload_plan(workload_plan))
 
         logger.info(f"Created vLLM container workload {self._workload_name}")
 

--- a/gpustack/worker/backends/vox_box.py
+++ b/gpustack/worker/backends/vox_box.py
@@ -103,7 +103,7 @@ class VoxBoxServer(InferenceServer):
             shm_size=10 * 1 << 30,  # 10 GiB
             containers=[run_container],
         )
-        create_workload(workload_plan)
+        create_workload(self._transform_workload_plan(workload_plan))
 
         logger.info(f"Created Vox-Box container workload {self._workload_name}")
 

--- a/gpustack/worker/worker.py
+++ b/gpustack/worker/worker.py
@@ -23,7 +23,6 @@ from gpustack.server import catalog
 from gpustack.utils.network import (
     get_first_non_loopback_ip,
     get_ifname_by_ip_hostname,
-    check_docker_hub_reachable,
 )
 from gpustack.client import ClientSet
 from gpustack.logging import setup_logging
@@ -225,8 +224,10 @@ class Worker:
         inference_backend_manager = InferenceBackendManager(self._clientset)
         # Start InferenceBackend listener to cache backend data
         self._create_async_task(inference_backend_manager.start_listener())
-        reachable = await check_docker_hub_reachable()
-        registration.dockerhub_reachable = reachable
+        # Trigger cache refresh
+        registration.determine_default_registry(
+            self._config.system_default_container_registry
+        )
 
         serve_manager = ServeManager(
             worker_id=self._worker_id,


### PR DESCRIPTION
If both of the fallback registries are not reachable, use docker.io as default
Refer to issue: #3435 
