### PR TITLE
perf: optimize worker inference backend cache init

### DIFF
--- a/gpustack/routes/inference_backend.py
+++ b/gpustack/routes/inference_backend.py
@@ -36,6 +36,7 @@ from gpustack.schemas.inference_backend import (
     is_built_in_backend,
 )
 from gpustack.schemas.models import BackendEnum, Model, BackendSourceEnum
+from gpustack.server.cache import locked_cached, delete_cache_by_prefix
 from gpustack.server.db import async_session
 from gpustack.server.deps import ListParamsDep, SessionDep, TenantContextDep
 from gpustack_runner import list_service_runners
@@ -44,6 +45,8 @@ from gpustack_runtime.detector import ManufacturerEnum
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+_INFERENCE_BACKENDS_ALL_CACHE_KEY = "inference_backends_all"
 
 
 def filter_yaml_fields(yaml_data: Dict, filter_keys: List[str]) -> Dict:  # noqa: C901
@@ -924,11 +927,23 @@ async def get_inference_backends(  # noqa: C901
     )
 
 
-@router.get("/all", response_model=List[InferenceBackend])
-async def get_all_inference_backends(
-    session: SessionDep,
-    ctx: TenantContextDep,
-):
+def _all_inference_backends_cache_key(f, *args, **kwargs):
+    """Shard cache by (current_principal_id, is_platform_admin) so each
+    tenant view gets its own entry. ``_fetch_visible_backend_rows`` and
+    ``_collapse_by_backend_name`` produce different rows per shard, so a
+    single global key would leak rows across tenants.
+    """
+    ctx = kwargs.get("ctx") if "ctx" in kwargs else (args[1] if len(args) > 1 else None)
+    if ctx is None:
+        return f"{_INFERENCE_BACKENDS_ALL_CACHE_KEY}:none:0"
+    principal_id = ctx.current_principal_id
+    is_admin = int(bool(ctx.is_platform_admin))
+    principal_part = principal_id if principal_id is not None else "all"
+    return f"{_INFERENCE_BACKENDS_ALL_CACHE_KEY}:{principal_part}:{is_admin}"
+
+
+@locked_cached(key=_all_inference_backends_cache_key, ttl=60)
+async def _get_all_inference_backends_cached(session: SessionDep, ctx):
     backends = await merge_runner_versions_to_db(session, ctx=ctx)
     ret = []
     for backend in backends:
@@ -943,6 +958,14 @@ async def get_all_inference_backends(
         ret.append(backend)
 
     return ret
+
+
+@router.get("/all", response_model=List[InferenceBackend])
+async def get_all_inference_backends(
+    session: SessionDep,
+    ctx: TenantContextDep,
+):
+    return await _get_all_inference_backends_cached(session, ctx)
 
 
 def _assert_backend_visible(ctx, backend):
@@ -1077,6 +1100,7 @@ async def create_inference_backend(
             message=f"Failed to create inference backend: {e}"
         )
 
+    await delete_cache_by_prefix(_INFERENCE_BACKENDS_ALL_CACHE_KEY)
     return backend
 
 
@@ -1218,6 +1242,7 @@ async def update_inference_backend(  # noqa: C901
             message=f"Failed to update inference backend: {e}"
         )
 
+    await delete_cache_by_prefix(_INFERENCE_BACKENDS_ALL_CACHE_KEY)
     return backend
 
 
@@ -1255,6 +1280,8 @@ async def delete_inference_backend(session: SessionDep, ctx: TenantContextDep, i
         raise InternalServerErrorException(
             message=f"Failed to delete inference backend: {e}"
         )
+
+    await delete_cache_by_prefix(_INFERENCE_BACKENDS_ALL_CACHE_KEY)
 
 
 @router.post("/from-yaml", response_model=InferenceBackend)
@@ -1361,6 +1388,7 @@ async def create_inference_backend_from_yaml(  # noqa: C901
         backend = InferenceBackend(**yaml_data, owner_principal_id=target_org_id)
         backend = await InferenceBackend.create(session, backend)
 
+        await delete_cache_by_prefix(_INFERENCE_BACKENDS_ALL_CACHE_KEY)
         return backend
 
     except yaml.YAMLError as e:
@@ -1466,6 +1494,7 @@ async def update_inference_backend_from_yaml(  # noqa: C901
         # Update the backend from YAML data (after normalization)
         await backend.update(session, yaml_data)
 
+        await delete_cache_by_prefix(_INFERENCE_BACKENDS_ALL_CACHE_KEY)
         return backend
 
     except yaml.YAMLError as e:

--- a/gpustack/server/cache.py
+++ b/gpustack/server/cache.py
@@ -122,6 +122,22 @@ async def delete_cache_by_key(
         await _broadcast_invalidation(key)
 
 
+async def delete_cache_by_prefix(prefix: str) -> int:
+    """Delete every in-memory cache entry whose key starts with ``prefix``.
+
+    Local-only — does not broadcast via the coordinator. Callers using
+    this helper accept that other replicas will see stale entries until
+    their TTL expires.
+    """
+    keys = [k for k in list(cache._cache.keys()) if k.startswith(prefix)]
+    for k in keys:
+        await cache.delete(k)
+        _cache_locks.pop(k, None)
+    if keys:
+        logger.trace(f"Deleted {len(keys)} cache entries with prefix: {prefix}")
+    return len(keys)
+
+
 async def set_cache_by_key(key: str, value: Any, ttl: Optional[int] = None):
     """Write ``value`` to the in-memory cache.
 

--- a/gpustack/worker/inference_backend_manager.py
+++ b/gpustack/worker/inference_backend_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import threading
+import time
 from typing import Dict, Optional
 
 
@@ -56,28 +57,78 @@ class InferenceBackendManager:
 
         return None
 
-    def _initialize_cache(self) -> None:
-        """Initialize the cache with existing InferenceBackend data."""
-        try:
-            logger.info("Initializing InferenceBackend cache")
-            resp = self._clientset.http_client.get_httpx_client().get(
-                "/inference-backends/all"
-            )
-            backends = resp.json()
-            if backends:
-                with _cache_lock:
-                    for backend in backends:
-                        backend = InferenceBackend.model_validate(backend)
-                        if backend:
-                            self.backends_cache[backend.backend_name] = backend
+    def _initialize_cache(self, max_retries: int = 3, retry_delay: float = 1.0) -> None:
+        """Initialize the cache with existing InferenceBackend data.
+
+        Args:
+            max_retries: Maximum number of retry attempts
+            retry_delay: Delay in seconds between retries
+        """
+        last_exception = None
+        for attempt in range(max_retries):
+            try:
                 logger.info(
-                    f"Initialized cache with {self.backends_cache.keys()} InferenceBackends"
+                    f"Initializing InferenceBackend cache (attempt {attempt + 1}/{max_retries})"
                 )
-            else:
-                logger.info("No existing InferenceBackends found")
-        except Exception as e:
-            logger.error(f"Failed to initialize InferenceBackend cache: {e}")
-            raise
+                resp = self._clientset.http_client.get_httpx_client().get(
+                    "/inference-backends/all"
+                )
+                # Validate HTTP response status
+                resp.raise_for_status()
+                backends = resp.json()
+                # Validate response data type
+                if not isinstance(backends, list):
+                    logger.error(
+                        f"Invalid response type: expected list, got {type(backends).__name__}. "
+                        f"Response content: {backends}"
+                    )
+                    raise ValueError(
+                        f"Expected list of backends, got {type(backends).__name__}"
+                    )
+                if not backends:
+                    logger.info("No InferenceBackends found in response")
+                    return
+                with _cache_lock:
+                    for backend_data in backends:
+                        # Validate individual backend data type
+                        if not isinstance(backend_data, dict):
+                            logger.warning(
+                                f"Skipping invalid backend data: expected dict, got {type(backend_data).__name__}. "
+                                f"Data: {backend_data}"
+                            )
+                            continue
+                        try:
+                            backend = InferenceBackend.model_validate(backend_data)
+                            if backend:
+                                self.backends_cache[backend.backend_name] = backend
+                        except Exception as validation_error:
+                            logger.error(
+                                f"Failed to validate backend data: {validation_error}. "
+                                f"Data: {backend_data}"
+                            )
+                            # Continue processing other backends instead of failing completely
+                            continue
+
+                logger.info(
+                    f"Initialized cache with {len(self.backends_cache)} InferenceBackends"
+                )
+                # Success - exit retry loop
+                return
+            except Exception as e:
+                last_exception = e
+                logger.error(
+                    f"Failed to initialize InferenceBackend cache (attempt {attempt + 1}/{max_retries}): {e}"
+                )
+                # If this is not the last attempt, wait before retrying
+                if attempt < max_retries - 1:
+                    logger.info(f"Retrying in {retry_delay} seconds...")
+                    time.sleep(retry_delay)
+
+        # All retries failed
+        logger.error(
+            f"Failed to initialize InferenceBackend cache after {max_retries} attempts"
+        )
+        raise last_exception
 
     async def _watch_changes(self) -> None:
         """Watch for InferenceBackend changes and update the cache."""


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4785

This issue is difficult to reproduce, but it is likely an error caused by high concurrency.
Adjustments as follows:
Catch exceptions and add a retry mechanism to ensure the worker can start normally even if the inference backend initialization fails.
Add caching to the inference backend query API on the server side to reduce concurrency overhead.