### PR TITLE
feat: models list add not_stopped(replicas > 0) status filter

### DIFF
--- a/gpustack/routes/models.py
+++ b/gpustack/routes/models.py
@@ -56,6 +56,7 @@ class ModelStateFilterEnum(str, Enum):
     READY = "ready"
     NOT_READY = "not_ready"
     STOPPED = "stopped"
+    NOT_STOPPED = "not_stopped"
 
 
 @router.get("", response_model=ModelsPublic)
@@ -130,6 +131,8 @@ async def _get_models(
         )
     elif state == ModelStateFilterEnum.STOPPED:
         extra_conditions.append(target_class.replicas == 0)
+    elif state == ModelStateFilterEnum.NOT_STOPPED:
+        extra_conditions.append(target_class.replicas > 0)
 
     order_by = params.order_by
     if order_by:


### PR DESCRIPTION
ie: `v2/models?page=1&perPage=10&state=not_stopped`


目的：只列出非停止状态，这样不用来回状态切换，以方便快速聚焦当前需要关注的模型列表