### PR TITLE
fix: no need to refresh worker after create/update

### DIFF
--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -577,7 +577,9 @@ class ActiveRecordMixin:
         """Update the object with the source and save to the database."""
 
         if isinstance(source, SQLModel):
-            source = source.model_dump(exclude_unset=True)
+            source = {
+                key: getattr(source, key, None) for key in source.model_fields_set
+            }
         elif source is None:
             source = {}
 

--- a/gpustack/routes/workers.py
+++ b/gpustack/routes/workers.py
@@ -497,7 +497,6 @@ async def create_worker(
             cluster.state = ClusterStateEnum.READY
             await cluster.update(session=session, auto_commit=False)
         await session.commit()
-        await session.refresh(worker)
         worker_dump = worker.model_dump()
         worker_dump["token"] = worker.token
         worker_dump["worker_config"] = PredefinedConfigNoDefaults.model_validate(


### PR DESCRIPTION
Avoid extra db operation after created worker.

Refer to issue:
- #4163 