### PR TITLE
fix: suppress misleading multi-GPU diagnostic for single-GPU workers

### DIFF
--- a/gpustack/policies/candidate_selectors/custom_backend_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/custom_backend_resource_fit_selector.py
@@ -300,8 +300,11 @@ class CustomBackendResourceFitSelector(ScheduleCandidatesSelector):
                     largest_worker_vram = total_available_vram
                     largest_worker_gpu_count = len(available_gpus)
 
-        if not candidates:
-            # Add diagnostic message similar to vLLM multi-GPU path (without utilization)
+        if not candidates and largest_worker_gpu_count >= 2:
+            # Only emit the multi-GPU diagnostic when at least one worker with
+            # >=2 GPUs was actually considered; otherwise this message would
+            # report "0.0 GiB across 0 GPUs" and mask the more relevant
+            # single-GPU diagnostic.
             event_msg_list = ListMessageBuilder(
                 f"The largest available worker has {byte_to_gib(largest_worker_vram)} GiB allocatable VRAM across {largest_worker_gpu_count} GPUs."
             )

--- a/tests/policies/candidate_selectors/custom_backend/test_custom_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/custom_backend/test_custom_resource_fit_selector.py
@@ -8,7 +8,11 @@ from gpustack.policies.candidate_selectors.custom_backend_resource_fit_selector 
     CustomBackendResourceFitSelector,
 )
 from gpustack.policies.scorers.placement_scorer import PlacementScorer
-from tests.fixtures.workers.fixtures import linux_nvidia_4_4080_16gx4, linux_cpu_1
+from tests.fixtures.workers.fixtures import (
+    linux_nvidia_0_4090_24gx1,
+    linux_nvidia_4_4080_16gx4,
+    linux_cpu_1,
+)
 from tests.policies.candidate_selectors.vllm.test_vllm_resource_fit_selector import (
     make_model,
 )
@@ -99,6 +103,18 @@ async def test_schedule_single_work_multi_gpu(
             [
                 '- The model requires approximately 700.0 GiB of VRAM and 70.0 GiB of RAM.\n'
                 '- CPU-only inference is supported. Requires at least 70.0 GiB RAM.'
+            ],
+        ),
+        (
+            # Single-GPU worker that cannot fit the model: the multi-GPU
+            # diagnostic must not appear (no worker has >=2 GPUs), otherwise
+            # the user sees a misleading "0.0 GiB across 0 GPUs" message.
+            [linux_nvidia_0_4090_24gx1()],
+            make_model(1, None, "Qwen/Qwen-Image-Edit"),
+            {"GPUSTACK_MODEL_VRAM_CLAIM": str(54 * 1024**3)},
+            [
+                '- The model requires approximately 54.0 GiB of VRAM and 5.4 GiB of RAM.\n'
+                '- The current available GPU only has 24.23 GiB allocatable VRAM.'
             ],
         ),
     ],


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5207

Skip emitting the "largest available worker has X GiB across N GPUs" message when no worker with >=2 GPUs was considered, so the more relevant single-GPU shortfall message surfaces instead of "0.0 GiB across 0 GPUs".