### PR TITLE
feat: remove optional depends such as vllm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,22 +91,11 @@ dev = [
 ]
 
 [project.optional-dependencies]
-vllm = [
-    "vllm==0.10.1.1",
-    "mistral_common[opencv]>=1.4.3",
-    "bitsandbytes>=0.45.2",
-    "timm>=1.0.15",
-]
 audio = [
-    "vox-box==0.0.19",
-    "numba>=0.56.0",
+    "vox-box==0.0.19"
 ]
 all = [
-    "vllm==0.10.1.1",
-    "mistral_common[opencv]>=1.4.3",
-    "bitsandbytes>=0.45.2",
-    "timm>=1.0.15",
-    "vox-box==0.0.19",
+    "vox-box==0.0.19"
 ]
 
 [project.scripts]


### PR DESCRIPTION
As gpustack has evolved, when building gpustack packages and building containers based on packages, we no longer need the documentation for dependencies such as vllm in gpustack, so it is best to remove them.