### PR TITLE
fix: use default worker status to avoid NoneType error

### DIFF
--- a/gpustack/worker/collector.py
+++ b/gpustack/worker/collector.py
@@ -87,7 +87,7 @@ class WorkerStatusCollector:
         self, clientset: ClientSet = None, initial: bool = False
     ) -> WorkerStatusPublic:  # noqa: C901
         """Collect worker status information."""
-        status = WorkerStatus()
+        status = WorkerStatus.get_default_status()
         state_message = None
         try:
             system_info = self._detector_factory.detect_system_info()


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4062
The root cause is that memory leaks or other special factors continuously exhaust the OS resource limits, preventing the detector from consistently collecting CPU and other metrics. This cannot be resolved at its source, but we can reduce errors caused by directly using NoneType.