### PR TITLE
fix: add necessary permissions for pod creation to gpustack-worker

### DIFF
--- a/gpustack/k8s/manifests.jinja
+++ b/gpustack/k8s/manifests.jinja
@@ -51,11 +51,26 @@ rules:
     resources:
       - "pods"
       - "configmaps"
+      - "secrets
       - "services"
       - "pods/log"
       - "pods/exec"
     verbs:
       - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources: 
+      - "events"
+    verbs: 
+      - "create"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Refer to issue:
- #3876 