### PR TITLE
Fix #5018: Failed to launch GPUStack worker with AWS EKS

### DIFF
--- a/gpustack/server/catalog.py
+++ b/gpustack/server/catalog.py
@@ -114,7 +114,13 @@ def prepare_chat_templates(data_dir: str):
     if not os.path.exists(source_dir):
         return
 
-    file.copy_with_owner(source_dir, target_dir)
+    try:
+        file.copy_with_owner(source_dir, target_dir)
+    except OSError as e:
+        logger.warning(
+            f"Failed to copy chat templates to {target_dir}, "
+            f"will use existing files if available: {e}"
+        )
 
 
 def get_builtin_model_catalog_file() -> str:

--- a/gpustack/utils/file.py
+++ b/gpustack/utils/file.py
@@ -24,12 +24,21 @@ def copy_with_owner(src, dst):
 def copy_owner_recursively(src, dst):
     if platform.system() in ["linux", "darwin"]:
         st = os.stat(src)
-        os.chown(dst, st.st_uid, st.st_gid)
+        try:
+            os.chown(dst, st.st_uid, st.st_gid)
+        except PermissionError:
+            return
         for dirpath, dirnames, filenames in os.walk(dst):
             for dirname in dirnames:
-                os.chown(os.path.join(dirpath, dirname), st.st_uid, st.st_gid)
+                try:
+                    os.chown(os.path.join(dirpath, dirname), st.st_uid, st.st_gid)
+                except PermissionError:
+                    pass
             for filename in filenames:
-                os.chown(os.path.join(dirpath, filename), st.st_uid, st.st_gid)
+                try:
+                    os.chown(os.path.join(dirpath, filename), st.st_uid, st.st_gid)
+                except PermissionError:
+                    pass
 
 
 @retry(stop=stop_after_attempt(10), wait=wait_fixed(1))

--- a/tests/server/test_catalog.py
+++ b/tests/server/test_catalog.py
@@ -1,13 +1,29 @@
 import os
 import time
+import shutil
 import pytest
+from unittest.mock import patch
 from tenacity import retry, stop_after_attempt, wait_fixed
 from gpustack.schemas.models import SourceEnum
-from gpustack.server.catalog import get_model_set_specs, init_model_catalog
+from gpustack.server.catalog import get_model_set_specs, init_model_catalog, prepare_chat_templates
 from gpustack.utils.hub import match_hugging_face_files, match_model_scope_file_paths
 from gpustack.utils.compat_importlib import pkg_resources
 from huggingface_hub import HfApi
 from modelscope.hub.api import HubApi
+
+
+def test_prepare_chat_templates_handles_permission_error(tmp_path):
+    """prepare_chat_templates should log a warning and not raise on PermissionError."""
+    with patch("gpustack.utils.file.copy_with_owner", side_effect=PermissionError("Permission denied")):
+        # Should not raise; worker startup must not crash on permission errors.
+        prepare_chat_templates(str(tmp_path))
+
+
+def test_prepare_chat_templates_handles_shutil_error(tmp_path):
+    """prepare_chat_templates should log a warning and not raise on shutil.Error."""
+    with patch("gpustack.utils.file.copy_with_owner", side_effect=shutil.Error([("src", "dst", "Permission denied")])):
+        # Should not raise; worker startup must not crash when copytree fails.
+        prepare_chat_templates(str(tmp_path))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #5018

Handle permission errors gracefully when copying chat templates during worker startup, preventing crashes on restricted filesystems like AWS EKS with Bottlerocket OS.

## Changes

**`gpustack/server/catalog.py` — `prepare_chat_templates`**
Wraps the `file.copy_with_owner(source_dir, target_dir)` call in a `try/except OSError` block. On failure, logs a warning that includes the target path and the underlying error, then continues using whatever files already exist at the destination rather than propagating the exception.

**`gpustack/utils/file.py` — `copy_owner_recursively`**
Each `os.chown` call is now wrapped individually in `try/except PermissionError`. The top-level `chown` on the destination directory returns early on failure; per-entry `chown` calls on subdirectories and files silently continue (`pass`) so that ownership changes are applied wherever permitted without aborting the entire walk.

**`tests/server/test_catalog.py`**
Adds two unit tests for `prepare_chat_templates`:
- `test_prepare_chat_templates_handles_permission_error`: patches `copy_with_owner` to raise `PermissionError` and asserts no exception escapes.
- `test_prepare_chat_templates_handles_shutil_error`: patches `copy_with_owner` to raise `shutil.Error` (the exception raised by `shutil.copytree` on partial failures) and asserts the same.

## Motivation

On AWS EKS with Bottlerocket OS, the GPUStack worker container runs without permission to `chown` files under `/var/lib/gpustack/chat_templates`. The unguarded `os.chown` call in `copy_owner_recursively` raised `PermissionError`, which propagated through `prepare_chat_templates` and caused `worker.start()` to crash with an unhandled exception before the worker could do any useful work. The chat templates themselves may copy successfully even when ownership cannot be changed, so blocking startup on a `chown` failure is unnecessarily strict.

## Testing

The two new unit tests in `tests/server/test_catalog.py` cover both error paths introduced by this fix and confirm that `prepare_chat_templates` does not raise. The tests mock at the `copy_with_owner` boundary so they run without filesystem side effects and without requiring a real data directory containing template assets.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*