### PR TITLE
chore: suppress do provision request info logs

### DIFF
--- a/gpustack/logging.py
+++ b/gpustack/logging.py
@@ -50,6 +50,7 @@ def setup_logging(debug: bool = False):
         "huggingface_hub.file_download",
         "docker.auth",
         "kubernetes_asyncio.client.rest",
+        "azure.core.pipeline.policies.http_logging_policy",
     ]
 
     for logger_name in disable_logger_names:


### PR DESCRIPTION
```
2025-12-03 15:48:15.571267+08:00 - azure.core.pipeline.policies.http_logging_policy - INFO - Request URL: 'https://api.digitalocean.com/v2/droplets/534166464/destroy_with_associated_resources/dangerous'
Request method: 'DELETE'
Request headers:
    'X-Dangerous': 'REDACTED'
    'Accept': 'application/json'
    'x-ms-client-request-id': '6d0ceb0c-d01c-11f0-8d09-727e23b9c94d'
    'User-Agent': 'azsdk-python-pydo/0.21.0 Python/3.11.14 (Linux-6.8.0-71-generic-x86_64-with-glibc2.35)'
    'Authorization': 'REDACTED'
No body was attached to the request
2025-12-03 15:48:16.136989+08:00 - gpustack.server.metrics_collector - DEBUG - Collecting gateway metrics from http://localhost:15020/stats/prometheus
2025-12-03 15:48:16.686553+08:00 - azure.core.pipeline.policies.http_logging_policy - INFO - Response status: 202
Response headers:
    'Date': 'Wed, 03 Dec 2025 07:48:16 GMT'
    'Content-Type': 'application/json; charset=utf-8'
    'Content-Length': '0'
    'Connection': 'keep-alive'
    'CF-RAY': 'REDACTED'
    'Cache-Control': 'max-age=0, private, must-revalidate'
    'ratelimit-limit': 'REDACTED'
    'ratelimit-remaining': 'REDACTED'
    'ratelimit-reset': 'REDACTED'
    'x-envoy-upstream-service-time': 'REDACTED'
    'x-gateway': 'REDACTED'
    'x-request-id': 'REDACTED'
    'x-response-from': 'REDACTED'
    'x-runtime': 'REDACTED'
    'do-upstream-service-time': 'REDACTED'
    'cf-cache-status': 'REDACTED'
    'Set-Cookie': 'REDACTED'
    'Server': 'cloudflare'
```

Notice the above logs during DO worker provisioning. Suppress it in server logs.