### PR TITLE
feat: implement API Key usage monitoring (requests, tokens, cached tokens)

### DIFF
--- a/gpustack/migrations/versions/2026_05_08_0845-acb303585994_add_api_key_usage_stats.py
+++ b/gpustack/migrations/versions/2026_05_08_0845-acb303585994_add_api_key_usage_stats.py
@@ -1,0 +1,50 @@
+"""add_api_key_usage_stats
+
+Revision ID: acb303585994
+Revises: 8bf38a6bb3b5
+Create Date: 2026-05-08 08:45:45.608786
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+import gpustack
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'acb303585994'
+down_revision: Union[str, None] = '8bf38a6bb3b5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'api_keys',
+        sa.Column(
+            'total_requests', sa.BigInteger(), nullable=False, server_default=sa.text('0')
+        ),
+    )
+    op.add_column(
+        'api_keys',
+        sa.Column(
+            'total_tokens', sa.BigInteger(), nullable=False, server_default=sa.text('0')
+        ),
+    )
+    op.add_column(
+        'api_keys',
+        sa.Column(
+            'total_cached_tokens',
+            sa.BigInteger(),
+            nullable=False,
+            server_default=sa.text('0'),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('api_keys', 'total_cached_tokens')
+    op.drop_column('api_keys', 'total_tokens')
+    op.drop_column('api_keys', 'total_requests')

--- a/gpustack/routes/api_keys.py
+++ b/gpustack/routes/api_keys.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 import secrets
-from typing import Optional
+from typing import Annotated, Optional
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import selectinload
@@ -48,6 +48,9 @@ def _api_key_to_public(
         allowed_model_names=api_key.allowed_model_names,
         is_custom=api_key.is_custom,
         scope=api_key.scope,
+        total_requests=api_key.total_requests,
+        total_tokens=api_key.total_tokens,
+        total_cached_tokens=api_key.total_cached_tokens,
     )
 
 
@@ -62,10 +65,11 @@ def _is_hidden_api_key(api_key: ApiKey) -> bool:
 async def get_api_keys(
     session: SessionDep,
     user: CurrentUserDep,
-    params: ApiKeyListParams = Depends(),
-    user_id: Optional[str] = Query(
-        None, description="Filter by user_id. Admin can use '*' to list all users."
-    ),
+    params: Annotated[ApiKeyListParams, Depends()],
+    user_id: Annotated[
+        Optional[str],
+        Query(description="Filter by user_id. Admin can use '*' to list all users."),
+    ] = None,
     search: str = None,
 ):
     fields = {"user_id": user.id}

--- a/gpustack/schemas/api_keys.py
+++ b/gpustack/schemas/api_keys.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from datetime import datetime
 from typing import ClassVar, Optional, List, TYPE_CHECKING
-from sqlalchemy import Column, UniqueConstraint
+from sqlalchemy import Column, UniqueConstraint, BigInteger
 from sqlmodel import Field, SQLModel, Text, JSON, Relationship
 
 from gpustack.mixins import BaseModelMixin
@@ -59,6 +59,15 @@ class ApiKey(ApiKeyBase, BaseModelMixin, table=True):
         sa_relationship_kwargs={"lazy": "noload"},
     )
     is_custom: bool = Field(default=False, nullable=False)
+    total_requests: int = Field(
+        default=0, sa_column=Column(BigInteger, nullable=False, server_default="0")
+    )
+    total_tokens: int = Field(
+        default=0, sa_column=Column(BigInteger, nullable=False, server_default="0")
+    )
+    total_cached_tokens: int = Field(
+        default=0, sa_column=Column(BigInteger, nullable=False, server_default="0")
+    )
 
     @property
     def user_name(self) -> Optional[str]:
@@ -69,6 +78,9 @@ class ApiKeyListParams(ListParams):
     sortable_fields: ClassVar[List[str]] = [
         "name",
         "expires_at",
+        "total_requests",
+        "total_tokens",
+        "total_cached_tokens",
         "created_at",
         "updated_at",
     ]
@@ -88,6 +100,9 @@ class ApiKeyPublic(ApiKeyBase):
     created_at: datetime
     updated_at: datetime
     expires_at: Optional[datetime] = None
+    total_requests: int = 0
+    total_tokens: int = 0
+    total_cached_tokens: int = 0
 
 
 ApiKeysPublic = PaginatedList[ApiKeyPublic]

--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, timezone
 from typing import Dict, List, Optional, Set, Tuple
 
 from pydantic import BaseModel
+from sqlalchemy import update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from gpustack import envs
@@ -166,6 +167,43 @@ def _resolve_usage_tokens(
     return prompt_tokens, completion_tokens
 
 
+def _accumulate_api_key_usage_delta(
+    usage_by_api_key_id: Dict[int, Dict[str, int]],
+    api_key: Optional[ApiKey],
+    metric: ModelUsageMetrics,
+) -> None:
+    if api_key is None or api_key.id is None:
+        return
+
+    usage = usage_by_api_key_id.setdefault(
+        api_key.id,
+        {
+            "requests": 0,
+            "tokens": 0,
+            "cached_tokens": 0,
+        },
+    )
+    usage["requests"] += metric.request_count
+    usage["tokens"] += metric.total_token
+    usage["cached_tokens"] += metric.input_cached_token
+
+
+async def _update_api_key_usage_stats(
+    session: AsyncSession,
+    usage_by_api_key_id: Dict[int, Dict[str, int]],
+) -> None:
+    for api_key_id, usage in usage_by_api_key_id.items():
+        await session.execute(
+            update(ApiKey)
+            .where(ApiKey.id == api_key_id)
+            .values(
+                total_requests=ApiKey.total_requests + usage["requests"],
+                total_tokens=ApiKey.total_tokens + usage["tokens"],
+                total_cached_tokens=ApiKey.total_cached_tokens + usage["cached_tokens"],
+            )
+        )
+
+
 async def accumulate_gateway_metrics(metrics: List[ModelUsageMetrics]):
     async with gateway_buffers_lock:
         for incoming in metrics:
@@ -288,7 +326,8 @@ def _validate_usage_metric(
             return False
         if model.name != metric.model:
             logger.debug(
-                f"Model name {metric.model} does not match database record {model.name} for model ID {metric.model_id}."
+                f"Model name {metric.model} does not match database record "
+                f"{model.name} for model ID {metric.model_id}."
             )
             return False
     if metric.provider_id is not None:
@@ -298,7 +337,8 @@ def _validate_usage_metric(
             return False
         if metric.model not in {m.name for m in provider.models}:
             logger.debug(
-                f"Model name {metric.model} not found for provider ID {metric.provider_id} in database."
+                f"Model name {metric.model} not found for provider ID "
+                f"{metric.provider_id} in database."
             )
             return False
     if metric.user_id is not None and metric.user_id not in user_ids:
@@ -437,6 +477,7 @@ async def store_usage_metrics(
             )
             cluster_names_by_id = {c.id: c.name for c in clusters}
             provider_by_id = {p.id: p for p in providers}
+            api_key_usage_by_id: Dict[int, Dict[str, int]] = {}
 
             for metric in metrics:
                 if not _validate_usage_metric(
@@ -466,6 +507,11 @@ async def store_usage_metrics(
                 )
                 await create_or_update_model_usage(
                     session, model_usage, auto_commit=False
+                )
+                _accumulate_api_key_usage_delta(
+                    api_key_usage_by_id,
+                    api_key_by_access_key.get(metric.access_key),
+                    metric,
                 )
 
             for metric in detail_metrics:
@@ -530,6 +576,7 @@ async def store_usage_metrics(
                     )
                 )
 
+            await _update_api_key_usage_stats(session, api_key_usage_by_id)
             await session.commit()
         except Exception as e:
             logger.exception(f"Error storing gateway metrics: {e}")

--- a/tests/server/test_metrics_collector.py
+++ b/tests/server/test_metrics_collector.py
@@ -1,12 +1,16 @@
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
+from gpustack.schemas.api_keys import ApiKey
 from gpustack.server.metrics_collector import (
     ModelUsageMetrics,
+    _accumulate_api_key_usage_delta,
     _estimate_partial_usage,
     _make_buffer_key,
     _resolve_usage_tokens,
+    _update_api_key_usage_stats,
     accumulate_gateway_metrics,
     gateway_details_buffer,
     gateway_metrics_buffer,
@@ -119,6 +123,72 @@ def test_accumulate_total_token_summed():
     asyncio.run(accumulate_gateway_metrics([m2]))
     entry = list(gateway_metrics_buffer.values())[0]
     assert entry.total_token == 400
+
+
+def test_accumulate_api_key_usage_delta_sums_rollups_by_key():
+    usage_by_api_key_id = {}
+    api_key = ApiKey(
+        id=7,
+        name="test-key",
+        access_key="access",
+        hashed_secret_key="secret",
+        user_id=1,
+    )
+
+    _accumulate_api_key_usage_delta(
+        usage_by_api_key_id,
+        api_key,
+        ModelUsageMetrics(
+            model="m",
+            request_count=2,
+            total_token=300,
+            input_cached_token=40,
+        ),
+    )
+    _accumulate_api_key_usage_delta(
+        usage_by_api_key_id,
+        api_key,
+        ModelUsageMetrics(
+            model="m",
+            request_count=1,
+            total_token=100,
+            input_cached_token=5,
+        ),
+    )
+
+    assert usage_by_api_key_id == {
+        7: {
+            "requests": 3,
+            "tokens": 400,
+            "cached_tokens": 45,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_api_key_usage_stats_uses_atomic_increments():
+    session = AsyncMock()
+
+    await _update_api_key_usage_stats(
+        session,
+        {
+            7: {
+                "requests": 3,
+                "tokens": 400,
+                "cached_tokens": 45,
+            }
+        },
+    )
+
+    session.execute.assert_awaited_once()
+    stmt = session.execute.await_args.args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+    assert "UPDATE api_keys SET" in sql
+    assert "total_requests=(api_keys.total_requests + 3)" in sql
+    assert "total_tokens=(api_keys.total_tokens + 400)" in sql
+    assert "total_cached_tokens=(api_keys.total_cached_tokens + 45)" in sql
+    assert "WHERE api_keys.id = 7" in sql
 
 
 def test_resolve_usage_tokens_falls_back_total_for_reranker_model():


### PR DESCRIPTION
### What this PR does / why we need it:

This PR implements usage tracking for API Keys. It tracks the total number of requests, total consumed tokens, and total cached tokens at the API key level. This enables administrators to accurately monitor billing, usage, and cache efficiency on a per-user/per-key basis.

**Changes:**
- Added `total_requests`, `total_tokens`, and `total_cached_tokens` fields to the `ApiKey` database model.
- Automatically increments these metrics inside `ModelUsageMiddleware` when an API Key is used.
- Exposes these usage statistics via the `ApiKeyPublic` API schema.
- Generated the corresponding Alembic database migration.

### Which issue(s) this PR fixes:
Resolves #1725