### PR TITLE
feat: add support for user and group configuration in workload creation

### DIFF
--- a/gpustack/worker/backends/ascend_mindie.py
+++ b/gpustack/worker/backends/ascend_mindie.py
@@ -1625,6 +1625,8 @@ class AscendMindIEServer(InferenceServer):
             host_network=True,
             shm_size=int(container_config.shm_size_gib * (1 << 30)),
             containers=[run_container],
+            run_as_user=container_config.user,
+            run_as_group=container_config.group,
         )
         create_workload(self._transform_workload_plan(workload_plan))
 

--- a/gpustack/worker/backends/custom.py
+++ b/gpustack/worker/backends/custom.py
@@ -129,6 +129,8 @@ class CustomServer(InferenceServer):
             host_network=True,
             shm_size=int(container_config.shm_size_gib * (1 << 30)),
             containers=[run_container],
+            run_as_user=container_config.user,
+            run_as_group=container_config.group,
         )
         create_workload(self._transform_workload_plan(workload_plan))
 

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -196,6 +196,8 @@ class SGLangServer(InferenceServer):
             host_network=True,
             shm_size=int(container_config.shm_size_gib * (1 << 30)),
             containers=[run_container],
+            run_as_user=container_config.user,
+            run_as_group=container_config.group,
         )
         create_workload(self._transform_workload_plan(workload_plan))
 

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -213,6 +213,8 @@ class VLLMServer(InferenceServer):
                 if not sidecar_container
                 else [run_container, sidecar_container]
             ),
+            run_as_user=container_config.user,
+            run_as_group=container_config.group,
         )
         create_workload(self._transform_workload_plan(workload_plan))
 

--- a/gpustack/worker/backends/vox_box.py
+++ b/gpustack/worker/backends/vox_box.py
@@ -123,6 +123,8 @@ class VoxBoxServer(InferenceServer):
             host_network=True,
             shm_size=int(container_config.shm_size_gib * (1 << 30)),
             containers=[run_container],
+            run_as_user=container_config.user,
+            run_as_group=container_config.group,
         )
         create_workload(self._transform_workload_plan(workload_plan))
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/3408
To specify run_as_user as root (uid=0), the runtime currently can only be set via WorkLoadPlan and is not supported in container.execution.