### PR TITLE
fix: keep and restore the auth info with ext-auth and transformer plugin

### DIFF
--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -309,6 +309,8 @@ def ext_auth_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
                 {"exact": "X-Mse-Consumer"},
                 {"exact": "Authorization"},
                 {"exact": "cookie"},
+                {"exact": "X-GPUStack-Original-Cookies"},
+                {"exact": "X-GPUStack-Original-Authorization"},
             ]
         },
         "endpoint": {
@@ -474,12 +476,20 @@ def transformer_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
                 transform_header(
                     "rename",
                     HeaderRule(
-                        newKey="x-higress-llm-model",
                         oldKey="x-gpustack-model",
+                        newKey="x-higress-llm-model",
                     ),
                     HeaderRule(
                         oldKey="x-gpustack-original-path",
                         newKey=":path",
+                    ),
+                    HeaderRule(
+                        oldKey="x-gpustack-original-cookies",
+                        newKey="cookie",
+                    ),
+                    HeaderRule(
+                        oldKey="x-gpustack-original-authorization",
+                        newKey="authorization",
                     ),
                 ),
                 transform_header(
@@ -494,6 +504,14 @@ def transformer_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
                     ),
                     HeaderRule(
                         key=":path",
+                        strategy="RETAIN_LAST",
+                    ),
+                    HeaderRule(
+                        key="cookie",
+                        strategy="RETAIN_LAST",
+                    ),
+                    HeaderRule(
+                        key="authorization",
                         strategy="RETAIN_LAST",
                     ),
                 ),

--- a/gpustack/routes/token.py
+++ b/gpustack/routes/token.py
@@ -98,8 +98,14 @@ async def server_auth(
         "X-Mse-Consumer": consumer,
         "Authorization": f"Bearer {registration_token}",
     }
+    # FIXME: The original info should be removed beforing routing.
+    # Remove this FIXME after we remove the original header in the gateway.
+    headers["x-gpustack-original-cookies"] = request.headers.get("cookie", "")
+    headers["x-gpustack-original-authorization"] = request.headers.get(
+        "authorization", ""
+    )
     if cookie_token is not None:
-        # reset the cookie in higress
+        # backup the cookie in higress
         headers["cookie"] = "dummy=dummy"
     return Response(
         status_code=200,


### PR DESCRIPTION
Refer to issue:
- #4815 