### PR TITLE
fix: use specific _key for preserved cache key

### DIFF
--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -711,7 +711,7 @@ class ActiveRecordMixin:
     async def _invalidate_cached_all(cls):
         """Invalidate cached_all cache for this model class."""
         cache_key = class_key("cached_all")(None, cls)
-        await delete_cache_by_key(key=cache_key)
+        await delete_cache_by_key(_key=cache_key)
 
     @classmethod
     async def delete_all(cls, session: AsyncSession, soft=False):

--- a/gpustack/server/cache.py
+++ b/gpustack/server/cache.py
@@ -25,7 +25,8 @@ def build_cache_key(func: Callable, *args, **kwargs):
     return func.__qualname__ + str(args) + str(ordered_kwargs)
 
 
-async def delete_cache_by_key(func=None, key: str = None, *args, **kwargs):
+async def delete_cache_by_key(func=None, *args, **kwargs):
+    key = kwargs.pop("_key", None)
     if key is None:
         if func is None:
             raise ValueError("Either func or key must be provided")

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -477,13 +477,10 @@ def intersection_nullable_set(set1: Set[str], set2: Optional[Set[str]]) -> Set[s
 
 
 async def delete_accessible_model_cache(
-    session: AsyncSession,
     *user_ids: int,
 ):
     for user_id in user_ids:
-        await delete_cache_by_key(
-            UserService(session).get_user_accessible_model_names, user_id
-        )
+        await delete_cache_by_key(UserService.get_user_accessible_model_names, user_id)
 
 
 async def revoke_model_access_cache(
@@ -499,4 +496,4 @@ async def revoke_model_access_cache(
         user_ids = {user.id for user in model.users}
     if extra_user_ids:
         user_ids.update(extra_user_ids)
-    await delete_accessible_model_cache(session, *user_ids)
+    await delete_accessible_model_cache(*user_ids)


### PR DESCRIPTION
Refer to issue:
- #4697 

Refer to the parameters defined for delete_cache_by_key:

```python
async def delete_cache_by_key(func=None, key: str = None, *args, **kwargs):
```

The original parameters for `delete_cache_by_key` function doesn't work properly with following use case:
- `delete_cache_by_key(UserService.get_user_accessible_model_names, user_id)`, the user_id is considered as key instead of part of args.
- `delete_cache_by_key(UserService.get_user_accessible_model_names, None, user_id)` will cause `ValueError("Either func or key must be provided")`
- `delete_cache_by_key(func=UserService.get_user_accessible_model_names, key=None, user_id)` will cause `位置参数不能出现在关键字参数之后`
- `delete_cache_by_key(func=UserService.get_user_accessible_model_names, key=None, user_id=user_id)` will consider `user_id` as **kwargs not *args.

So dial back the function parameters and defined a specific `_key` kwargs for the key.