### PR TITLE
fix: improve GPU driver upgrade message for better clarity

### DIFF
--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -511,6 +511,7 @@ class Config(WorkerConfig, BaseSettings):
             vendor = gd.get("vendor")
             memory = gd.get("memory")
             network = gd.get("network")
+            runtime_version = gd.get("runtime_version")
             type_ = gd.get("type") or manufacturer_to_backend(vendor)
 
             if not name:
@@ -563,6 +564,7 @@ class Config(WorkerConfig, BaseSettings):
                     device_chip_index=device_chip_index,
                     name=name,
                     vendor=vendor,
+                    runtime_version=runtime_version,
                     memory=MemoryInfo(
                         total=memory.get("total"),
                         is_unified_memory=memory.get("is_unified_memory", False),

--- a/gpustack/scheduler/evaluator.py
+++ b/gpustack/scheduler/evaluator.py
@@ -396,7 +396,11 @@ async def evaluate_runtime_version(
         return True, []
 
     msg = _format_runtime_upgrade_message(
-        backend_name, max_gpu_type, max_runtime_version, version_list
+        backend_name,
+        model.backend_version,
+        max_gpu_type,
+        max_runtime_version,
+        version_list,
     )
     return False, [msg]
 
@@ -425,6 +429,7 @@ async def _check_runtime_version(
         "backend": gpu_type,
         "service": backend_name.lower(),
         "backend_version": runtime_version,
+        "service_version": model_backend_version,
     }
 
     if not model_backend_version:
@@ -464,6 +469,7 @@ async def _check_runtime_version(
 
 def _format_runtime_upgrade_message(
     backend_name: str,
+    backend_version: Optional[str],
     gpu_type: str,
     current_version: str,
     all_versions: List[str],
@@ -481,14 +487,14 @@ def _format_runtime_upgrade_message(
         Formatted error message
     """
     msg = (
-        f"The highest GPU runtime version available ({gpu_type} {current_version}) "
-        f"does not meet the requirements for backend {backend_name}. "
+        f"The highest supported GPU runtime version ({gpu_type} {current_version}) "
+        f"does not meet the requirements for backend {backend_name if not backend_version else backend_name + ' ' + backend_version}. "
     )
 
     if all_versions:
         versions_str = ", ".join(all_versions)
         msg += f"Supported versions: {versions_str}. "
-        msg += f"Please upgrade to at least version {all_versions[0]}."
+        msg += f"It is recommended to upgrade your GPU driver to a version compatible with {gpu_type} {all_versions[-1]} or later."
 
     return msg
 

--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -759,6 +759,10 @@ $@
             if not backend_variant:
                 backend_variant = "910b"
 
+        logger.info(
+            f"_resolve_image query: backend={backend}, backend_variant={backend_variant}, service={service}, service_version={service_version}, platform={platform.system_arch()}"
+        )
+
         runners = list_backend_runners(
             backend=backend,
             backend_variant=backend_variant,


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/4873#issuecomment-4098182305

The updated message like:
`The highest GPU runtime version available (cuda 12.4) does not meet the requirements for backend vLLM. Supported versions: 12.6, 12.8, 12.9. Please upgrade your GPU driver to a version compatible with cuda 12.6 or later.`