### PR TITLE
fix: validate_gpu_ids crash when gpu_selector lacks gpu_ids

### DIFF
--- a/gpustack/routes/models.py
+++ b/gpustack/routes/models.py
@@ -308,6 +308,11 @@ async def validate_gpu_ids(  # noqa: C901
                 message="The number of selected GPUs must be greater than or equal to gpus_per_replica."
             )
 
+    # Nothing to validate per-GPU when gpu_ids is empty
+    # (e.g. only gpus_per_replica is set — auto-scheduling).
+    if not model_in.gpu_selector or not model_in.gpu_selector.gpu_ids:
+        return
+
     model_backend = model_in.backend
 
     if model_backend == BackendEnum.VOX_BOX and (


### PR DESCRIPTION
## Summary

`validate_gpu_ids` in `gpustack/routes/models.py` crashes with `TypeError: 'NoneType' object is not iterable` whenever a model's `gpu_selector` only specifies `gpus_per_replica` (no `gpu_ids`) — which is a schema-valid configuration (`gpu_ids: Optional[List[str]] = None`) meaning "let the scheduler pick GPUs".

The 500 is returned to every model update, including the meta-sync update the worker fires in `sync_model_instances_state` right before transitioning an instance to `RUNNING`. The exception aborts that function, the state patch never lands, and the instance stays stuck in `STARTING` indefinitely while the inference backend is healthy and serving traffic.

Full root-cause analysis, traceback, and reproduction steps are in #5268.

## Fix

Skip the per-GPU validation early when there are no `gpu_ids` to validate. This also incidentally protects the `len(... .gpu_ids) > 1` check in the VOX_BOX branch immediately below.

## Test plan

- [ ] Create a model with `gpu_selector = {"gpus_per_replica": N}` (no `gpu_ids`); start it; observe `model_instances.state` reaches `RUNNING` and `/v1/models` returns the model
- [ ] Existing manual GPU-pinning path (`gpu_selector.gpu_ids = [...]`) still validates GPU IDs as before
- [ ] Existing `gpus_per_replica` consistency check (`len(gpu_ids) >= gpus_per_replica`) still raises when both are set and inconsistent

Fixes #5268