### PR TITLE
fix: skip evaluate_runtime_version for custom version of built-in backends

### DIFF
--- a/gpustack/scheduler/evaluator.py
+++ b/gpustack/scheduler/evaluator.py
@@ -33,7 +33,10 @@ from gpustack.schemas.models import (
     is_audio_model,
 )
 from gpustack.schemas.workers import Worker, WorkerStateEnum
-from gpustack.schemas.inference_backend import is_custom_backend
+from gpustack.schemas.inference_backend import (
+    is_built_in_backend_custom_version,
+    is_custom_backend,
+)
 from gpustack.server.worker_selector import WorkerSelector
 from gpustack_runner import list_backend_runners
 from gpustack_runtime.deployer.__utils__ import compare_versions
@@ -358,6 +361,11 @@ async def evaluate_runtime_version(
     backend_name = get_backend(model)
 
     if is_custom_backend(backend_name):
+        return True, []
+
+    if is_built_in_backend_custom_version(
+        backend_name, model.backend_version, model.image_name
+    ):
         return True, []
 
     max_runtime_version = None

--- a/gpustack/schemas/inference_backend.py
+++ b/gpustack/schemas/inference_backend.py
@@ -382,3 +382,22 @@ def is_custom_backend(backend_name: Optional[str]) -> bool:
         not is_built_in_backend(backend_name)
         or backend_name == BackendEnum.CUSTOM.value
     )
+
+
+def is_built_in_backend_custom_version(
+    backend_name: Optional[str],
+    backend_version: Optional[str],
+    image_name: Optional[str],
+) -> bool:
+    """
+    True when a built-in backend uses user-defined runner configuration that is
+    outside gpustack-runner catalogs: explicit model image, or an inference
+    backend version key ending with '-custom' (see validate_custom_suffix).
+    """
+    if not is_built_in_backend(backend_name):
+        return False
+    if image_name:
+        return True
+    if backend_version and backend_version.lower().endswith("-custom"):
+        return True
+    return False

--- a/tests/scheduler/test_runtime_version_filter.py
+++ b/tests/scheduler/test_runtime_version_filter.py
@@ -139,3 +139,31 @@ async def test_all_workers_below_requirement():
     assert len(messages) == 1, "Should have one error message"
     assert "12.4" in messages[0], "Message should contain highest version 12.4"
     assert "12.6" in messages[0], "Message should contain minimum version 12.6"
+
+
+@pytest.mark.asyncio
+async def test_built_in_custom_backend_version_skips_runtime_check():
+    """
+    User-defined versions on built-in backends (suffix -custom) use their own
+    images; gpustack-runner runtime matrix does not apply.
+    """
+    model = create_vllm_model().model_copy(update={"backend_version": "0.0.1-custom"})
+    workers = [create_cuda_worker("12.2", "worker-below-default-req")]
+
+    compatible, messages = await evaluate_runtime_version(model, workers)
+
+    assert compatible is True
+    assert messages == []
+
+
+@pytest.mark.asyncio
+async def test_built_in_explicit_image_skips_runtime_check():
+    model = create_vllm_model().model_copy(
+        update={"image_name": "example.com/my-vllm:tag"}
+    )
+    workers = [create_cuda_worker("12.2", "worker-below-default-req")]
+
+    compatible, messages = await evaluate_runtime_version(model, workers)
+
+    assert compatible is True
+    assert messages == []


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5076