### PR TITLE
fix: preserve total-only usage for reranker and embedding

### DIFF
--- a/gpustack/routes/benchmarks.py
+++ b/gpustack/routes/benchmarks.py
@@ -20,7 +20,7 @@ from gpustack.schemas.models import (
     is_audio_model,
     is_embedding_model,
     is_image_model,
-    is_renaker_model,
+    is_reranker_model,
 )
 from gpustack.schemas.workers import Worker
 from gpustack.server.db import async_session
@@ -248,7 +248,7 @@ async def validate_and_mutate_benchmark_in(
         is_image_model(model)
         or is_audio_model(model)
         or is_embedding_model(model)
-        or is_renaker_model(model)
+        or is_reranker_model(model)
     ):
         raise BadRequestException(
             message=f"Benchmarking is not supported for model type '{model.type.value}'"

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -674,7 +674,7 @@ def is_embedding_model(model: Model):
     return "embedding" in model.categories
 
 
-def is_renaker_model(model: Model):
+def is_reranker_model(model: Model):
     """
     Check if the model is a reranker model.
     Args:

--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -10,7 +10,7 @@ from gpustack.schemas.api_keys import ApiKey
 from gpustack.schemas.clusters import Cluster
 from gpustack.schemas.model_provider import ModelProvider
 from gpustack.schemas.model_usage import ModelUsage
-from gpustack.schemas.models import Model
+from gpustack.schemas.models import Model, is_embedding_model, is_renaker_model
 from gpustack.schemas.users import User
 from gpustack.server.db import async_session
 from gpustack.utils.usage_snapshots import build_model_usage_snapshot
@@ -50,6 +50,20 @@ def _make_buffer_key(metric: ModelUsageMetrics) -> str:
             metric.access_key,
         ]
     )
+
+
+def _resolve_usage_tokens(
+    metric: ModelUsageMetrics, model: Optional[Model]
+) -> tuple[int, int]:
+    prompt_tokens = metric.input_token
+    completion_tokens = metric.output_token
+    if (
+        model is not None
+        and (is_renaker_model(model) or is_embedding_model(model))
+        and metric.total_token > (prompt_tokens + completion_tokens)
+    ):
+        return metric.total_token - completion_tokens, completion_tokens
+    return prompt_tokens, completion_tokens
 
 
 async def accumulate_gateway_metrics(metrics: List[ModelUsageMetrics]):
@@ -249,6 +263,7 @@ async def store_usage_metrics(metrics: List[ModelUsageMetrics]):
                         api_key=api_key,
                         provider=provider,
                     )
+                prompt_tokens, completion_tokens = _resolve_usage_tokens(metric, model)
                 snapshot.setdefault("user_id", metric.user_id)
                 snapshot.setdefault("provider_id", metric.provider_id)
                 snapshot.setdefault("provider_name", metric.provider_name)
@@ -257,8 +272,8 @@ async def store_usage_metrics(metrics: List[ModelUsageMetrics]):
                 snapshot.setdefault("api_key_is_custom", None)
                 model_usage = ModelUsage(
                     date=date.today(),
-                    prompt_token_count=metric.input_token,
-                    completion_token_count=metric.output_token,
+                    prompt_token_count=prompt_tokens,
+                    completion_token_count=completion_tokens,
                     request_count=metric.request_count,
                     **snapshot,
                 )

--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -10,7 +10,7 @@ from gpustack.schemas.api_keys import ApiKey
 from gpustack.schemas.clusters import Cluster
 from gpustack.schemas.model_provider import ModelProvider
 from gpustack.schemas.model_usage import ModelUsage
-from gpustack.schemas.models import Model, is_embedding_model, is_renaker_model
+from gpustack.schemas.models import Model, is_embedding_model, is_reranker_model
 from gpustack.schemas.users import User
 from gpustack.server.db import async_session
 from gpustack.utils.usage_snapshots import build_model_usage_snapshot
@@ -59,7 +59,7 @@ def _resolve_usage_tokens(
     completion_tokens = metric.output_token
     if (
         model is not None
-        and (is_renaker_model(model) or is_embedding_model(model))
+        and (is_reranker_model(model) or is_embedding_model(model))
         and metric.total_token > (prompt_tokens + completion_tokens)
     ):
         return metric.total_token - completion_tokens, completion_tokens

--- a/tests/server/test_metrics_collector.py
+++ b/tests/server/test_metrics_collector.py
@@ -5,6 +5,7 @@ import pytest
 from gpustack.server.metrics_collector import (
     ModelUsageMetrics,
     _make_buffer_key,
+    _resolve_usage_tokens,
     accumulate_gateway_metrics,
     gateway_metrics_buffer,
 )
@@ -96,3 +97,13 @@ def test_accumulate_total_token_summed():
     asyncio.run(accumulate_gateway_metrics([m2]))
     entry = list(gateway_metrics_buffer.values())[0]
     assert entry.total_token == 400
+
+
+def test_resolve_usage_tokens_falls_back_total_for_reranker_model():
+    metric = ModelUsageMetrics(model="bge-m3", total_token=77)
+    model = type("StubModel", (), {"categories": ["reranker"]})()
+
+    prompt_tokens, completion_tokens = _resolve_usage_tokens(metric, model)
+
+    assert prompt_tokens == 77
+    assert completion_tokens == 0


### PR DESCRIPTION
- #5176 