### PR TITLE
fix: refactor token usage plugin

### DIFF
--- a/gpustack/gateway/plugins.py
+++ b/gpustack/gateway/plugins.py
@@ -58,7 +58,7 @@ supported_plugins: List[HigressPlugin] = [
     HigressPlugin(
         name="gpustack-token-usage",
         version="1.0.0",
-        digest="sha256:e1fc0663fcabe109720e250f5338d33513bbe5c280f7b726123517fac8d87db0",
+        digest="sha256:0bdaa6e9c814677475364e47f893cd08b157a7f244131c018fc2d57efd6ece97",
         registry_prefix="oci://docker.io/gpustack/higress-plugin-",
     ),
 ]


### PR DESCRIPTION
Refer to commit:
https://github.com/gpustack/gpustack-higress-plugin/commit/7023f4

Refactor the streaming logic
Should consider the frame has incomplete json.
Assemble the chunk into a valid json before check the usage because the usage key might be split into usa and ge, then we can't determine the right usage from data.

Refer to issue:
- #3964 