### PR TITLE
fix: enforce num_attention_heads constraint when transformers encounters unsupported model architectures

### DIFF
--- a/tests/fixtures/workers/fixtures.py
+++ b/tests/fixtures/workers/fixtures.py
@@ -275,6 +275,10 @@ def linux_nvidia_25_H100_80gx8(reserved=False):
     return load_from_file("linux_nvidia_25_H100_80gx8.json", reserved=reserved)
 
 
+def linux_nvidia_26_H200_141gx8(reserved=False):
+    return load_from_file("linux_nvidia_26_H200_141gx8.json", reserved=reserved)
+
+
 def linux_rocm_1_7800_16gx1(reserved=True):
     return load_from_file("linux_rocm_1_7800_16gx1.json", reserved=reserved)
 

--- a/tests/fixtures/workers/linux_nvidia_26_H200_141gx8.json
+++ b/tests/fixtures/workers/linux_nvidia_26_H200_141gx8.json
@@ -1,0 +1,195 @@
+{
+    "name": "host26-h200",
+    "hostname": "host26-h200",
+    "ip": "192.168.50.26",
+    "labels": {
+        "os": "Linux"
+    },
+    "state": "ready",
+    "system_reserved": {
+        "memory": 2147483648,
+        "gpu_memory": 0
+    },
+    "status": {
+        "memory": {
+            "total": 1610612736000,
+            "utilization_rate": 5.905919020930682,
+            "is_unified_memory": false,
+            "used": 3967795200,
+            "allocated": 0
+        },
+        "gpu_devices": [
+            {
+                "uuid": "GPU-f41f9601-2307-3af8-98c3-f25afe04c263",
+                "name": "H200 SXM5",
+                "vendor": "nvidia",
+                "index": 0,
+                "device_index": 0,
+                "device_chip_index": 0,
+                "core": {
+                    "total": 10240,
+                    "utilization_rate": 0.0
+                },
+                "memory": {
+                    "total": 151511121920,
+                    "utilization_rate": 2.500228993649243,
+                    "is_unified_memory": false,
+                    "used": 429326336,
+                    "allocated": 0
+                },
+                "temperature": 36.0,
+                "type": "cuda"
+            },
+            {
+                "uuid": "GPU-f41f9601-2307-3af8-98c3-f25afe04c264",
+                "name": "H200 SXM5",
+                "vendor": "nvidia",
+                "index": 1,
+                "device_index": 1,
+                "device_chip_index": 0,
+                "core": {
+                    "total": 10240,
+                    "utilization_rate": 0.0
+                },
+                "memory": {
+                    "total": 151511121920,
+                    "utilization_rate": 3.6070316316560818,
+                    "is_unified_memory": false,
+                    "used": 619380736,
+                    "allocated": null
+                },
+                "temperature": 38.0,
+                "type": "cuda"
+            },
+            {
+                "uuid": "GPU-f41f9601-2307-3af8-98c3-f25afe04c265",
+                "name": "H200 SXM5",
+                "vendor": "nvidia",
+                "index": 2,
+                "device_index": 2,
+                "device_chip_index": 0,
+                "core": {
+                    "total": 10240,
+                    "utilization_rate": 0.0
+                },
+                "memory": {
+                    "total": 151511121920,
+                    "utilization_rate": 2.500228993649243,
+                    "is_unified_memory": false,
+                    "used": 429326336,
+                    "allocated": 0
+                },
+                "temperature": 36.0,
+                "type": "cuda"
+            },
+            {
+                "uuid": "GPU-f41f9601-2307-3af8-98c3-f25afe04c266",
+                "name": "H200 SXM5",
+                "vendor": "nvidia",
+                "index": 3,
+                "device_index": 3,
+                "device_chip_index": 0,
+                "core": {
+                    "total": 10240,
+                    "utilization_rate": 0.0
+                },
+                "memory": {
+                    "total": 151511121920,
+                    "utilization_rate": 3.6070316316560818,
+                    "is_unified_memory": false,
+                    "used": 619380736,
+                    "allocated": null
+                },
+                "temperature": 38.0,
+                "type": "cuda"
+            },
+            {
+                "uuid": "GPU-f41f9601-2307-3af8-98c3-f25afe04c267",
+                "name": "H200 SXM5",
+                "vendor": "nvidia",
+                "index": 4,
+                "device_index": 4,
+                "device_chip_index": 0,
+                "core": {
+                    "total": 10240,
+                    "utilization_rate": 0.0
+                },
+                "memory": {
+                    "total": 151511121920,
+                    "utilization_rate": 2.500228993649243,
+                    "is_unified_memory": false,
+                    "used": 429326336,
+                    "allocated": 0
+                },
+                "temperature": 36.0,
+                "type": "cuda"
+            },
+            {
+                "uuid": "GPU-f41f9601-2307-3af8-98c3-f25afe04c268",
+                "name": "H200 SXM5",
+                "vendor": "nvidia",
+                "index": 5,
+                "device_index": 5,
+                "device_chip_index": 0,
+                "core": {
+                    "total": 10240,
+                    "utilization_rate": 0.0
+                },
+                "memory": {
+                    "total": 151511121920,
+                    "utilization_rate": 3.6070316316560818,
+                    "is_unified_memory": false,
+                    "used": 619380736,
+                    "allocated": null
+                },
+                "temperature": 38.0,
+                "type": "cuda"
+            },
+            {
+                "uuid": "GPU-f41f9601-2307-3af8-98c3-f25afe04c269",
+                "name": "H200 SXM5",
+                "vendor": "nvidia",
+                "index": 6,
+                "device_index": 6,
+                "device_chip_index": 0,
+                "core": {
+                    "total": 10240,
+                    "utilization_rate": 0.0
+                },
+                "memory": {
+                    "total": 151511121920,
+                    "utilization_rate": 2.500228993649243,
+                    "is_unified_memory": false,
+                    "used": 429326336,
+                    "allocated": 0
+                },
+                "temperature": 36.0,
+                "type": "cuda"
+            },
+            {
+                "uuid": "GPU-f41f9601-2307-3af8-98c3-f25afe04c270",
+                "name": "H200 SXM5",
+                "vendor": "nvidia",
+                "index": 7,
+                "device_index": 7,
+                "device_chip_index": 0,
+                "core": {
+                    "total": 10240,
+                    "utilization_rate": 0.0
+                },
+                "memory": {
+                    "total": 151511121920,
+                    "utilization_rate": 3.6070316316560818,
+                    "is_unified_memory": false,
+                    "used": 619380736,
+                    "allocated": null
+                },
+                "temperature": 38.0,
+                "type": "cuda"
+            }
+        ]
+    },
+    "id": 26,
+    "created_at": "2024-07-05T02:17:42",
+    "updated_at": "2024-07-05T10:36:21"
+}

--- a/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
@@ -26,6 +26,7 @@ from tests.fixtures.workers.fixtures import (
     linux_nvidia_6_a100_80gx2,
     linux_nvidia_7_a100_80gx2,
     linux_nvidia_2_4080_16gx2,
+    linux_nvidia_26_H200_141gx8,
 )
 from tests.utils.scheduler import compare_candidates
 
@@ -127,6 +128,36 @@ def expected_candidate(
                     "host4080",
                     [0, 1],
                     {0: 15454332518, 1: 15454332518},
+                )
+            ],
+            0,
+        ),
+        # Auto schedule for DeepSeekV32 model
+        (
+            "auto_select_deepseekv32_model",
+            new_model(
+                1,
+                "test_name",
+                1,
+                huggingface_repo_id="deepseek-ai/DeepSeek-V3.2",
+                backend_version="0.11.0",
+            ),
+            [linux_nvidia_26_H200_141gx8()],
+            [
+                expected_candidate(
+                    26,
+                    "host26-h200",
+                    [0, 1, 2, 3, 4, 5, 6, 7],
+                    {
+                        0: 136360009728,
+                        1: 136360009728,
+                        2: 136360009728,
+                        3: 136360009728,
+                        4: 136360009728,
+                        5: 136360009728,
+                        6: 136360009728,
+                        7: 136360009728,
+                    },
                 )
             ],
             0,

--- a/tests/policies/candidate_selectors/vllm/test_vllm_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/vllm/test_vllm_resource_fit_selector.py
@@ -31,6 +31,7 @@ from tests.fixtures.workers.fixtures import (
     linux_nvidia_7_a100_80gx2,
     linux_nvidia_2_4080_16gx2,
     linux_ascend_1_910b_64gx8,
+    linux_nvidia_26_H200_141gx8,
 )
 from tests.utils.scheduler import compare_candidates
 
@@ -463,6 +464,36 @@ def expected_candidate(
             ),
             [linux_nvidia_1_4090_24gx1()],
             [expected_candidate(2, "host4090", [0], {0: 23413653504}, ram=46827307008)],
+            0,
+        ),
+        # Auto schedule DeepSeekV32
+        (
+            "auto_schedule_deepseekv32",
+            new_model(
+                1,
+                "test_name",
+                1,
+                huggingface_repo_id="deepseek-ai/DeepSeek-V3.2",
+                backend_version="0.11.0",
+            ),
+            [linux_nvidia_26_H200_141gx8()],
+            [
+                expected_candidate(
+                    26,
+                    "host26-h200",
+                    [0, 1, 2, 3, 4, 5, 6, 7],
+                    {
+                        0: 136360009728,
+                        1: 136360009728,
+                        2: 136360009728,
+                        3: 136360009728,
+                        4: 136360009728,
+                        5: 136360009728,
+                        6: 136360009728,
+                        7: 136360009728,
+                    },
+                )
+            ],
             0,
         ),
     ],


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3640

The root cause is that `get_pretrained_config` fails on unsupported model architectures, preventing `num_attention_heads` retrieval from `pretrained_config`