### PR TITLE
ci: use dev tag

### DIFF
--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -95,8 +95,11 @@ jobs:
         with:
           images: "${{ env.INPUT_NAMESPACE }}/${{ env.INPUT_REPOSITORY }}"
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=dev-,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch,enable=${{ contains(github.ref, 'refs/heads/v') && endsWith(github.ref, '-dev') }}
+            type=sha,prefix={{branch}}-,enable=${{ contains(github.ref, 'refs/heads/v') && endsWith(github.ref, '-dev') }}
             type=pep440,pattern={{raw}}
             type=pep440,pattern=v{{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3294

Use "dev" for images built from the main branch

Publish `dev-<commit-hash>` and `vx.y-dev-<commit-hash>` to help locate broken commits.