### PR TITLE
fix: empty worker_id in scheduled model instance deletion

### DIFF
--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -142,12 +142,17 @@ class ActiveRecordMixin:
         return result.first()
 
     @classmethod
-    async def all_by_field(cls, session: AsyncSession, field: str, value: Any):
+    async def all_by_field(
+        cls, session: AsyncSession, field: str, value: Any, for_update: bool = False
+    ):
         """
         Return all objects with the given field and value.
         Return an empty list if not found.
         """
         statement = select(cls).where(getattr(cls, field) == value)
+        if for_update:
+            statement = statement.with_for_update()
+
         result = await session.exec(statement)
         return result.all()
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4060

Problem:
In the following timeline, worker receives empty worker_id for scheduled model instance:
1. controller gets model instances list in sync_replicas
2. scheduler schedules a model instance and set its worker_id
3. controller scales down by deleting the above instance and publish a legacy data with empty worker_id

Solution:
Add db locking in sync_replicas.