### PR TITLE
fix: improve whitespace handling in backend parameter parsing

### DIFF
--- a/tests/worker/backends/test_backend.py
+++ b/tests/worker/backends/test_backend.py
@@ -111,6 +111,35 @@ async def test_apply_registry_override(
                 """--hf-overrides={"architectures": ["NewModel"]}""",
             ],
         ),
+        # Test cases for whitespace handling
+        (
+            [" --ctx-size=1024"],
+            ["--ctx-size=1024"],
+        ),
+        (
+            ["--ctx-size =1024"],
+            ["--ctx-size=1024"],
+        ),
+        (
+            ["  --ctx-size  =1024"],
+            ["--ctx-size=1024"],
+        ),
+        (
+            ["--ctx-size  =  1024"],
+            ["--ctx-size=1024"],
+        ),
+        (
+            ["  --ctx-size 1024"],
+            ["--ctx-size", "1024"],
+        ),
+        (
+            [" --max-model-len=8192"],
+            ["--max-model-len=8192"],
+        ),
+        (
+            ["--foo =bar", "  --baz  =  qux"],
+            ["--foo=bar", "--baz=qux"],
+        ),
         (
             None,
             [],


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4375#issuecomment-3845555968

Add space handling to the `_flatten_backend_param` method which was missed in previous changes.