### PR TITLE
docs: update server metrics port exposure

### DIFF
--- a/docs/installation/air-gapped.md
+++ b/docs/installation/air-gapped.md
@@ -136,13 +136,12 @@ For more details on `load-images`, see the [CLI Reference](../cli-reference/load
 
 ## Installation
 
-After preparing the internal container registry with the required images, you can install GPUStack in the air-gapped environment. Port 80 is the primary server endpoint, while port 10161 is used to expose metrics for observability.
+After preparing the internal container registry with the required images, you can install GPUStack in the air-gapped environment.
 
 ```diff
  sudo docker run -d --name gpustack \
      --restart unless-stopped \
      -p 80:80 \
-     -p 10161:10161 \
      --volume gpustack-data:/var/lib/gpustack \
 -    gpustack/gpustack
 +    <your_internal_registry>/gpustack/gpustack \

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -14,13 +14,12 @@
 
 ## Install GPUStack Server
 
-Run the following command to install and start the GPUStack server using Docker. Port 80 is the primary server endpoint, while port 10161 is used to expose metrics for observability.
+Run the following command to install and start the GPUStack server using Docker:
 
 ```bash
 sudo docker run -d --name gpustack \
     --restart unless-stopped \
     -p 80:80 \
-    -p 10161:10161 \
     --volume gpustack-data:/var/lib/gpustack \
     gpustack/gpustack
 ```
@@ -61,7 +60,6 @@ The following sections describe examples of custom configuration options when st
  sudo docker run -d --name gpustack \
      ...
      -p 80:80 \
-     -p 10161:10161 \
 +    -p 443:443 \
      --volume gpustack-data:/var/lib/gpustack \
 +    --volume /path/to/cert_files:/path/to/cert_files:ro \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,13 +11,12 @@ This guide will walk you through running GPUStack on your own self-hosted GPU se
 
 ## Install GPUStack
 
-Run the following command to install and start the GPUStack server using [Docker](https://docs.docker.com/engine/install/), port 80 is the primary server endpoint, while port 10161 is used to expose metrics for observability.:
+Run the following command to install and start the GPUStack server using [Docker](https://docs.docker.com/engine/install/):
 
 ```bash
 sudo docker run -d --name gpustack \
     --restart unless-stopped \
     -p 80:80 \
-    -p 10161:10161 \
     --volume gpustack-data:/var/lib/gpustack \
     gpustack/gpustack
 ```
@@ -30,7 +29,6 @@ sudo docker run -d --name gpustack \
     sudo docker run -d --name gpustack \
         --restart unless-stopped \
         -p 80:80 \
-        -p 10161:10161 \
         --volume gpustack-data:/var/lib/gpustack \
         quay.io/gpustack/gpustack \
         --system-default-container-registry quay.io

--- a/docs/tutorials/running-deepseek-r1-671b-with-distributed-ascend-mindie.md
+++ b/docs/tutorials/running-deepseek-r1-671b-with-distributed-ascend-mindie.md
@@ -36,7 +36,6 @@ According to the [Installation](../installation/installation.md), you can use th
 sudo docker run -d --name gpustack \
     --restart unless-stopped \
     -p 80:80 \
-    -p 10161:10161 \
     --volume gpustack-data:/var/lib/gpustack \
     --volume /path/to/your/model:/path/to/your/model \
     gpustack/gpustack

--- a/docs/tutorials/running-deepseek-r1-671b-with-distributed-vllm.md
+++ b/docs/tutorials/running-deepseek-r1-671b-with-distributed-vllm.md
@@ -35,7 +35,6 @@ According to the [Installation](../installation/installation.md), you can use th
 sudo docker run -d --name gpustack \
     --restart unless-stopped \
     -p 80:80 \
-    -p 10161:10161 \
     --volume gpustack-data:/var/lib/gpustack \
     --volume /path/to/your/model:/path/to/your/model \
     gpustack/gpustack


### PR DESCRIPTION
Now observability components are embeded and the server metrics port doesn't need to be exposed by default 