### PR TITLE
docs: redirects legacy installations

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,16 @@ theme:
 plugins:
   - glightbox
   - search
+  - redirects:
+      redirect_maps:
+        'installation/nvidia/installation.md': 'installation/requirements.md'
+        'installation/amd/installation.md': 'installation/requirements.md'
+        'installation/ascend/installation.md': 'installation/requirements.md'
+        'installation/hygon/installation.md': 'installation/requirements.md'
+        'installation/mthreads/installation.md': 'installation/requirements.md'
+        'installation/iluvatar/installation.md': 'installation/requirements.md'
+        'installation/cambricon/installation.md': 'installation/requirements.md'
+        'installation/metax/installation.md': 'installation/requirements.md'
 extra:
   generator: false
   version:


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3829


The URL fragment is not handled for now: https://github.com/mkdocs/mkdocs-redirects/issues/69