### PR TITLE
refactor(mindie): enhance estimation with multimodal

### DIFF
--- a/gpustack/scheduler/model_registry.py
+++ b/gpustack/scheduler/model_registry.py
@@ -2,6 +2,9 @@
 # Update these when the builtin vLLM is updated
 # List of supported model architectures for the default version of the vLLM backend
 # TODO version-aware support list
+from typing import List
+
+from gpustack.schemas.models import CategoryEnum
 
 _TEXT_GENERATION_MODELS = [
     # [Decoder-only]
@@ -258,13 +261,45 @@ _TRANSFORMERS_BACKEND_MODELS = [
     "TransformersForMultimodalLM",
 ]
 
-vllm_supported_embedding_architectures = _EMBEDDING_MODELS
-
-vllm_supported_reranker_architectures = _CROSS_ENCODER_MODELS
-
-vllm_supported_llm_architectures = (
+_LLM_MODELS = (
     _TEXT_GENERATION_MODELS
     + _MULTIMODAL_MODELS
     + _TRANSFORMERS_SUPPORTED_MODELS
     + _TRANSFORMERS_BACKEND_MODELS
 )
+
+
+def detect_model_type(architectures: List[str]) -> CategoryEnum:
+    """
+    Detect the model type based on the architectures.
+
+    Args:
+        architectures: List of model architecture names.
+
+    Returns:
+        The detected model category.
+    """
+    for architecture in architectures:
+        if architecture in _EMBEDDING_MODELS:
+            return CategoryEnum.EMBEDDING
+        if architecture in _CROSS_ENCODER_MODELS:
+            return CategoryEnum.RERANKER
+        if architecture in _LLM_MODELS:
+            return CategoryEnum.LLM
+    return CategoryEnum.UNKNOWN
+
+
+def is_multimodal_model(architectures: List[str]) -> bool:
+    """
+    Check if the model is a multimodal model based on the architectures.
+
+    Args:
+        architectures: List of model architecture names.
+
+    Returns:
+        True if the model is multimodal, False otherwise.
+    """
+    for architecture in architectures:
+        if architecture in _MULTIMODAL_MODELS:
+            return True
+    return False

--- a/gpustack/scheduler/scheduler.py
+++ b/gpustack/scheduler/scheduler.py
@@ -32,11 +32,7 @@ from gpustack.policies.worker_filters.backend_framework_filter import (
 from gpustack.policies.worker_filters.label_matching_filter import LabelMatchingFilter
 from gpustack.policies.worker_filters.gpu_matching_filter import GPUMatchingFilter
 from gpustack.policies.worker_filters.cluster_filter import ClusterFilter
-from gpustack.scheduler.model_registry import (
-    vllm_supported_embedding_architectures,
-    vllm_supported_llm_architectures,
-    vllm_supported_reranker_architectures,
-)
+from gpustack.scheduler.model_registry import detect_model_type
 from gpustack.scheduler.queue import AsyncUniqueQueue
 from gpustack.policies.worker_filters.status_filter import StatusFilter
 from gpustack.schemas.inference_backend import is_built_in_backend
@@ -756,17 +752,3 @@ def set_model_gpus_per_replica(model: Model) -> bool:
         # Ignore if the given model is not a SQLModel instance.
         pass
     return True
-
-
-def detect_model_type(architectures: List[str]) -> CategoryEnum:
-    """
-    Detect the model type based on the architectures.
-    """
-    for architecture in architectures:
-        if architecture in vllm_supported_embedding_architectures:
-            return CategoryEnum.EMBEDDING
-        if architecture in vllm_supported_reranker_architectures:
-            return CategoryEnum.RERANKER
-        if architecture in vllm_supported_llm_architectures:
-            return CategoryEnum.LLM
-    return CategoryEnum.UNKNOWN

--- a/gpustack/worker/backends/ascend_mindie.py
+++ b/gpustack/worker/backends/ascend_mindie.py
@@ -568,6 +568,10 @@ class AscendMindIEParameters:
                 )
             else:
                 self.max_input_token_len = self.max_seq_len
+        # Model config
+        self.max_prefill_batch_size = min(
+            self.max_prefill_batch_size, self.max_batch_size
+        )
         # Schedule config
         if self.max_prefill_tokens <= 0:
             self.max_prefill_tokens = self.max_seq_len


### PR DESCRIPTION
This PR cannot completely solve the problem of https://github.com/gpustack/gpustack/issues/3541, especially in the automatic scheduling phase. This PR is only to fit the memory estimation of MultiModal in MindIE >= 2.2.RC1.

MindIE >= 2.2.RC1 introduces an area calculation for MultiModal model, according to the `--max-prefill-tokens`, from 18 GiB to 26 GiB. The failure of https://github.com/gpustack/gpustack/issues/3541 happens on the warm up phase. Based on the `--max-prefill-tokens`, `--max-batch-size` and `--max-iter-times`, MindIE do warmming up to confirm the peak memory and free memory. 

Taking https://github.com/gpustack/gpustack/issues/3541 as example, the total VRAM is 64 GiB, of which 3.3 GiB is usually unusable, leaving only 60 GiB available for allocation. Under the default configuration, peak memory reaches 36 GiB, while free memory is below 26 GiB, hence the error.

So that, for MindIE 2.2.RC1 multimodal deployment, users can try to reduce `--max-batch-size` or `--max-seq-len` to make it works on one device. 
