### PR TITLE
Revert "feat: supported to show registry in add worker command"

### DIFF
--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -395,7 +395,7 @@ class ClusterRegistrationTokenPublic(BaseModel):
     server_url: str
     image: str
     env: Dict[str, str]
-    args: List[List[str]]
+    args: List[str]
 
 
 class CredentialType(str, Enum):


### PR DESCRIPTION
This reverts commit dd5acf61acb021ed3d4e8ab94a498a3fcb2c3045.
https://github.com/gpustack/gpustack/issues/4334
Revert reason: Hardcoding parameters in the docker startup command prevents dynamic updates to the same field in worker_config, requiring worker recreation to take effect. This contradicts the original design.