### PR TITLE
fix: use specified plugin to set x-gpustack-model header

### DIFF
--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -403,12 +403,14 @@ def model_router_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
 
 def model_pre_route_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
     resource_name = "gpustack-set-model-pre-route"
-    enabled_paths = supported_openai_routes.copy()
-    enabled_paths.append("/model/proxy")
+    enabled_path_suffixes = supported_openai_routes.copy()
+    enabled_path_prefixes = ["/model/proxy"]
     expected_spec = WasmPluginSpec(
         defaultConfig={
-            'modelToHeader': router_header_key,
-            'enableOnPathSuffix': enabled_paths,
+            'clusterNameHeader': 'X-GPUStack-Model',
+            'routeNameHeader': 'X-GPUStack-Route-Name',
+            'enableOnPathSuffix': enabled_path_suffixes,
+            'enableOnPathPrefix': enabled_path_prefixes,
         },
         defaultConfigDisable=False,
         failStrategy="FAIL_OPEN",
@@ -417,7 +419,7 @@ def model_pre_route_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         phase="AUTHN",
         priority=90,
         url=get_plugin_url_with_name_and_version(
-            name="model-router", version="2.0.0", cfg=cfg
+            name="gpustack-set-header-pre-route", version="1.0.0", cfg=cfg
         ),
     )
     return resource_name, expected_spec

--- a/gpustack/gateway/plugins.py
+++ b/gpustack/gateway/plugins.py
@@ -71,6 +71,12 @@ supported_plugins: List[HigressPlugin] = [
         digest="sha256:8cc102de760e8aba2856149da9cbc8eae3d04f6d42127b624326885a013ac239",
         registry_prefix="oci://docker.io/gpustack/higress-plugin-",
     ),
+    HigressPlugin(
+        name="gpustack-set-header-pre-route",
+        version="1.0.0",
+        digest="sha256:103e2bb42c1a9f65544c4bbec549e418ae1af1417180f1c0307d52aab226e6bd",
+        registry_prefix="oci://docker.io/gpustack/higress-plugin-",
+    ),
 ]
 
 

--- a/gpustack/worker/worker.py
+++ b/gpustack/worker/worker.py
@@ -331,8 +331,8 @@ class Worker:
         app.state.config = self._config
         app.state.token = read_worker_token(self._config.data_dir)
         app.state.worker_ip_getter = self.worker_ip
-        app.state.instance_port_by_model_name = (
-            self._serve_manager.get_instance_ports_by_model_name
+        app.state.get_instance_port_by_model_instance_id = (
+            self._serve_manager.get_instance_port_by_model_instance_id
         )
         app.add_middleware(BaseHTTPMiddleware, dispatch=proxy.set_port_from_model_name)
         app.include_router(route_config.router, prefix=default_versioned_prefix)


### PR DESCRIPTION
That header value between server and worker is changed to use `model-<id>-<instance.id>.static`. The value is from the cluster_name envoy context and it is the routing target for this request. The worker proxy is based on the model instance id and forward the request to model instance serving port.