### PR TITLE
Fix --oidc-use-userinfo flag

### DIFF
--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -610,6 +610,7 @@ def set_server_options(args, config_data: dict):
         "oidc_client_id",
         "oidc_client_secret",
         "oidc_redirect_uri",
+        "oidc_use_userinfo",
         "saml_idp_server_url",
         "saml_idp_entity_id",
         "saml_idp_x509_cert",


### PR DESCRIPTION
#3565 

This pull request introduces a minor update to the server options configuration in `gpustack/cmd/start.py`. The change fixes support for a OIDC-related option.

- Added the `oidc_use_userinfo` option to the list of supported server options, allowing configuration of whether to use the OIDC UserInfo endpoint. Fixes #3565 