### PR TITLE
feat: copy major ingress tls and host to the ingress of model instance

### DIFF
--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -64,6 +64,10 @@ GATEWAY_PORT_CHECK_RETRY_COUNT = int(
     os.getenv("GPUSTACK_GATEWAY_PORT_CHECK_RETRY_COUNT", 300)
 )  # number of retries
 
+GATEWAY_MIRROR_INGRESS_NAME = os.getenv(
+    "GPUSTACK_GATEWAY_MIRROR_INGRESS_NAME", "gpustack"
+)
+
 DEFAULT_CLUSTER_KUBERNETES = (
     os.getenv("GPUSTACK_DEFAULT_CLUSTER_KUBERNETES", "false").lower() == "true"
 )

--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -34,6 +34,8 @@ from gpustack.gateway.plugins import (
     get_plugin_url_with_name_and_version,
 )
 
+from gpustack.envs import GATEWAY_MIRROR_INGRESS_NAME
+
 mcp_registry_port = 80
 
 supported_openai_routes = [
@@ -190,7 +192,7 @@ async def ensure_ingress_resources(cfg: Config, api_client: k8s_client.ApiClient
     hostname = cfg.get_external_hostname()
     tls_secret_name = cfg.get_tls_secret_name()
     network_v1_client = k8s_client.NetworkingV1Api(api_client=api_client)
-    ingress_name = "gpustack"
+    ingress_name = GATEWAY_MIRROR_INGRESS_NAME
     try:
         ingress: k8s_client.V1Ingress = await network_v1_client.read_namespaced_ingress(
             name=ingress_name, namespace=gateway_namespace

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -630,8 +630,6 @@ async def sync_gateway(
         model=model,
         destinations=destinations,
         networking_api=networking_api,
-        hostname=None,
-        tls_secret_name=cfg.get_tls_secret_name(),
         included_generic_route=False,
         included_proxy_route=model.generic_proxy,
     )

--- a/gpustack/worker/worker_gateway.py
+++ b/gpustack/worker/worker_gateway.py
@@ -150,8 +150,6 @@ class WorkerGatewayController:
                     model=model,
                     event_type=event.type,
                     networking_api=self._networking_api,
-                    hostname=None,
-                    tls_secret_name=None,
                     included_generic_route=model.generic_proxy,
                     included_proxy_route=False,
                 )


### PR DESCRIPTION
Refer to issues:
- #3669 

Supports mirroring gpustack's main ingress tls and host configuration into model instance's ingress.
Following cases should be tested:
- For embedded gateway
  - Add TLS certificate pair for GPUStack server to serve https with hostname
  - Serve http GPUStack server without tls certificates
  - Create model instance for above setups and try chatting in playground
- **Optional** For in cluster gateway
  - Deploy GPUStack in k8s cluster
  - Create a ingress with name `gpustack` with tls configuration and hostname.
  - Create model instance for above setup and try to chatting in playground.
  - Make sure the model instance ingress created in the same namespace has the same host and tls configuration as `gpustack` ingress.