### PR TITLE
[v2.2.0]feat: update hf-xet to version 1.3.1 and add to dependencies

### DIFF
--- a/docs/cli-reference/start.md
+++ b/docs/cli-reference/start.md
@@ -104,7 +104,7 @@ gpustack start [OPTIONS]
 | `--log-dir` value                        | (empty)                                | Directory to store logs.                                                                                                                                                                        |
 | `--system-reserved` value                | (empty)                                | The system reserves resources for the worker during scheduling, measured in GiB. By default, no resources are reserved, Example: '{\"ram\": 2, \"vram\": 1}'.                                   |
 | `--enable-hf-transfer`                   | `False`                                | Enable faster downloads from the Hugging Face Hub using hf_transfer. https://huggingface.co/docs/huggingface_hub/v0.29.3/package_reference/environment_variables#hfhubenablehftransfer          |
-| `--enable-hf-xet`                        | `False`                                | Enable downloading model files using Hugging Face Xet.                                                                                                                                          |
+| `--enable-hf-xet`                        | `False`                                | [Deprecated] Enable downloading model files using Hugging Face Xet.                                                                                                                                          |
 | `--worker-ifname` value                  | (empty)                                | Network interface name of the worker node. Auto-detected by default.                                                                                                                            |
 | `--proxy-mode` value                     | (empty)                                | Proxy mode for server accessing model instances: direct (server connects directly) or worker (via worker proxy). Default value is direct for embedded worker, and worker for standalone worker. |
 | `--benchmark-image-repo` value           | `gpustack/benchmark-runner`            | Override the default benchmark image repo for the GPUStack benchmark container.                                                                                                                 |
@@ -184,6 +184,5 @@ system_reserved:
   ram: 2
   vram: 1
 enable_hf_transfer: false
-enable_hf_xet: false
 proxy_mode: worker
 ```

--- a/docs/user-guide/cluster-management.md
+++ b/docs/user-guide/cluster-management.md
@@ -118,7 +118,6 @@ system_reserved:
 # ========= huggingface ===========
 huggingface_token: xxxxxx
 enable_hf_transfer: false
-enable_hf_xet: false
 ```
 
 The above YAML lists all currently supported options for the `Worker Configuration YAML`. For the meaning of each option, refer to the full GPUStack [config file documentation](../cli-reference/start.md#config-file).

--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -576,7 +576,7 @@ def start_cmd_options(parser_server: argparse.ArgumentParser):
     worker_group.add_argument(
         "--enable-hf-xet",
         action=OptionalBoolAction,
-        help="Enable downloading model files using Hugging Face Xet.",
+        help="[Deprecated] Enable downloading model files using Hugging Face Xet.",
     )
     worker_group.add_argument(
         "--proxy-mode",
@@ -764,7 +764,6 @@ def set_worker_options(args, config_data: dict):
         "system_reserved",
         "tools_download_base_url",
         "enable_hf_transfer",
-        "enable_hf_xet",
         "proxy_mode",
     ]
 
@@ -791,10 +790,6 @@ def set_third_party_env(cfg: Config):
         # https://huggingface.co/docs/huggingface_hub/guides/download#faster-downloads
         os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
         logger.debug("set env HF_HUB_ENABLE_HF_TRANSFER=1")
-
-    if not cfg.enable_hf_xet:
-        os.environ["HF_HUB_DISABLE_XET"] = "1"
-        logger.debug("set env HF_HUB_DISABLE_XET=1")
 
 
 # Adapted from: https://github.com/vllm-project/vllm/blob/main/vllm/utils.py#L2438

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -105,7 +105,6 @@ class Config(WorkerConfig, BaseSettings):
         system_reserved: Reserved system resources.
         tools_download_base_url: Base URL to download dependency tools.
         enable_hf_transfer: Speed up file transfers with the huggingface Hub.
-        enable_hf_xet: Using Hugging Face XET for download model files.
         enable_cors: Enable CORS in server.
         allow_origins: A list of origins that should be permitted to make cross-origin requests.
         allow_credentials: Indicate that cookies should be supported for cross-origin requests.

--- a/gpustack/schemas/config.py
+++ b/gpustack/schemas/config.py
@@ -75,7 +75,7 @@ class PredefinedConfig(SensitivePredefinedConfig):
     pipx_path: Optional[str] = None
     tools_download_base_url: Optional[str] = None
     enable_hf_transfer: bool = False
-    enable_hf_xet: bool = False
+    enable_hf_xet: bool = False  # Deprecated
     proxy_mode: Optional[ModelInstanceProxyModeEnum] = None
 
 
@@ -83,7 +83,7 @@ class PredefinedConfigNoDefaults(PredefinedConfig):
     debug: Optional[bool] = None
     disable_worker_metrics: Optional[bool] = None
     enable_hf_transfer: Optional[bool] = None
-    enable_hf_xet: Optional[bool] = None
+    enable_hf_xet: Optional[bool] = None  # Deprecated
     worker_port: Optional[int] = None
     worker_metrics_port: Optional[int] = None
     service_port_range: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "psutil>=7.0.0",
     "requests>=2.32.3",
     "huggingface-hub>=0.32.0",
+    "hf-xet>=1.3.1,<1.4.0",
     "attrs>=24.2.0",
     "aiosqlite>=0.20.0",
     "sqlalchemy[asyncio]>=2.0.38",

--- a/uv.lock
+++ b/uv.lock
@@ -1898,6 +1898,7 @@ dependencies = [
     { name = "gpustack-runner" },
     { name = "gpustack-runtime" },
     { name = "hf-transfer" },
+    { name = "hf-xet" },
     { name = "httpx", extra = ["socks"] },
     { name = "huggingface-hub" },
     { name = "importlib-resources" },
@@ -2005,6 +2006,7 @@ requires-dist = [
     { name = "gpustack-runner", specifier = "==0.1.25.post4" },
     { name = "gpustack-runtime", specifier = "==0.1.42.post6" },
     { name = "hf-transfer", specifier = ">=0.1.9" },
+    { name = "hf-xet", specifier = ">=1.3.1,<1.4.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "huggingface-hub", specifier = ">=0.32.0" },
     { name = "importlib-resources", specifier = ">=6.4.0" },
@@ -2243,17 +2245,18 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/d0/73454ef7ca885598a3194d07d5c517d91a840753c5b35d272600d7907f64/hf_xet-1.3.1.tar.gz", hash = "sha256:513aa75f8dc39a63cc44dbc8d635ccf6b449e07cdbd8b2e2d006320d2e4be9bb", size = 641393, upload-time = "2026-02-25T00:57:56.701Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f8/c2da4352c0335df6ae41750cf5bab09fdbfc30d3b4deeed9d621811aa835/hf_xet-1.3.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:581d1809a016f7881069d86a072168a8199a46c839cf394ff53970a47e4f1ca1", size = 3761755, upload-time = "2026-02-25T00:57:43.621Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e5/a2f3eaae09da57deceb16a96ebe9ae1f6f7b9b94145a9cd3c3f994e7782a/hf_xet-1.3.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:329c80c86f2dda776bafd2e4813a46a3ee648dce3ac0c84625902c70d7a6ddba", size = 3523677, upload-time = "2026-02-25T00:57:42.3Z" },
+    { url = "https://files.pythonhosted.org/packages/61/cd/acbbf9e51f17d8cef2630e61741228e12d4050716619353efc1ac119f902/hf_xet-1.3.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2973c3ff594c3a8da890836308cae1444c8af113c6f10fe6824575ddbc37eca7", size = 4178557, upload-time = "2026-02-25T00:57:35.399Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4f/014c14c4ae3461d9919008d0bed2f6f35ba1741e28b31e095746e8dac66f/hf_xet-1.3.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ed4bfd2e6d10cb86c9b0f3483df1d7dd2d0220f75f27166925253bacbc1c2dbe", size = 3958975, upload-time = "2026-02-25T00:57:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/86/50/043f5c5a26f3831c3fa2509c17fcd468fd02f1f24d363adc7745fbe661cb/hf_xet-1.3.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:713913387cc76e300116030705d843a9f15aee86158337eeffb9eb8d26f47fcd", size = 4158298, upload-time = "2026-02-25T00:57:51.14Z" },
+    { url = "https://files.pythonhosted.org/packages/08/9c/b667098a636a88358dbeb2caf90e3cb9e4b961f61f6c55bb312793424def/hf_xet-1.3.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e5063789c9d21f51e9ed4edbee8539655d3486e9cad37e96b7af967da20e8b16", size = 4395743, upload-time = "2026-02-25T00:57:52.783Z" },
+    { url = "https://files.pythonhosted.org/packages/70/37/4db0e4e1534270800cfffd5a7e0b338f2137f8ceb5768000147650d34ea9/hf_xet-1.3.1-cp37-abi3-win_amd64.whl", hash = "sha256:607d5bbc2730274516714e2e442a26e40e3330673ac0d0173004461409147dee", size = 3638145, upload-time = "2026-02-25T00:58:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/46/1ba8d36f8290a4b98f78898bdce2b0e8fe6d9a59df34a1399eb61a8d877f/hf_xet-1.3.1-cp37-abi3-win_arm64.whl", hash = "sha256:851b1be6597a87036fe7258ce7578d5df3c08176283b989c3b165f94125c5097", size = 3500490, upload-time = "2026-02-25T00:58:00.667Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2604

Try to update hf-xet to v1.3.1, in order to resolve the download issue.
Merge it into v2.2.0.