### PR TITLE
fix: use actual GPU VRAM instead of tensor-split ratios for multi-GPU…

### DIFF
--- a/gpustack/policies/candidate_selectors/gguf_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/gguf_resource_fit_selector.py
@@ -1825,9 +1825,20 @@ class GGUFResourceFitSelector(ScheduleCandidatesSelector):
         if self._param_tensor_split:
             # use specified tensor split when the param is set.
             total_gpu = len(worker.status.gpu_devices) or len(self._selected_gpu_ids)
-            if total_gpu < len(self._param_tensor_split.split(",")):
+            n_split = len(self._param_tensor_split.split(","))
+            if total_gpu < n_split:
                 return None, False
-            gpu_combinations = self._generate_combinations_given_tensor_split()
+            # User-provided tensor-split values are proportional hints for llama.cpp,
+            # not byte sizes. Using them as VRAM causes the vram_sum check in
+            # _find_single_worker_multi_gpu_full_offloading_candidates_with_combinations
+            # to fail (e.g. sum([1,1,1]) << required VRAM). Use actual GPU VRAM instead.
+            sorted_gpus = sorted(
+                allocatable.vram.items(), key=lambda x: x[1], reverse=True
+            )
+            selected_gpus = sorted_gpus[:n_split]
+            gpu_combinations = [
+                tuple((gpu_idx, vram) for gpu_idx, vram in selected_gpus)
+            ]
             return gpu_combinations, False
 
         if self._selected_gpu_ids_by_worker.get(worker.name):


### PR DESCRIPTION
… scheduling

When a user specifies `--tensor-split` in backend_parameters, the values are proportional hints for llama.cpp (e.g. `1,1,1,1`), not byte sizes.

Previously, `_generate_combinations_given_tensor_split()` stored these ratio values directly into the GPU combination tuples used for VRAM validation. The subsequent `vram_sum` check in
`_find_single_worker_multi_gpu_full_offloading_candidates_with_combinations` would then compare e.g. `1+1+1+1 = 4 bytes` against the full model size (tens of GB), always returning None and failing with "Unable to find a combination of GPUs that satisfies the requirements when splitting by layers".

Fix: use the tensor-split count to determine how many GPUs to allocate, but build the combination tuples using actual allocatable VRAM values (sorted descending to prefer GPUs with more free memory).