### PR TITLE
feat: provide first login info

### DIFF
--- a/gpustack/routes/ui.py
+++ b/gpustack/routes/ui.py
@@ -1,6 +1,5 @@
 import os
-from gpustack.config.config import Config
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -20,18 +19,3 @@ def register(app: FastAPI):
     @app.get("/", include_in_schema=False)
     async def index():
         return FileResponse(os.path.join(ui_dir, "index.html"))
-
-    # Provide configuration interface
-    @app.get("/auth-config")
-    async def get_auth_config(request: Request):
-        req_dict = {}
-        config: Config = request.app.state.server_config
-        auth_type = 'Local'
-        if config.external_auth_type:
-            auth_type = config.external_auth_type
-        if auth_type.lower() == 'oidc':
-            req_dict = {"is_oidc": True, "is_saml": False}
-        if auth_type.lower() == 'saml':
-            req_dict = {"is_oidc": False, "is_saml": True}
-
-        return req_dict


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3770

Move `/auth-config` to `/auth/config`

Provide first login info:
```json
{
    "first_time_setup": true,
    "get_initial_password_command": "docker exec <container_name_or_id> cat /var/lib/gpustack/initial_admin_password"
}
```

CC @hibig 