### PR TITLE
[v2.1.1]fix: Custom backend needn't evaluate_runtime_version

### DIFF
--- a/gpustack/scheduler/evaluator.py
+++ b/gpustack/scheduler/evaluator.py
@@ -33,7 +33,7 @@ from gpustack.schemas.models import (
     is_audio_model,
 )
 from gpustack.schemas.workers import Worker, WorkerStateEnum
-from gpustack.schemas.inference_backend import is_built_in_backend
+from gpustack.schemas.inference_backend import is_custom_backend
 from gpustack.server.worker_selector import WorkerSelector
 from gpustack_runner import list_backend_runners
 from gpustack_runtime.deployer.__utils__ import compare_versions
@@ -357,7 +357,7 @@ async def evaluate_runtime_version(
     """
     backend_name = get_backend(model)
 
-    if not is_built_in_backend(backend_name):
+    if is_custom_backend(backend_name):
         return True, []
 
     max_runtime_version = None


### PR DESCRIPTION
https://github.com/gpustack/gpustack/pull/4991