### PR TITLE
refactor: add metrics config server cache

### DIFF
--- a/gpustack/routes/metrics.py
+++ b/gpustack/routes/metrics.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from fastapi import APIRouter, Request
 from gpustack.config.config import get_global_config
@@ -8,12 +9,56 @@ from gpustack.utils.metrics import get_builtin_metrics_config_file_path
 
 router = APIRouter()
 
+# Cache for parsed YAML configs: {file_path: parsed_data}
+_config_cache: dict[str, dict] = {}
+# Locks for each file path to ensure async-safe cache access
+_cache_locks: dict[str, asyncio.Lock] = {}
+
+
+def _load_yaml_sync(file_path: str) -> dict:
+    """Synchronous YAML loading function to be run in thread pool."""
+    with open(file_path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def _save_yaml_sync(file_path: str, data: dict) -> None:
+    """Synchronous YAML saving function to be run in thread pool."""
+    with open(file_path, "w") as f:
+        yaml.safe_dump(data, f)
+
+
+async def _load_yaml_cached(file_path: str) -> dict:
+    """Load YAML file with caching. Async-safe and non-blocking.
+
+    Cache is only invalidated via _invalidate_cache(), typically called after POST updates.
+    External file changes will not be detected automatically.
+    """
+    # Get or create lock for this file path (setdefault is atomic in CPython)
+    lock = _cache_locks.setdefault(file_path, asyncio.Lock())
+
+    async with lock:
+        # Check if we have a cached version
+        if file_path in _config_cache:
+            return _config_cache[file_path]
+
+        # Load and cache the file in thread pool to avoid blocking event loop
+        data = await asyncio.to_thread(_load_yaml_sync, file_path)
+
+        _config_cache[file_path] = data
+        return data
+
+
+async def _invalidate_cache(file_path: str) -> None:
+    """Invalidate cache for a specific file. Async-safe."""
+    lock = _cache_locks.setdefault(file_path, asyncio.Lock())
+    async with lock:
+        _config_cache.pop(file_path, None)
+
 
 @router.get("/default-config")
 async def get_default_metrics_config(user: CurrentUserDep):
     builtin_metrics_config_path = get_builtin_metrics_config_file_path()
-    with open(builtin_metrics_config_path, "r") as f:
-        return yaml.safe_load(f)
+    return await _load_yaml_cached(builtin_metrics_config_path)
 
 
 @router.get("/config")
@@ -28,8 +73,7 @@ async def get_metrics_config(user: CurrentUserDep):
         else builtin_metrics_config_path
     )
 
-    with open(file_path, "r") as f:
-        return yaml.safe_load(f)
+    return await _load_yaml_cached(file_path)
 
 
 @router.post("/config")
@@ -38,6 +82,11 @@ async def update_metrics_config(user: CurrentUserDep, request: Request):
     custom_metrics_config_path = f"{data_dir}/custom_metrics_config.yaml"
 
     new_config = await request.json()
-    with open(custom_metrics_config_path, "w") as f:
-        yaml.safe_dump(new_config, f)
+
+    # Write file in thread pool to avoid blocking event loop
+    await asyncio.to_thread(_save_yaml_sync, custom_metrics_config_path, new_config)
+
+    # Invalidate cache after updating the config
+    await _invalidate_cache(custom_metrics_config_path)
+
     return {"status": "ok"}


### PR DESCRIPTION
Add server cache for metrics config to avoid parsing yaml for each request.

<img width="1216" height="262" alt="image" src="https://github.com/user-attachments/assets/36b53ec7-6cd9-413c-b622-6438ca2dbf71" />

Before the change:
```
# ab -n 1000 -c 10 http://localhost/v2/metrics/config
Concurrency Level:      10
Time taken for tests:   127.104 seconds
Complete requests:      1000
Failed requests:        2
   (Connect: 0, Receive: 0, Length: 2, Exceptions: 0)
Non-2xx responses:      2
Total transferred:      4864900 bytes
HTML transferred:       4571030 bytes
Requests per second:    7.87 [#/sec] (mean)
Time per request:       1271.043 [ms] (mean)
Time per request:       127.104 [ms] (mean, across all concurrent requests)
Transfer rate:          37.38 [Kbytes/sec] received
```
After the change
```
# ab -n 1000 -c 10 http://localhost:9092/v2/metrics/config

Concurrency Level:      10
Time taken for tests:   21.312 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      4873014 bytes
HTML transferred:       4580000 bytes
Requests per second:    46.92 [#/sec] (mean)
Time per request:       213.123 [ms] (mean)
Time per request:       21.312 [ms] (mean, across all concurrent requests)
Transfer rate:          223.29 [Kbytes/sec] received
```