### PR TITLE
feat: add L3 disk cache support for extended KV cache (LMCache and HiCache)

### DIFF
--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -369,10 +369,10 @@ def start_cmd_options(parser_server: argparse.ArgumentParser):
         "Default value is direct for embedded worker, and worker for standalone worker.",
     )
     group.add_argument(
-        "--kv-cache-disk-path",
+        "--kv-cache-dir",
         type=str,
-        help="Path to SSD storage for KV cache offloading (L3 cache). If set, enables disk-based cache for extended KV cache. The path should be accessible from the container.",
-        default=get_gpustack_env("KV_CACHE_DISK_PATH"),
+        help="Directory for KV cache storage (L3 cache). Default is <cache-dir>/kv_cache. The path should be accessible from the container.",
+        default=get_gpustack_env("KV_CACHE_DIR"),
     )
 
     group.add_argument(
@@ -711,7 +711,7 @@ def set_worker_options(args, config_data: dict):
         "enable_hf_transfer",
         "enable_hf_xet",
         "proxy_mode",
-        "kv_cache_disk_path",
+        "kv_cache_dir",
     ]
 
     for option in options:

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -57,7 +57,7 @@ class WorkerConfig(PredefinedConfig):
     worker_ip: Optional[str] = None
     worker_ifname: Optional[str] = None
     worker_name: Optional[str] = None
-    kv_cache_disk_path: Optional[str] = None
+    kv_cache_dir: Optional[str] = None
 
 
 class Config(WorkerConfig, BaseSettings):
@@ -205,6 +205,9 @@ class Config(WorkerConfig, BaseSettings):
         self.data_dir = prepare_dir(self.data_dir, self.get_data_dir())
         self.cache_dir = prepare_dir(
             self.cache_dir, os.path.join(self.data_dir, "cache")
+        )
+        self.kv_cache_dir = prepare_dir(
+            self.kv_cache_dir, os.path.join(self.cache_dir, "kv_cache")
         )
         self.bin_dir = prepare_dir(self.bin_dir, os.path.join(self.data_dir, "bin"))
         self.log_dir = prepare_dir(self.log_dir, os.path.join(self.data_dir, "log"))

--- a/gpustack/schemas/workers.py
+++ b/gpustack/schemas/workers.py
@@ -312,12 +312,6 @@ class WorkerUpdate(SQLModel):
         default=None,
         sa_column=Column(pydantic_column_type(Maintenance), default=None),
     )
-    disk_path: Optional[str] = Field(
-        default=None,
-        sa_column=Column(Text, nullable=True),
-    )
-    """ Path to SSD storage for KV cache offloading (L3 cache). If set, enables disk-based cache.
-    The path should be accessible from the container. GPUStack will automatically mount this path if it exists on the host."""
 
 
 class WorkerCreate(WorkerStatusStored, WorkerUpdate):
@@ -395,12 +389,6 @@ class WorkerBase(WorkerCreate):
     provider_config: Optional[Dict[str, Any]] = Field(
         default=None, sa_column=Column(JSON, nullable=True)
     )
-    disk_path: Optional[str] = Field(
-        default=None,
-        sa_column=Column(Text, nullable=True),
-    )
-    """ Path to SSD storage for KV cache offloading (L3 cache). If set, enables disk-based cache.
-    The path should be accessible from the container. GPUStack will automatically mount this path if it exists on the host."""
 
 
 class Worker(WorkerBase, BaseModelMixin, table=True):

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -492,14 +492,14 @@ class SGLangServer(InferenceServer):
             )
 
         # SSD (L3) cache configuration
-        # disk_path is configured at worker level, disk_size is configured at model level
-        if self._worker.disk_path:
+        # kv_cache_dir is configured at worker level, disk_size is configured at model level
+        if self._config.kv_cache_dir:
             # Note: SGLang HiCache disk cache support may vary by version
             # These parameters are added for future compatibility
             arguments.extend(
                 [
                     "--hicache-disk-path",
-                    self._worker.disk_path,
+                    self._config.kv_cache_dir,
                 ]
             )
             if extended_kv_cache.disk_size and extended_kv_cache.disk_size > 0:
@@ -514,8 +514,8 @@ class SGLangServer(InferenceServer):
 
     def _add_hicache_ssd_mount(self, mounts: List[ContainerMount]):
         """
-        Add SSD mount for HiCache L3 cache if disk_path is configured.
-        disk_path is configured at worker level.
+        Add SSD mount for HiCache L3 cache if kv_cache_dir is configured.
+        kv_cache_dir is configured at worker level via config.
 
         Args:
             mounts: List of container mounts to append to
@@ -524,24 +524,24 @@ class SGLangServer(InferenceServer):
         if not (extended_kv_cache and extended_kv_cache.enabled):
             return
 
-        # disk_path is configured at worker level
-        if not self._worker.disk_path:
+        # kv_cache_dir is configured at worker level via config
+        if not self._config.kv_cache_dir:
             return
 
         # Check if the path exists on the host
-        disk_path = self._worker.disk_path
-        if os.path.exists(disk_path):
+        kv_cache_dir = self._config.kv_cache_dir
+        if os.path.exists(kv_cache_dir):
             # Mount the SSD path to the container
             # Use the same path inside the container for simplicity
             mounts.append(
                 ContainerMount(
-                    path=disk_path,
+                    path=kv_cache_dir,
                 )
             )
-            logger.info(f"Added SSD mount for HiCache L3 cache: {disk_path}")
+            logger.info(f"Added SSD mount for HiCache L3 cache: {kv_cache_dir}")
         else:
             logger.warning(
-                f"SSD path for HiCache L3 cache does not exist on host: {disk_path}. "
+                f"KV cache directory for HiCache L3 cache does not exist on host: {kv_cache_dir}. "
                 "Please ensure the path exists or create it before deploying the model."
             )
 

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -262,16 +262,16 @@ class VLLMServer(InferenceServer):
             env["LMCACHE_MAX_LOCAL_CPU_SIZE"] = str(byte_to_gib(ram_size))
 
         # SSD (L3) cache configuration via environment variables
-        # disk_path is configured at worker level, disk_size is configured at model level
-        if self._worker.disk_path:
-            env["LMCACHE_LOCAL_DISK"] = self._worker.disk_path
+        # kv_cache_dir is configured at worker level, disk_size is configured at model level
+        if self._config.kv_cache_dir:
+            env["LMCACHE_LOCAL_DISK"] = self._config.kv_cache_dir
             if extended_kv_cache.disk_size and extended_kv_cache.disk_size > 0:
                 env["LMCACHE_MAX_LOCAL_DISK_SIZE"] = str(extended_kv_cache.disk_size)
 
     def _add_lmcache_ssd_mount(self, mounts: List[ContainerMount]):
         """
-        Add SSD mount for LMCache L3 cache if disk_path is configured.
-        disk_path is configured at worker level.
+        Add SSD mount for LMCache L3 cache if kv_cache_dir is configured.
+        kv_cache_dir is configured at worker level via config.
 
         Args:
             mounts: List of container mounts to append to
@@ -280,24 +280,24 @@ class VLLMServer(InferenceServer):
         if not (extended_kv_cache and extended_kv_cache.enabled):
             return
 
-        # disk_path is configured at worker level
-        if not self._worker.disk_path:
+        # kv_cache_dir is configured at worker level via config
+        if not self._config.kv_cache_dir:
             return
 
         # Check if the path exists on the host
-        disk_path = self._worker.disk_path
-        if os.path.exists(disk_path):
+        kv_cache_dir = self._config.kv_cache_dir
+        if os.path.exists(kv_cache_dir):
             # Mount the SSD path to the container
             # Use the same path inside the container for simplicity
             mounts.append(
                 ContainerMount(
-                    path=disk_path,
+                    path=kv_cache_dir,
                 )
             )
-            logger.info(f"Added SSD mount for LMCache L3 cache: {disk_path}")
+            logger.info(f"Added SSD mount for LMCache L3 cache: {kv_cache_dir}")
         else:
             logger.warning(
-                f"SSD path for LMCache L3 cache does not exist on host: {disk_path}. "
+                f"KV cache directory for LMCache L3 cache does not exist on host: {kv_cache_dir}. "
                 "Please ensure the path exists or create it before deploying the model."
             )
 

--- a/gpustack/worker/worker_manager.py
+++ b/gpustack/worker/worker_manager.py
@@ -116,7 +116,6 @@ class WorkerManager:
         workerUpdate = WorkerUpdate(
             name=self._worker_name,
             labels=self._ensure_builtin_labels(),
-            disk_path=self._cfg.kv_cache_disk_path,
         )
         to_register = WorkerCreate.model_validate(
             {


### PR DESCRIPTION
This commit adds L3 (SSD disk) cache support for extended KV cache,
enabling three-tier cache architecture: L1 (GPU VRAM) -> L2 (CPU RAM) -> L3 (SSD Disk).

### Key Changes

#### Schema Changes
- **Worker-level `disk_path`**: Move `disk_path` from Model level to Worker level
  - `disk_path` represents physical storage resource, belongs to worker node
  - Added to `WorkerBase` and `WorkerUpdate` schemas
  - Allows administrators to configure disk path per worker via API/UI
  
- **Model-level `disk_size`**: Keep `disk_size` at Model level
  - `disk_size` represents logical resource requirement per model
  - Remains in `ExtendedKVCacheConfig` schema
  - Different models can use different cache sizes on the same disk

#### vLLM + LMCache Support
- Add L3 disk cache configuration via environment variables:
  - `LMCACHE_LOCAL_DISK`: Disk path (from worker)
  - `LMCACHE_MAX_LOCAL_DISK_SIZE`: Disk cache size (from model)
- Add `_add_lmcache_ssd_mount()` method to automatically mount SSD path
- Maintain backward compatibility with environment variable approach
- Support automatic disk path validation and mount

#### SGLang + HiCache Support
- Add L3 disk cache support parallel to vLLM+LMCache:
  - `--hicache-disk-path`: Disk path parameter (from worker)
  - `--hicache-disk-size`: Disk cache size parameter (from model)
- Add `_add_hicache_ssd_mount()` method for SSD mount
- Complete three-tier cache support: L1 -> L2 -> L3

### Design Rationale

**Why `disk_path` at Worker level?**
- Physical resource: Each worker node has its own storage configuration
- Operational management: Storage paths, permissions, and performance vary per node
- Flexibility: Different workers can use different storage backends

**Why `disk_size` at Model level?**
- Logical resource: Each model has different cache size requirements
- Resource allocation: Models can share the same disk with different size limits
- Model-specific: Cache size depends on model context length and usage patterns

### API Changes

- `WorkerUpdate` schema now includes `disk_path` field
- Allows updating worker disk path via PUT `/v2/workers/{id}` API
- Supports server-worker separated deployment scenarios

### Files Modified

- `gpustack/schemas/models.py`: Remove `disk_path`, keep `disk_size` in `ExtendedKVCacheConfig`
- `gpustack/schemas/workers.py`: Add `disk_path` to `WorkerBase` and `WorkerUpdate`
- `gpustack/worker/backends/vllm.py`: Add L3 cache support for LMCache
- `gpustack/worker/backends/sglang.py`: Add L3 cache support for HiCache

### Backward Compatibility

- Maintains environment variable approach for LMCache (backward compatible)
- Existing configurations without disk cache continue to work
- New disk cache features are opt-in via worker and model configuration