### PR TITLE
fix: use await for commit and rollback operations

### DIFF
--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -646,10 +646,11 @@ class ActiveRecordMixin:
             cls._publish_event_after_commit(session, EventType.DELETED, obj)
             await obj.delete(session, soft=soft, auto_commit=False)
         try:
-            session.commit()
+            await session.commit()
         except Exception as e:
-            session.rollback()
+            await session.rollback()
             logger.error(f"Failed to delete all objects of {cls.__name__}: {e}")
+            raise
 
     @classmethod
     def _publish_event_after_commit(

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -474,7 +474,7 @@ class Server:
             await session.commit()
         except Exception as e:
             logger.error(f"Failed to migrate legacy token: {e}")
-            session.rollback()
+            await session.rollback()
             raise e
 
     async def _migrate_legacy_workers(self, session: AsyncSession):
@@ -543,7 +543,7 @@ class Server:
                 logger.error(
                     f"Failed to migrate worker {worker.id} ({worker.name}): {e}"
                 )
-                session.rollback()
+                await session.rollback()
                 raise e
 
     async def _ensure_registration_token(self, session: AsyncSession):
@@ -576,7 +576,7 @@ class Server:
                 await session.commit()
             except Exception as e:
                 logger.error(f"Failed to ensure registration token: {e}")
-                session.rollback()
+                await session.rollback()
                 raise e
 
         write_registration_token(


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4386

The key exception `asyncpg.exceptions.InterfaceError: cannot use Connection.transaction() in a manually started transaction` occurs because an unawaited `session.rollback()` leaves the connection in an invalid transaction state, contaminating it for the next request and raising this error.