### PR TITLE
fix: use triton attention backend to blackwell when deploy qwen 3.5

### DIFF
--- a/gpustack/assets/model-catalog-modelscope.yaml
+++ b/gpustack/assets/model-catalog-modelscope.yaml
@@ -491,6 +491,7 @@ model_sets:
     - apache-2.0
   release_date: "2026-03-02"
   specs:
+    # Ascend NPUs
     - mode: standard
       quantization: BF16
       gpu_filters:
@@ -505,6 +506,20 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-0.8B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --context-length=32768
+        - --attention-backend=triton
+    # Other GPUs
     - mode: standard
       quantization: BF16
       source: model_scope
@@ -529,6 +544,7 @@ model_sets:
     - apache-2.0
   release_date: "2026-03-02"
   specs:
+    # Ascend NPUs
     - mode: standard
       quantization: BF16
       gpu_filters:
@@ -543,6 +559,20 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-2B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --context-length=32768
+        - --attention-backend=triton
+    # Other GPUs
     - mode: standard
       quantization: BF16
       source: model_scope
@@ -567,6 +597,7 @@ model_sets:
     - apache-2.0
   release_date: "2026-03-02"
   specs:
+    # Ascend NPUs
     - mode: standard
       quantization: BF16
       gpu_filters:
@@ -582,6 +613,21 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-4B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # Other GPUs
     - mode: standard
       quantization: BF16
       source: model_scope
@@ -607,6 +653,7 @@ model_sets:
     - apache-2.0
   release_date: "2026-03-02"
   specs:
+    # Ascend NPUs
     - mode: standard
       quantization: BF16
       gpu_filters:
@@ -622,6 +669,21 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-9B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # Other GPUs
     - mode: standard
       quantization: BF16
       source: model_scope
@@ -647,6 +709,7 @@ model_sets:
     - apache-2.0
   release_date: "2026-02-24"
   specs:
+    # Ascend NPUs
     - mode: standard
       quantization: BF16
       gpu_filters:
@@ -662,6 +725,21 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-27B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # Other GPUs
     - mode: standard
       quantization: BF16
       source: model_scope
@@ -671,11 +749,29 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=qwen3
         - --context-length=32768
+    # Split FP8 throughput by architecture: on Blackwell, SGLang may
+    # auto-select flashinfer, while hybrid GDN Qwen3.5 requires triton/trtllm_mha.
+    # Ref: https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/attention_registry.py#L201-L207
+    # NVIDIA Blackwell (e.g. RTX 5090)
     - mode: throughput
       quantization: FP8
       gpu_filters:
         vendor: nvidia
-        compute_capability: ">=9.0" # Hopper or later
+        compute_capability: ">=12.0" # Blackwell
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-27B-FP8
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # NVIDIA Hopper/Ada before Blackwell
+    - mode: throughput
+      quantization: FP8
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=9.0,<12.0"
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-27B-FP8
       backend: SGLang
@@ -700,6 +796,7 @@ model_sets:
     - apache-2.0
   release_date: "2026-02-24"
   specs:
+    # Ascend NPUs
     - mode: standard
       quantization: BF16
       gpu_filters:
@@ -715,6 +812,21 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-35B-A3B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # Other GPUs
     - mode: standard
       quantization: BF16
       source: model_scope
@@ -724,11 +836,26 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=qwen3
         - --context-length=32768
+    # NVIDIA Blackwell (e.g. RTX 5090)
     - mode: throughput
       quantization: FP8
       gpu_filters:
         vendor: nvidia
-        compute_capability: ">=9.0" # Hopper or later
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-35B-A3B-FP8
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # NVIDIA Hopper/Ada before Blackwell
+    - mode: throughput
+      quantization: FP8
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=9.0,<12.0"
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-35B-A3B-FP8
       backend: SGLang
@@ -753,6 +880,7 @@ model_sets:
     - apache-2.0
   release_date: "2026-02-24"
   specs:
+    # Ascend NPUs
     - mode: standard
       quantization: BF16
       gpu_filters:
@@ -768,6 +896,21 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-122B-A10B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # Other GPUs
     - mode: standard
       quantization: BF16
       source: model_scope
@@ -777,11 +920,26 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=qwen3
         - --context-length=32768
+    # NVIDIA Blackwell (e.g. RTX 5090)
     - mode: throughput
       quantization: FP8
       gpu_filters:
         vendor: nvidia
-        compute_capability: ">=9.0" # Hopper or later
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-122B-A10B-FP8
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # NVIDIA Hopper/Ada before Blackwell
+    - mode: throughput
+      quantization: FP8
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=9.0,<12.0"
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-122B-A10B-FP8
       backend: SGLang
@@ -806,6 +964,7 @@ model_sets:
     - apache-2.0
   release_date: "2026-02-16"
   specs:
+    # Ascend NPUs
     - mode: standard
       quantization: BF16
       gpu_filters:
@@ -821,6 +980,21 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-397B-A17B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # Other GPUs
     - mode: standard
       quantization: BF16
       source: model_scope
@@ -830,11 +1004,26 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=qwen3
         - --context-length=32768
+    # NVIDIA Blackwell (e.g. RTX 5090)
     - mode: throughput
       quantization: FP8
       gpu_filters:
         vendor: nvidia
-        compute_capability: ">=9.0" # Hopper or later
+        compute_capability: ">=12.0"
+      source: model_scope
+      model_scope_model_id: Qwen/Qwen3.5-397B-A17B-FP8
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # NVIDIA Hopper/Ada before Blackwell
+    - mode: throughput
+      quantization: FP8
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=9.0,<12.0"
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-397B-A17B-FP8
       backend: SGLang

--- a/gpustack/assets/model-catalog.yaml
+++ b/gpustack/assets/model-catalog.yaml
@@ -484,6 +484,19 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-0.8B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --context-length=32768
+        - --attention-backend=triton
     # Other GPUs
     - mode: standard
       quantization: BF16
@@ -524,6 +537,19 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-2B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --context-length=32768
+        - --attention-backend=triton
     # Other GPUs
     - mode: standard
       quantization: BF16
@@ -565,6 +591,20 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-4B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
     # Other GPUs
     - mode: standard
       quantization: BF16
@@ -607,6 +647,20 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-9B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
     # Other GPUs
     - mode: standard
       quantization: BF16
@@ -649,6 +703,20 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-27B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
     # Other GPUs
     - mode: standard
       quantization: BF16
@@ -659,11 +727,29 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=qwen3
         - --context-length=32768
+    # Split FP8 throughput by architecture: on Blackwell, SGLang may
+    # auto-select flashinfer, while hybrid GDN Qwen3.5 requires triton/trtllm_mha.
+    # Ref: https://github.com/sgl-project/sglang/blob/bbe9c7eeb520b0a67e92d133dfc137a3688dc7f2/python/sglang/srt/layers/attention/attention_registry.py#L202
+    # NVIDIA Blackwell (e.g. RTX 5090)
     - mode: throughput
       quantization: FP8
       gpu_filters:
         vendor: nvidia
-        compute_capability: ">=9.0" # Hopper or later
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-27B-FP8
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # NVIDIA Hopper/Ada before Blackwell
+    - mode: throughput
+      quantization: FP8
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=9.0,<12.0"
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-27B-FP8
       backend: SGLang
@@ -704,6 +790,20 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-35B-A3B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
     # Other GPUs
     - mode: standard
       quantization: BF16
@@ -714,11 +814,26 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=qwen3
         - --context-length=32768
+    # NVIDIA Blackwell (e.g. RTX 5090)
     - mode: throughput
       quantization: FP8
       gpu_filters:
         vendor: nvidia
-        compute_capability: ">=9.0" # Hopper or later
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-35B-A3B-FP8
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # NVIDIA Hopper/Ada before Blackwell
+    - mode: throughput
+      quantization: FP8
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=9.0,<12.0"
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-35B-A3B-FP8
       backend: SGLang
@@ -759,6 +874,20 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-122B-A10B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
     # Other GPUs
     - mode: standard
       quantization: BF16
@@ -769,11 +898,26 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=qwen3
         - --context-length=32768
+    # NVIDIA Blackwell (e.g. RTX 5090)
     - mode: throughput
       quantization: FP8
       gpu_filters:
         vendor: nvidia
-        compute_capability: ">=9.0" # Hopper or later
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-122B-A10B-FP8
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    # NVIDIA Hopper/Ada before Blackwell
+    - mode: throughput
+      quantization: FP8
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=9.0,<12.0"
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-122B-A10B-FP8
       backend: SGLang
@@ -814,6 +958,20 @@ model_sets:
         - --chunked-prefill-size=4096
         - --max-prefill-tokens=4096
         - --max-total-tokens=40960
+    # NVIDIA Blackwell (e.g. RTX 5090)
+    - mode: standard
+      quantization: BF16
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-397B-A17B
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
     # Other GPUs
     - mode: standard
       quantization: BF16
@@ -824,11 +982,25 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=qwen3
         - --context-length=32768
+    # NVIDIA Blackwell (e.g. RTX 5090)
     - mode: throughput
       quantization: FP8
       gpu_filters:
         vendor: nvidia
-        compute_capability: ">=9.0" # Hopper or later
+        compute_capability: ">=12.0"
+      source: huggingface
+      huggingface_repo_id: Qwen/Qwen3.5-397B-A17B-FP8
+      backend: SGLang
+      backend_version: 0.5.9
+      backend_parameters:
+        - --reasoning-parser=qwen3
+        - --context-length=32768
+        - --attention-backend=triton
+    - mode: throughput
+      quantization: FP8
+      gpu_filters:
+        vendor: nvidia
+        compute_capability: ">=9.0,<12.0" # Hopper/Ada before Blackwell
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-397B-A17B-FP8
       backend: SGLang


### PR DESCRIPTION
- #4770

User deploy Qwen3.5 from huggingface/modelscope to Blackwell, not from catalog, SGLang may pick an incompatible default backend; set --attention-backend=triton manually when deploying from Hugging Face. This is an SGLang backend auto-selection limitation.