### PR TITLE
fix: override image ENTRYPOINT with command_args in container execution

### DIFF
--- a/docs/user-guide/inference-backend-management.md
+++ b/docs/user-guide/inference-backend-management.md
@@ -117,6 +117,8 @@ These are essentially custom backends with a "community" source label, allowing 
 
     vLLM has changed the entrypoint of its Docker image since v0.11.1. Therefore, when adding a custom version for vLLM v0.11.1 or later, you must specify the `Override Image Entrypoint` and `Execution Command` field; otherwise, the model will fail to start. If you use newer versions of `gpustack/runner` images, you don't need to set the `Execution Command` field.
 
+    For backends that supply the executable through `Override Image Entrypoint` (such as vLLM and SGLang), the `Execution Command` must contain arguments only. Do not put the executable (e.g. `vllm serve` or `python -m vllm ...`) in the `Execution Command`, otherwise it would be appended after the entrypoint and produce a duplicated prefix like `vllm serve python -m vllm ...`.
+
 ### Example: Add a Custom Version to the Built-in SGLang Inference Backend
 
 1. On the Inference Backend page, locate the SGLang inference backend. From the card's top-right dropdown menu, choose "Edit".

--- a/gpustack/worker/backends/ascend_mindie.py
+++ b/gpustack/worker/backends/ascend_mindie.py
@@ -1865,11 +1865,9 @@ class AscendMindIEServer(InferenceServer):
         if not image:
             raise ValueError("Failed to get Ascend MindIE backend image")
 
-        # Command script will override the given command,
-        # so we need to prepend command to command args.
-        if command_script and command:
-            command_args = command + command_args
-            command = None
+        command, command_args = self._override_entrypoint(
+            command, command_args, command_script
+        )
 
         resources = self._get_configured_resources(
             mount_all_devices=deployment_metadata.distributed,

--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -732,7 +732,7 @@ exec "$@"
         when the version uses non-built-in version and defines a custom run_command
 
         Args:
-        - default_args: The default command argument list (e.g., ["vllm", "serve", "/path/to/model"]).
+        - default_args: The default command argument list.
         - model_path: Path used to replace {{model_path}}; if None, fall back to self._model_path.
         - port: Port used to replace {{port}}; if None, fall back to self._model_instance.port.
 
@@ -780,30 +780,48 @@ exec "$@"
         return default_args
 
     @staticmethod
+    def _override_entrypoint(
+        command: Optional[List[str]],
+        command_args: List[str],
+        command_script: Optional[str],
+    ) -> Tuple[Optional[List[str]], Optional[List[str]]]:
+        """
+        Map command / command_args / command_script onto the container's
+        ENTRYPOINT/CMD override semantics.
+
+        - command_script becomes the entrypoint, so the original command is
+          prepended to its args.
+        - Otherwise merge command and args into command to override the image
+          ENTRYPOINT (args alone would be appended to ENTRYPOINT, not replace it).
+        - When there is no command to override the ENTRYPOINT, leave the args
+          appended as-is.
+        """
+        if command_script:
+            return None, (command or []) + command_args
+        if not command:
+            return None, command_args
+        return command + command_args, None
+
+    @staticmethod
     def _get_backend_parameter_start_index(
         arguments: List[str],
         entrypoint: Optional[List[str]] = None,
     ) -> int:
         """
-        Return where backend parameters start in container args.
-
-        When a container entrypoint is configured separately, `arguments`
-        contains only entrypoint arguments, so backend parameters start at 0.
-        Otherwise, skip the command prefix embedded in `arguments`.
+        Return where backend parameters start in `arguments`, skipping any
+        command prefix or model path that may precede the first option.
         """
-        if entrypoint:
-            return 0
-
         if not arguments:
             return 0
 
-        command = os.path.basename(arguments[0])
-        if (
-            len(arguments) >= 3
-            and command.startswith("python")
-            and arguments[1] == "-m"
-        ):
-            return 3
+        if not entrypoint:
+            command = os.path.basename(arguments[0])
+            if (
+                len(arguments) >= 3
+                and command.startswith("python")
+                and arguments[1] == "-m"
+            ):
+                return 3
 
         for index, argument in enumerate(arguments):
             if argument.startswith("-"):
@@ -902,11 +920,11 @@ exec "$@"
             # Return directly if there is not a valid device.
             # GPUStack-Runner does not provide CPU-only platform images.
             # To use a CPU-only version, user must configure in `Inference Backend` page.
-            return None
+            return None, None
 
         if backend not in available_backends():
             # Return directly if found backend is not within the available backends.
-            return None
+            return None, None
 
         """
         Retrieve runners by queries.

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -85,24 +85,25 @@ class SGLangServer(InferenceServer):
 
     is_diffusion = False
 
-    def start(self):  # noqa: C901
+    def start(self):
         try:
             if CategoryEnum.IMAGE in self._model.categories:
                 self.is_diffusion = True
-                self._start_diffusion()
-            else:
-                self._start()
+            self._start()
         except Exception as e:
             self._handle_error(e)
 
     def _start(self):
-        logger.info(f"Starting SGLang model instance: {self._model_instance.name}")
+        kind = "Diffusion " if self.is_diffusion else ""
+        logger.info(
+            f"Starting SGLang {kind}model instance: {self._model_instance.name}"
+        )
 
         deployment_metadata = self._get_deployment_metadata()
 
-        # Setup environment variables
+        # Diffusion path does not support distributed deployment.
         env = self._get_configured_env(
-            is_distributed=deployment_metadata.distributed,
+            is_distributed=(not self.is_diffusion) and deployment_metadata.distributed,
         )
 
         # Resolve image first so that backend_version is populated before
@@ -111,71 +112,29 @@ class SGLangServer(InferenceServer):
         if not image:
             raise ValueError("Can't find compatible SGLang image")
 
-        command = None
+        command = ["sglang", "serve"]
         if self.inference_backend:
-            command = self.inference_backend.get_container_entrypoint(
+            entrypoint = self.inference_backend.get_container_entrypoint(
                 self._model.backend_version
             )
+            if entrypoint:
+                command = entrypoint
 
         command_script = self._get_serving_command_script(env)
 
         # Build SGLang command arguments
-        command_args, injected = self._build_command_args(
-            port=self._get_serving_port(),
-            is_distributed=deployment_metadata.distributed,
-            is_distributed_leader=deployment_metadata.distributed_leader,
-            entrypoint=command,
-        )
-
-        try:
-            self._update_model_instance(
-                self._model_instance.id,
-                injected_backend_parameters=format_backend_parameters(injected) or None,
+        if self.is_diffusion:
+            command_args, injected = self._build_command_args_for_diffusion(
+                port=self._get_serving_port(),
+                entrypoint=command,
             )
-        except Exception as e:
-            logger.warning(
-                f"Failed to persist injected backend parameters for {self._model_instance.name}: {e}"
+        else:
+            command_args, injected = self._build_command_args(
+                port=self._get_serving_port(),
+                is_distributed=deployment_metadata.distributed,
+                is_distributed_leader=deployment_metadata.distributed_leader,
+                entrypoint=command,
             )
-
-        self._create_workload(
-            deployment_metadata=deployment_metadata,
-            command=command,
-            command_script=command_script,
-            command_args=command_args,
-            env=env,
-            image=image,
-        )
-
-    def _start_diffusion(self):
-        logger.info(
-            f"Starting SGLang Diffusion model instance: {self._model_instance.name}"
-        )
-
-        deployment_metadata = self._get_deployment_metadata()
-
-        # Setup environment variables
-        env = self._get_configured_env(
-            is_distributed=False,
-        )
-
-        # Resolve image first so that backend_version is populated before
-        # building command args (version-gated arguments depend on it).
-        image = self._get_configured_image()
-        if not image:
-            raise ValueError("Can't find compatible SGLang image")
-
-        command = None
-        if self.inference_backend:
-            command = self.inference_backend.get_container_entrypoint(
-                self._model.backend_version
-            )
-
-        command_script = self._get_serving_command_script(env)
-
-        command_args, injected = self._build_command_args_for_diffusion(
-            port=self._get_serving_port(),
-            entrypoint=command,
-        )
 
         try:
             self._update_model_instance(
@@ -213,11 +172,9 @@ class SGLangServer(InferenceServer):
                 "SGLang versions <= 0.5.5 do not support Diffusion models."
             )
 
-        # Command script will override the given command,
-        # so we need to prepend command to command args.
-        if command_script and command:
-            command_args = command + command_args
-            command = None
+        command, command_args = self._override_entrypoint(
+            command, command_args, command_script
+        )
 
         resources = self._get_configured_resources()
 
@@ -257,7 +214,7 @@ class SGLangServer(InferenceServer):
         logger.info(
             f"With image: {image}, "
             f"command: [{' '.join(command) if command else ''}], "
-            f"arguments: [{' '.join(command_args)}], "
+            f"arguments: [{' '.join(command_args) if command_args else ''}], "
             f"ports: [{','.join([str(port.internal) for port in ports])}], "
             f"envs(inconsistent input items mean unchangeable):{os.linesep}"
             f"{os.linesep.join(f'{k}={v}' for k, v in sorted(sanitize_env(env).items()))}"
@@ -365,9 +322,6 @@ class SGLangServer(InferenceServer):
             backend parameters.
         """
         arguments = [
-            "python",
-            "-m",
-            "sglang.launch_server",
             "--model-path",
             self._model_path,
         ]
@@ -486,8 +440,6 @@ class SGLangServer(InferenceServer):
         self, port: int, entrypoint: Optional[List[str]] = None
     ) -> Tuple[List[str], List[str]]:
         arguments = [
-            "sglang",
-            "serve",
             "--model-path",
             self._model_path,
         ]

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -148,11 +148,13 @@ class VLLMServer(InferenceServer):
         if not image:
             raise ValueError("Failed to get vLLM backend image")
 
-        command = None
+        command = ["vllm", "serve"]
         if self.inference_backend:
-            command = self.inference_backend.get_container_entrypoint(
+            entrypoint = self.inference_backend.get_container_entrypoint(
                 self._model.backend_version
             )
+            if entrypoint:
+                command = entrypoint
 
         command_script = self._get_serving_command_script(env)
 
@@ -191,11 +193,9 @@ class VLLMServer(InferenceServer):
         env: Dict[str, str],
         image: str,
     ):
-        # Command script will override the given command,
-        # so we need to prepend command to command args.
-        if command_script and command:
-            command_args = command + command_args
-            command = None
+        command, command_args = self._override_entrypoint(
+            command, command_args, command_script
+        )
 
         resources = self._get_configured_resources()
 
@@ -242,12 +242,11 @@ class VLLMServer(InferenceServer):
             ray_command, ray_command_args, ray_ports = self._build_ray_configuration(
                 is_leader=False,
             )
-
-            # Command script will override the given command,
-            # so we need to prepend command to command args.
-            if command_script:
-                ray_command_args = ray_command + ray_command_args
-                ray_command = None
+            ray_command, ray_command_args = self._override_entrypoint(
+                ray_command,
+                ray_command_args,
+                command_script,
+            )
 
             run_container.execution.command = ray_command
             # run_container.execution.command_script = command_script # already set
@@ -269,12 +268,11 @@ class VLLMServer(InferenceServer):
             ray_command, ray_command_args, ray_ports = self._build_ray_configuration(
                 is_leader=True,
             )
-
-            # Command script will override the given command,
-            # so we need to prepend command to command args.
-            if command_script:
-                ray_command_args = ray_command + ray_command_args
-                ray_command = None
+            ray_command, ray_command_args = self._override_entrypoint(
+                ray_command,
+                ray_command_args,
+                command_script,
+            )
 
             # Copy envs and override RAY_LOG_TO_STDERR for the sidecar
             # so Ray head logs go to stderr (captured by container log stream),
@@ -313,7 +311,7 @@ class VLLMServer(InferenceServer):
         logger.info(
             f"With image: {image}, "
             f"command: [{' '.join(command) if command else ''}], "
-            f"arguments: [{' '.join(command_args)}], "
+            f"arguments: [{' '.join(command_args) if command_args else ''}], "
             f"ports: [{','.join([str(port.internal) for port in ports])}], "
             f"envs(inconsistent input items mean unchangeable):{os.linesep}"
             f"{os.linesep.join(f'{k}={v}' for k, v in sorted(sanitize_env(env).items()))}"
@@ -585,7 +583,7 @@ class VLLMServer(InferenceServer):
             port, is_distributed, entrypoint, deployment_metadata
         )
 
-        arguments: List[str] = ["vllm", "serve", self._model_path]
+        arguments: List[str] = [self._model_path]
         arguments = self.build_versioned_command_args(arguments)
 
         arguments.extend(self._build_omni_arguments(ctx))

--- a/gpustack/worker/backends/vox_box.py
+++ b/gpustack/worker/backends/vox_box.py
@@ -77,11 +77,9 @@ class VoxBoxServer(InferenceServer):
         if not image:
             raise ValueError("Failed to get VoxBox backend image")
 
-        # Command script will override the given command,
-        # so we need to prepend command to command args.
-        if command_script and command:
-            command_args = command + command_args
-            command = None
+        command, command_args = self._override_entrypoint(
+            command, command_args, command_script
+        )
 
         resources = self._get_configured_resources(
             # Pass-through all devices as vox-box handles device itself.

--- a/tests/worker/backends/test_backend.py
+++ b/tests/worker/backends/test_backend.py
@@ -10,6 +10,7 @@ from gpustack.schemas.inference_backend import (
 )
 from gpustack.schemas.models import BackendEnum
 from gpustack.utils.config import apply_registry_override_to_image
+from gpustack.worker.backends.base import InferenceServer
 from gpustack.worker.backends.custom import CustomServer
 from gpustack.worker.backends.sglang import (
     SGLangServer,
@@ -755,3 +756,76 @@ def test_custom_backend_configured_entrypoint_injected_parameters(
     assert entrypoint == expected_entrypoint
     assert arguments[-2:] == ["--user-param", "1"]
     assert injected == expected_injected
+
+
+@pytest.mark.parametrize(
+    "command, command_args, command_script, expected_command, expected_args",
+    [
+        # No script + non-empty command (vLLM/SGLang main path): merge into
+        # command so the image ENTRYPOINT is fully overridden.
+        (
+            ["vllm", "serve"],
+            ["/models/llm", "--port", "8000"],
+            None,
+            ["vllm", "serve", "/models/llm", "--port", "8000"],
+            None,
+        ),
+        # No script + command is None (vox_box/ascend with no entrypoint):
+        # keep args as-is, must not raise TypeError on None + list.
+        (
+            None,
+            ["vox-box", "start", "--model", "/models/audio"],
+            None,
+            None,
+            ["vox-box", "start", "--model", "/models/audio"],
+        ),
+        # No script + empty command: same as None.
+        ([], ["mindieservice_daemon"], None, None, ["mindieservice_daemon"]),
+        # Script + non-empty command: script becomes entrypoint, command is
+        # prepended to its args.
+        (
+            ["vllm", "serve"],
+            ["/models/llm"],
+            "setup.sh",
+            None,
+            ["vllm", "serve", "/models/llm"],
+        ),
+        # Script + command is None: just pass the args through under the script.
+        (None, ["vox-box", "start"], "setup.sh", None, ["vox-box", "start"]),
+    ],
+)
+def test_override_entrypoint(
+    command, command_args, command_script, expected_command, expected_args
+):
+    result_command, result_args = InferenceServer._override_entrypoint(
+        command, command_args, command_script
+    )
+
+    assert result_command == expected_command
+    assert result_args == expected_args
+
+
+@pytest.mark.parametrize(
+    "arguments, entrypoint, expected_start_index",
+    [
+        # Empty arguments.
+        ([], None, 0),
+        # vLLM/SGLang style: executable carried in command (not args here),
+        # first option marks the start.
+        (["vllm", "serve", "/models/llm", "--port", "8000"], None, 3),
+        # python -m module ...: skip the launcher and module, start at 3.
+        (["python", "-m", "vllm", "--host", "x"], None, 3),
+        # With an explicit container entrypoint, the python -m heuristic is
+        # skipped; the first dash-prefixed token wins ("-m" at index 1).
+        (["python", "-m", "vllm", "--host", "x"], ["llama-server"], 1),
+        # Entrypoint set, model path then first option.
+        (["/models/llm", "--port", "8000"], ["vllm", "serve"], 1),
+        # First token already an option.
+        (["--port", "8000"], None, 0),
+    ],
+)
+def test_get_backend_parameter_start_index(arguments, entrypoint, expected_start_index):
+    assert (
+        InferenceServer._get_backend_parameter_start_index(arguments, entrypoint)
+        == expected_start_index
+    )


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4717

To prevent errors caused by modifications to the ENTRYPOINT in official images (e.g., vLLM, SGLang), we can extract the inference backend startup command from the existing CMD and set it as the default ENTRYPOINT. 
This ensures that all launched inference backend containers will have a stable, well-defined ENTRYPOINT, except in cases where it is explicitly overridden within the inference backend configuration or when using the common_script.