### PR TITLE
refactor: update default model sort

### DIFF
--- a/gpustack/routes/models.py
+++ b/gpustack/routes/models.py
@@ -6,7 +6,7 @@ from gpustack_runtime.detector import ManufacturerEnum
 from sqlalchemy import bindparam, cast
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.mysql import JSON
-from sqlmodel import and_, case, col, or_, func
+from sqlmodel import and_, col, or_, func
 from sqlmodel.ext.asyncio.session import AsyncSession
 from enum import Enum
 
@@ -144,10 +144,6 @@ async def _get_models(
                 new_order_by.append(("model_scope_file_path", direction))
                 new_order_by.append(("local_path", direction))
         order_by = new_order_by
-    else:
-        # Default ordering: active models first, then by creation time descending
-        active_model_priority_expr = case((target_class.replicas > 0, 0), else_=1)
-        order_by = [(active_model_priority_expr, "asc"), ("created_at", "desc")]
 
     return await target_class.paginated_by_query(
         session=session,


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2589#issuecomment-3690703699

If models are sorted by "active" status by default, their order will jump around after being stopped or started, leading to a poor user experience.

Update the models' default sorting.

