### PR TITLE
docs: additional trusted CAs

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -94,6 +94,23 @@ sudo docker run -d --name gpustack \
     ...
 ```
 
+### Additional Trusted CAs
+
+If GPUStack needs to communicate with services that use certificates issued by a private or corporate CA (e.g., a self-hosted Identity Provider, a Hugging Face mirror, or an internal API endpoint), mount the CA certificate into the container under `/usr/local/share/ca-certificates/`. GPUStack will automatically import the mounted CA certificates during startup and add them to the system trust store.
+
+```diff
+ sudo docker run -d --name gpustack \
+     ...
+     --volume gpustack-data:/var/lib/gpustack \
++    --volume /path/to/custom-root-ca.crt:/usr/local/share/ca-certificates/custom-root-ca.crt:ro \
+     gpustack/gpustack
+     ...
+```
+
+!!! note
+
+    The certificate file must have a `.crt` extension. You can mount multiple CA certificates by adding additional `--volume` flags.
+
 ## Installation via Docker Compose
 
 ### Prerequisites

--- a/docs/user-guide/sso.md
+++ b/docs/user-guide/sso.md
@@ -6,7 +6,8 @@ GPUStack supports Single Sign-On (SSO) authentication methods such as OIDC and S
 
 Any authentication provider that supports OIDC can be configured. The `email`, `name` and `picture` claims are used if available. The allowed redirect URI should include `<server-url>/auth/oidc/callback`.
 
-If your OIDC provider uses a certificate issued by a private or corporate CA, mount the CA certificate into the container under `/usr/local/share/ca-certificates/*.crt`. GPUStack will automatically import the mounted CA certificates during startup and use the system trust store for OIDC discovery and callback requests.
+If your OIDC provider uses a certificate issued by a private or corporate CA, see [Additional Trusted CAs](../installation/installation.md#additional-trusted-cas) for how to mount CA certificates into the GPUStack container.
+
 The following CLI flags are available for OIDC configuration:
 
 | <div style="width:180px">Flag</div>                   | Description                                                                                                                                                          |


### PR DESCRIPTION
Make the instruction more general and the example clearer.

Related: https://github.com/gpustack/gpustack/issues/5006