### PR TITLE
fix: matchRules defaults to None in docker environment

### DIFF
--- a/gpustack/gateway/utils.py
+++ b/gpustack/gateway/utils.py
@@ -1166,7 +1166,9 @@ async def ensure_gpustack_ai_proxy_config(
             )
         )
         existing_plugin.spec.matchRules = compare_and_append_proxy_match_rules(
-            existing_plugin.spec.matchRules, expected_match_rules, operating_id_prefix
+            existing_plugin.spec.matchRules or [],
+            expected_match_rules,
+            operating_id_prefix,
         )
         await extensions_api.edit_wasmplugin(
             namespace=namespace,


### PR DESCRIPTION
To avoid NoneType is not iterable exception.
refer to issue:
- #4465 