### PR TITLE
fix: yield initial list outside session context manager

### DIFF
--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -660,10 +660,12 @@ class ActiveRecordMixin:
             topic,
             id(subscriber),
         )
+
         async with async_session() as session:
-            items = await cls.all(session)
-            for item in items:
-                yield Event(type=EventType.CREATED, data=item)
+            initial_items = await cls.all(session)
+
+        for item in initial_items:
+            yield Event(type=EventType.CREATED, data=item)
 
         heartbeat_interval = timedelta(seconds=15)
         last_event_time = datetime.now(timezone.utc)


### PR DESCRIPTION
Potential fix for https://github.com/gpustack/gpustack/issues/4305.

Close session early before yielding initial list on subscribe