### PR TITLE
refactor: get pretrained config

### DIFF
--- a/gpustack/policies/candidate_selectors/ascend_mindie_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/ascend_mindie_resource_fit_selector.py
@@ -64,7 +64,12 @@ class AscendMindIEResourceFitSelector(ScheduleCandidatesSelector):
 
         # Store and format the abnormal message during scheduling, finally it will be extended to self._diagnostic_messages.
         self._scheduling_messages: ListMessageBuilder = ListMessageBuilder([])
+
+    async def _init_model_parameters(self, workers: List[Worker] = None):
+        await super()._init_model_parameters(workers)
+
         # Parse model params.
+        model = self._model
         max_seq_len = self._model_params.derived_max_seq_len
         if max_seq_len > 8192:
             max_seq_len = 8192
@@ -142,6 +147,9 @@ class AscendMindIEResourceFitSelector(ScheduleCandidatesSelector):
         1. Estimating the resource requirements.
         2. Constructing candidates that can accommodate the estimated resource requirements.
         """
+
+        # Initialize model parameters.
+        await self._init_model_parameters(workers)
 
         # Estimate resource usage.
         estimated_usage = await self._estimate_usage(workers)

--- a/gpustack/policies/candidate_selectors/custom_backend_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/custom_backend_resource_fit_selector.py
@@ -45,7 +45,7 @@ class CustomBackendResourceFitSelector(ScheduleCandidatesSelector):
     """
 
     def __init__(self, cfg: Config, model: Model, model_instances: List[ModelInstance]):
-        super().__init__(cfg, model, model_instances, parse_model_params=False)
+        super().__init__(cfg, model, model_instances)
         self._event_collector = EventCollector(model, logger)
         self._messages = []
 

--- a/gpustack/policies/candidate_selectors/sglang_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/sglang_resource_fit_selector.py
@@ -82,6 +82,9 @@ class SGLangResourceFitSelector(ScheduleCandidatesSelector):
             SGLangResourceFitSelector.get_world_size_from_backend_parameters(model)
         )
         self._set_gpu_count(world_size, strategies)
+
+    async def _init_model_parameters(self, workers: List[Worker]):
+        await super()._init_model_parameters(workers)
         self._validate_and_set_arguments()
 
     @staticmethod
@@ -260,6 +263,10 @@ class SGLangResourceFitSelector(ScheduleCandidatesSelector):
         """
         Get schedule candidates that fit the GPU resources requirement for SGLang.
         """
+
+        # Initialize model parameters.
+        await self._init_model_parameters(workers)
+
         if self._is_diffusion:
             self._vram_claim = await estimate_diffusion_model_vram(
                 self._model, self._config.huggingface_token, workers

--- a/gpustack/policies/candidate_selectors/vllm_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/vllm_resource_fit_selector.py
@@ -83,6 +83,8 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
         self._set_gpu_count(world_size, strategies)
         self._set_gpu_memory_utilization()
 
+    async def _init_model_parameters(self, workers: List[Worker]):
+        await super()._init_model_parameters(workers)
         self._validate_arguments()
 
     @staticmethod
@@ -239,6 +241,9 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
         """
         Get schedule candidates that fit the GPU resources requirement.
         """
+
+        # Initialize model parameters.
+        await self._init_model_parameters(workers)
 
         self._vram_claim = await estimate_model_vram(
             self._model, self._config.huggingface_token, workers

--- a/gpustack/policies/candidate_selectors/vox_box_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/vox_box_resource_fit_selector.py
@@ -43,9 +43,7 @@ class VoxBoxResourceFitSelector(ScheduleCandidatesSelector):
         model_instances: List[ModelInstance],
         cache_dir: str,
     ):
-        super().__init__(
-            config, model, model_instances=model_instances, parse_model_params=False
-        )
+        super().__init__(config, model, model_instances=model_instances)
         self._cache_dir = os.path.join(cache_dir, "vox-box")
         self._messages = []
 

--- a/gpustack/policies/utils.py
+++ b/gpustack/policies/utils.py
@@ -377,7 +377,7 @@ async def estimate_diffusion_model_vram(
             or model.source == SourceEnum.MODEL_SCOPE
         ):
             weight_size = await asyncio.wait_for(
-                get_diffusion_model_weight_size(model, token),
+                asyncio.to_thread(get_diffusion_model_weight_size, model, token),
                 timeout=timeout_in_seconds,
             )
         elif model.source == SourceEnum.LOCAL_PATH:

--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -43,7 +43,7 @@ from gpustack.server.bus import Event
 from gpustack.utils.config import apply_registry_override_to_image
 from gpustack.utils.envs import filter_env_vars
 from gpustack.utils.hub import get_hf_text_config, get_max_model_len
-from gpustack.scheduler.calculator import get_pretrained_config_sync
+from gpustack.utils.hub import get_pretrained_config
 from gpustack.utils.profiling import time_decorator
 from gpustack.utils import platform
 from gpustack.utils.runtime import transform_workload_plan
@@ -223,7 +223,7 @@ class InferenceServer(ABC):
             return self._pretrained_config
 
         try:
-            pretrained_config = get_pretrained_config_sync(self._model)
+            pretrained_config = get_pretrained_config(self._model)
             self._pretrained_config = pretrained_config
             return pretrained_config
         except Exception as e:

--- a/tests/policies/candidate_selectors/ascend_mindie/test_ascend_mindie_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/ascend_mindie/test_ascend_mindie_resource_fit_selector.py
@@ -1544,7 +1544,7 @@ async def test_select_candidates_4x_64gx8(config, m, expected):
                 cpu_offloading=False,
                 backend_parameters=[
                     "--max-seq-len=32768",
-                    "--npu-memory-fraction=0.5",
+                    "--npu-memory-fraction=0.2",
                     "--trust-remote-code",
                 ],
             ),
@@ -1565,7 +1565,7 @@ async def test_select_candidates_4x_64gx8(config, m, expected):
                 cpu_offloading=False,
                 backend_parameters=[
                     "--max-seq-len=32768",
-                    "--npu-memory-fraction=0.5",
+                    "--npu-memory-fraction=0.2",
                     "--trust-remote-code",
                 ],
             ),
@@ -1586,7 +1586,7 @@ async def test_select_candidates_4x_64gx8(config, m, expected):
                 cpu_offloading=False,
                 backend_parameters=[
                     "--max-seq-len=32768",
-                    "--npu-memory-fraction=0.5",
+                    "--npu-memory-fraction=0.2",
                     "--trust-remote-code",
                 ],
                 distributed_inference_across_workers=False,
@@ -1646,8 +1646,6 @@ async def test_select_candidates_2x_64gx4_2x_64gx2_check_msg(
 
     resource_fit_selector = AscendMindIEResourceFitSelector(config, m, model_instances)
 
-    resource_fit_selector._serving_params.npu_memory_fraction = 0.2
-
     with (
         patch(
             "gpustack.policies.utils.get_worker_model_instances",
@@ -1675,7 +1673,7 @@ async def test_select_candidates_2x_64gx4_2x_64gx2_check_msg(
                 cpu_offloading=False,
                 backend_parameters=[
                     "--max-seq-len=32768",
-                    "--npu-memory-fraction=0.5",
+                    "--npu-memory-fraction=0.9",
                     "--trust-remote-code",
                 ],
                 gpu_selector=GPUSelector(
@@ -1709,7 +1707,7 @@ async def test_select_candidates_2x_64gx4_2x_64gx2_check_msg(
                 cpu_offloading=False,
                 backend_parameters=[
                     "--max-seq-len=32768",
-                    "--npu-memory-fraction=0.5",
+                    "--npu-memory-fraction=0.1",
                     "--trust-remote-code",
                 ],
                 gpu_selector=GPUSelector(
@@ -1743,7 +1741,7 @@ async def test_select_candidates_2x_64gx4_2x_64gx2_check_msg(
                 cpu_offloading=False,
                 backend_parameters=[
                     "--max-seq-len=32768",
-                    "--npu-memory-fraction=0.5",
+                    "--npu-memory-fraction=0.9",
                     "--trust-remote-code",
                 ],
                 gpu_selector=GPUSelector(
@@ -1850,21 +1848,8 @@ async def test_select_candidates_4x_64gx4_manually_check_msg(  # noqa: C901
         if gpu.memory.allocated
     ]
 
-    if index == 1:
-        resource_fit_selector = AscendMindIEResourceFitSelector(
-            config, m, model_instances
-        )
-        resource_fit_selector._serving_params.npu_memory_fraction = 0.9
-    elif index == 2:
-        resource_fit_selector = AscendMindIEResourceFitSelector(
-            config, m, model_instances
-        )
-        resource_fit_selector._serving_params.npu_memory_fraction = 0.1
-    elif index == 3:
-        resource_fit_selector = AscendMindIEResourceFitSelector(
-            config, m, model_instances
-        )
-        resource_fit_selector._serving_params.npu_memory_fraction = 0.9
+    resource_fit_selector = AscendMindIEResourceFitSelector(config, m, model_instances)
+    if index == 3:
         for worker in workers:
             worker.system_reserved.ram = worker.status.memory.total - 500
 

--- a/tests/policies/candidate_selectors/vllm/test_vllm_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/vllm/test_vllm_resource_fit_selector.py
@@ -903,11 +903,16 @@ async def test_auto_schedule_single_work_multi_gpu(
     resource_fit_selector = VLLMResourceFitSelector(config, m, mis)
     placement_scorer = PlacementScorer(m, mis)
 
-    if index == 1:
-        # Simulate a scenario where the model's num_attention_heads cannot be evenly divided by the gpu_count through auto-scheduling.
-        resource_fit_selector._num_attention_heads = 25
-    if index == 3:
-        resource_fit_selector._model_params.vocab_size = 10001
+    original_init_model_params = resource_fit_selector._init_model_parameters
+
+    async def mock_init_model_parameters(self, workers):
+        if index == 1:
+            # Simulate a scenario where the model's num_attention_heads cannot be evenly divided by the gpu_count through auto-scheduling.
+            resource_fit_selector._num_attention_heads = 25
+        elif index == 3:
+            resource_fit_selector._model_params.vocab_size = 10001
+        else:
+            await original_init_model_params(workers)
 
     with (
         patch(
@@ -921,6 +926,11 @@ async def test_auto_schedule_single_work_multi_gpu(
         patch(
             'gpustack.policies.scorers.placement_scorer.async_session',
             return_value=AsyncMock(),
+        ),
+        patch.object(
+            VLLMResourceFitSelector,
+            '_init_model_parameters',
+            new=mock_init_model_parameters,
         ),
     ):
 

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest.mock import AsyncMock
 from gpustack.scheduler.evaluator import evaluate_model_metadata
 from tests.utils.model import new_model
 from gpustack.scheduler.scheduler import evaluate_pretrained_config
@@ -211,7 +210,7 @@ async def test_evaluate_model_metadata(
 ):
     try:
         actual_compatible, actual_error = await evaluate_model_metadata(
-            config, AsyncMock(), model, []
+            config, model, []
         )
         assert (
             actual_compatible == expect_compatible

--- a/tests/utils/test_hub.py
+++ b/tests/utils/test_hub.py
@@ -205,7 +205,6 @@ def test_get_ms_min_gguf_file():
         ),
     ],
 )
-@pytest.mark.asyncio
-async def test_read_repo_file_content(m, file, token, predicate):
-    config_dict = await read_repo_file_content(m, file, token)
+def test_read_repo_file_content(m, file, token, predicate):
+    config_dict = read_repo_file_content(m, file, token)
     assert predicate(config_dict)


### PR DESCRIPTION
Problems:
1. HfFileSystem in read_repo_file_content() uses sync functions but get wrapped in async, blocking the async loop.
2. fetching remote workers does not work for pretrained_config in base_candidate_selector.
3. Current structure of get_pretrained_config/get_pretrained_config_sync are messy with overlapped code and async context switch
4. It seems redundant when a worker in both target_workers and filtered workers are handled twice.
5. It passes session everywhere to query model_files, making it difficult to manage db sessions.

Solution:
1. Fix async blocker. Unify get_pretrained_config(). Now all functions in hub.py are sync. Async callers(calculator.py) use the to_thread wrapper when calling functions in hub.py.
2. Instead of querying model file deep down, do it early and sort workers by priority.
3. The code has been restructrued as:
    - for non-present local_path, fetch metadata from remote.
    - for other cases, use the unified get_pretrained_config() as before.
