### PR TITLE
fix: thread-safe tqdm progress hijack + cleanup hook on close (#3456)

### DIFF
--- a/gpustack/worker/model_file_manager.py
+++ b/gpustack/worker/model_file_manager.py
@@ -603,9 +603,18 @@ class ModelFileDownloadTask:
                 # in the global counter so the percentage reflects actual progress.
                 self._model_downloaded_size += tqdm_instance.n
 
-        # Write initial progress line for this file using ANSI cursor positioning
-        file_desc = getattr(tqdm_instance, 'desc', None) or f"File {tqdm_id}"
-        self._assign_file_basename(tqdm_id, file_desc)
+            # _assign_file_basename mutates self._tqdm_file_basename, which is
+            # also a shared dict touched by _handle_tqdm_close. Keep it inside
+            # _speed_lock for the same reason (per gemini-code-assist review on
+            # PR #5274).
+            file_desc = getattr(tqdm_instance, 'desc', None) or f"File {tqdm_id}"
+            self._assign_file_basename(tqdm_id, file_desc)
+
+        # Write initial progress line for this file using ANSI cursor positioning.
+        # _write_progress_with_cursor_positioning writes to the log file (I/O),
+        # which has its own per-file lock and does not touch the shared dicts;
+        # leaving it outside the lock avoids holding _speed_lock across an I/O
+        # call.
         self._write_progress_with_cursor_positioning(
             line_number, f"{file_desc}: Initializing...", tqdm_id
         )

--- a/gpustack/worker/model_file_manager.py
+++ b/gpustack/worker/model_file_manager.py
@@ -553,6 +553,9 @@ class ModelFileDownloadTask:
         _original_update = (
             tqdm._original_update if hasattr(tqdm, "_original_update") else tqdm.update
         )
+        _original_close = (
+            tqdm._original_close if hasattr(tqdm, "_original_close") else tqdm.close
+        )
 
         def _new_init(self: tqdm, *args, **kwargs):
             task_self._handle_tqdm_init(self, _original_init, *args, **kwargs)
@@ -560,33 +563,45 @@ class ModelFileDownloadTask:
         def _new_update(self: tqdm, n=1):
             task_self._handle_tqdm_update(self, _original_update, n)
 
+        def _new_close(self: tqdm):
+            task_self._handle_tqdm_close(self, _original_close)
+
         tqdm.__init__ = _new_init
         tqdm.update = _new_update
+        tqdm.close = _new_close
         tqdm._original_init = _original_init
         tqdm._original_update = _original_update
+        tqdm._original_close = _original_close
 
     def _handle_tqdm_init(self, tqdm_instance, original_init, *args, **kwargs):
         kwargs["disable"] = False  # enable the progress bar anyway
         original_init(tqdm_instance, *args, **kwargs)
 
-        # Assign unique ID and line number for this tqdm instance
-        tqdm_id = self._tqdm_counter
-        self._tqdm_counter += 1
-        tqdm_instance._gpustack_id = tqdm_id
+        # Assign unique ID and line number for this tqdm instance.
+        # Counter and mapping mutations happen under _speed_lock to avoid
+        # races with parallel downloads (HfDownloader uses thread_map with
+        # max_workers=8, so up to 8 tqdm instances can pass through __init__
+        # concurrently).
+        with self._speed_lock:
+            tqdm_id = self._tqdm_counter
+            self._tqdm_counter += 1
+            tqdm_instance._gpustack_id = tqdm_id
 
-        # Assign a fixed line number for this file (same as tqdm_id)
-        line_number = tqdm_id
-        self._file_line_mapping[tqdm_id] = line_number
+            # Assign a fixed line number for this file (same as tqdm_id)
+            line_number = tqdm_id
+            self._file_line_mapping[tqdm_id] = line_number
 
-        # Initialize progress tracking for this file
-        self._file_progress_tracking[tqdm_id] = {
-            'last_update_time': 0,
-            'last_progress': 0.0,
-        }
+            # Initialize progress tracking for this file
+            self._file_progress_tracking[tqdm_id] = {
+                'last_update_time': 0,
+                'last_progress': 0.0,
+            }
 
-        if hasattr(self, '_model_file_size'):
-            # Resume downloading
-            self._model_downloaded_size += tqdm_instance.n
+            if hasattr(self, '_model_file_size'):
+                # Resume downloading: tqdm may be created with initial=<bytes_already_on_disk>
+                # which means tqdm_instance.n > 0 at init time. Account for those bytes
+                # in the global counter so the percentage reflects actual progress.
+                self._model_downloaded_size += tqdm_instance.n
 
         # Write initial progress line for this file using ANSI cursor positioning
         file_desc = getattr(tqdm_instance, 'desc', None) or f"File {tqdm_id}"
@@ -594,6 +609,24 @@ class ModelFileDownloadTask:
         self._write_progress_with_cursor_positioning(
             line_number, f"{file_desc}: Initializing...", tqdm_id
         )
+
+    def _handle_tqdm_close(self, tqdm_instance, original_close):
+        """
+        Cleanup tracking dictionaries when a tqdm instance closes.
+
+        Without this hook, _file_line_mapping and _file_progress_tracking grow
+        for the lifetime of the worker. On long-lived workers that download many
+        models, the dicts accumulate stale entries; restarting the container is
+        the only way to reset them, which is the workaround users have been
+        reporting (see #3456).
+        """
+        tqdm_id = getattr(tqdm_instance, '_gpustack_id', None)
+        if tqdm_id is not None:
+            with self._speed_lock:
+                self._file_line_mapping.pop(tqdm_id, None)
+                self._file_progress_tracking.pop(tqdm_id, None)
+                self._tqdm_file_basename.pop(tqdm_id, None)
+        original_close(tqdm_instance)
 
     def _handle_tqdm_update(self, tqdm_instance, original_update, n=1):
         # Get the tqdm ID and line number for this instance


### PR DESCRIPTION
## Summary

Two race conditions in `ModelFileDownloadTask`'s tqdm hijack, both contributing to the wrong-progress / stuck-progress reports in #3456 (and likely #3547, #3833, #3853, #3882, #5253):

1. **`_handle_tqdm_init` is not thread-safe.** `HfDownloader.download` runs files through `tqdm.contrib.concurrent.thread_map` with `max_workers=8`, so up to eight tqdm instances pass through `__init__` concurrently. The current code mutates `_tqdm_counter`, `_file_line_mapping`, `_file_progress_tracking`, and increments `_model_downloaded_size` without holding `self._speed_lock`. The lock is only acquired in `_handle_tqdm_update`. Result: initial state of `_model_downloaded_size` can be wrong, which propagates into every subsequent percentage.

2. **`tqdm.close` is not hooked.** Entries in `_file_line_mapping` and `_file_progress_tracking` are never removed when a download finishes. On long-lived workers downloading many models, the dicts grow without bound, and stale entries can interfere with newly assigned `tqdm_id`s. The "container restart fixes the progress display" workaround users have been reporting is exactly this: a fresh manager starts with empty dicts and `_model_downloaded_size = 0`.

## Changes

- `_handle_tqdm_init`: counter and mapping mutations now happen inside `self._speed_lock`. The `_model_downloaded_size += tqdm_instance.n` (resume bookkeeping) is also inside the lock.
- `hijack_tqdm_progress`: now hooks `tqdm.close` in addition to `__init__` and `update`. `_original_close` is saved on the tqdm class so the hijack remains idempotent across worker tasks (matching the existing pattern for init/update).
- New `_handle_tqdm_close`: pops the closing instance's entries from `_file_line_mapping`, `_file_progress_tracking`, and `_tqdm_file_basename` under `_speed_lock`, then forwards to `original_close`.

## Out of scope

The "two simultaneous tqdm instances on the same file" pattern visible in @Finenyaco's log (`dia-v0 1.pth: 4.00G/6.44G` and `3.92G/6.44G` in adjacent lines) is left for a separate investigation. Reproducing it requires interrupting an HF chunked download mid-transfer, and the right fix may involve coordinating with `hf_hub_download`'s retry path rather than the local hijack. The thread-safety fix here is a prerequisite for any cleaner architectural change (e.g., replacing the global monkey-patch with a `tqdm_class=` parameter passed to `hf_hub_download`).

## Test plan

- [ ] Existing tests pass (no test coverage exists for the hijack itself, so this is a no-op verification)
- [ ] Manual: download a multi-file HF model (e.g., `nari-labs/Dia-1.6B`), verify percentage moves monotonically without going past 100% or jumping backward
- [ ] Manual: trigger a worker restart while a download is in progress; on restart, verify the new manager's `_file_line_mapping` is empty (no stale entries from the previous run)
- [ ] Long-soak: run several model downloads in sequence on the same worker process, inspect `_file_line_mapping` size at the end (should be empty if all closes fired)

## Related

- Issue: #3456
- Likely also helps: #3547, #3833, #3882, #5253


## Context

Engineering log for this contribution and the cluster discovery is on the author's blog: [sovgrid.org/upstream/](https://sovgrid.org/upstream/) lists the open-source contributions filed from the same self-hosted-AI stack (`Mistral Small 4 + Voxtral 4B + ComfyUI` on a DGX Spark). Each entry links to the upstream issue or PR plus the engineering write-up that produced it.
