### PR TITLE
fix: correct parameter name for memory fraction static in backend model

### DIFF
--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -338,7 +338,7 @@ class SGLangServer(InferenceServer):
             and self._model_instance.computed_resource_claim.vram_utilization
         ):
             input_utilization = find_parameter(
-                self._model.backend_parameters, ["mem_fraction_static"]
+                self._model.backend_parameters, ["mem-fraction-static"]
             )
             if not input_utilization:
                 arguments.extend(


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4153#issuecomment-3722451711