### PR TITLE
feat: add is_default to cluster

### DIFF
--- a/gpustack/migrations/versions/2025_12_08_1623-2aed534bd7b2_v2_0_2_database_changes.py
+++ b/gpustack/migrations/versions/2025_12_08_1623-2aed534bd7b2_v2_0_2_database_changes.py
@@ -42,6 +42,7 @@ def upgrade() -> None:
     with op.batch_alter_table('clusters', schema=None) as batch_op:
         batch_op.add_column(sa.Column('server_url', sa.String(length=2048), nullable=True))
         batch_op.add_column(sa.Column('worker_config',  SQLAlchemyJSON(), nullable=True))
+        batch_op.add_column(sa.Column('is_default', sa.Boolean(), nullable=False, server_default=sa.false()))
 
     op.execute(model_user_after_drop_view_stmt)
 
@@ -74,6 +75,7 @@ def downgrade() -> None:
     with op.batch_alter_table('clusters', schema=None) as batch_op:
         batch_op.drop_column('server_url')
         batch_op.drop_column('worker_config')
+        batch_op.drop_column('is_default')
 
     op.execute(model_user_after_drop_view_stmt)
 

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -277,6 +277,7 @@ class ClusterBase(ClusterCreateBase):
         default=None, sa_column=Column(Text, nullable=True)
     )
     reported_gateway_endpoint: Optional[str] = None
+    is_default: bool = Field(default=False)
 
 
 class Cluster(ClusterBase, BaseModelMixin, table=True):

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -573,6 +573,7 @@ class Server:
             state=ClusterStateEnum.READY,
             hashed_suffix=hashed_suffix,
             registration_token="",
+            is_default=True,
         )
         default_cluster = await Cluster.create(
             session, default_cluster, auto_commit=False


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3790

Problem:
Now we need a cluster_id to perform model compatibility evaluation. If there are many clusters, evaluating all clusters is time-consuming, evaluating one cluster may not be ideal as there's no deterministic way to select the expected cluster for deployment by default.

Solution:
Provide a path to let user specify the default cluster for evaluation/deployment. See the [proposal](https://github.com/gpustack/gpustack/issues/3790#issuecomment-3680370834) for the UX details.

CC @hibig 