### PR TITLE
fix: remove some model validations

### DIFF
--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -234,26 +234,6 @@ class ModelSpecBase(SQLModel, ModelSource):
 
 
 class ModelBase(ModelSpecBase):
-    @model_validator(mode="after")
-    def validate(self):
-        backend = get_backend(self)
-        if self.cpu_offloading and backend in [
-            BackendEnum.VLLM,
-            BackendEnum.SGLANG,
-            BackendEnum.ASCEND_MINDIE,
-        ]:
-            raise ValueError(
-                f"CPU offloading is not supported for the {backend} backend"
-            )
-
-        if backend == BackendEnum.VOX_BOX:
-            if self.distributed_inference_across_workers:
-                raise ValueError(
-                    "Distributed inference across workers is not supported for the vox-box backend"
-                )
-
-        return self
-
     cluster_id: Optional[int] = Field(default=None, foreign_key="clusters.id")
     access_policy: AccessPolicyEnum = Field(default=AccessPolicyEnum.AUTHED)
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3597

Some model schema validations cause errors. They seem to be unneccesary. cpu_offloading and distributed_inference_across_workers are best-effort, not deterministic. UI has removed the entries of related backends. Even it's set via API, we just ignore them in related backend serving.