### PR TITLE
chore: bump runtime

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -118,6 +118,7 @@ They are only usable within workers. Please set the environment variables in the
 | -------- | ----------- | ------- |
 | `GPUSTACK_RUNTIME_DETECT` | Detector to use. Options: Auto, AMD, ASCEND, CAMBRICON, HYGON, ILUVATAR, METAX, MTHREADS, NVIDIA. | `Auto` |
 | `GPUSTACK_RUNTIME_DETECT_NO_PCI_CHECK` | Enable no PCI check during detection. Useful for WSL environments. | (empty) |
+| `GPUSTACK_RUNTIME_DETECT_NO_TOOLKIT_CALL` | Enable only using management libraries calls during detection. Device detection typically involves calling platform-side management libraries and platform-side toolkit to retrieve extra information. For example, during NVIDIA detection, the NVML and CUDA are called, with CUDA used to retrieve GPU cores. However, if certain toolchains are not correctly installed in the environment, such as the Nvidia Fabric Manager being missing, calling the CUDA can cause blocking. Enabling this parameter can prevent blocking events. | (empty) |
 | `GPUSTACK_RUNTIME_DETECT_BACKEND_MAP_RESOURCE_KEY` | Backend mapping to resource keys. | The default values named by each vendor |
 | `GPUSTACK_RUNTIME_DETECT_PHYSICAL_INDEX_PRIORITY` | Use physical index priority at detecting devices. | `1` |
 
@@ -142,7 +143,7 @@ They are only usable within workers. Please set the environment variables in the
 | `GPUSTACK_RUNTIME_DEPLOY_RUNTIME_VISIBLE_DEVICES_VALUE_UUID` | Use UUIDs for the given runtime visible devices environment variables. | (empty)                                        |
 | `GPUSTACK_RUNTIME_DEPLOY_BACKEND_VISIBLE_DEVICES_VALUE_ALIGNMENT` | Enable value alignment for the given backend visible devices environment variables. | `ASCEND_RT_VISIBLE_DEVICES,NPU_VISIBLE_DEVICES` |
 
-### Docker Variables
+#### Docker Variables
 
 | Variable | Description | Default |
 | -------- | ----------- | ------- |
@@ -152,7 +153,7 @@ They are only usable within workers. Please set the environment variables in the
 | `GPUSTACK_RUNTIME_DOCKER_EPHEMERAL_FILES_DIR` | Directory for storing ephemeral files for Docker. | `~/.cache/gpustack-runtime` |
 | `GPUSTACK_RUNTIME_DOCKER_MUTE_ORIGINAL_HEALTHCHECK` | Mute the original healthcheck of the container. | `1` |
 
-### Kubernetes Variables
+#### Kubernetes Variables
 
 | Variable | Description | Default |
 | -------- | ----------- | ------- |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "kubernetes-asyncio>=33.1.0",
     "msgpack>=1.1.2",
     "gpustack-runner>=0.1.21.post1",
-    "gpustack-runtime==0.1.34.post3",
+    "gpustack-runtime==0.1.35",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1997,7 +1997,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastapi-cdn-host", specifier = ">=0.8.0" },
     { name = "gpustack-runner", specifier = ">=0.1.21.post1" },
-    { name = "gpustack-runtime", specifier = "==0.1.34.post3" },
+    { name = "gpustack-runtime", specifier = "==0.1.35" },
     { name = "hf-transfer", specifier = ">=0.1.9" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "huggingface-hub", specifier = ">=0.32.0" },
@@ -2084,7 +2084,7 @@ wheels = [
 
 [[package]]
 name = "gpustack-runtime"
-version = "0.1.34.post3"
+version = "0.1.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -2094,9 +2094,9 @@ dependencies = [
     { name = "nvidia-ml-py" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/95/b74003145442d89534be7bd913fe48ab4a171ac9f6ce9bf231e4bf9f37d0/gpustack_runtime-0.1.34.post3.tar.gz", hash = "sha256:df1dcc64c89f368e06bfb93ed29cf78cca9276f789e9a3ee160bafdf293e788f", size = 198593, upload-time = "2025-11-25T14:41:26.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/53/394345d735d6b8f19967efb6d2bd136ca01f80c38d19b48382ff2c270622/gpustack_runtime-0.1.35.tar.gz", hash = "sha256:2a1e291daa8ff0eabbd46099f4788ab6b53329dd3bfbb3599aba4b4d291796a2", size = 198948, upload-time = "2025-12-02T06:07:49.304Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/45/94a21da887e9794dd4ad0fba491f4ced4d7f9a7d812833f22b754425b5a1/gpustack_runtime-0.1.34.post3-py3-none-any.whl", hash = "sha256:9288663bd76fa370621c0a03ac7ad6fe2f6986648fd2726646df8de0ae576cd0", size = 170973, upload-time = "2025-11-25T14:41:24.866Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/f6ae43a27848caa0c8dd808d3ec528297abe64625c66c9060bbc720deabb/gpustack_runtime-0.1.35-py3-none-any.whl", hash = "sha256:b49834e9443b47dd87f6b865375021c2276cee52692d0079f51410c12a9dab4b", size = 171405, upload-time = "2025-12-02T06:07:48.089Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
finish https://github.com/gpustack/gpustack/issues/3590 and introduce an env `GPUSTACK_RUNTIME_DETECT_NO_TOOLKIT_CALL` to mitigate something like https://github.com/gpustack/gpustack/issues/3556.
