### PR TITLE
fix: set ai_statistics only process specific content-type

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -73,12 +73,13 @@ The **Applies to** column indicates where the environment variable should be set
 
 ### Gateway Configuration
 
-| Variable                                  | Description                                                                         | Default | Applies to |
-| ----------------------------------------- | ----------------------------------------------------------------------------------- | ------- | ---------- |
-| `GPUSTACK_HIGRESS_EXT_AUTH_TIMEOUT_MS`    | Higress external authentication timeout in milliseconds.                            | `30000` | Server     |
-| `GPUSTACK_GATEWAY_PORT_CHECK_INTERVAL`    | The interval in seconds of GPUStack Server checking embedded gateway listening port | `2`     | Server     |
-| `GPUSTACK_GATEWAY_PORT_CHECK_RETRY_COUNT` | The retry count of GPUStack Server checking embedded gateway listening port         | `300`   | Server     |
-| `GPUSTACK_GATEWAY_EXTERNAL_METRICS_URL`   | The external gateway metrics url. e.g. `http://<gateway-ip>:15020/stats/prometheus` | None    | Server     |
+| Variable                                              | Description                                                                                                                        | Default                              | Applies to |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ---------- |
+| `GPUSTACK_HIGRESS_EXT_AUTH_TIMEOUT_MS`                | Higress external authentication timeout in milliseconds.                                                                           | `30000`                              | Server     |
+| `GPUSTACK_GATEWAY_PORT_CHECK_INTERVAL`                | The interval in seconds of GPUStack Server checking embedded gateway listening port                                                | `2`                                  | Server     |
+| `GPUSTACK_GATEWAY_PORT_CHECK_RETRY_COUNT`             | The retry count of GPUStack Server checking embedded gateway listening port                                                        | `300`                                | Server     |
+| `GPUSTACK_GATEWAY_EXTERNAL_METRICS_URL`               | The external gateway metrics url. e.g. `http://<gateway-ip>:15020/stats/prometheus`                                                | None                                 | Server     |
+| `GPUSTACK_GATEWAY_AI_STATISTICS_PLUGIN_CONTENT_TYPES` | Comma-separated list of content-types to be monitored by the ai-statistics plugin. Each value should be a valid HTTP Content-Type. | `application/json,text/event-stream` | Server     |
 
 ### Cluster Configuration
 

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -95,6 +95,15 @@ GATEWAY_MIRROR_INGRESS_NAME = os.getenv(
 
 GATEWAY_EXTERNAL_METRICS_URL = os.getenv("GPUSTACK_GATEWAY_EXTERNAL_METRICS_URL", None)
 
+GATEWAY_AI_STATISTICS_PLUGIN_CONTENT_TYPES = [
+    ct.strip()
+    for ct in os.getenv(
+        "GPUSTACK_GATEWAY_AI_STATISTICS_PLUGIN_CONTENT_TYPES",
+        "application/json,text/event-stream",
+    ).split(",")
+    if ct.strip()
+]
+
 DEFAULT_CLUSTER_KUBERNETES = (
     os.getenv("GPUSTACK_DEFAULT_CLUSTER_KUBERNETES", "false").lower() == "true"
 )

--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -356,6 +356,7 @@ def ai_statistics_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
     resource_name = "gpustack-ai-statistics"
     expected_spec = WasmPluginSpec(
         defaultConfig={
+            "enable_content_types": envs.GATEWAY_AI_STATISTICS_PLUGIN_CONTENT_TYPES,
             "attributes": [
                 {
                     "apply_to_log": True,
@@ -364,7 +365,7 @@ def ai_statistics_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
                     "value": "x-mse-consumer",
                     "value_source": "request_header",
                 }
-            ]
+            ],
         },
         defaultConfigDisable=False,
         failStrategy="FAIL_OPEN",
@@ -671,6 +672,14 @@ def spec_replace(
     return expected_spec
 
 
+def validate_ai_statistics_plugin_content_types():
+    for content_type in envs.GATEWAY_AI_STATISTICS_PLUGIN_CONTENT_TYPES:
+        if content_type == "audio/pcm":
+            raise ValueError(
+                "audio/pcm content type is not supported in ai statistics plugin"
+            )
+
+
 def initialize_gateway(cfg: Config, timeout: int = 60, interval: int = 5):
     if cfg.gateway_mode == GatewayModeEnum.disabled:
         return
@@ -680,6 +689,7 @@ def initialize_gateway(cfg: Config, timeout: int = 60, interval: int = 5):
         GatewayModeEnum.embedded,
         GatewayModeEnum.external,
     ]:
+        validate_ai_statistics_plugin_content_types()
         plugin_list: List[Tuple[str, WasmPluginSpec]] = [
             ext_auth_plugin(cfg=cfg),
             ai_statistics_plugin(cfg=cfg),


### PR DESCRIPTION
Don't process `audio/pcm` content-type for audio streaming output.
Refer to issue:
- #4719 