### PR TITLE
refactor: enhance event bus

### DIFF
--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -185,13 +185,15 @@ These metrics are mapped from various runtime engines (vLLM, SGLang, MindIE) as 
 
 ### Server Metrics
 
-| Metric Name                      | Type  | Description                                       |
-| -------------------------------- | ----- | ------------------------------------------------- |
-| gpustack:cluster                 | Info  | Cluster information (ID, name, provider).         |
-| gpustack:cluster_status          | Gauge | Cluster status (with state label).                |
-| gpustack:model                   | Info  | Model information (ID, name, runtime, source).    |
-| gpustack:model_desired_instances | Gauge | Desired number of model instances.                |
-| gpustack:model_running_instances | Gauge | Number of running model instances.                |
-| gpustack:model_instance_status   | Gauge | Status of each model instance (with state label). |
+| Metric Name                                 | Type  | Description                                                   |
+| ------------------------------------------- | ----- | ------------------------------------------------------------- |
+| gpustack:cluster                            | Info  | Cluster information (ID, name, provider).                     |
+| gpustack:cluster_status                     | Gauge | Cluster status (with state label).                            |
+| gpustack:model                              | Info  | Model information (ID, name, runtime, source).                |
+| gpustack:model_desired_instances            | Gauge | Desired number of model instances.                            |
+| gpustack:model_running_instances            | Gauge | Number of running model instances.                            |
+| gpustack:model_instance_status              | Gauge | Status of each model instance (with state label).             |
+| gpustack:model_instance_restart_count       | Gauge | Model instance restart count.                                 |
+| gpustack:model_instance_latest_restart_time | Gauge | Model instance latest restart time as Unix timestamp seconds. |
 
 > **Note**: All metrics are labeled with relevant identifiers (cluster, worker, model, instance, user) for fine-grained monitoring and filtering.

--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -196,4 +196,16 @@ These metrics are mapped from various runtime engines (vLLM, SGLang, MindIE) as 
 | gpustack:model_instance_restart_count       | Gauge | Model instance restart count.                                 |
 | gpustack:model_instance_latest_restart_time | Gauge | Model instance latest restart time as Unix timestamp seconds. |
 
+### Event Bus Metrics
+
+| Metric Name                         | Type    | Description                                                       |
+| ----------------------------------- | ------- | ----------------------------------------------------------------- |
+| gpustack:bus_subscribers            | Gauge   | Active bus subscribers per topic.                                 |
+| gpustack:bus_queue_depth            | Gauge   | Per-subscriber queue depth at scrape time.                        |
+| gpustack:bus_queue_capacity         | Gauge   | Per-subscriber queue maxsize (see env knob below).                |
+| gpustack:bus_queue_full             | Gauge   | 1 if the queue is full at scrape time, 0 otherwise.               |
+| gpustack:bus_queue_saturation_ratio | Gauge   | `qsize / maxsize` in `[0, 1]`. Sustained > 0.8 ⇒ slow consumer.   |
+| gpustack:bus_subscriber_latest_keys | Gauge   | Ids pending coalesced UPDATED delivery (size of `latest_by_key`). |
+| gpustack:bus_events_total           | Counter | Cumulative event counts. Extra labels: `kind`, `event_type`.      |
+
 > **Note**: All metrics are labeled with relevant identifiers (cluster, worker, model, instance, user) for fine-grained monitoring and filtering.

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -31,6 +31,11 @@ SERVER_CACHE_LOCKS_MAX_SIZE = int(
     os.getenv("GPUSTACK_SERVER_CACHE_LOCKS_MAX_SIZE", 10000)
 )
 
+# Server event bus queue capacity. Configurable via env so large clusters can tune the buffer.
+EVENT_BUS_SUBSCRIBER_QUEUE_SIZE = int(
+    os.getenv("GPUSTACK_EVENT_BUS_SUBSCRIBER_QUEUE_SIZE", 1024)
+)
+
 # Worker configuration
 WORKER_HEARTBEAT_INTERVAL = int(
     os.getenv("GPUSTACK_WORKER_HEARTBEAT_INTERVAL", 30)

--- a/gpustack/exporter/bus_metrics.py
+++ b/gpustack/exporter/bus_metrics.py
@@ -1,0 +1,86 @@
+"""Prometheus metrics for the in-process event bus, pulled at scrape time."""
+
+from typing import Iterator
+
+from prometheus_client.registry import Collector
+from prometheus_client.core import (
+    CounterMetricFamily,
+    GaugeMetricFamily,
+    Metric,
+)
+
+from gpustack.server.bus import event_bus
+from gpustack.utils.name import metric_name
+
+
+class BusMetricsCollector(Collector):
+    def collect(self) -> Iterator[Metric]:
+        subscribers = GaugeMetricFamily(
+            metric_name("bus_subscribers"),
+            "Number of active bus subscribers per topic.",
+            labels=["topic"],
+        )
+        queue_depth = GaugeMetricFamily(
+            metric_name("bus_queue_depth"),
+            "Current per-subscriber queue depth at scrape time.",
+            labels=["topic", "source"],
+        )
+        queue_capacity = GaugeMetricFamily(
+            metric_name("bus_queue_capacity"),
+            "Per-subscriber queue maxsize.",
+            labels=["topic", "source"],
+        )
+        queue_full = GaugeMetricFamily(
+            metric_name("bus_queue_full"),
+            "1 if the subscriber queue is full at scrape time, 0 otherwise. "
+            "A sustained 1 indicates a slow consumer holding back the bus.",
+            labels=["topic", "source"],
+        )
+        queue_saturation = GaugeMetricFamily(
+            metric_name("bus_queue_saturation_ratio"),
+            "Per-subscriber queue depth as a fraction of capacity "
+            "(qsize / maxsize).",
+            labels=["topic", "source"],
+        )
+        latest_keys = GaugeMetricFamily(
+            metric_name("bus_subscriber_latest_keys"),
+            "Number of distinct ids pending coalesced UPDATED delivery "
+            "per subscriber (size of latest_by_key).",
+            labels=["topic", "source"],
+        )
+        events = CounterMetricFamily(
+            metric_name("bus_events"),
+            "Cumulative event counts per subscriber. Kinds: "
+            "received, filtered, coalesced, enqueued, backpressured "
+            "(see EventCountKind).",
+            labels=["topic", "source", "kind", "event_type"],
+        )
+
+        # Copy in case subscribe/unsubscribe races with collection.
+        snapshot = {topic: list(subs) for topic, subs in event_bus.subscribers.items()}
+
+        for topic, subs in snapshot.items():
+            subscribers.add_metric([topic], len(subs))
+            for sub in subs:
+                source = sub.source or ""
+                qsize = sub.queue.qsize()
+                maxsize = sub.queue.maxsize
+                queue_depth.add_metric([topic, source], qsize)
+                queue_capacity.add_metric([topic, source], maxsize)
+                queue_full.add_metric([topic, source], 1.0 if sub.queue.full() else 0.0)
+                queue_saturation.add_metric(
+                    [topic, source], qsize / maxsize if maxsize else 0.0
+                )
+                latest_keys.add_metric([topic, source], len(sub.latest_by_key))
+                for (kind, event_type_name), count in sub.event_counts.items():
+                    events.add_metric(
+                        [topic, source, kind.value, event_type_name], count
+                    )
+
+        yield subscribers
+        yield queue_depth
+        yield queue_capacity
+        yield queue_full
+        yield queue_saturation
+        yield latest_keys
+        yield events

--- a/gpustack/exporter/exporter.py
+++ b/gpustack/exporter/exporter.py
@@ -8,6 +8,7 @@ from prometheus_client.core import (
 )
 import uvicorn
 from gpustack.config.config import Config
+from gpustack.exporter.bus_metrics import BusMetricsCollector
 from gpustack.logging import setup_logging
 from gpustack.schemas.config import ModelInstanceProxyModeEnum
 from gpustack.schemas.clusters import Cluster
@@ -245,6 +246,7 @@ class MetricExporter(Collector):
     async def start(self):
         try:
             REGISTRY.register(self)
+            REGISTRY.register(BusMetricsCollector())
 
             # Start FastAPI server
             app = FastAPI(

--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -4,7 +4,7 @@ import importlib
 import json
 import logging
 import math
-from typing import Any, AsyncGenerator, Callable, List, Optional, Union, Tuple
+from typing import Any, AsyncGenerator, Callable, Iterable, List, Optional, Union, Tuple
 
 import anyio
 from fastapi.encoders import jsonable_encoder
@@ -74,8 +74,9 @@ def send_post_commit_events(session: AsyncSession):
         logger.trace(f"Sending event {event.name} of type {event.event.type}, id {id}")
         bus_event = event.event
         try:
-            copied_dict = bus_event.data.model_dump(warnings=False)
-            bus_event.data = type(bus_event.data).model_validate(copied_dict)
+            # Detach from the SQLAlchemy session so subscribers don't see
+            # lazy loads or further mutations on the same row.
+            bus_event.data = bus_event.data.model_copy(deep=True)
             asyncio.create_task(event_bus.publish(event.name, bus_event))
         except Exception as e:
             logger.exception(f"Failed to publish events: {e}")
@@ -745,10 +746,21 @@ class ActiveRecordMixin:
 
     @classmethod
     async def subscribe(
-        cls, source: str, options: Optional[List] = None
+        cls,
+        source: str,
+        options: Optional[List] = None,
+        event_types: Optional[Iterable[EventType]] = None,
+        replay_existing: bool = True,
     ) -> AsyncGenerator[Event, None]:
+        """Subscribe to bus events for this model.
+
+        ``source`` labels the consumer in queue-full logs. ``event_types``
+        whitelists pre-enqueue, so filtered events don't take queue slots.
+        ``replay_existing=False`` skips the initial CREATED snapshot for
+        consumers that bootstrap themselves.
+        """
         topic = cls.__name__.lower()
-        subscriber = event_bus.subscribe(cls.__name__.lower())
+        subscriber = event_bus.subscribe(topic, source=source, event_types=event_types)
         logger.info(
             "subscribed, source=%s topic=%s subscriber=%s",
             source,
@@ -756,10 +768,12 @@ class ActiveRecordMixin:
             id(subscriber),
         )
 
-        initial_items = await cls.cached_all(options=options)
-
-        for item in initial_items:
-            yield Event(type=EventType.CREATED, data=item)
+        if replay_existing:
+            include_created = event_types is None or EventType.CREATED in event_types
+            if include_created:
+                initial_items = await cls.cached_all(options=options)
+                for item in initial_items:
+                    yield Event(type=EventType.CREATED, data=item)
 
         heartbeat_interval = timedelta(seconds=15)
         last_event_time = datetime.now(timezone.utc)

--- a/gpustack/scheduler/scheduler.py
+++ b/gpustack/scheduler/scheduler.py
@@ -123,16 +123,30 @@ class Scheduler:
 
         logger.info("Scheduler started.")
 
-        # scheduler job trigger by event.
-        async for event in ModelInstance.subscribe(source="scheduler"):
+        # Bootstrap pending state once at startup; replaces the bus replay
+        # of every existing instance which would flood the queue (#4794).
+        await self._enqueue_pending_instances()
+
+        # Live trigger. event_types/replay_existing keep this subscription
+        # cheap so UPDATED/HEARTBEAT bursts don't fill the queue.
+        async for event in ModelInstance.subscribe(
+            source="scheduler",
+            event_types={EventType.CREATED},
+            replay_existing=False,
+        ):
+            # The bus filter only blocks events from publishers; the
+            # subscribe() generator still yields HEARTBEAT events on its
+            # own to keep the stream alive (active_record.py). Skip those
+            # and any other non-CREATED events that may surface in future.
             if event.type != EventType.CREATED:
                 continue
-
-            await self._enqueue_pending_instances()
+            # Single-instance path; the IntervalTrigger above is still the
+            # full-scan fallback for anything missed here.
+            await self._enqueue_event_instance(event.data)
 
     async def _enqueue_pending_instances(self):
         """
-        Get the pending model instances.
+        Periodic / bootstrap full scan of pending model instances.
         """
         try:
             async with async_session() as session:
@@ -147,6 +161,17 @@ class Scheduler:
         except Exception as e:
             logger.error(f"Failed to enqueue pending model instances: {e}")
 
+    async def _enqueue_event_instance(self, instance: Optional[ModelInstance]):
+        """Event-driven single-instance path. ``_evaluate`` re-fetches from
+        DB, so the event payload is used only for ``_should_schedule``."""
+        if instance is None or instance.id is None:
+            return
+        try:
+            if self._should_schedule(instance):
+                await self._evaluate(instance)
+        except Exception as e:
+            logger.error(f"Failed to evaluate instance {instance.id} from event: {e}")
+
     async def _evaluate(self, instance: ModelInstance):  # noqa: C901
         """
         Evaluate the model instance's metadata.
@@ -154,6 +179,12 @@ class Scheduler:
         async with async_session() as session:
             try:
                 instance = await ModelInstance.one_by_id(session, instance.id)
+                # Re-check against the freshly-fetched row: the caller's
+                # snapshot may be stale (event payload, last full scan, etc.)
+                # and the user may have deleted or transitioned the instance
+                # between dispatch and now.
+                if instance is None or not self._should_schedule(instance):
+                    return
 
                 model = await Model.one_by_id(session, instance.model_id)
                 if model is None:

--- a/gpustack/server/bus.py
+++ b/gpustack/server/bus.py
@@ -1,6 +1,9 @@
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+from gpustack.envs import EVENT_BUS_SUBSCRIBER_QUEUE_SIZE
 
 # Re-export from coordinator.base for backward compatibility
 from gpustack.server.coordinator.base import Event, EventType
@@ -9,10 +12,30 @@ from gpustack.server.coordinator.models import get_model_for_topic
 
 logger = logging.getLogger(__name__)
 
+
+class EventCountKind(Enum):
+    """Subscriber-side counter buckets surfaced as Prometheus labels.
+
+    On the normal completion path:
+    ``RECEIVED = FILTERED + COALESCED + ENQUEUED`` and
+    ``BACKPRESSURED ⊆ ENQUEUED``. If a ``put`` is cancelled mid-flight,
+    BACKPRESSURED may have been bumped without a matching ENQUEUED — the
+    ``latest_by_key`` rollback in ``enqueue`` keeps the queue/dict
+    invariant intact, but the counter invariant is best-effort.
+    """
+
+    RECEIVED = "received"
+    FILTERED = "filtered"
+    COALESCED = "coalesced"
+    ENQUEUED = "enqueued"
+    BACKPRESSURED = "backpressured"
+
+
 # Re-export for backward compatibility
 __all__ = [
     'Event',
     'EventType',
+    'EventCountKind',
     'Subscriber',
     'EventBus',
     'event_bus',
@@ -28,33 +51,96 @@ def event_decoder(obj):
 
 
 class Subscriber:
-    def __init__(self):
-        self.queue = asyncio.Queue(maxsize=1024)
-        self.latest_by_key = {}
+    """A bus subscriber owning its own bounded queue.
+
+    UPDATED events for the same id are coalesced via ``latest_by_key``.
+    Invariant: ``id ∈ latest_by_key`` iff there is (or will be) a queue
+    token whose ``receive()`` will pop it. When the queue is full the
+    producer awaits ``put`` rather than dropping. Publish paths spawn
+    enqueue in their own tasks (see ``EventBus._route_event``), so
+    backpressure stalls only the per-event task, not the caller.
+    """
+
+    def __init__(
+        self,
+        topic: Optional[str] = None,
+        source: Optional[str] = None,
+        event_types: Optional[Iterable[EventType]] = None,
+        queue_size: Optional[int] = None,
+    ):
+        self.topic = topic
+        self.source = source
+        self.event_types: Optional[Set[EventType]] = (
+            set(event_types) if event_types else None
+        )
+        self.queue: asyncio.Queue = asyncio.Queue(
+            maxsize=(
+                queue_size
+                if queue_size is not None
+                else EVENT_BUS_SUBSCRIBER_QUEUE_SIZE
+            )
+        )
+        self.latest_by_key: Dict[Any, Event] = {}
         self.lock = asyncio.Lock()
+        # Read by ``BusMetricsCollector`` and reflected as Prometheus counters.
+        self.event_counts: Dict[Tuple[EventCountKind, str], int] = {}
+
+    def _bump(self, kind: EventCountKind, event_type: EventType) -> None:
+        key = (kind, event_type.name)
+        self.event_counts[key] = self.event_counts.get(key, 0) + 1
+
+    def should_enqueue(self, event: Event) -> bool:
+        """Pre-enqueue filter. Drops events the subscriber has opted out of."""
+        if self.event_types is not None and event.type not in self.event_types:
+            return False
+        return True
 
     async def enqueue(self, event: Event):
-        # Squash UPDATED events by keeping only the latest per key
+        self._bump(EventCountKind.RECEIVED, event.type)
+
+        if not self.should_enqueue(event):
+            self._bump(EventCountKind.FILTERED, event.type)
+            return
+
         if event.type == EventType.UPDATED and event.id is not None:
             async with self.lock:
                 if event.id in self.latest_by_key:
                     self.latest_by_key[event.id] = event
+                    self._bump(EventCountKind.COALESCED, event.type)
                     return
                 self.latest_by_key[event.id] = event
-
+            # Release the lock before awaiting put: a full queue would
+            # otherwise serialize unrelated ids behind it.
             try:
-                self.queue.put_nowait(event)
-            except asyncio.QueueFull:
-                # If the queue is full, skip adding the event, relying on latest_by_key, could receive it later
-                logger.warning(
-                    "Subscriber:%s queue full, skipping UPDATED event for id=%s",
-                    id(self),
-                    event.id,
-                )
+                await self._put_with_backpressure(event)
+            except BaseException:
+                # If the put was cancelled or errored before a token reached
+                # the queue, neither this event nor any later UPDATED that
+                # piggybacked on the same dict entry will ever be popped.
+                # Roll back so the next UPDATED for this id can re-enter
+                # the queue — otherwise we'd reproduce the #4794 stranded-id
+                # bug, just triggered by cancellation instead of QueueFull.
+                async with self.lock:
+                    self.latest_by_key.pop(event.id, None)
+                raise
             return
 
-        # For other event types, enqueue directly
+        await self._put_with_backpressure(event)
+
+    async def _put_with_backpressure(self, event: Event):
+        if self.queue.full():
+            logger.warning(
+                "Subscriber queue full, applying backpressure: "
+                "source=%s topic=%s event_type=%s id=%s queue_size=%s",
+                self.source,
+                self.topic,
+                event.type.name,
+                event.id,
+                self.queue.qsize(),
+            )
+            self._bump(EventCountKind.BACKPRESSURED, event.type)
         await self.queue.put(event)
+        self._bump(EventCountKind.ENQUEUED, event.type)
 
     async def receive(self) -> Any:
         event = await self.queue.get()
@@ -77,6 +163,17 @@ class EventBus:
         self._coordinator = None
         self._listen_task: Optional[asyncio.Task] = None
         self._subscribed_channels: set = set()
+        # Holds strong references to fire-and-forget tasks so the GC
+        # doesn't reap them mid-execution (Python's create_task only
+        # holds a weak reference to the task it returns).
+        self._pending_tasks: Set[asyncio.Task] = set()
+
+    def _spawn(self, coro) -> asyncio.Task:
+        """``asyncio.create_task`` plus retain-and-discard bookkeeping."""
+        task = asyncio.create_task(coro)
+        self._pending_tasks.add(task)
+        task.add_done_callback(self._pending_tasks.discard)
+        return task
 
     def set_coordinator(self, coordinator):
         """Set the coordinator for distributed pub/sub."""
@@ -100,14 +197,25 @@ class EventBus:
                 pass
         logger.info("EventBus stopped")
 
-    def subscribe(self, topic: str) -> Subscriber:
-        """Subscribe to a topic."""
-        subscriber = Subscriber()
+    def subscribe(
+        self,
+        topic: str,
+        source: Optional[str] = None,
+        event_types: Optional[Iterable[EventType]] = None,
+    ) -> Subscriber:
+        """Subscribe to a topic.
+
+        ``source`` is a free-form label used in queue-full log lines so
+        operators can identify which consumer is backpressuring. ``event_types``
+        is an optional whitelist applied before enqueue — events not matching
+        are dropped without occupying a queue slot.
+        """
+        subscriber = Subscriber(topic=topic, source=source, event_types=event_types)
         if topic not in self.subscribers:
             self.subscribers[topic] = []
             # Subscribe to coordinator if available
             if self._coordinator:
-                asyncio.create_task(self._subscribe_to_coordinator(topic))
+                self._spawn(self._subscribe_to_coordinator(topic))
 
         self.subscribers[topic].append(subscriber)
         return subscriber
@@ -138,7 +246,7 @@ class EventBus:
         to the main loop itself (e.g. via loop.call_soon_threadsafe).
         """
         try:
-            asyncio.create_task(self._process_coordinator_event(event, topic))
+            self._spawn(self._process_coordinator_event(event, topic))
         except RuntimeError:
             logger.warning(
                 f"No running event loop for coordinator event on topic {topic}, skipping"
@@ -257,10 +365,18 @@ class EventBus:
             return
 
     def _route_event(self, event: Event, topic: str):
-        """Route event to subscribers of the specific topic."""
+        """Route event to subscribers of the specific topic.
+
+        Per-subscriber enqueue runs in its own task so a slow consumer
+        cannot head-of-line block its peers under blocking backpressure.
+        Trade-off: this fan-out is unbounded — for very hot topics with no
+        coalescing protection (CREATED/DELETED), bursts can spawn many
+        pending enqueue tasks on slow consumers. UPDATED is naturally
+        bounded by ``latest_by_key`` coalescing.
+        """
         if topic in self.subscribers:
             for subscriber in self.subscribers[topic]:
-                asyncio.create_task(subscriber.enqueue(event))
+                self._spawn(subscriber.enqueue(event))
 
     def unsubscribe(self, topic: str, subscriber: Subscriber):
         """Unsubscribe from a topic."""
@@ -272,10 +388,11 @@ class EventBus:
     async def publish(self, topic: str, event: Event):
         """Publish an event to a topic.
 
-        When a coordinator is configured, distribution normally happens via the
-        coordinator so all instances (including this one) receive the event on
-        the same path. If the coordinator publish fails, fall back to local
-        delivery so this instance can still process its own events.
+        With a coordinator, distribution flows through it so every instance
+        sees the event on the same path. On failure or in standalone mode,
+        fall back to ``_route_event`` for local fan-out — each subscriber's
+        enqueue runs in its own task, so backpressure on one consumer does
+        not head-of-line block its peers.
         """
         if self._coordinator:
             try:
@@ -287,10 +404,7 @@ class EventBus:
                     f"falling back to local delivery: {e}"
                 )
 
-        # Local delivery (no coordinator configured, or coordinator publish failed).
-        if topic in self.subscribers:
-            for subscriber in self.subscribers[topic]:
-                await subscriber.enqueue(event)
+        self._route_event(event, topic)
 
 
 event_bus = EventBus()

--- a/tests/exporter/test_bus_metrics.py
+++ b/tests/exporter/test_bus_metrics.py
@@ -1,0 +1,278 @@
+"""Tests for the pull-based bus metrics collector."""
+
+import asyncio
+
+import pytest
+
+from gpustack.exporter.bus_metrics import BusMetricsCollector
+from gpustack.server.bus import (
+    Event,
+    EventCountKind,
+    EventType,
+    Subscriber,
+    event_bus,
+)
+
+
+def _sample_for(metrics, metric_name, label_match):
+    for metric in metrics:
+        if metric.name != metric_name:
+            continue
+        for sample in metric.samples:
+            if all(sample.labels.get(k) == v for k, v in label_match.items()):
+                return sample
+    raise AssertionError(
+        f"Sample for metric={metric_name} labels={label_match} not found"
+    )
+
+
+def _all_samples(metrics, metric_name):
+    for metric in metrics:
+        if metric.name == metric_name:
+            return list(metric.samples)
+    return []
+
+
+@pytest.mark.asyncio
+async def test_bus_metrics_collector_reflects_subscriber_state():
+    topic = "_test_bus_metrics_topic"
+    sub_a = event_bus.subscribe(topic, source="test_a")
+    sub_b = event_bus.subscribe(topic, source="test_b", event_types={EventType.CREATED})
+
+    try:
+        # sub_a takes everything (second UPDATED for id=2 → COALESCED);
+        # sub_b filters non-CREATED.
+        await sub_a.enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+        await sub_a.enqueue(Event(type=EventType.UPDATED, data={"id": 2}, id=2))
+        await sub_a.enqueue(Event(type=EventType.UPDATED, data={"id": 2}, id=2))
+        await sub_b.enqueue(Event(type=EventType.UPDATED, data={"id": 3}, id=3))
+        await sub_b.enqueue(Event(type=EventType.CREATED, data={"id": 4}, id=4))
+
+        metrics = list(BusMetricsCollector().collect())
+
+        # 2 subscribers under our topic.
+        sample = _sample_for(metrics, "gpustack:bus_subscribers", {"topic": topic})
+        assert sample.value == 2
+
+        # sub_a — RECEIVED total = 3.
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "test_a",
+                "kind": EventCountKind.RECEIVED.value,
+                "event_type": EventType.UPDATED.name,
+            },
+        )
+        assert sample.value == 2  # two UPDATED events received
+
+        # sub_a — second UPDATED merged into latest_by_key.
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "test_a",
+                "kind": EventCountKind.COALESCED.value,
+                "event_type": EventType.UPDATED.name,
+            },
+        )
+        assert sample.value == 1
+
+        # sub_a — first UPDATED actually entered the queue.
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "test_a",
+                "kind": EventCountKind.ENQUEUED.value,
+                "event_type": EventType.UPDATED.name,
+            },
+        )
+        assert sample.value == 1
+
+        # sub_a — CREATED enqueued.
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "test_a",
+                "kind": EventCountKind.ENQUEUED.value,
+                "event_type": EventType.CREATED.name,
+            },
+        )
+        assert sample.value == 1
+
+        # sub_b — UPDATED received then filtered.
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "test_b",
+                "kind": EventCountKind.RECEIVED.value,
+                "event_type": EventType.UPDATED.name,
+            },
+        )
+        assert sample.value == 1
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "test_b",
+                "kind": EventCountKind.FILTERED.value,
+                "event_type": EventType.UPDATED.name,
+            },
+        )
+        assert sample.value == 1
+        # Filter rejected before enqueue → no ENQUEUED for that event_type.
+        for sample in _all_samples(metrics, "gpustack:bus_events"):
+            if (
+                sample.labels.get("topic") == topic
+                and sample.labels.get("source") == "test_b"
+                and sample.labels.get("event_type") == EventType.UPDATED.name
+            ):
+                assert sample.labels.get("kind") != EventCountKind.ENQUEUED.value
+
+        # sub_b — CREATED received and enqueued.
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "test_b",
+                "kind": EventCountKind.ENQUEUED.value,
+                "event_type": EventType.CREATED.name,
+            },
+        )
+        assert sample.value == 1
+
+        # No backpressure samples expected — queues weren't full.
+        for sample in _all_samples(metrics, "gpustack:bus_events"):
+            if sample.labels.get("topic") == topic:
+                assert sample.labels.get("kind") != EventCountKind.BACKPRESSURED.value
+
+        # queue_full gauge = 0 for both subs (queues have items but aren't full).
+        for source in ("test_a", "test_b"):
+            sample = _sample_for(
+                metrics,
+                "gpustack:bus_queue_full",
+                {
+                    "topic": topic,
+                    "source": source,
+                },
+            )
+            assert sample.value == 0
+    finally:
+        event_bus.unsubscribe(topic, sub_a)
+        event_bus.unsubscribe(topic, sub_b)
+
+
+@pytest.mark.asyncio
+async def test_bus_metrics_collector_reports_backpressure_and_queue_full():
+    topic = "_test_bus_metrics_qfull"
+    sub = Subscriber(topic=topic, source="slow", queue_size=1)
+    event_bus.subscribers.setdefault(topic, []).append(sub)
+
+    try:
+        await sub.enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+
+        pending = asyncio.create_task(
+            sub.enqueue(Event(type=EventType.CREATED, data={"id": 2}, id=2))
+        )
+        # Yield so the enqueue task hits the full-queue branch.
+        for _ in range(5):
+            await asyncio.sleep(0)
+            if sub.event_counts.get(
+                (EventCountKind.BACKPRESSURED, EventType.CREATED.name)
+            ):
+                break
+        pending.cancel()
+        try:
+            await pending
+        except (asyncio.CancelledError, Exception):
+            pass
+
+        metrics = list(BusMetricsCollector().collect())
+
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "slow",
+                "kind": EventCountKind.BACKPRESSURED.value,
+                "event_type": EventType.CREATED.name,
+            },
+        )
+        assert sample.value >= 1
+
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_queue_full",
+            {
+                "topic": topic,
+                "source": "slow",
+            },
+        )
+        assert sample.value == 1
+
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_queue_saturation_ratio",
+            {
+                "topic": topic,
+                "source": "slow",
+            },
+        )
+        assert sample.value == 1.0
+
+        sample = _sample_for(
+            metrics,
+            "gpustack:bus_queue_capacity",
+            {
+                "topic": topic,
+                "source": "slow",
+            },
+        )
+        assert sample.value == 1
+    finally:
+        event_bus.unsubscribe(topic, sub)
+
+
+@pytest.mark.asyncio
+async def test_received_equals_filtered_plus_coalesced_plus_enqueued():
+    """Sanity: ``RECEIVED = FILTERED + COALESCED + ENQUEUED``."""
+    topic = "_test_bus_metrics_invariant"
+    sub = event_bus.subscribe(
+        topic, source="invariant", event_types={EventType.CREATED, EventType.UPDATED}
+    )
+
+    try:
+        # Mix: 2 CREATED (both enqueued), 3 UPDATED for id=10 (1 enqueued + 2
+        # coalesced), 1 DELETED (filtered out by event_types).
+        await sub.enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+        await sub.enqueue(Event(type=EventType.CREATED, data={"id": 2}, id=2))
+        await sub.enqueue(Event(type=EventType.UPDATED, data={"id": 10}, id=10))
+        await sub.enqueue(Event(type=EventType.UPDATED, data={"id": 10}, id=10))
+        await sub.enqueue(Event(type=EventType.UPDATED, data={"id": 10}, id=10))
+        await sub.enqueue(Event(type=EventType.DELETED, data={"id": 99}, id=99))
+
+        def total(kind: EventCountKind) -> int:
+            return sum(
+                count for (k, _evt), count in sub.event_counts.items() if k is kind
+            )
+
+        assert total(EventCountKind.RECEIVED) == 6
+        assert total(EventCountKind.FILTERED) == 1
+        assert total(EventCountKind.COALESCED) == 2
+        assert total(EventCountKind.ENQUEUED) == 3
+        assert total(EventCountKind.RECEIVED) == total(EventCountKind.FILTERED) + total(
+            EventCountKind.COALESCED
+        ) + total(EventCountKind.ENQUEUED)
+    finally:
+        event_bus.unsubscribe(topic, sub)

--- a/tests/scheduler/test_scheduler_subscribe.py
+++ b/tests/scheduler/test_scheduler_subscribe.py
@@ -1,0 +1,140 @@
+"""Regression tests for scheduler bus-subscription parameters (issue #4794)."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gpustack.scheduler.scheduler import Scheduler
+from gpustack.server.bus import EventType
+
+
+async def _stop_task(task: asyncio.Task) -> None:
+    if not task.done():
+        task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_scheduler_subscribes_only_to_created_and_skips_replay():
+    cfg = SimpleNamespace(cache_dir=None)
+    scheduler = Scheduler(cfg, check_interval=180)
+
+    captured_kwargs = {}
+    forever = asyncio.Event()
+
+    async def fake_subscribe(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        await forever.wait()
+        if False:
+            yield  # pragma: no cover
+
+    with (
+        patch(
+            "gpustack.scheduler.scheduler.ModelInstance.subscribe",
+            side_effect=fake_subscribe,
+        ),
+        patch.object(scheduler, "_schedule_cycle", AsyncMock()),
+        patch.object(
+            scheduler, "_enqueue_pending_instances", AsyncMock()
+        ) as mock_enqueue,
+        patch("gpustack.scheduler.scheduler.AsyncIOScheduler"),
+    ):
+        task = asyncio.create_task(scheduler.start())
+        # Give start() a chance to set up the subscription.
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if captured_kwargs:
+                break
+        try:
+            assert captured_kwargs.get("source") == "scheduler"
+            assert captured_kwargs.get("event_types") == {EventType.CREATED}
+            assert captured_kwargs.get("replay_existing") is False
+            # Bootstrap scan must have run at least once before the live loop.
+            assert mock_enqueue.await_count >= 1
+        finally:
+            forever.set()
+            await _stop_task(task)
+
+
+@pytest.mark.asyncio
+async def test_enqueue_event_instance_evaluates_only_the_passed_instance():
+    cfg = SimpleNamespace(cache_dir=None)
+    scheduler = Scheduler(cfg, check_interval=180)
+
+    instance = SimpleNamespace(id=7)
+
+    with (
+        patch.object(scheduler, "_evaluate", AsyncMock()) as mock_evaluate,
+        patch.object(scheduler, "_should_schedule", return_value=True) as mock_should,
+    ):
+        await scheduler._enqueue_event_instance(instance)
+        mock_should.assert_called_once_with(instance)
+        mock_evaluate.assert_awaited_once_with(instance)
+
+    # When _should_schedule returns False, no evaluation happens.
+    with (
+        patch.object(scheduler, "_evaluate", AsyncMock()) as mock_evaluate,
+        patch.object(scheduler, "_should_schedule", return_value=False),
+    ):
+        await scheduler._enqueue_event_instance(instance)
+        mock_evaluate.assert_not_awaited()
+
+    # None and id-less payloads are no-ops.
+    with (
+        patch.object(scheduler, "_evaluate", AsyncMock()) as mock_evaluate,
+        patch.object(scheduler, "_should_schedule", return_value=True) as mock_should,
+    ):
+        await scheduler._enqueue_event_instance(None)
+        await scheduler._enqueue_event_instance(SimpleNamespace(id=None))
+        mock_should.assert_not_called()
+        mock_evaluate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_handles_live_created_event_with_single_instance_path():
+    cfg = SimpleNamespace(cache_dir=None)
+    scheduler = Scheduler(cfg, check_interval=180)
+
+    instance_payload = SimpleNamespace(id=42)
+    created_event = SimpleNamespace(
+        type=EventType.CREATED, data=instance_payload, id=42
+    )
+    forever = asyncio.Event()
+
+    async def fake_subscribe(*args, **kwargs):
+        yield created_event
+        await forever.wait()
+
+    with (
+        patch(
+            "gpustack.scheduler.scheduler.ModelInstance.subscribe",
+            side_effect=fake_subscribe,
+        ),
+        patch.object(scheduler, "_schedule_cycle", AsyncMock()),
+        patch.object(
+            scheduler, "_enqueue_pending_instances", AsyncMock()
+        ) as mock_full_scan,
+        patch.object(
+            scheduler, "_enqueue_event_instance", AsyncMock()
+        ) as mock_event_path,
+    ):
+        with patch("gpustack.scheduler.scheduler.AsyncIOScheduler"):
+            task = asyncio.create_task(scheduler.start())
+            for _ in range(100):
+                await asyncio.sleep(0)
+                if mock_event_path.await_count >= 1:
+                    break
+            try:
+                # Bootstrap scan ran exactly once at startup.
+                assert mock_full_scan.await_count == 1
+                # Event path was invoked once with the instance from the event.
+                assert mock_event_path.await_count == 1
+                mock_event_path.assert_awaited_with(instance_payload)
+            finally:
+                forever.set()
+                await _stop_task(task)

--- a/tests/server/test_bus.py
+++ b/tests/server/test_bus.py
@@ -1,0 +1,196 @@
+import asyncio
+import logging
+
+import pytest
+
+from gpustack.server.bus import Event, EventType, Subscriber
+
+
+@pytest.mark.asyncio
+async def test_updated_event_overflow_does_not_leave_unreceivable_latest_event():
+    """Regression for #4794: queue-full UPDATED ids must remain deliverable."""
+    queue_size = 4
+    subscriber = Subscriber(topic="modelinstance", source="test", queue_size=queue_size)
+
+    total = queue_size + 5
+    enqueue_tasks = [
+        asyncio.create_task(
+            subscriber.enqueue(
+                Event(
+                    type=EventType.UPDATED,
+                    data={"id": event_id, "value": event_id},
+                    id=event_id,
+                )
+            )
+        )
+        for event_id in range(total)
+    ]
+
+    received_ids = []
+    for _ in range(total):
+        event = await asyncio.wait_for(subscriber.receive(), timeout=2)
+        received_ids.append(event.id)
+
+    await asyncio.gather(*enqueue_tasks)
+
+    assert sorted(received_ids) == list(range(total))
+    assert subscriber.latest_by_key == {}
+    assert subscriber.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_updated_events_for_same_id_are_coalesced_to_latest():
+    subscriber = Subscriber(topic="modelinstance", source="test")
+
+    await subscriber.enqueue(
+        Event(type=EventType.UPDATED, data={"id": 1, "value": "old"}, id=1)
+    )
+    await subscriber.enqueue(
+        Event(type=EventType.UPDATED, data={"id": 1, "value": "mid"}, id=1)
+    )
+    await subscriber.enqueue(
+        Event(type=EventType.UPDATED, data={"id": 1, "value": "new"}, id=1)
+    )
+
+    event = await asyncio.wait_for(subscriber.receive(), timeout=1)
+    assert event.id == 1
+    assert event.data["value"] == "new"
+    assert subscriber.latest_by_key == {}
+    assert subscriber.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_subscriber_filters_event_types_before_enqueue():
+    subscriber = Subscriber(
+        topic="modelinstance",
+        source="scheduler",
+        event_types={EventType.CREATED},
+    )
+
+    await subscriber.enqueue(Event(type=EventType.UPDATED, data={"id": 1}, id=1))
+    await subscriber.enqueue(Event(type=EventType.DELETED, data={"id": 2}, id=2))
+    assert subscriber.queue.empty()
+    assert subscriber.latest_by_key == {}
+
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 3}, id=3))
+    event = await asyncio.wait_for(subscriber.receive(), timeout=1)
+    assert event.type == EventType.CREATED
+    assert event.id == 3
+
+
+@pytest.mark.asyncio
+async def test_queue_full_log_includes_metadata(caplog):
+    """The warning must identify which subscriber backpressured."""
+    subscriber = Subscriber(topic="modelinstance", source="scheduler", queue_size=1)
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+
+    caplog.set_level(logging.WARNING, logger="gpustack.server.bus")
+    pending = asyncio.create_task(
+        subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 2}, id=2))
+    )
+    # Yield so the enqueue task hits the full-queue branch.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    await asyncio.wait_for(subscriber.receive(), timeout=1)
+    await asyncio.wait_for(subscriber.receive(), timeout=1)
+    await pending
+
+    matching = [
+        rec
+        for rec in caplog.records
+        if "queue full, applying backpressure" in rec.getMessage()
+    ]
+    assert matching, "expected queue-full backpressure log entry"
+    msg = matching[0].getMessage()
+    assert "source=scheduler" in msg
+    assert "topic=modelinstance" in msg
+    assert "event_type=CREATED" in msg
+    assert "id=2" in msg
+    assert "queue_size=1" in msg
+
+
+@pytest.mark.asyncio
+async def test_publish_does_not_let_slow_subscriber_block_peers():
+    """A full-queue subscriber must not head-of-line block its peers."""
+    from gpustack.server.bus import EventBus
+
+    bus = EventBus()
+    topic = "_test_publish_fanout"
+    slow = bus.subscribe(topic, source="slow")
+    fast = bus.subscribe(topic, source="fast")
+    slow.queue = asyncio.Queue(maxsize=1)
+    await slow.enqueue(Event(type=EventType.CREATED, data={"id": 0}, id=0))
+
+    try:
+        await bus.publish(topic, Event(type=EventType.CREATED, data={"id": 1}, id=1))
+        delivered = await asyncio.wait_for(fast.receive(), timeout=1)
+        assert delivered.id == 1
+        assert slow.queue.qsize() == 1  # still backpressured
+    finally:
+        bus.unsubscribe(topic, slow)
+        bus.unsubscribe(topic, fast)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_updated_put_rolls_back_latest_by_key():
+    """If the producer task is cancelled while awaiting backpressure,
+    ``latest_by_key`` must be rolled back so the next UPDATED for the same
+    id can re-enter the queue. Without rollback this reproduces the
+    #4794 stranded-id bug, just triggered by cancel rather than QueueFull.
+    """
+    subscriber = Subscriber(topic="modelinstance", source="test", queue_size=1)
+
+    # Fill the queue with an unrelated event so the next put will block.
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 0}, id=0))
+
+    # Start an UPDATED enqueue for id=42 — it writes latest_by_key[42]
+    # then awaits put on the full queue.
+    cancelled = asyncio.create_task(
+        subscriber.enqueue(Event(type=EventType.UPDATED, data={"id": 42}, id=42))
+    )
+    for _ in range(5):
+        await asyncio.sleep(0)
+        if 42 in subscriber.latest_by_key:
+            break
+    assert 42 in subscriber.latest_by_key
+
+    cancelled.cancel()
+    try:
+        await cancelled
+    except asyncio.CancelledError:
+        pass
+    # Rollback should clear the orphan entry.
+    assert 42 not in subscriber.latest_by_key
+
+    # A fresh UPDATED for id=42 must be deliverable. Drain the prefill
+    # first to avoid a second blocking put.
+    drained = await asyncio.wait_for(subscriber.receive(), timeout=1)
+    assert drained.id == 0
+    await subscriber.enqueue(
+        Event(type=EventType.UPDATED, data={"id": 42, "v": "fresh"}, id=42)
+    )
+    delivered = await asyncio.wait_for(subscriber.receive(), timeout=1)
+    assert delivered.id == 42
+    assert delivered.data["v"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_non_updated_events_block_under_backpressure_not_drop():
+    subscriber = Subscriber(topic="modelinstance", source="test", queue_size=2)
+
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 2}, id=2))
+    pending = asyncio.create_task(
+        subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 3}, id=3))
+    )
+    await asyncio.sleep(0)
+    assert not pending.done()
+
+    first = await asyncio.wait_for(subscriber.receive(), timeout=1)
+    assert first.id == 1
+    await asyncio.wait_for(pending, timeout=1)
+
+    second = await asyncio.wait_for(subscriber.receive(), timeout=1)
+    third = await asyncio.wait_for(subscriber.receive(), timeout=1)
+    assert {second.id, third.id} == {2, 3}


### PR DESCRIPTION
- #4794 

### Before:
- gpustack_bus_subscriber_latest_keys never go down
- scheduler has dropped event(queue full)
<img width="3024" height="3498" alt="bus-old" src="https://github.com/user-attachments/assets/9b0aec6f-6d64-46ea-8c09-fb83a0925125" />


### After:
- gpustack_bus_subscriber_latest_keys keep low value
- scheduler doesn't have backpressured event(queue full)
<img width="3024" height="3650" alt="bus-new" src="https://github.com/user-attachments/assets/f99d70c9-e588-4db2-8f2c-6b3e2abada6c" />

[gpustack-event-bus.json](https://github.com/user-attachments/files/27193152/gpustack-event-bus.json)
