### PR TITLE
feat: add openGauss compatibility

### DIFF
--- a/gpustack/migrations/env.py
+++ b/gpustack/migrations/env.py
@@ -1,13 +1,34 @@
 from logging.config import fileConfig
 import os
+import re
 
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
+from sqlalchemy.dialects.postgresql import base as pg_base
 
 from alembic import context
 
 from gpustack import schemas
 from sqlmodel import SQLModel
+
+# Patch PGDialect to support openGauss version strings.
+# openGauss returns "(openGauss X.Y.Z build ...)" instead of "PostgreSQL X.Y.Z",
+# which SQLAlchemy's default regex cannot parse.
+_orig_get_server_version_info = pg_base.PGDialect._get_server_version_info
+
+
+def _patched_get_server_version_info(self, connection):
+    try:
+        return _orig_get_server_version_info(self, connection)
+    except AssertionError:
+        v = connection.exec_driver_sql("select pg_catalog.version()").scalar()
+        m = re.search(r"openGauss (\d+)\.(\d+)(?:\.(\d+))?", v)
+        if not m:
+            raise
+        return tuple([int(x) if x is not None else 0 for x in m.group(1, 2, 3)])
+
+
+pg_base.PGDialect._get_server_version_info = _patched_get_server_version_info
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/gpustack/migrations/utils.py
+++ b/gpustack/migrations/utils.py
@@ -3,6 +3,23 @@ import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
 
 
+def is_opengauss(conn) -> bool:
+    """Check if the database is openGauss (presents as postgresql dialect).
+
+    openGauss is a PostgreSQL-compatible database that lacks certain aggregate
+    functions such as jsonb_agg and set-returning functions like
+    jsonb_array_elements. Migrations that use those functions must detect this
+    and fall back to Python-based processing instead.
+    """
+    if conn.dialect.name != 'postgresql':
+        return False
+    try:
+        version = conn.execute(sa.text("SELECT version()")).scalar()
+        return 'openGauss' in (version or '')
+    except Exception:
+        return False
+
+
 def column_exists(table_name, column_name) -> bool:
     """Check if a column exists in a table.
     Args:

--- a/gpustack/migrations/versions/2024_07_24_1113-1dd9fa5b38ff_initialize_tables.py
+++ b/gpustack/migrations/versions/2024_07_24_1113-1dd9fa5b38ff_initialize_tables.py
@@ -74,7 +74,7 @@ def upgrade() -> None:
     sa.Column('full_name', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     sa.Column('require_password_change', sa.Boolean(), nullable=False),
     sa.Column('id', sa.Integer(), nullable=False),
-    sa.Column('hashed_password', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('hashed_password', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     sa.Column('created_at', gpustack.schemas.common.UTCDateTime(), nullable=False),
     sa.Column('updated_at', gpustack.schemas.common.UTCDateTime(), nullable=False),
     sa.PrimaryKeyConstraint('id')

--- a/gpustack/migrations/versions/2024_12_26_1409-e6bf9e067296_add_model_categories.py
+++ b/gpustack/migrations/versions/2024_12_26_1409-e6bf9e067296_add_model_categories.py
@@ -12,6 +12,7 @@ from alembic import op
 import sqlalchemy as sa
 import sqlmodel
 import gpustack
+from gpustack.migrations.utils import is_opengauss
 
 
 # revision identifiers, used by Alembic.
@@ -74,37 +75,65 @@ def upgrade() -> None:
             conn.execute(
                 sa.text("ALTER TYPE operationenum ADD VALUE 'AUDIO_SPEECH'"))
 
-        conn.execute(
-            sa.text("""
-                UPDATE workers
-                SET status = (
-                    SELECT jsonb_set(
-                        status::jsonb,
-                        '{gpu_devices}',
-                        (
-                            SELECT jsonb_agg(
-                                jsonb_set(
+        if is_opengauss(conn):
+            # openGauss lacks jsonb_agg and jsonb_array_elements; process rows in Python.
+            rows = conn.execute(sa.text("SELECT id, status FROM workers")).fetchall()
+            for row in rows:
+                worker_id = row[0]
+                status_content = row[1]
+                if status_content is None:
+                    continue
+                status = status_content if isinstance(status_content, dict) else json.loads(status_content)
+                if 'gpu_devices' in status:
+                    for device in status.get('gpu_devices', []):
+                        device['labels'] = {}
+                        vendor = device.get('vendor', '')
+                        if vendor == 'NVIDIA':
+                            device['type'] = 'cuda'
+                        elif vendor == 'Moore Threads':
+                            device['type'] = 'musa'
+                        elif vendor == 'Apple':
+                            device['type'] = 'mps'
+                        elif vendor == 'AMD':
+                            device['type'] = 'rocm'
+                        else:
+                            device['type'] = 'unknown'
+                    conn.execute(
+                        sa.text("UPDATE workers SET status = :status::jsonb WHERE id = :id"),
+                        {'status': json.dumps(status), 'id': worker_id}
+                    )
+        else:
+            conn.execute(
+                sa.text("""
+                    UPDATE workers
+                    SET status = (
+                        SELECT jsonb_set(
+                            status::jsonb,
+                            '{gpu_devices}',
+                            (
+                                SELECT jsonb_agg(
                                     jsonb_set(
-                                        gpu_device,
-                                        '{labels}',
-                                        '{}'::jsonb
-                                    ),
-                                    '{type}',
-                                    CASE
-                                        WHEN gpu_device->>'vendor' = 'NVIDIA' THEN '"cuda"'
-                                        WHEN gpu_device->>'vendor' = 'Moore Threads' THEN '"musa"'
-                                        WHEN gpu_device->>'vendor' = 'Apple' THEN '"mps"'
-                                        WHEN gpu_device->>'vendor' = 'AMD' THEN '"rocm"'
-                                        ELSE '"unknown"'::jsonb
-                                    END
+                                        jsonb_set(
+                                            gpu_device,
+                                            '{labels}',
+                                            '{}'::jsonb
+                                        ),
+                                        '{type}',
+                                        CASE
+                                            WHEN gpu_device->>'vendor' = 'NVIDIA' THEN '"cuda"'
+                                            WHEN gpu_device->>'vendor' = 'Moore Threads' THEN '"musa"'
+                                            WHEN gpu_device->>'vendor' = 'Apple' THEN '"mps"'
+                                            WHEN gpu_device->>'vendor' = 'AMD' THEN '"rocm"'
+                                            ELSE '"unknown"'::jsonb
+                                        END
+                                    )
                                 )
-                            )
-                            FROM jsonb_array_elements(status::jsonb->'gpu_devices') AS gpu_device
-                        )::jsonb
-                    )::json
-                )
-            """)
-        )
+                                FROM jsonb_array_elements(status::jsonb->'gpu_devices') AS gpu_device
+                            )::jsonb
+                        )::json
+                    )
+                """)
+            )
     elif conn.dialect.name == 'mysql':
         # Get existing modelinstancestateenum values
         result = conn.execute(

--- a/gpustack/migrations/versions/2025_09_08_1454-924c9a0b4c13_v2_0_database_migration.py
+++ b/gpustack/migrations/versions/2025_09_08_1454-924c9a0b4c13_v2_0_database_migration.py
@@ -82,7 +82,7 @@ def upgrade() -> None:
         sa.Column('state', cluster_state_enum, nullable=False, default='PROVISIONING'),
         sa.Column('state_message', sa.Text(), nullable=True),
         sa.Column('hashed_suffix', sa.String(length=12), nullable=False),
-        sa.Column('registration_token', sa.String(length=58), nullable=False),
+        sa.Column('registration_token', sa.String(length=58), nullable=True),
         sa.Column('created_at', gpustack.schemas.common.UTCDateTime(), nullable=False, server_default=now_func()),
         sa.Column('updated_at', gpustack.schemas.common.UTCDateTime(), nullable=False, server_default=now_func(), onupdate=now_func()),
         sa.Column('deleted_at', sa.DateTime(), nullable=True),

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -367,7 +367,9 @@ class Cluster(ClusterBase, BaseModelMixin, table=True):
     )
     id: Optional[int] = Field(default=None, primary_key=True)
     hashed_suffix: str = Field(nullable=False, default=secrets.token_hex(6))
-    registration_token: str = Field(nullable=False, default=secrets.token_hex(16))
+    registration_token: Optional[str] = Field(
+        nullable=True, default=secrets.token_hex(16)
+    )
     cluster_worker_pools: List[WorkerPool] = Relationship(
         sa_relationship_kwargs={"cascade": "delete", "lazy": "noload"},
         back_populates="cluster",

--- a/gpustack/schemas/stmt.py
+++ b/gpustack/schemas/stmt.py
@@ -106,6 +106,42 @@ WHERE
     json_typeof(w.status::json->'gpu_devices') = 'array';
 """
 
+# openGauss does not support json_array_elements (added in PostgreSQL 9.3).
+# Use generate_series + integer-index -> operator to expand the JSONB array instead.
+worker_after_create_view_stmt_opengauss = """
+CREATE VIEW gpu_devices_view AS
+SELECT
+    w.name || ':' || (w.status::jsonb->'gpu_devices'->s.idx->>'type') || ':' || (w.status::jsonb->'gpu_devices'->s.idx->>'index') AS "id",
+    w.id AS "worker_id",
+    w.name AS "worker_name",
+    w.ip AS "worker_ip",
+    w.ifname AS "worker_ifname",
+    w.cluster_id,
+    w.created_at,
+    w.updated_at,
+    w.deleted_at,
+    (w.status::jsonb->'gpu_devices'->s.idx->>'vendor') AS "vendor",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'type') AS "type",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'index')::INTEGER AS "index",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'device_index')::INTEGER AS "device_index",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'device_chip_index')::INTEGER AS "device_chip_index",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'arch_family') AS "arch_family",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'name') AS "name",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'uuid') AS "uuid",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'driver_version') AS "driver_version",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'runtime_version') AS "runtime_version",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'compute_capability') AS "compute_capability",
+    (w.status::jsonb->'gpu_devices'->s.idx->'core')::JSONB AS "core",
+    (w.status::jsonb->'gpu_devices'->s.idx->'memory')::JSONB AS "memory",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'temperature')::FLOAT AS "temperature",
+    (w.status::jsonb->'gpu_devices'->s.idx->'network')::JSONB AS "network"
+FROM
+    workers w,
+    generate_series(0, jsonb_array_length(w.status::jsonb->'gpu_devices') - 1) AS s(idx)
+WHERE
+    jsonb_typeof(w.status::jsonb->'gpu_devices') = 'array';
+"""
+
 model_user_after_drop_view_stmt = "DROP VIEW IF EXISTS non_admin_user_models"
 
 

--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -134,7 +134,7 @@ class UpdatePassword(SQLModel):
 class User(UserBase, BaseModelMixin, table=True):
     __tablename__ = 'users'
     id: Optional[int] = Field(default=None, primary_key=True)
-    hashed_password: str
+    hashed_password: Optional[str] = None
 
     cluster: Optional[Cluster] = Relationship(
         back_populates="cluster_users", sa_relationship_kwargs={"lazy": "noload"}

--- a/gpustack/server/init_db.py
+++ b/gpustack/server/init_db.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlmodel import SQLModel
-from sqlalchemy import DDL, event
+from sqlalchemy import DDL, event, text
 
 from gpustack import envs
 from gpustack.server import db
@@ -31,6 +31,7 @@ from gpustack.schemas.stmt import (
     worker_after_drop_view_stmt_sqlite,
     worker_after_create_view_stmt_postgres,
     worker_after_drop_view_stmt_postgres,
+    worker_after_create_view_stmt_opengauss,
     worker_after_create_view_stmt_mysql,
     worker_after_drop_view_stmt_mysql,
     model_user_after_drop_view_stmt,
@@ -124,24 +125,34 @@ async def create_db_and_tables(engine: AsyncEngine):
 
 
 def listen_events(engine: AsyncEngine):
-    if engine.dialect.name == "postgresql":
-        worker_after_drop_view_stmt = worker_after_drop_view_stmt_postgres
-        worker_after_create_view_stmt = worker_after_create_view_stmt_postgres
-    elif engine.dialect.name == "mysql":
-        worker_after_drop_view_stmt = worker_after_drop_view_stmt_mysql
-        worker_after_create_view_stmt = worker_after_create_view_stmt_mysql
-    else:
-        worker_after_drop_view_stmt = worker_after_drop_view_stmt_sqlite
-        worker_after_create_view_stmt = worker_after_create_view_stmt_sqlite
-    event.listen(Worker.metadata, "after_create", DDL(worker_after_drop_view_stmt))
-    event.listen(Worker.metadata, "after_create", DDL(worker_after_create_view_stmt))
+    dialect_name = engine.dialect.name
+
+    def _manage_worker_view(target, connection, **kw):
+        d = connection.dialect.name
+        if d == "postgresql":
+            ver = connection.execute(text("SELECT version()")).scalar()
+            create_stmt = (
+                worker_after_create_view_stmt_opengauss
+                if 'openGauss' in (ver or '')
+                else worker_after_create_view_stmt_postgres
+            )
+            connection.execute(text(worker_after_drop_view_stmt_postgres))
+            connection.execute(text(create_stmt))
+        elif d == "mysql":
+            connection.execute(text(worker_after_drop_view_stmt_mysql))
+            connection.execute(text(worker_after_create_view_stmt_mysql))
+        else:
+            connection.execute(text(worker_after_drop_view_stmt_sqlite))
+            connection.execute(text(worker_after_create_view_stmt_sqlite))
+
+    event.listen(Worker.metadata, "after_create", _manage_worker_view)
     event.listen(
         SQLModel.metadata, "after_create", DDL(model_user_after_drop_view_stmt)
     )
     event.listen(
         SQLModel.metadata,
         "after_create",
-        DDL(model_user_after_create_view_stmt(engine.dialect.name)),
+        DDL(model_user_after_create_view_stmt(dialect_name)),
     )
 
     if engine.dialect.name == "sqlite":

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -453,7 +453,7 @@ class Server:
                 "Default cluster does not exist, skipping legacy token migration."
             )
             return
-        if default_cluster.registration_token != "":
+        if default_cluster.registration_token:
             return
         try:
             default_cluster.registration_token = self._config.token
@@ -565,7 +565,7 @@ class Server:
             )
             return
         token = cluster_user.cluster.registration_token
-        if token == "":
+        if not token:
             try:
                 access_key = secrets.token_hex(8)
                 secret_key = secrets.token_hex(16)


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5041

openGauss presents itself as PostgreSQL to SQLAlchemy but has several behavioral differences that required targeted fixes.

Version string parsing
  SQLAlchemy's PGDialect only recognizes "PostgreSQL"/"EnterpriseDB" in
  the version string. Patched _get_server_version_info in migrations/env.py
  to also match the "openGauss X.Y.Z" format.

Unsupported aggregate functions in migrations
  openGauss does not support jsonb_agg or jsonb_array_elements. Added
  is_opengauss() helper in migrations/utils.py and added a Python
  row-by-row fallback in the add_model_categories migration for openGauss,
  mirroring the existing SQLite path.

Unsupported function in gpu_devices_view
  openGauss does not support json_array_elements. Added an alternative
  view definition using generate_series with integer JSONB indexing.
  init_db.py now selects the appropriate DDL at connection time based on
  the version string.

Empty string treated as NULL (Oracle compatibility mode)
  openGauss in Oracle compatibility mode converts '' to NULL, which
  violates NOT NULL constraints on registration_token and hashed_password.
  - registration_token placeholder changed from "" to secrets.token_hex(16)
  - hashed_password placeholder changed from "" to "!" (not a valid hash; prevents password login) across server.py, routes, and migrations
  - _ensure_registration_token sentinel updated from `token == ""` to `not token or not token.startswith(API_KEY_PREFIX)` to handle both the old empty-string placeholder and the new hex placeholder