### PR TITLE
fix: add nodes readonly privilege for gpustack-worker in k8s

### DIFF
--- a/gpustack/k8s/manifests.jinja
+++ b/gpustack/k8s/manifests.jinja
@@ -22,6 +22,9 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingressclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Related issue:
- #3513 