### PR TITLE
feat: add OpenAI Responses API proxy support

### DIFF
--- a/docs/integrations/inference-apis.md
+++ b/docs/integrations/inference-apis.md
@@ -13,6 +13,7 @@ The following API endpoints are supported:
 - [x] [List Models](https://platform.openai.com/docs/api-reference/models/list)
 - [x] [Create Completion](https://platform.openai.com/docs/api-reference/completions/create)
 - [x] [Create Chat Completion](https://platform.openai.com/docs/api-reference/chat/create)
+- [x] [Create Response](https://platform.openai.com/docs/api-reference/responses/create)
 - [x] [Create Embeddings](https://platform.openai.com/docs/api-reference/embeddings/create)
 - [x] [Create Image](https://platform.openai.com/docs/api-reference/images/create)
 - [x] [Create Image Edit](https://platform.openai.com/docs/api-reference/images/createEdit)

--- a/gpustack/gateway/utils.py
+++ b/gpustack/gateway/utils.py
@@ -87,6 +87,7 @@ openai_model_prefixes: List[RoutePrefix] = [
         [
             "/chat/completions",
             "/completions",
+            "/responses",
             "/embeddings",
             "/audio/transcriptions",
             "/audio/speech",

--- a/gpustack/routes/openai.py
+++ b/gpustack/routes/openai.py
@@ -92,6 +92,7 @@ async def list_models(
 
 @router.post("/completions")
 @router.post("/chat/completions")
+@router.post("/responses")
 @router.post("/embeddings")
 @router.post("/images/generations")
 @router.post("/images/edits")

--- a/tests/gateway/test_gateway_utils.py
+++ b/tests/gateway/test_gateway_utils.py
@@ -2,18 +2,25 @@ from gpustack.gateway.utils import RoutePrefix
 
 
 def test_flattened_prefixes():
-    assert RoutePrefix(["/chat/completions", "/completions"]).flattened_prefixes() == [
+    assert RoutePrefix(
+        ["/chat/completions", "/completions", "/responses"]
+    ).flattened_prefixes() == [
         "/v1/chat/completions",
         "/v1/completions",
+        "/v1/responses",
         "/v1-openai/chat/completions",
         "/v1-openai/completions",
+        "/v1-openai/responses",
     ]
 
 
 def test_regex_prefixes():
-    assert RoutePrefix(["/chat/completions", "/completions"]).regex_prefixes() == [
+    assert RoutePrefix(
+        ["/chat/completions", "/completions", "/responses"]
+    ).regex_prefixes() == [
         r"/(v1)(-openai)?(/chat/completions)",
         r"/(v1)(-openai)?(/completions)",
+        r"/(v1)(-openai)?(/responses)",
     ]
     assert RoutePrefix(
         ["/chat/completions", "/completions"], support_legacy=False


### PR DESCRIPTION
Add /v1/responses support to the OpenAI-compatible proxy path and gateway route matching so vLLM Responses API requests are forwarded correctly.