### PR TITLE
feat: persist vLLM torch compile cache across restarts

### DIFF
--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -241,6 +241,9 @@ class VLLMServer(InferenceServer):
         )
         env["RUNAI_STREAMER_LOG_LEVEL"] = env.pop("RUNAI_STREAMER_LOG_LEVEL", "INFO")
 
+        # Persist the torch compile cache so repeated starts don't recompile.
+        self._set_cache_env(env)
+
         # Apply LMCache environment variables if extended KV cache is enabled
         self._set_lmcache_env(env)
 
@@ -253,6 +256,28 @@ class VLLMServer(InferenceServer):
             self._set_ascend_env(env)
 
         return env
+
+    def _set_cache_env(self, env: Dict[str, str]):
+        """
+        Point VLLM_CACHE_ROOT at a persistent directory under gpustack's data dir
+        so the torch compile cache survives container restarts. The directory is
+        inherited by the inference container via gpustack-runtime's mirrored
+        deployment (worker's data-dir mount is replicated to the vLLM container).
+        """
+        if "VLLM_CACHE_ROOT" in env:
+            return
+        if not self._config or not self._config.cache_dir:
+            return
+        cache_dir = os.path.join(self._config.cache_dir, "vllm")
+        try:
+            os.makedirs(cache_dir, exist_ok=True)
+        except OSError as e:
+            logger.warning(
+                f"Failed to create vLLM cache dir {cache_dir}: {e}. "
+                "Torch compile cache will not be persisted."
+            )
+            return
+        env["VLLM_CACHE_ROOT"] = cache_dir
 
     def _set_lmcache_env(self, env: Dict[str, str]):
         """

--- a/tests/worker/backends/test_backend.py
+++ b/tests/worker/backends/test_backend.py
@@ -8,6 +8,7 @@ from gpustack.worker.backends.sglang import (
     get_access_log_arguments as get_sglang_access_log_arguments,
 )
 from gpustack.worker.backends.vllm import (
+    VLLMServer,
     get_access_log_arguments as get_vllm_access_log_arguments,
 )
 
@@ -194,3 +195,27 @@ def test_vllm_access_log_arguments(backend_parameters, expected):
 )
 def test_sglang_access_log_arguments(backend_parameters, expected):
     assert get_sglang_access_log_arguments(backend_parameters) == expected
+
+
+def test_vllm_set_cache_env_defaults_to_config_cache_dir(tmp_path):
+    backend = VLLMServer.__new__(VLLMServer)
+    backend._config = types.SimpleNamespace(cache_dir=str(tmp_path))
+
+    env = {}
+    backend._set_cache_env(env)
+
+    expected = tmp_path / "vllm"
+    assert env["VLLM_CACHE_ROOT"] == str(expected)
+    assert expected.is_dir()
+
+
+def test_vllm_set_cache_env_respects_user_override(tmp_path):
+    backend = VLLMServer.__new__(VLLMServer)
+    backend._config = types.SimpleNamespace(cache_dir=str(tmp_path))
+
+    env = {"VLLM_CACHE_ROOT": "/custom/cache"}
+    backend._set_cache_env(env)
+
+    assert env["VLLM_CACHE_ROOT"] == "/custom/cache"
+    # Default cache dir should not be created when the user overrode it.
+    assert not (tmp_path / "vllm").exists()


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5175

Point VLLM_CACHE_ROOT at <cache_dir>/vllm so the torch compile cache survives container restarts. The directory is inherited by the vLLM container via gpustack-runtime's mirrored deployment.