### PR TITLE
refactor: upgrade benchmark to fix issues

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -103,6 +103,7 @@ The **Applies to** column indicates where the environment variable should be set
 | Variable                                   | Description                                                                                                                                      | Default                                                                               | Applies to |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- | ---------- |
 | `GPUSTACK_BENCHMARK_DATASET_SHAREGPT_PATH` | ShareGPT dataset path used by the benchmark container when `dataset_name` is set to `ShareGPT`. The default image already includes this dataset. | `/workspace/benchmark-runner/sharegpt_data/ShareGPT_V3_unfiltered_cleaned_split.json` | Worker     |
+| `GPUSTACK_BENCHMARK_REQUEST_TIMEOUT`       | Timeout for each benchmark request in seconds.                                                                                                   | `3600`                                                                                | Worker     |
 
 ### Model Deployment Configuration
 

--- a/gpustack/__init__.py
+++ b/gpustack/__init__.py
@@ -1,2 +1,3 @@
 __version__ = '0.0.0'
 __git_commit__ = 'HEAD'
+__benchmark_runner_version__ = 'v0.0.2'

--- a/gpustack/cmd/images.py
+++ b/gpustack/cmd/images.py
@@ -1,6 +1,6 @@
 import argparse
 
-from gpustack import __version__
+from gpustack import __version__, __benchmark_runner_version__
 
 from gpustack_runtime.cmds import (
     CopyImagesSubCommand,
@@ -13,7 +13,7 @@ from gpustack_runtime.cmds import (
 # Append images used by GPUStack here.
 append_images(
     f"gpustack/gpustack:{'dev' if __version__.removeprefix('v') == '0.0.0' else __version__}",
-    f"gpustack/benchmark-runner:{'dev' if __version__.removeprefix('v') == '0.0.0' else 'v0.0.1'}",
+    f"gpustack/benchmark-runner:{__benchmark_runner_version__}",
 )
 
 

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -102,3 +102,6 @@ BENCHMARK_DATASET_SHAREGPT_PATH = os.getenv(
     "GPUSTACK_BENCHMARK_DATASET_SHAREGPT_PATH",
     "/workspace/benchmark-runner/sharegpt_data/ShareGPT_V3_unfiltered_cleaned_split.json",
 )
+BENCHMARK_REQUEST_TIMEOUT = int(
+    os.getenv("GPUSTACK_BENCHMARK_REQUEST_TIMEOUT", 3600)  # 1 hour
+)  # in seconds

--- a/gpustack/schemas/config.py
+++ b/gpustack/schemas/config.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import Optional
 from pydantic import BaseModel, Field
 
+from gpustack import __benchmark_runner_version__
+
 
 class GatewayModeEnum(str, Enum):
     """
@@ -53,7 +55,9 @@ class PredefinedConfig(SensitivePredefinedConfig):
     system_default_container_registry: Optional[str] = None
     image_name_override: Optional[str] = None
     image_repo: str = "gpustack/gpustack"
-    benchmark_image_repo: str = "gpustack/benchmark-runner"
+    benchmark_image_repo: str = (
+        f"gpustack/benchmark-runner:{__benchmark_runner_version__}"
+    )
     gateway_mode: GatewayModeEnum = GatewayModeEnum.auto
     gateway_kubeconfig: Optional[str] = None
     gateway_namespace: str = "higress-system"


### PR DESCRIPTION
- #4541 

Cause by benchmark-runner is update, need to upgrade benchmark-runner image to resolve

- #4501 

Add first 5 error/incomplete requests to the log and extend the default request timeout to 1h

- #4503

Cause by sometimes only reasoning data or empty content, upgrade benchmark-runner image
```json
{'index': 0, 'delta': {'reasoning': ' talk', 'reasoning_content': ' talk'}, 'logprobs': None, 'finish_reason': None, 'token_ids': None}
{'index': 0, 'delta': {'role': 'assistant', 'content': '', 'reasoning_content': None}, 'logprobs': None, 'finish_reason': None}
```
