### PR TITLE
fix: handle empty workers and prevent duplicate model instance starts

### DIFF
--- a/gpustack/policies/base.py
+++ b/gpustack/policies/base.py
@@ -112,6 +112,8 @@ class WorkerFilterChain:
         for policy in self.filters:
             workers, filter_messages = await policy.filter(workers)
             messages.extend(filter_messages)
+            if not workers:
+                break
         return workers, messages
 
 

--- a/gpustack/scheduler/scheduler.py
+++ b/gpustack/scheduler/scheduler.py
@@ -300,7 +300,7 @@ class Scheduler:
 
         async with async_session() as session:
             workers = await Worker.all(session)
-            if len(workers) == 0:
+            if not workers:
                 state_message = "No available workers"
 
             model = await Model.one_by_id(session, instance.model_id)
@@ -413,6 +413,8 @@ async def find_candidate(
     messages = []
     if filter_messages:
         messages.append(str(ListMessageBuilder(filter_messages)) + "\n")
+    if len(workers) == 0:
+        return None, messages
 
     # Initialize candidate selector.
     try:

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -547,6 +547,11 @@ class ServeManager:
             return
 
         if event.type == EventType.CREATED:
+            if mi.state == ModelInstanceStateEnum.RUNNING:
+                logger.warning(
+                    f"Model instance {mi.name} is already running. Skipping start."
+                )
+                return
             self._start_model_instance(mi)
             logger.trace(f"CREATED event: started created model instance {mi.name}.")
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4855

1. Prevent `select_candidates` from running when filter removes all workers.
2. Prevent gpustack restarts from interfering with existing model_instances in the RUNNING state.