### PR TITLE
ci: ignore scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+scratch/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -68,6 +68,11 @@ function gpustack::version::get_version_vars() {
 
     # specify to v0.0.0 if the tree is dirty.
     if [[ "${GIT_TREE_STATE:-dirty}" == "dirty" ]]; then
+      echo "GIT Tree is dirty"
+      echo "======= GIT STATUS ======="
+      git status --short
+      echo "======= GIT DIFF ======="
+      git --no-pager diff
       GIT_VERSION="v0.0.0"
     elif ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-?[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
       GIT_VERSION="v0.0.0"


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3469

The scratch directory breaks tag CI. It's unclear how it's created in the build CI. Add it to gitignore.

Diagnose via https://github.com/gitlawr/gpustack/actions/runs/19611454712
Verified via https://github.com/gitlawr/gpustack/actions/runs/19611605564