### PR TITLE
feat: add PATCH /v2/models/{id} for partial model updates

### DIFF
--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -302,6 +302,15 @@ class ModelUpdate(ModelBase):
     pass
 
 
+class ModelPatch(SQLModel):
+    """Partial update - only specified fields are updated."""
+    backend_parameters: Optional[List[str]] = Field(default=None)
+    replicas: Optional[int] = None
+    backend_version: Optional[str] = None
+    worker_selector: Optional[Dict[str, str]] = None
+    env: Optional[Dict[str, str]] = None
+
+
 class ModelPublic(
     ModelBase,
 ):


### PR DESCRIPTION
## Summary

- Adds `PATCH /v2/models/{id}` endpoint for partial model updates
- Adds `ModelPatch` schema (5 fields: `backend_parameters`, `replicas`, `backend_version`, `worker_selector`, `env`)
- With `?restart_instances=true` (default) — automatically deletes running instances so the controller recreates them with new config
- Uses `model_dump(exclude_unset=True)` so only fields present in the request body are applied

## Motivation

Currently updating `backend_parameters` (e.g. changing `--parallel`, `--ctx-size`) requires:
1. `GET /v2/models/{id}` to fetch full spec
2. Merge the single changed field into the full body
3. `PUT /v2/models/{id}` with the entire spec

A PATCH endpoint allows atomic partial updates without needing to know the full model spec upfront, which is useful for automation scripts and infrastructure-as-code tools.

## Changes

```
gpustack/routes/models.py  | 29 +++++++++++++++++++++++++++++
gpustack/schemas/models.py |  9 +++++++++
2 files changed, 38 insertions(+)
```

## Test plan

- [ ] `PATCH /v2/models/{id}` with `{"backend_parameters": ["--ctx-size", "8192"]}` updates the field without touching other fields
- [ ] With `restart_instances=true`: running instances are deleted and recreated with new params
- [ ] With `restart_instances=false`: model updated in DB, existing instances unchanged
- [ ] Empty body returns 400
- [ ] Unknown model ID returns 404