### PR TITLE
fix: server memory leak

### DIFF
--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -52,9 +52,16 @@ api_key_header_auth = APIKeyHeader(name="X-API-Key", auto_error=False)
 cookie_auth = APIKeyCookie(name=SESSION_COOKIE_NAME, auto_error=False)
 _gateway_auth_header = APIKeyHeader(name=GATEWAY_AUTH_TOKEN_HEADER, auto_error=False)
 
-credentials_exception = UnauthorizedException(
-    message="Invalid authentication credentials"
-)
+
+# DO NOT make this a module-level singleton — see issue #5121.
+# ``raise existing_instance`` writes the current call-stack traceback onto
+# the instance's ``__traceback__``. Because the instance is a module-level
+# attribute it is never garbage-collected, and its ``__traceback__`` keeps
+# every frame in that call stack alive (along with every frame.f_locals,
+# i.e. the entire per-request object stack). Always raise a freshly
+# constructed instance instead.
+def credentials_exception() -> UnauthorizedException:
+    return UnauthorizedException(message="Invalid authentication credentials")
 
 
 def gateway_token_auth(
@@ -122,7 +129,7 @@ async def get_current_user(
     except Exception as e:
         raise InternalServerErrorException(message=f"Failed to authenticate user: {e}")
 
-    raise credentials_exception
+    raise credentials_exception()
 
 
 async def get_admin_user(
@@ -196,7 +203,7 @@ def get_access_token(
     elif cookie_token:
         return cookie_token
     else:
-        raise credentials_exception
+        raise credentials_exception()
 
 
 async def get_user_from_jwt_token(

--- a/gpustack/routes/token.py
+++ b/gpustack/routes/token.py
@@ -31,15 +31,25 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-model_name_missing_exception = BadRequestException(
-    message="Missing 'model' field",
-    is_openai_exception=True,
-)
 
-model_not_found_exception = NotFoundException(
-    message="Model not found",
-    is_openai_exception=True,
-)
+# DO NOT make these module-level singletons — see issue #5121. Raising the
+# same instance repeatedly keeps every prior call-stack alive on the
+# instance's ``__traceback__`` (the instance lives forever as a module
+# attribute), retaining every ``frame.f_locals`` (Request, AsyncSession,
+# user, api_key, ...) and burning ~30 KB per request. Always raise a freshly
+# constructed instance instead.
+def model_name_missing_exception() -> BadRequestException:
+    return BadRequestException(
+        message="Missing 'model' field",
+        is_openai_exception=True,
+    )
+
+
+def model_not_found_exception() -> NotFoundException:
+    return NotFoundException(
+        message="Model not found",
+        is_openai_exception=True,
+    )
 
 
 @router.get("")
@@ -102,12 +112,14 @@ async def server_auth(
         logger.debug(
             "Missing x-higress-llm-model header for token authentication",
         )
-        raise credentials_exception if user is None else model_name_missing_exception
+        raise (
+            credentials_exception() if user is None else model_name_missing_exception()
+        )
     pair = await ModelRouteService(session=session).get_model_auth_info_by_name(
         model_name
     )
     if pair is None:
-        raise credentials_exception if user is None else model_not_found_exception
+        raise credentials_exception() if user is None else model_not_found_exception()
     policy = pair[0]
     registration_token = pair[1]
 
@@ -115,7 +127,7 @@ async def server_auth(
         logger.debug(
             f"Unauthenticated request to access model {model_name} with policy {policy}",
         )
-        raise credentials_exception
+        raise credentials_exception()
 
     if policy != AccessPolicyEnum.PUBLIC:
         # llm_scope will raise exception if the api key is not allowed to access llm.
@@ -155,12 +167,12 @@ async def worker_auth(
     model_name = request.headers.get("X-Higress-Llm-Model")
     if model_name is None:
         logger.warning("Missing X-Higress-Llm-Model header for token authentication")
-        raise credentials_exception
+        raise credentials_exception()
     token_value = (bearer_token.credentials if bearer_token else None) or x_api_key
     if token_value is None:
-        raise credentials_exception
+        raise credentials_exception()
     if token_value != token and token_value != registration_token:
-        raise credentials_exception
+        raise credentials_exception()
     return Response(
         status_code=200,
         headers={

--- a/gpustack/server/bus.py
+++ b/gpustack/server/bus.py
@@ -84,6 +84,13 @@ class Subscriber:
         self.lock = asyncio.Lock()
         # Read by ``BusMetricsCollector`` and reflected as Prometheus counters.
         self.event_counts: Dict[Tuple[EventCountKind, str], int] = {}
+        # Set by ``EventBus.unsubscribe``. Pending ``enqueue`` tasks still
+        # retain a strong reference to this subscriber via ``_pending_tasks``,
+        # and a task blocked on ``queue.put`` (full queue + slow/dead
+        # consumer) would otherwise pin the subscriber + its 1024 queued
+        # events alive forever. ``close()`` drains the queue so those puts
+        # resolve and the tasks unwind.
+        self._closed: bool = False
 
     def _bump(self, kind: EventCountKind, event_type: EventType) -> None:
         key = (kind, event_type.name)
@@ -96,6 +103,12 @@ class Subscriber:
         return True
 
     async def enqueue(self, event: Event):
+        if self._closed:
+            # The subscriber has been unsubscribed; drop without taking the
+            # lock or touching latest_by_key so we don't strand entries that
+            # nobody will ever pop.
+            return
+
         self._bump(EventCountKind.RECEIVED, event.type)
 
         if not self.should_enqueue(event):
@@ -149,6 +162,40 @@ class Subscriber:
                 return self.latest_by_key.pop(event.id, event)
 
         return event
+
+    def close(self) -> None:
+        """Mark closed and release every event still tied to this subscriber.
+
+        Two distinct holders to clear:
+          1. Events already enqueued — events sitting in ``queue``.
+          2. Events still waiting to enqueue — events held by ``put``
+             callers parked on ``Queue._putters`` because the queue was
+             full when they arrived.
+
+        ``get_nowait`` covers (1) and, as a side effect, wakes one parked
+        putter per call. So it reaches at most ``maxsize`` of (2); under
+        a long stall + high event rate the parked count can exceed that
+        and the surplus stays stuck. The cancel pass cleans those up
+        directly. Both passes are sync and O(N), so ``unsubscribe`` never
+        blocks. Idempotent.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        # (1) Drop everything already in the queue.
+        while True:
+            try:
+                self.queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        # (2) Cancel parked putters drain didn't reach. ``_putters`` is
+        # private but stable since 3.4; getattr keeps us safe if it moves.
+        putters = getattr(self.queue, "_putters", None)
+        if putters is not None:
+            for putter in list(putters):
+                if not putter.done():
+                    putter.cancel()
+            putters.clear()
 
 
 class EventBus:
@@ -379,11 +426,22 @@ class EventBus:
                 self._spawn(subscriber.enqueue(event))
 
     def unsubscribe(self, topic: str, subscriber: Subscriber):
-        """Unsubscribe from a topic."""
+        """Unsubscribe from a topic.
+
+        Closing the subscriber here (rather than relying on GC) drains its
+        queue so any in-flight enqueue tasks blocked on ``queue.put`` can
+        unwind. Without this, ``_pending_tasks`` would retain those tasks —
+        and through them the subscriber + its 1024 queued events — forever.
+        """
         if topic in self.subscribers:
-            self.subscribers[topic].remove(subscriber)
+            try:
+                self.subscribers[topic].remove(subscriber)
+            except ValueError:
+                # Defensive: tolerate double-unsubscribe.
+                pass
             if not self.subscribers[topic]:
                 del self.subscribers[topic]
+        subscriber.close()
 
     async def publish(self, topic: str, event: Event):
         """Publish an event to a topic.

--- a/gpustack/server/cache.py
+++ b/gpustack/server/cache.py
@@ -122,9 +122,22 @@ async def delete_cache_by_key(
         await _broadcast_invalidation(key)
 
 
-async def set_cache_by_key(key: str, value: Any):
+async def set_cache_by_key(key: str, value: Any, ttl: Optional[int] = None):
+    """Write ``value`` to the in-memory cache.
+
+    A TTL is required in practice — the underlying aiocache memory backend
+    only schedules expiration when ``ttl`` is truthy, so calling without one
+    leaves the entry in the dict forever. ModelUsageService.update goes
+    through this function on every chat completion with a per-(date,
+    model, user, access_key) cache key, so an unbounded backend turns a
+    high-cardinality key space (rotated API keys) into a permanent leak.
+    Default to ``SERVER_CACHE_TTL_SECONDS`` so inactive entries roll off
+    naturally; active ones get refreshed on every update.
+    """
+    if ttl is None:
+        ttl = envs.SERVER_CACHE_TTL_SECONDS
     logger.trace(f"Set cache for key: {key}")
-    await cache.set(key, value)
+    await cache.set(key, value, ttl=ttl)
 
 
 def class_key(suffix: str):

--- a/tests/server/test_bus.py
+++ b/tests/server/test_bus.py
@@ -194,3 +194,94 @@ async def test_non_updated_events_block_under_backpressure_not_drop():
     second = await asyncio.wait_for(subscriber.receive(), timeout=1)
     third = await asyncio.wait_for(subscriber.receive(), timeout=1)
     assert {second.id, third.id} == {2, 3}
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_drains_pending_puts_and_releases_pending_tasks():
+    """An SSE consumer that disconnects while its queue is full leaves
+    enqueue tasks stuck on ``queue.put``. Without the close-on-unsubscribe
+    drain, those tasks (held by the bus's ``_pending_tasks`` retain set)
+    pin the subscriber + 1024 events alive forever — that's the
+    ghost-subscriber half of the issue #5073 leak.
+    """
+    from gpustack.server.bus import EventBus
+
+    bus = EventBus()
+    topic = "_test_unsubscribe_drain"
+    subscriber = bus.subscribe(topic, source="ghost")
+    subscriber.queue = asyncio.Queue(maxsize=1)
+    # Saturate the queue so the next route call will block on put.
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 0}, id=0))
+
+    # Route a non-UPDATED event — fan-out spawns a task that blocks on put.
+    bus._route_event(Event(type=EventType.CREATED, data={"id": 1}, id=1), topic)
+    await asyncio.sleep(0)
+    blocked = next(iter(bus._pending_tasks))
+    assert not blocked.done()
+
+    # Unsubscribe must close the subscriber, draining its queue so the
+    # blocked enqueue task can finish and the retain-set discards it.
+    qsize_before = subscriber.queue.qsize()
+    bus.unsubscribe(topic, subscriber)
+    await asyncio.wait_for(blocked, timeout=1)
+    # The done callback on _spawn fires before ``await blocked`` returns,
+    # so by here the retain set must have released the task.
+    assert blocked not in bus._pending_tasks
+    assert subscriber._closed is True
+    # The drained event is gone; the previously-blocked put resolved and
+    # placed its event back, so the net queue depth is at most what we
+    # started with — no leak amplification.
+    assert subscriber.queue.qsize() <= qsize_before
+
+    # Post-close enqueues are silently dropped: no new entries reach the
+    # queue, no new entries land in latest_by_key.
+    pre_post_qsize = subscriber.queue.qsize()
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 2}, id=2))
+    await subscriber.enqueue(Event(type=EventType.UPDATED, data={"id": 3}, id=3))
+    assert subscriber.queue.qsize() == pre_post_qsize
+    assert subscriber.latest_by_key == {}
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_unwinds_putters_beyond_queue_capacity():
+    """Stalled consumer + high event rate parks more putters than the
+    queue can hold. ``close`` must unwind every one of them — the surplus
+    beyond ``maxsize`` cannot be reached by drain alone (each get_nowait
+    wakes only one putter), so we also cancel residual ``_putters``.
+    """
+    from gpustack.server.bus import EventBus
+
+    bus = EventBus()
+    topic = "_test_unsubscribe_deep_backlog"
+    subscriber = bus.subscribe(topic, source="stalled")
+    subscriber.queue = asyncio.Queue(maxsize=2)
+
+    # Fill the queue, then route enough additional events that the parked
+    # putter count exceeds the queue's capacity by a wide margin.
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 0}, id=0))
+    await subscriber.enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+    extra = 8
+    for i in range(extra):
+        bus._route_event(
+            Event(type=EventType.CREATED, data={"id": 100 + i}, id=100 + i),
+            topic,
+        )
+    # Yield so each enqueue task reaches its blocking put.
+    for _ in range(extra + 2):
+        await asyncio.sleep(0)
+    blocked_tasks = list(bus._pending_tasks)
+    assert len(blocked_tasks) == extra
+    assert all(not t.done() for t in blocked_tasks)
+
+    bus.unsubscribe(topic, subscriber)
+    # All blocked enqueue tasks must finish — either via the woken
+    # put-and-exit path (up to maxsize) or via the cancellation path.
+    await asyncio.wait_for(
+        asyncio.gather(*blocked_tasks, return_exceptions=True),
+        timeout=1,
+    )
+    for t in blocked_tasks:
+        assert t.done()
+    assert all(t not in bus._pending_tasks for t in blocked_tasks)
+    putters = getattr(subscriber.queue, "_putters", None)
+    assert putters is None or len(putters) == 0


### PR DESCRIPTION
## Leak points in v2.1.1

- **1 `Subscriber.latest_by_key` strands entries on `QueueFull`.** [`v2.1.1 bus.py#L65-L83`](https://github.com/gpustack/gpustack/blob/v2.1.1/gpustack/server/bus.py#L65-L83): for an UPDATED event the dict is set *before* `put_nowait`. If the queue is full the put raises `QueueFull`, but the dict entry stays. Every later UPDATED for the same id short-circuits on `if id in latest_by_key` and never tries to put again — there is no queue token, so `receive()` never pops the entry. One permanent entry per id that ever hit a full queue. Ramps with churn.
- **2 Publisher tasks pin ghost subscribers.** [`v2.1.1 active_record.py#L79`](https://github.com/gpustack/gpustack/blob/v2.1.1/gpustack/mixins/active_record.py#L79) fires `asyncio.create_task(event_bus.publish(...))` per commit. v2.1.1 [`publish`](https://github.com/gpustack/gpustack/blob/v2.1.1/gpustack/server/bus.py#L114-L117) iterates `for subscriber in subscribers[topic]: await subscriber.enqueue(event)` — sequential. One slow consumer head-of-line blocks the publish task on `queue.put`. Tasks accumulate, each retaining the deep-copied event payload and the slow subscriber. Even after `unsubscribe`, the in-flight publish tasks still pin the subscriber + 1024 queued events.
- **3 `GatewayMetricsCollector.cached_dict` grows monotonically.** [`v2.1.1 metrics_collector.py#L184`](https://github.com/gpustack/gpustack/blob/v2.1.1/gpustack/server/metrics_collector.py#L184) declares `cached_dict: Dict[str, ModelUsageMetrics] = {}` at class scope, keyed by `f"{model_id}.{provider_id}.{model}.{user_id}.{access_key}"`. The collector only writes — never prunes — so every distinct access key (rotated API keys, new users) becomes a permanent entry. The hottest path under issue 5121's high-QPS workload.

- **4 memory leak from module-level singleton exception instances** https://github.com/gpustack/gpustack/issues/5121
[`gpustack/api/auth.py`](https://github.com/gpustack/gpustack/blob/914ae2e99be270af761447994cb2321cc1de479c/gpustack/api/auth.py#L55) and [`gpustack/routes/token.py`](https://github.com/gpustack/gpustack/blob/914ae2e99be270af761447994cb2321cc1de479c/gpustack/routes/token.py#L34) declare three exception instances at module scope and reuse them at 8 `raise` sites. In Python, raise <existing instance> sets instance.__traceback__ to the current call stack. Because the instance is a module attribute it is never garbage-collected, so its __traceback__ is never released either. That traceback chain holds every frame in the call stack, and each frame.f_locals holds the full per-request state — Request, AsyncSession, user, bearer token, headers. Each failed-auth request therefore retains ~30 KB; at 10 QPS over 100 h that lands at ~100 GB.
> ```python
> credentials_exception = UnauthorizedException(...)
> model_name_missing_exception = BadRequestException(...)
> model_not_found_exception = NotFoundException(...)
> ...
> raise credentials_exception
> ```
  

## Memory Status
Run time scripts and check the gpustack memory in gpustack 2.1.1

- **For 1, 2** while start the server it comsume ~8G, after run and stop below script several times, the memory never go down. 

```bash
SERVER_URL=http://xxx \
ADMIN_TOKEN=xxx\
MODEL_ID=2 \
WATCHERS=200 \
TARGET_REPLICAS=20 \
TOGGLE_COUNT=-1 \
TOGGLE_INTERVAL_SECONDS=0.2 \
WATCH_URL=http://192.168.50.16:10107/v2/model-instances?watch=true \
bash .cache/shell/repro-model-instance-event-bus-full.sh
```
<img width="2974" height="3654" alt="leak-2 1 1-bus-test" src="https://github.com/user-attachments/assets/7a715f98-da44-4849-b73e-7d8f5896cedb" />

- **For 3** while start the server it comsume ~5G, after run below script, the memory never go down even after stop the script at 16:28 
[repro-gateway-cached-dict-leak.py](https://github.com/user-attachments/files/27586573/repro-gateway-cached-dict-leak.py)
[repro-gateway-cached-dict-leak.sh](https://github.com/user-attachments/files/27586574/repro-gateway-cached-dict-leak.sh)
<img width="2974" height="3654" alt="leak-2 1 1-metrics-cache-test" src="https://github.com/user-attachments/assets/c96f33d8-a7a1-4213-b782-bc8487b9b83c" />

- **For 4**
While start the server, after run below script at 12:12, the memory climbing. Start the server with fix, after run below script at 15:24 the memory climbing slowly. 
[repro-issue-5121-bad-token.py](https://github.com/user-attachments/files/27586860/repro-issue-5121-bad-token.py)

<img width="2072" height="1256" alt="image" src="https://github.com/user-attachments/assets/97cffbca-c966-487f-9f8e-e8fc1ddfd0b3" />

