### PR TITLE
fix: reserve service and ray port ranges against kernel ephemeral range

### DIFF
--- a/gpustack/cmd/prerun.py
+++ b/gpustack/cmd/prerun.py
@@ -14,7 +14,8 @@ from gpustack.cmd.start import (
     parse_args,
 )
 from gpustack.utils.envs import get_gpustack_env
-from gpustack.utils.network import is_port_available
+from gpustack.utils.ephemeral_ports import ensure_reserved_against_ephemeral
+from gpustack.utils.network import is_port_available, parse_port_range
 from gpustack.utils.s6_services import (
     gateway_services,
     postgres_services,
@@ -65,6 +66,7 @@ def run(args: argparse.Namespace):
         prepare_s6_overlay(enabled_services, dependency_services, Path(s6_base_path))
 
         check_ports_availability(cfg, *enabled_services)
+        reserve_ports_against_ephemeral(cfg)
         if "postgres" in enabled_services:
             prepare_postgres_config(cfg)
         if cfg.gateway_mode == GatewayModeEnum.embedded:
@@ -130,6 +132,34 @@ def check_ports_availability(cfg: Config, *services: str):
             should_fail = True
     if should_fail:
         raise Exception("One or more required ports are not available.")
+
+
+def reserve_ports_against_ephemeral(cfg: Config):
+    """
+    Reserve gpustack's service and Ray port ranges against the kernel's
+    ephemeral port range so outbound connections (by gpustack, higress, or
+    any other sibling process sharing the netns) don't transiently squat on
+    ports that Ray or inference servers will later bind().
+
+    Runs here (in prerun) rather than inside the worker so the reservation
+    is applied before any s6 service starts. Skipped on server-only hosts:
+    the configured ranges are only bound by model instances and Ray, both
+    of which run on worker hosts.
+    """
+    if cfg.server_role() not in [Config.ServerRole.WORKER, Config.ServerRole.BOTH]:
+        return
+
+    ranges = []
+    for name in ("service_port_range", "ray_port_range"):
+        value = getattr(cfg, name, None)
+        if not value:
+            continue
+        try:
+            ranges.append((name, parse_port_range(value)))
+        except ValueError:
+            logger.debug("Skipping unparseable %s=%r", name, value)
+    if ranges:
+        ensure_reserved_against_ephemeral(ranges)
 
 
 def cleanup_s6_services(base_path: Path, *services: str):

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -72,6 +72,14 @@ DISABLE_OS_FILELOCK = os.getenv("GPUSTACK_DISABLE_OS_FILELOCK", "false").lower()
     "true",
     "1",
 ]
+
+# Opt out of automatically writing gpustack's configured port ranges to
+# /proc/sys/net/ipv4/ip_local_reserved_ports. Use when the environment already
+# manages the reservation, or when the configured ranges would starve the
+# ephemeral pool after reservation.
+SKIP_RESERVE_EPHEMERAL_PORTS = os.getenv(
+    "GPUSTACK_SKIP_RESERVE_EPHEMERAL_PORTS", "false"
+).lower() in ["true", "1"]
 # Add debug logs for slow worker status collection, default to 3 minutes
 WORKER_STATUS_COLLECTION_LOG_SLOW_SECONDS = float(
     os.getenv("GPUSTACK_WORKER_STATUS_COLLECTION_LOG_SLOW_SECONDS", 180)

--- a/gpustack/utils/ephemeral_ports.py
+++ b/gpustack/utils/ephemeral_ports.py
@@ -1,0 +1,204 @@
+"""
+Helpers to reconcile gpustack's configured port ranges (service, Ray) with the
+Linux kernel's ephemeral port range.
+
+When an outbound TCP connection is made, the kernel picks a local source port
+from `net.ipv4.ip_local_port_range` (default 32768-60999). gpustack's default
+`ray_port_range` (41000-41999) and `service_port_range` (40000-40063) fall
+inside this window, so a worker-side outbound connection (e.g. gpustack-worker
+talking to the server on :80) can transiently squat on a port that Ray or an
+inference server later tries to bind(), causing "Address already in use".
+
+The fix is to append the gpustack ranges to `ip_local_reserved_ports`. This
+module detects the conflict and, when running with enough privilege, applies
+the reservation automatically. Otherwise it logs the exact sysctl command the
+operator must run.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from gpustack import envs
+from gpustack.utils import platform
+
+logger = logging.getLogger(__name__)
+
+_LOCAL_PORT_RANGE_PATH = Path("/proc/sys/net/ipv4/ip_local_port_range")
+_RESERVED_PORTS_PATH = Path("/proc/sys/net/ipv4/ip_local_reserved_ports")
+
+Range = Tuple[int, int]
+
+
+def _parse_ranges(text: str) -> List[Range]:
+    """
+    Parse a sysctl port list (comma-separated ports and N1-N2 ranges) into
+    a list of inclusive (start, end) tuples. Returns [] on empty input.
+    """
+    ranges: List[Range] = []
+    for token in text.replace(",", " ").split():
+        if not token:
+            continue
+        if "-" in token:
+            a, b = token.split("-", 1)
+            ranges.append((int(a), int(b)))
+        else:
+            p = int(token)
+            ranges.append((p, p))
+    return ranges
+
+
+def _merge(ranges: List[Range]) -> List[Range]:
+    """
+    Merge overlapping/adjacent ranges. Result is sorted and disjoint.
+    """
+    if not ranges:
+        return []
+    ordered = sorted(ranges)
+    merged: List[Range] = [ordered[0]]
+    for start, end in ordered[1:]:
+        last_start, last_end = merged[-1]
+        if start <= last_end + 1:
+            merged[-1] = (last_start, max(last_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _format_ranges(ranges: List[Range]) -> str:
+    parts: List[str] = []
+    for start, end in ranges:
+        parts.append(str(start) if start == end else f"{start}-{end}")
+    return ",".join(parts)
+
+
+def _covered_by(target: Range, ranges: List[Range]) -> bool:
+    start, end = target
+    for rs, re_ in ranges:
+        if rs <= start and re_ >= end:
+            return True
+    return False
+
+
+def _overlaps(a: Range, b: Range) -> bool:
+    return a[0] <= b[1] and b[0] <= a[1]
+
+
+def _read_port_range(path: Path) -> Optional[Range]:
+    try:
+        text = path.read_text().strip()
+    except OSError as e:
+        logger.debug("Cannot read %s: %s", path, e)
+        return None
+    parts = text.split()
+    if len(parts) != 2:
+        logger.debug("Unexpected content in %s: %r", path, text)
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        logger.debug("Non-numeric content in %s: %r", path, text)
+        return None
+
+
+def _read_reserved_ports(path: Path) -> Optional[List[Range]]:
+    """
+    Returns the currently reserved ranges, [] if the file is missing/empty,
+    or None if the content is unparseable — in which case callers should
+    abort rather than risk overwriting user-managed reservations.
+    """
+    try:
+        text = path.read_text().strip()
+    except OSError as e:
+        logger.debug("Cannot read %s: %s", path, e)
+        return []
+    try:
+        return _merge(_parse_ranges(text))
+    except ValueError:
+        logger.warning(
+            "Cannot parse %s: %r. Skipping auto-reservation to avoid "
+            "overwriting existing configuration.",
+            path,
+            text,
+        )
+        return None
+
+
+def ensure_reserved_against_ephemeral(
+    port_ranges: List[Tuple[str, Range]],
+) -> None:
+    """
+    Ensure each given port range is reserved against the kernel's ephemeral
+    range on Linux. No-op on other platforms or when /proc sysctls are
+    unreadable (e.g., unprivileged container, unusual kernels).
+
+    port_ranges: list of (human_name, (start, end)) tuples.
+    """
+    if envs.SKIP_RESERVE_EPHEMERAL_PORTS:
+        logger.info(
+            "Skipping ephemeral port reservation because "
+            "GPUSTACK_SKIP_RESERVE_EPHEMERAL_PORTS is set."
+        )
+        return
+
+    if platform.system() != "linux":
+        return
+
+    if not _LOCAL_PORT_RANGE_PATH.exists():
+        return
+
+    ephemeral = _read_port_range(_LOCAL_PORT_RANGE_PATH)
+    if ephemeral is None:
+        return
+
+    reserved = _read_reserved_ports(_RESERVED_PORTS_PATH)
+    if reserved is None:
+        return
+
+    conflicts: List[Tuple[str, Range]] = []
+    for name, rng in port_ranges:
+        if not _overlaps(rng, ephemeral):
+            continue
+        if _covered_by(rng, reserved):
+            continue
+        conflicts.append((name, rng))
+
+    if not conflicts:
+        return
+
+    desired = _merge(reserved + [rng for _, rng in conflicts])
+    payload = _format_ranges(desired)
+
+    conflict_desc = ", ".join(
+        f"{name}={start}-{end}" for name, (start, end) in conflicts
+    )
+    try:
+        _RESERVED_PORTS_PATH.write_text(payload)
+    except OSError as e:
+        logger.warning(
+            "gpustack port ranges (%s) overlap the kernel ephemeral port "
+            "range %d-%d and are not reserved. Ray or inference servers may "
+            "fail to bind when the kernel transiently assigns one of these "
+            "ports as an outbound ephemeral port. Failed to auto-reserve "
+            "(%s). Run on each worker host:\n"
+            "    echo 'net.ipv4.ip_local_reserved_ports = %s' | "
+            "sudo tee -a /etc/sysctl.conf && sudo sysctl -p",
+            conflict_desc,
+            ephemeral[0],
+            ephemeral[1],
+            e,
+            payload,
+        )
+        return
+
+    logger.info(
+        "Reserved gpustack port ranges (%s) against kernel ephemeral range "
+        "%d-%d via %s (now: %s).",
+        conflict_desc,
+        ephemeral[0],
+        ephemeral[1],
+        _RESERVED_PORTS_PATH,
+        payload,
+    )

--- a/tests/utils/test_ephemeral_ports.py
+++ b/tests/utils/test_ephemeral_ports.py
@@ -1,0 +1,184 @@
+from pathlib import Path
+
+from gpustack.utils import ephemeral_ports
+
+
+def test_parse_ranges_mixed():
+    result = ephemeral_ports._parse_ranges("80, 8000-8010,\t9000")
+    assert result == [(80, 80), (8000, 8010), (9000, 9000)]
+
+
+def test_parse_ranges_empty():
+    assert ephemeral_ports._parse_ranges("") == []
+
+
+def test_merge_adjacent_and_overlap():
+    merged = ephemeral_ports._merge(
+        [(40000, 40063), (41000, 41999), (41500, 42000), (42001, 42010)]
+    )
+    assert merged == [(40000, 40063), (41000, 42010)]
+
+
+def test_format_ranges_single_and_range():
+    assert ephemeral_ports._format_ranges([(80, 80), (8000, 8010)]) == "80,8000-8010"
+
+
+def test_covered_by_true():
+    assert ephemeral_ports._covered_by((41005, 41500), [(41000, 41999)])
+
+
+def test_covered_by_false_partial():
+    assert not ephemeral_ports._covered_by((41000, 42500), [(41000, 41999)])
+
+
+def test_ensure_noop_when_no_overlap(monkeypatch, tmp_path: Path):
+    ephemeral = tmp_path / "ip_local_port_range"
+    ephemeral.write_text("32768\t60999\n")
+    reserved = tmp_path / "ip_local_reserved_ports"
+    reserved.write_text("")
+    monkeypatch.setattr(ephemeral_ports, "_LOCAL_PORT_RANGE_PATH", ephemeral)
+    monkeypatch.setattr(ephemeral_ports, "_RESERVED_PORTS_PATH", reserved)
+    monkeypatch.setattr(ephemeral_ports.platform, "system", lambda: "linux")
+
+    ephemeral_ports.ensure_reserved_against_ephemeral(
+        [("ray_port_range", (61000, 61999))]
+    )
+
+    assert reserved.read_text() == ""
+
+
+def test_ensure_writes_reservation_on_conflict(monkeypatch, tmp_path: Path):
+    ephemeral = tmp_path / "ip_local_port_range"
+    ephemeral.write_text("32768\t60999\n")
+    reserved = tmp_path / "ip_local_reserved_ports"
+    reserved.write_text("")
+    monkeypatch.setattr(ephemeral_ports, "_LOCAL_PORT_RANGE_PATH", ephemeral)
+    monkeypatch.setattr(ephemeral_ports, "_RESERVED_PORTS_PATH", reserved)
+    monkeypatch.setattr(ephemeral_ports.platform, "system", lambda: "linux")
+
+    ephemeral_ports.ensure_reserved_against_ephemeral(
+        [
+            ("service_port_range", (40000, 40063)),
+            ("ray_port_range", (41000, 41999)),
+        ]
+    )
+
+    assert reserved.read_text() == "40000-40063,41000-41999"
+
+
+def test_ensure_merges_with_existing_reservation(monkeypatch, tmp_path: Path):
+    ephemeral = tmp_path / "ip_local_port_range"
+    ephemeral.write_text("32768 60999")
+    reserved = tmp_path / "ip_local_reserved_ports"
+    reserved.write_text("12345,40000-40100")
+    monkeypatch.setattr(ephemeral_ports, "_LOCAL_PORT_RANGE_PATH", ephemeral)
+    monkeypatch.setattr(ephemeral_ports, "_RESERVED_PORTS_PATH", reserved)
+    monkeypatch.setattr(ephemeral_ports.platform, "system", lambda: "linux")
+
+    ephemeral_ports.ensure_reserved_against_ephemeral(
+        [("ray_port_range", (41000, 41999))]
+    )
+
+    assert reserved.read_text() == "12345,40000-40100,41000-41999"
+
+
+def test_ensure_noop_when_already_covered(monkeypatch, tmp_path: Path):
+    ephemeral = tmp_path / "ip_local_port_range"
+    ephemeral.write_text("32768 60999")
+    reserved = tmp_path / "ip_local_reserved_ports"
+    reserved.write_text("40000-42000")
+    monkeypatch.setattr(ephemeral_ports, "_LOCAL_PORT_RANGE_PATH", ephemeral)
+    monkeypatch.setattr(ephemeral_ports, "_RESERVED_PORTS_PATH", reserved)
+    monkeypatch.setattr(ephemeral_ports.platform, "system", lambda: "linux")
+
+    ephemeral_ports.ensure_reserved_against_ephemeral(
+        [
+            ("service_port_range", (40000, 40063)),
+            ("ray_port_range", (41000, 41999)),
+        ]
+    )
+
+    assert reserved.read_text() == "40000-42000"
+
+
+def test_ensure_aborts_on_unparseable_reserved(monkeypatch, tmp_path: Path, caplog):
+    ephemeral = tmp_path / "ip_local_port_range"
+    ephemeral.write_text("32768 60999")
+    reserved = tmp_path / "ip_local_reserved_ports"
+    reserved.write_text("not-a-port-list")
+    monkeypatch.setattr(ephemeral_ports, "_LOCAL_PORT_RANGE_PATH", ephemeral)
+    monkeypatch.setattr(ephemeral_ports, "_RESERVED_PORTS_PATH", reserved)
+    monkeypatch.setattr(ephemeral_ports.platform, "system", lambda: "linux")
+
+    with caplog.at_level("WARNING"):
+        ephemeral_ports.ensure_reserved_against_ephemeral(
+            [("ray_port_range", (41000, 41999))]
+        )
+
+    assert reserved.read_text() == "not-a-port-list"
+    assert any("Cannot parse" in rec.message for rec in caplog.records)
+
+
+def test_parse_ranges_whitespace_separated():
+    assert ephemeral_ports._parse_ranges("40000-40063 41000-41999") == [
+        (40000, 40063),
+        (41000, 41999),
+    ]
+
+
+def test_ensure_warns_when_write_fails(monkeypatch, tmp_path: Path, caplog):
+    ephemeral = tmp_path / "ip_local_port_range"
+    ephemeral.write_text("32768 60999")
+    reserved = tmp_path / "ip_local_reserved_ports"
+    reserved.write_text("")
+    monkeypatch.setattr(ephemeral_ports, "_LOCAL_PORT_RANGE_PATH", ephemeral)
+    monkeypatch.setattr(ephemeral_ports, "_RESERVED_PORTS_PATH", reserved)
+    monkeypatch.setattr(ephemeral_ports.platform, "system", lambda: "linux")
+
+    original_write_text = Path.write_text
+
+    def _fail_write(self, *args, **kwargs):
+        if self == reserved:
+            raise PermissionError("read-only")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", _fail_write)
+
+    with caplog.at_level("WARNING"):
+        ephemeral_ports.ensure_reserved_against_ephemeral(
+            [("ray_port_range", (41000, 41999))]
+        )
+
+    assert any(
+        "overlap the kernel ephemeral port" in rec.message for rec in caplog.records
+    )
+
+
+def test_ensure_skips_when_env_opt_out(monkeypatch, tmp_path: Path):
+    ephemeral = tmp_path / "ip_local_port_range"
+    ephemeral.write_text("32768 60999")
+    reserved = tmp_path / "ip_local_reserved_ports"
+    reserved.write_text("")
+    monkeypatch.setattr(ephemeral_ports, "_LOCAL_PORT_RANGE_PATH", ephemeral)
+    monkeypatch.setattr(ephemeral_ports, "_RESERVED_PORTS_PATH", reserved)
+    monkeypatch.setattr(ephemeral_ports.platform, "system", lambda: "linux")
+    monkeypatch.setattr(ephemeral_ports.envs, "SKIP_RESERVE_EPHEMERAL_PORTS", True)
+
+    ephemeral_ports.ensure_reserved_against_ephemeral(
+        [("ray_port_range", (41000, 41999))]
+    )
+
+    assert reserved.read_text() == ""
+
+
+def test_ensure_skips_non_linux(monkeypatch, tmp_path: Path):
+    reserved = tmp_path / "ip_local_reserved_ports"
+    reserved.write_text("")
+    monkeypatch.setattr(ephemeral_ports, "_RESERVED_PORTS_PATH", reserved)
+    monkeypatch.setattr(ephemeral_ports.platform, "system", lambda: "darwin")
+
+    ephemeral_ports.ensure_reserved_against_ephemeral(
+        [("ray_port_range", (41000, 41999))]
+    )
+
+    assert reserved.read_text() == ""


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5181

The default service_port_range (40000-40063) and ray_port_range (41000-41999) overlap the Linux default ephemeral port range (32768-60999), so an outbound socket from gpustack-worker to the server can transiently hold a port that Ray or an inference server later tries to bind(), failing with "Address already in use".

Add ensure_reserved_against_ephemeral() to merge the configured ranges into /proc/sys/net/ipv4/ip_local_reserved_ports, and call it from `gpustack prerun` so the reservation is applied before any s6 service (higress, gpustack server/worker) starts making outbound connections. Falls back to a warning with the exact sysctl command when the write is not permitted.

Also add GPUSTACK_SKIP_RESERVE_EPHEMERAL_PORTS as an explicit opt-out for environments where the automatic reservation is unwanted or harmful (e.g., a narrowly configured ip_local_port_range where the reservation would starve the ephemeral pool).