### PR TITLE
feat(vllm): add --num-gpus parameter to ray start command

### DIFF
--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -635,6 +635,7 @@ class VLLMServer(InferenceServer):
             f"--min-worker-port={worker_port_min}",
             f"--max-worker-port={worker_port_max}",
             f"--node-ip-address={self._worker.ip}",
+            f"--num-gpus={len(self._get_selected_gpu_devices())}",
         ]
         ports = [
             ContainerPort(


### PR DESCRIPTION
## Description
Add --num-gpus parameter to the ray start command in VLLM backend to specify the number of GPUs for the Ray node.

## Changes
- Added f"--num-gpus={len(self._get_selected_gpu_devices())}" to ray start arguments in vllm.py