### PR TITLE
fix: Revoke user's accessible model names cache when model changed

### DIFF
--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -88,12 +88,8 @@ async def get_current_user(
         if not user.is_active:
             raise UnauthorizedException(message="User account is deactivated")
         request.state.user = user
-        access_key = None if api_key is None else api_key.access_key
         if api_key is not None:
             request.state.api_key = api_key
-        request.state.user_allow_model_names = await UserService(
-            session
-        ).get_user_accessible_model_names(user.id, access_key)
         return user
 
     raise credentials_exception


### PR DESCRIPTION
The model_name cache is linked to user_id instead of user_id + access_key which make it easier to manage with users.
And when model is created/deleted/modified_access, revoke related user's cache.

Related issues:
- #3897 