### PR TITLE
fix: patch backend version with updated data

### DIFF
--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -843,11 +843,10 @@ $@
                     self._model.id, ModelUpdate(**self._model.model_dump())
                 )
             if not self._model_instance.backend_version:
-                self._model_instance.backend_version = service_version
-                self._clientset.model_instances.update(
-                    self._model_instance.id,
-                    ModelInstanceUpdate(**self._model_instance.model_dump()),
-                )
+                patch_dict = {
+                    "backend_version": service_version,
+                }
+                self._update_model_instance(self._model_instance.id, patch_dict)
         except Exception as e:
             logger.error(
                 f"Failed to update model service version {service_version}: {e}"


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4099

Problem:
The state is updated by inference server when setting the backend version with a legacy state.

Solution:
Patch backend_version only.