### PR TITLE
fix: ensure lock directory is created if it does not exist

### DIFF
--- a/gpustack/utils/locks.py
+++ b/gpustack/utils/locks.py
@@ -121,6 +121,9 @@ class HeartbeatSoftFileLock:
             self._release_os_lock()
 
     def _acquire_os_lock(self):
+        dirpath = os.path.dirname(self._lock_path)
+        if dirpath:
+            os.makedirs(dirpath, exist_ok=True)
         fd = os.open(self._lock_path, os.O_CREAT | os.O_RDWR, 0o644)
         try:
             fcntl.lockf(fd, fcntl.LOCK_EX)


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/1621#issuecomment-3562342405

If directories in the path are not created when executing `os.open(self._lock_path, os.O_CREAT | os.O_RDWR, 0o644)`, an exception will be thrown. Ensure the complete path exists.