### PR TITLE
fix: missing evaluation meta

### DIFF
--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -334,9 +334,12 @@ class ServeManager:
                         meta = get_meta_from_running_instance(
                             model_instance, backend, model
                         )
-                        if meta and meta != model.meta:
-                            model_patch_dict = {"meta": meta}
-                            self._update_model(model.id, **model_patch_dict)
+                        if meta:
+                            # Some meta is set in server evaluation and should be preserved, so we update meta instead of overwrite.
+                            merged_meta = dict(model.meta or {})
+                            merged_meta.update(meta)
+                            if merged_meta != model.meta:
+                                self._update_model(model.id, meta=merged_meta)
                     # Otherwise, update the main worker state to ERROR.
                     else:
                         patch_dict = {


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4948


Some meta relies on model config and is set in server evaluation(https://github.com/gpustack/gpustack/blob/9911051223d6c0d4d8e66a45d44dba77ae79f947/gpustack/scheduler/scheduler.py#L760). When updating meta from instance endpoint we need to preserve those.