### PR TITLE
Add deployment instructions for GGUF models with llama.cpp

### DIFF
--- a/docs/tutorials/using-custom-backends.md
+++ b/docs/tutorials/using-custom-backends.md
@@ -76,8 +76,8 @@ Screenshots:
     default_version: v1-custom
     ```
    ROCM gpu
-   a) use docker.io/rocm/llama.cpp:llama.cpp-b6652.amd0_rocm7.0.0_ubuntu24.04_full
-   b) use docker.io/rocm/llama.cpp:llama.cpp-b6356_rocm6.4.3_ubuntu22.04_full
+   a) use docker.io/rocm/llama.cpp:llama.cpp-b6652.amd0_rocm7.0.0_ubuntu24.04_server
+   b) use docker.io/rocm/llama.cpp:llama.cpp-b6356_rocm6.4.3_ubuntu22.04_server
    
 3. On the Deployment page, locate a GGUF-format model, select `llama.cpp`, and deploy.
    ghcr.io/ggml-org/llama.cpp:server-vulkan


### PR DESCRIPTION
Added instructions for deploying GGUF models using llama.cpp on AMD GPUs.

<img width="3351" height="1279" alt="Снимок экрана от 2025-11-24 02-29-36" src="https://github.com/user-attachments/assets/20470954-2b25-42c3-b129-dca93d07a7cc" />


<img width="3338" height="1298" alt="Снимок экрана от 2025-11-24 02-30-12" src="https://github.com/user-attachments/assets/0c6c6c59-78a8-4966-bbe5-0f442fb48539" />

<img width="3343" height="1104" alt="Снимок экрана от 2025-11-24 02-32-24" src="https://github.com/user-attachments/assets/e7dd1661-457e-42bf-956d-c6da0b4c0da7" />

