### PR TITLE
(Options) docs: Update primary color to unify light and dark themes

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,9 +1,8 @@
 :root {
-    --md-primary-fg-color: #007BFF;
+    --md-primary-fg-color: #0D47A1;
     --md-primary-fg-color--light: #2997FF;
     --md-primary-fg-color--dark: #0062d9;
 }
-
 
 .center-table {
     text-align: center;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ theme:
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: light blue
+      primary: custom
       accent: orange
       toggle:
         icon: material/brightness-4


### PR DESCRIPTION
Before modification:

<img width="3821" height="1933" alt="image" src="https://github.com/user-attachments/assets/7c538373-93ef-4b8d-833e-422ae8b19012" />


Revised version:

<img width="3821" height="1933" alt="image" src="https://github.com/user-attachments/assets/876b42a2-84fd-4146-a1ea-e3614cfccf3f" />
