### PR TITLE
fix: update Prometheus queries in dashboard dropdown filters

### DIFF
--- a/docker-compose/grafana/grafana_dashboards/gpustack-model.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-model.json
@@ -2643,7 +2643,7 @@
           "query": "query_result(gpustack:model_info{cluster_name=\"$cluster_name\"})",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/model_name=\"([^\"]+)\"/",
         "type": "query"
       },

--- a/docker-compose/grafana/grafana_dashboards/gpustack-model.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-model.json
@@ -2663,7 +2663,7 @@
           "query": "query_result(gpustack:model_instance_status{model_name=\"$model_name\", cluster_name=\"$cluster_name\"})",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/model_instance_name=\"([^\"]+)\"/",
         "type": "query"
       }

--- a/docker-compose/grafana/grafana_dashboards/gpustack-model.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-model.json
@@ -2616,17 +2616,17 @@
           "text": "",
           "value": ""
         },
-        "definition": "label_values(gpustack:cluster_info,cluster_name)",
-        "label": "Cluster Name",
+        "definition": "query_result(gpustack:cluster_info)",
+        "label": "Cluster",
         "name": "cluster_name",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(gpustack:cluster_info,cluster_name)",
+          "query": "query_result(gpustack:cluster_info)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
-        "regex": "",
+        "regex": "/cluster_name=\"([^\"]+)\"/",
         "type": "query"
       },
       {
@@ -2634,17 +2634,17 @@
           "text": "",
           "value": ""
         },
-        "definition": "label_values(gpustack:model_info{cluster_name=\"$cluster_name\"},model_name)",
+        "definition": "query_result(gpustack:model_info{cluster_name=\"$cluster_name\"})",
         "label": "Model",
         "name": "model_name",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(gpustack:model_info{cluster_name=\"$cluster_name\"},model_name)",
+          "query": "query_result(gpustack:model_info{cluster_name=\"$cluster_name\"})",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "",
+        "regex": "/model_name=\"([^\"]+)\"/",
         "type": "query"
       },
       {
@@ -2653,18 +2653,18 @@
           "text": "All",
           "value": "$__all"
         },
-        "definition": "label_values(gpustack:model_instance_status{model_name=\"$model_name\", cluster_name=\"$cluster_name\"},model_instance_name)",
+        "definition": "query_result(gpustack:model_instance_status{model_name=\"$model_name\", cluster_name=\"$cluster_name\"})",
         "includeAll": true,
         "label": "Model Instance",
         "name": "model_instance_name",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(gpustack:model_instance_status{model_name=\"$model_name\", cluster_name=\"$cluster_name\"},model_instance_name)",
+          "query": "query_result(gpustack:model_instance_status{model_name=\"$model_name\", cluster_name=\"$cluster_name\"})",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "",
+        "regex": "/model_instance_name=\"([^\"]+)\"/",
         "type": "query"
       }
     ]

--- a/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
@@ -1855,18 +1855,18 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(gpustack:cluster_info,cluster_name)",
+        "definition": "query_result(gpustack:cluster_info)",
         "includeAll": false,
         "label": "Cluster",
         "name": "cluster_name",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(gpustack:cluster_info,cluster_name)",
+          "query": "query_result(gpustack:cluster_info)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
-        "regex": "",
+        "regex": "/cluster_name=\"([^\"]+)\"/",
         "sort": 1,
         "type": "query"
       },
@@ -1882,7 +1882,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(gpustack:worker_status{cluster_name=\"$cluster_name\"},worker_name)",
+        "definition": "query_result(gpustack:worker_info{cluster_name=\"$cluster_name\"})",
         "includeAll": true,
         "label": "Worker",
         "multi": true,
@@ -1890,11 +1890,11 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(gpustack:worker_status{cluster_name=\"$cluster_name\"},worker_name)",
+          "query": "query_result(gpustack:worker_info{cluster_name=\"$cluster_name\"})",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
-        "regex": "",
+        "regex": "/worker_name=\"([^\"]+)\"/",
         "type": "query"
       }
     ]


### PR DESCRIPTION
Currently, the panel dropdown menu uses Grafana's `label_values` function to fetch data. It queries index data, whose timestamp is determined by the underlying storage block and cannot accurately follow the user's selected time range.

This will cause a problem similar to the following:

1. The Worker was deleted a long time ago, but it still appears in the dropdown menu. Selecting this Worker shows no data in the user's selected timeline, and the Worker count statistics are also inconsistent.
2. Similarly, with clusters, in practice, when navigating from the GPUStack UI to a cluster that no longer exists, the interface displays "No Data", requiring manual cluster switching.

Over time, this phenomenon will disappear, but it may take days or even longer

### Before

<img width="2240" height="1198" alt="image" src="https://github.com/user-attachments/assets/c73e30d4-4994-4541-8eb7-f58d48184f47" />

### After

<img width="2240" height="1198" alt="image" src="https://github.com/user-attachments/assets/c75140bb-16a8-4377-b7e4-84bb3dde4cbf" />
