### PR TITLE
feat: support re-register worker if worker_token is not vaild

### DIFF
--- a/gpustack/client/generated_inference_backend_client.py
+++ b/gpustack/client/generated_inference_backend_client.py
@@ -13,7 +13,7 @@ from .generated_http_client import HTTPClient
 class InferenceBackendClient:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/inference-backends"
+        self._url = "/inference-backends"
 
     def list(self, params: Dict[str, Any] = None) -> InferenceBackendsPublic:
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_model_client.py
+++ b/gpustack/client/generated_model_client.py
@@ -13,7 +13,7 @@ from .generated_http_client import HTTPClient
 class ModelClient:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/models"
+        self._url = "/models"
 
     def list(self, params: Dict[str, Any] = None) -> ModelsPublic:
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_model_file_client.py
+++ b/gpustack/client/generated_model_file_client.py
@@ -13,7 +13,7 @@ from .generated_http_client import HTTPClient
 class ModelFileClient:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/model-files"
+        self._url = "/model-files"
 
     def list(self, params: Dict[str, Any] = None) -> ModelFilesPublic:
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_model_instance_client.py
+++ b/gpustack/client/generated_model_instance_client.py
@@ -13,7 +13,7 @@ from .generated_http_client import HTTPClient
 class ModelInstanceClient:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/model-instances"
+        self._url = "/model-instances"
 
     def list(self, params: Dict[str, Any] = None) -> ModelInstancesPublic:
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_user_client.py
+++ b/gpustack/client/generated_user_client.py
@@ -13,7 +13,7 @@ from .generated_http_client import HTTPClient
 class UserClient:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/users"
+        self._url = "/users"
 
     def list(self, params: Dict[str, Any] = None) -> UsersPublic:
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_worker_client.py
+++ b/gpustack/client/generated_worker_client.py
@@ -13,7 +13,7 @@ from .generated_http_client import HTTPClient
 class WorkerClient:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/workers"
+        self._url = "/workers"
 
     def list(self, params: Dict[str, Any] = None) -> WorkersPublic:
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/worker_manager_clients.py
+++ b/gpustack/client/worker_manager_clients.py
@@ -10,7 +10,7 @@ from .generated_http_client import HTTPClient
 class WorkerStatusClient:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/worker-status"
+        self._url = "/worker-status"
 
     def create(self, model_create: WorkerStatusPublic):
         response = self._client.get_httpx_client().post(
@@ -25,7 +25,7 @@ class WorkerStatusClient:
 class WorkerRegistrationClient:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/workers"
+        self._url = "/workers"
 
     def create(self, model_create: WorkerCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/codegen/templates/client.py.jinja
+++ b/gpustack/codegen/templates/client.py.jinja
@@ -13,7 +13,7 @@ from .generated_http_client import HTTPClient
 class {{ class_name }}Client:
     def __init__(self, client: HTTPClient):
         self._client = client
-        self._url = f"{client._base_url}/v2/{{ class_name | to_dash_plural }}"
+        self._url = "/{{ class_name | to_dash_plural }}"
 
     def list(self, params: Dict[str, Any] = None) -> {{ class_name | to_plural }}Public:
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/config/registration.py
+++ b/gpustack/config/registration.py
@@ -56,9 +56,6 @@ def registration_client(
     wait_token_file: bool = False,
 ) -> Optional[WorkerRegistrationClient]:
     # if token exists, skip registration
-    worker_token = read_worker_token(data_dir)
-    if worker_token is not None:
-        return None
     if registration_token is None and wait_token_file:
         timeout = 10
         start_time = time.time()

--- a/gpustack/worker/inference_backend_manager.py
+++ b/gpustack/worker/inference_backend_manager.py
@@ -61,7 +61,7 @@ class InferenceBackendManager:
         try:
             logger.info("Initializing InferenceBackend cache")
             resp = self._clientset.http_client.get_httpx_client().get(
-                self._clientset.base_url + "/v2/inference-backends/all"
+                "/inference-backends/all"
             )
             backends = resp.json()
             if backends:


### PR DESCRIPTION
Also Improve the clientset with centralizing the v2 versioned prefix.

Refer to issue:
- #3528 