### PR TITLE
fix: align route user-access helpers with principals schema

### DIFF
--- a/gpustack/api/tenant.py
+++ b/gpustack/api/tenant.py
@@ -66,7 +66,7 @@ class TenantContext:
     # True when ``current_principal_id`` is the user's own
     # USER-principal (personal scope) rather than an ORG-principal.
     # Lets endpoints treat the "owner of a one-member namespace" case
-    # differently from a real multi-user Org admin — e.g.
+    # differently from a real multi-user Org owner — e.g.
     # ``scope='all'`` on the Usage page should behave like ``self``
     # here (no other tenants share this scope).
     current_is_personal_scope: bool = False
@@ -466,11 +466,11 @@ def assert_org_owned_writable(
     - Platform admin / system user → allowed (bypass via
       ``bypass_tenant_filter`` for "All" mode admin and system users;
       admin in act-as falls through to row-owner check, where they're
-      treated like an Org admin).
-    - **Owned by current principal**: an Org admin can write; platform
+      treated like an Org owner).
+    - **Owned by current principal**: an Org owner can write; platform
       admin in act-as bypasses the role check (admin is admin
       everywhere, even when scoped to one Org).
-    - **Global** (owner IS NULL): only "All"-mode admin — Org admins
+    - **Global** (owner IS NULL): only "All"-mode admin — Org owners
       and admin-in-act-as cannot mutate Global rows directly. Resource
       handlers redirect such writes to the caller's own row instead.
     - **Other principal's row**: never writable for non-admin.
@@ -490,8 +490,8 @@ def assert_org_owned_writable(
             )
         )
     # Platform admin acting-as the Org passes the role check unconditionally;
-    # for non-admin we require Org admin.
-    if not ctx.is_platform_admin and ctx.org_role != OrgRole.ADMIN:
+    # for non-admin we require Org owner.
+    if not ctx.is_platform_admin and ctx.org_role != OrgRole.OWNER:
         raise OrgRoleError(
             message=(
                 f"Insufficient organization role to modify this " f"{resource_label}"
@@ -516,7 +516,7 @@ def validate_owner_principal(
     ``input_owner_principal_id``.
 
     - Platform admin: any value (including NULL = global)
-    - Org admin: must equal ``current_principal_id``; can't create global
+    - Org owner: must equal ``current_principal_id``; can't create global
     """
     if ctx.is_platform_admin:
         return
@@ -531,7 +531,7 @@ def validate_owner_principal(
         raise InvalidException(
             message="owner_principal_id must match the current organization"
         )
-    if ctx.org_role != OrgRole.ADMIN:
+    if ctx.org_role != OrgRole.OWNER:
         raise InvalidException(
             message=(f"Insufficient organization role to create a " f"{resource_label}")
         )

--- a/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
+++ b/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
@@ -16,7 +16,7 @@ Logical groups, run in order:
    name=username).
 4. Add `users.principal_id` (NOT NULL UNIQUE FK → principals.id),
    backfill from step 3.
-5. Backfill memberships in the platform Org for admin users (role=ADMIN).
+5. Backfill memberships in the platform Org for admin users (role=OWNER).
    Regular users get no auto-membership — admins must add them
    explicitly when team-workspace access is wanted.
 6. Add `owner_principal_id` to existing tenant-scoped tables: api_keys
@@ -73,7 +73,7 @@ PLATFORM_PRINCIPAL_NAME = 'Default'
 
 
 def _enums():
-    org_role = sa.Enum('ADMIN', 'USER', name='orgrole')
+    org_role = sa.Enum('OWNER', 'MEMBER', name='orgrole')
     principal_type = sa.Enum('ORG', 'GROUP', 'USER', name='principaltype')
     return org_role, principal_type
 
@@ -127,7 +127,7 @@ def upgrade() -> None:
             sa.Column('id', sa.Integer(), nullable=False),
             sa.Column('parent_principal_id', sa.Integer(), nullable=False),
             sa.Column('member_principal_id', sa.Integer(), nullable=False),
-            # NULL for GROUP memberships (no role tiers); ADMIN / USER
+            # NULL for GROUP memberships (no role tiers); OWNER / MEMBER
             # for ORG memberships.
             sa.Column('role', org_role, nullable=True),
             sa.Column('created_at', sa.TIMESTAMP(), nullable=False),
@@ -404,7 +404,7 @@ def upgrade() -> None:
                 INSERT INTO principal_memberships
                     (parent_principal_id, member_principal_id, role,
                      created_at, updated_at, deleted_at)
-                SELECT :platform_id, u.principal_id, 'ADMIN'::orgrole,
+                SELECT :platform_id, u.principal_id, 'OWNER'::orgrole,
                        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL
                 FROM users u
                 WHERE u.is_admin = true
@@ -425,7 +425,7 @@ def upgrade() -> None:
                 INSERT INTO principal_memberships
                     (parent_principal_id, member_principal_id, role,
                      created_at, updated_at, deleted_at)
-                SELECT :platform_id, u.principal_id, 'ADMIN',
+                SELECT :platform_id, u.principal_id, 'OWNER',
                        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL
                 FROM users u
                 WHERE u.is_admin = 1

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -429,7 +429,7 @@ async def set_default_cluster(session: SessionDep, ctx: TenantContextDep, id: in
     # "Default cluster" is a per-Org concept now: each Org has at most
     # one default, and that's what its members' deploy form falls back
     # to. Writing it follows the standard cluster-write rule (admin
-    # always; Org admin only on their own Org's clusters).
+    # always; Org owner only on their own Org's clusters).
     cluster = await Cluster.one_by_id(session, id)
     if not cluster:
         raise NotFoundException(message=f"cluster {id} not found")

--- a/gpustack/routes/me_orgs.py
+++ b/gpustack/routes/me_orgs.py
@@ -46,7 +46,7 @@ async def list_my_orgs(session: SessionDep, user: CurrentUserDep):
         items.append(
             MyOrganization(
                 organization=OrganizationPublic.from_principal(user_principal),
-                role=OrgRole.ADMIN,
+                role=OrgRole.OWNER,
             )
         )
 
@@ -67,7 +67,7 @@ async def list_my_orgs(session: SessionDep, user: CurrentUserDep):
     items.extend(
         MyOrganization(
             organization=OrganizationPublic.from_principal(org),
-            role=membership.role or OrgRole.USER,
+            role=membership.role or OrgRole.MEMBER,
         )
         for membership, org in rows
     )

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -770,13 +770,12 @@ async def _replace_route_user_principals(
     alone, even if the OSS UI happens to call this endpoint on the
     same route.
     """
-    user_to_principal: Dict[int, int] = {}
+    desired_principal_ids: Set[int] = set()
     if user_ids:
-        users = (
-            await session.exec(select(User).where(col(User.id).in_(user_ids)))
-        ).all()
-        user_to_principal = {u.id: u.principal_id for u in users}
-    desired_principal_ids = set(user_to_principal.values())
+        stmt = select(User.principal_id).where(col(User.id).in_(user_ids))
+        desired_principal_ids = {
+            pid for pid in (await session.exec(stmt)).all() if pid is not None
+        }
 
     existing_stmt = (
         select(ModelRoutePrincipalLink)

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -1,6 +1,5 @@
 import logging
 import secrets
-from datetime import datetime, timezone
 from sqlalchemy.orm import selectinload
 from sqlmodel import col, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -30,6 +29,7 @@ from gpustack.schemas.model_routes import (
 )
 from gpustack.schemas.links import ModelRoutePrincipalLink
 from gpustack.schemas.organizations import PLATFORM_PRINCIPAL_ID
+from gpustack.schemas.principals import Principal, PrincipalType
 from gpustack.schemas.model_provider import ModelProvider
 from gpustack.schemas.models import Model
 from gpustack.server.db import async_session
@@ -730,20 +730,22 @@ async def set_fallback_target(
 async def _list_route_users(session, route_id: int) -> List[ModelUserAccessExtended]:
     """Build the OSS-facing access list for a route.
 
-    User-only ACL rows live in ``model_route_principals`` with
-    ``user_id`` set; we join them with ``users`` so the response can
-    carry display-only fields (``username`` / ``full_name`` /
-    ``avatar_url``) without an extra round trip from the client.
+    User-only ACL rows live in ``model_route_principals`` with a
+    ``principal_id`` referencing a USER-kind principal; we hop through
+    ``principals`` to ``users`` so the response can carry display-only
+    fields (``username`` / ``full_name`` / ``avatar_url``) without an
+    extra round trip from the client.
     """
     stmt = (
         select(User, ModelRoutePrincipalLink)
+        .join(Principal, Principal.id == User.principal_id)
         .join(
             ModelRoutePrincipalLink,
-            ModelRoutePrincipalLink.user_id == User.id,
+            ModelRoutePrincipalLink.principal_id == Principal.id,
         )
         .where(
             ModelRoutePrincipalLink.route_id == route_id,
-            ModelRoutePrincipalLink.user_id.is_not(None),
+            Principal.kind == PrincipalType.USER,
         )
     )
     rows = (await session.exec(stmt)).all()
@@ -763,34 +765,41 @@ async def _replace_route_user_principals(
 ) -> None:
     """Replace the user-grant rows on a route with exactly ``user_ids``.
 
-    Touches only rows where ``user_id IS NOT NULL`` — org / group
+    Touches only rows whose principal is USER-kind — org / group
     grants set by the enterprise UI's ALLOWED_PRINCIPALS flow are left
     alone, even if the OSS UI happens to call this endpoint on the
     same route.
     """
-    existing_stmt = select(ModelRoutePrincipalLink).where(
-        ModelRoutePrincipalLink.route_id == route_id,
-        ModelRoutePrincipalLink.user_id.is_not(None),
+    user_to_principal: Dict[int, int] = {}
+    if user_ids:
+        users = (
+            await session.exec(select(User).where(col(User.id).in_(user_ids)))
+        ).all()
+        user_to_principal = {u.id: u.principal_id for u in users}
+    desired_principal_ids = set(user_to_principal.values())
+
+    existing_stmt = (
+        select(ModelRoutePrincipalLink)
+        .join(Principal, Principal.id == ModelRoutePrincipalLink.principal_id)
+        .where(
+            ModelRoutePrincipalLink.route_id == route_id,
+            Principal.kind == PrincipalType.USER,
+        )
     )
     existing = list((await session.exec(existing_stmt)).all())
-    existing_by_user = {row.user_id: row for row in existing}
-    desired = set(user_ids)
+    existing_by_principal = {row.principal_id: row for row in existing}
 
-    for user_id, row in existing_by_user.items():
-        if user_id not in desired:
+    for principal_id, row in existing_by_principal.items():
+        if principal_id not in desired_principal_ids:
             await session.delete(row)
 
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
-    for user_id in desired:
-        if user_id in existing_by_user:
+    for principal_id in desired_principal_ids:
+        if principal_id in existing_by_principal:
             continue
         session.add(
             ModelRoutePrincipalLink(
                 route_id=route_id,
-                user_id=user_id,
-                principal=f"user:{user_id}",
-                created_at=now,
-                updated_at=now,
+                principal_id=principal_id,
             )
         )
 

--- a/gpustack/routes/organization_members.py
+++ b/gpustack/routes/organization_members.py
@@ -1,7 +1,7 @@
 """Organization membership management.
 
 These routes are nested under /organizations/{org_id}/members. Both the
-platform admin and any Org admin can manage memberships. The last admin
+platform admin and any Org owner can manage memberships. The last owner
 of an Org cannot be demoted or removed — that would leave the Org
 without anyone able to manage members or infra.
 
@@ -41,7 +41,7 @@ router = APIRouter()
 
 class MembershipCreate(BaseModel):
     user_id: int
-    role: OrgRole = OrgRole.USER
+    role: OrgRole = OrgRole.MEMBER
 
 
 class MembershipUpdate(BaseModel):
@@ -49,7 +49,7 @@ class MembershipUpdate(BaseModel):
 
 
 def _can_manage(ctx, org_id: int) -> bool:
-    """Platform admin can manage any Org's memberships; an Org admin
+    """Platform admin can manage any Org's memberships; an Org owner
     can only manage their own Org. The role check is bound to the
     target Org from the URL path — ``ctx.org_role`` reflects the
     caller's *current* Org context, which may not match the path when
@@ -60,7 +60,7 @@ def _can_manage(ctx, org_id: int) -> bool:
         return True
     if ctx.current_principal_id != org_id:
         return False
-    return ctx.org_role == OrgRole.ADMIN
+    return ctx.org_role == OrgRole.OWNER
 
 
 async def _load_org(session, org_id: int) -> Principal:
@@ -109,12 +109,12 @@ async def _find_membership(
     return (await session.exec(stmt)).first()
 
 
-async def _has_other_admin(
+async def _has_other_owner(
     session, org_principal_id: int, exclude_member_principal_id: int
 ) -> bool:
     stmt = select(PrincipalMembership.id).where(
         PrincipalMembership.parent_principal_id == org_principal_id,
-        PrincipalMembership.role == OrgRole.ADMIN,
+        PrincipalMembership.role == OrgRole.OWNER,
         PrincipalMembership.member_principal_id != exclude_member_principal_id,
         PrincipalMembership.deleted_at.is_(None),
     )
@@ -257,12 +257,12 @@ async def update_org_member(
     if not _can_manage(ctx, org_id):
         raise ForbiddenException(message="Insufficient permission to change role")
 
-    if membership.role == OrgRole.ADMIN and body.role != OrgRole.ADMIN:
-        if not await _has_other_admin(
+    if membership.role == OrgRole.OWNER and body.role != OrgRole.OWNER:
+        if not await _has_other_owner(
             session, org_id, exclude_member_principal_id=user.principal_id
         ):
             raise ConflictException(
-                message="Cannot demote the only admin of this organization"
+                message="Cannot demote the only owner of this organization"
             )
 
     try:
@@ -303,12 +303,12 @@ async def remove_org_member(
     if not _can_manage(ctx, org_id):
         raise ForbiddenException(message="Insufficient permission to remove member")
 
-    if membership.role == OrgRole.ADMIN:
-        if not await _has_other_admin(
+    if membership.role == OrgRole.OWNER:
+        if not await _has_other_owner(
             session, org_id, exclude_member_principal_id=user.principal_id
         ):
             raise ConflictException(
-                message="Cannot remove the only admin of this organization"
+                message="Cannot remove the only owner of this organization"
             )
 
     try:

--- a/gpustack/routes/usage.py
+++ b/gpustack/routes/usage.py
@@ -381,10 +381,10 @@ def _filter_condition(group_by: str, item: UsageFilterItem):
 
 def _can_use_all_scope(user: User, ctx) -> bool:
     """The cross-user (``all``) view is meaningful for platform admin
-    and real Org admin only. Others fall back to ``self``.
+    and real Org owner only. Others fall back to ``self``.
 
-    Personal Org admin doesn't qualify even though their ``org_role``
-    is ADMIN: a Personal Org has exactly one member, so ``all`` would
+    Personal Org owner doesn't qualify even though their ``org_role``
+    is OWNER: a Personal Org has exactly one member, so ``all`` would
     just be ``self`` — and worse, the org_id filter applied for ``all``
     would hide the user's own usage from Platform-shared models, since
     those rows carry the model owner's owner_principal_id, not the
@@ -394,7 +394,7 @@ def _can_use_all_scope(user: User, ctx) -> bool:
         return True
     if ctx is None:
         return False
-    if ctx.org_role != OrgRole.ADMIN:
+    if ctx.org_role != OrgRole.OWNER:
         return False
     return not ctx.current_is_personal_scope
 

--- a/gpustack/routes/user_groups.py
+++ b/gpustack/routes/user_groups.py
@@ -1,4 +1,4 @@
-"""UserGroup management — Org admin+ or platform admin.
+"""UserGroup management — Org owner+ or platform admin.
 
 Groups are GROUP-kind ``Principal`` rows whose ``parent_principal_id``
 points at their owning ORG-principal. Group memberships live in the
@@ -48,7 +48,7 @@ def _can_manage_groups(ctx, org_id: int) -> bool:
         return True
     if ctx.current_principal_id != org_id:
         return False
-    return ctx.org_role == OrgRole.ADMIN
+    return ctx.org_role == OrgRole.OWNER
 
 
 async def _load_org(session, org_id: int) -> Principal:

--- a/gpustack/routes/users.py
+++ b/gpustack/routes/users.py
@@ -112,7 +112,7 @@ async def list_user_memberships(session: SessionDep, id: int):
     return [
         UserMembership(
             organization=OrganizationPublic.from_principal(org),
-            role=membership.role or OrgRole.USER,
+            role=membership.role or OrgRole.MEMBER,
         )
         for membership, org in rows
     ]
@@ -136,7 +136,7 @@ async def create_user(session: SessionDep, user_in: UserCreate):
         # User row + USER-principal go in one transactional helper —
         # ``users.principal_id`` is NOT NULL so the principal must
         # exist first. Admin additionally joins the platform Org as
-        # ADMIN; regular users do NOT auto-join — admin can add them
+        # OWNER; regular users do NOT auto-join — admin can add them
         # later if shared workspace access is needed.
         user = await create_user_with_principal(session, to_create)
         if user.is_admin:
@@ -145,7 +145,7 @@ async def create_user(session: SessionDep, user_in: UserCreate):
                 PrincipalMembership(
                     parent_principal_id=PLATFORM_PRINCIPAL_ID,
                     member_principal_id=user.principal_id,
-                    role=OrgRole.ADMIN,
+                    role=OrgRole.OWNER,
                     created_at=now,
                     updated_at=now,
                 )
@@ -282,7 +282,7 @@ async def update_user_me(
     return user
 
 
-# User-search endpoint accessible to org admins (any) and platform
+# User-search endpoint accessible to org owners (any) and platform
 # admins, so the Add Member picker works without the admin-gated full
 # /users endpoint. Returns the standard UsersPublic page.
 directory_router = APIRouter()
@@ -295,7 +295,7 @@ async def list_user_directory(
     perPage: int = 30,
     search: str = None,
 ):
-    if not ctx.is_platform_admin and ctx.org_role != OrgRole.ADMIN:
+    if not ctx.is_platform_admin and ctx.org_role != OrgRole.OWNER:
         raise ForbiddenException(message="Insufficient permission")
     fuzzy_fields = {}
     if search:

--- a/gpustack/schemas/principals.py
+++ b/gpustack/schemas/principals.py
@@ -64,13 +64,15 @@ class PrincipalType(str, Enum):
 
 
 class OrgRole(str, Enum):
-    # Two-tier Org membership model: ADMIN can manage the Org's infra
-    # (resources, members, settings); USER is a plain consumer. The
+    # Two-tier Org membership model: OWNER can manage the Org's infra
+    # (resources, members, settings); MEMBER is a plain consumer. The
     # platform-wide superuser lives on `users.is_admin` and is distinct
-    # from `OrgRole.ADMIN` — always disambiguate with `is_platform_admin`
-    # vs `org_role == OrgRole.ADMIN` in code.
-    ADMIN = "admin"
-    USER = "user"
+    # from `OrgRole.OWNER` — always disambiguate with `is_platform_admin`
+    # vs `org_role == OrgRole.OWNER` in code. The names intentionally
+    # diverge from the platform admin/user role so the two never get
+    # conflated.
+    OWNER = "owner"
+    MEMBER = "member"
 
 
 class PrincipalBase(SQLModel):

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -247,7 +247,7 @@ async def provision_user_principal(session: AsyncSession, user: User) -> Princip
 
 
 async def provision_bootstrap_admin_orgs(session: AsyncSession, user: User) -> None:
-    """Add the bootstrap admin as ADMIN of the platform Org.
+    """Add the bootstrap admin as OWNER of the platform Org.
 
     Assumes ``user`` already has a ``principal_id`` (created via
     ``create_user_with_principal``). Caller commits.
@@ -257,7 +257,7 @@ async def provision_bootstrap_admin_orgs(session: AsyncSession, user: User) -> N
         PrincipalMembership(
             parent_principal_id=PLATFORM_PRINCIPAL_ID,
             member_principal_id=user.principal_id,
-            role=OrgRole.ADMIN,
+            role=OrgRole.OWNER,
             created_at=now,
             updated_at=now,
         )

--- a/tests/api/test_p2_routes.py
+++ b/tests/api/test_p2_routes.py
@@ -115,17 +115,17 @@ def test_can_manage_platform_admin_always():
 
 
 def test_can_manage_admin_in_org_can_manage():
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.OWNER)
     assert organization_members._can_manage(ctx, 10) is True
 
 
 def test_can_manage_admin_cannot_manage_other_org():
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.OWNER)
     assert organization_members._can_manage(ctx, 99) is False
 
 
 def test_can_manage_member_cannot_manage():
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.USER)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.MEMBER)
     assert organization_members._can_manage(ctx, 10) is False
 
 
@@ -138,17 +138,17 @@ def test_can_manage_groups_admin_passthrough():
 
 
 def test_can_manage_groups_member_blocked():
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.USER)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.MEMBER)
     assert user_groups_route._can_manage_groups(ctx, org_id=10) is False
 
 
 def test_can_manage_groups_admin_role_in_org_passes():
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.OWNER)
     assert user_groups_route._can_manage_groups(ctx, org_id=10) is True
 
 
 def test_can_manage_groups_wrong_org_blocked():
-    ctx = _ctx(current_principal_id=99, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=99, org_role=OrgRole.OWNER)
     assert user_groups_route._can_manage_groups(ctx, org_id=10) is False
 
 
@@ -204,13 +204,13 @@ async def test_delete_org_blocked_when_resources_exist(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_remove_only_admin_blocked(monkeypatch):
+async def test_remove_only_owner_blocked(monkeypatch):
     org = _principal(id=10, name="Acme", slug="acme")
     user = _user_row(id=2, principal_id=200)
     membership = MagicMock(spec=PrincipalMembership)
     membership.parent_principal_id = 10
     membership.member_principal_id = 200
-    membership.role = OrgRole.ADMIN
+    membership.role = OrgRole.OWNER
     membership.deleted_at = None
     monkeypatch.setattr(
         organization_members.Principal,
@@ -229,7 +229,7 @@ async def test_remove_only_admin_blocked(monkeypatch):
     )
     monkeypatch.setattr(
         organization_members,
-        "_has_other_admin",
+        "_has_other_owner",
         AsyncMock(return_value=False),
     )
     ctx = _ctx(is_admin=True)
@@ -240,13 +240,13 @@ async def test_remove_only_admin_blocked(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_demote_only_admin_blocked(monkeypatch):
+async def test_demote_only_owner_blocked(monkeypatch):
     org = _principal(id=10, name="Acme", slug="acme")
     user = _user_row(id=2, principal_id=200)
     membership = MagicMock(spec=PrincipalMembership)
     membership.parent_principal_id = 10
     membership.member_principal_id = 200
-    membership.role = OrgRole.ADMIN
+    membership.role = OrgRole.OWNER
     membership.deleted_at = None
     monkeypatch.setattr(
         organization_members.Principal,
@@ -265,7 +265,7 @@ async def test_demote_only_admin_blocked(monkeypatch):
     )
     monkeypatch.setattr(
         organization_members,
-        "_has_other_admin",
+        "_has_other_owner",
         AsyncMock(return_value=False),
     )
     ctx = _ctx(is_admin=True)
@@ -275,7 +275,7 @@ async def test_demote_only_admin_blocked(monkeypatch):
             ctx=ctx,
             org_id=10,
             user_id=2,
-            body=organization_members.MembershipUpdate(role=OrgRole.USER),
+            body=organization_members.MembershipUpdate(role=OrgRole.MEMBER),
         )
 
 
@@ -370,7 +370,7 @@ async def test_create_group_blocked_for_member(monkeypatch):
         "one_by_id",
         AsyncMock(return_value=org),
     )
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.USER)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.MEMBER)
     with pytest.raises(ForbiddenException):
         await user_groups_route.create_group(
             session=MagicMock(),

--- a/tests/api/test_tenant.py
+++ b/tests/api/test_tenant.py
@@ -140,7 +140,7 @@ async def test_member_uses_team_org_via_header():
     membership = PrincipalMembership(
         member_principal_id=100,
         parent_principal_id=5,
-        role=OrgRole.USER,
+        role=OrgRole.MEMBER,
     )
     session = _session_returning(
         membership,  # _resolve_membership
@@ -158,7 +158,7 @@ async def test_member_uses_team_org_via_header():
 
     assert ctx.is_platform_admin is False
     assert ctx.current_principal_id == 5
-    assert ctx.org_role == OrgRole.USER
+    assert ctx.org_role == OrgRole.MEMBER
     assert ctx.accessible_cluster_ids == {101, 102}
     assert ctx.current_is_personal_scope is False
 
@@ -230,7 +230,7 @@ async def test_api_key_overrides_header():
     membership = PrincipalMembership(
         member_principal_id=100,
         parent_principal_id=42,
-        role=OrgRole.USER,
+        role=OrgRole.MEMBER,
     )
     session = _session_returning(
         membership,
@@ -269,7 +269,7 @@ async def test_require_platform_admin_allows_admin():
 
 @pytest.mark.asyncio
 async def test_require_org_role_admin_passthrough():
-    dep = require_org_role(OrgRole.ADMIN)
+    dep = require_org_role(OrgRole.OWNER)
     ctx = MagicMock()
     ctx.is_platform_admin = True
     assert await dep(ctx) is ctx
@@ -277,7 +277,7 @@ async def test_require_org_role_admin_passthrough():
 
 @pytest.mark.asyncio
 async def test_require_org_role_blocks_when_no_org_context():
-    dep = require_org_role(OrgRole.ADMIN)
+    dep = require_org_role(OrgRole.OWNER)
     ctx = MagicMock()
     ctx.is_platform_admin = False
     ctx.current_principal_id = None
@@ -287,16 +287,16 @@ async def test_require_org_role_blocks_when_no_org_context():
 
 @pytest.mark.asyncio
 async def test_require_org_role_blocks_insufficient_role():
-    dep = require_org_role(OrgRole.ADMIN)
+    dep = require_org_role(OrgRole.OWNER)
 
     def _assert_role(*allowed):
-        if OrgRole.USER not in allowed:
+        if OrgRole.MEMBER not in allowed:
             raise ForbiddenException(message="nope")
 
     ctx = MagicMock()
     ctx.is_platform_admin = False
     ctx.current_principal_id = 1
-    ctx.org_role = OrgRole.USER
+    ctx.org_role = OrgRole.MEMBER
     ctx.assert_org_role = _assert_role
     with pytest.raises(ForbiddenException):
         await dep(ctx)
@@ -304,15 +304,15 @@ async def test_require_org_role_blocks_insufficient_role():
 
 @pytest.mark.asyncio
 async def test_require_org_role_passes_for_matching_role():
-    dep = require_org_role(OrgRole.ADMIN, OrgRole.ADMIN)
+    dep = require_org_role(OrgRole.OWNER, OrgRole.OWNER)
 
     def _assert_role(*allowed):
-        if OrgRole.ADMIN not in allowed:
+        if OrgRole.OWNER not in allowed:
             raise AssertionError("did not pass owner role through")
 
     ctx = MagicMock()
     ctx.is_platform_admin = False
     ctx.current_principal_id = 1
-    ctx.org_role = OrgRole.ADMIN
+    ctx.org_role = OrgRole.OWNER
     ctx.assert_org_role = _assert_role
     assert await dep(ctx) is ctx

--- a/tests/routers/test_workers.py
+++ b/tests/routers/test_workers.py
@@ -237,7 +237,7 @@ def _patch_worker_one_by_id(worker):
 @pytest.mark.asyncio
 async def test_delete_worker_allowed_for_org_admin_in_owning_org():
     worker = _worker(owner_principal_id=10)
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.OWNER)
     session = MagicMock()
 
     with (
@@ -253,7 +253,7 @@ async def test_delete_worker_allowed_for_org_admin_in_owning_org():
 @pytest.mark.asyncio
 async def test_delete_worker_forbidden_for_plain_org_user():
     worker = _worker(owner_principal_id=10)
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.USER)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.MEMBER)
     session = MagicMock()
 
     with _patch_worker_one_by_id(worker):
@@ -265,7 +265,7 @@ async def test_delete_worker_forbidden_for_plain_org_user():
 async def test_delete_worker_returns_not_found_for_other_org():
     """Cross-org access must 404, not 403, to avoid leaking row existence."""
     worker = _worker(owner_principal_id=10)
-    ctx = _ctx(current_principal_id=99, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=99, org_role=OrgRole.OWNER)
     session = MagicMock()
 
     with _patch_worker_one_by_id(worker):
@@ -276,10 +276,10 @@ async def test_delete_worker_returns_not_found_for_other_org():
 @pytest.mark.asyncio
 async def test_delete_worker_on_globally_shared_cluster_requires_platform_admin():
     """Workers on a global cluster (owner is None) shared via cluster_access
-    are visible to the recipient Org admin but not writable — only platform
+    are visible to the recipient Org owner but not writable — only platform
     admin may mutate global rows."""
     worker = _worker(owner_principal_id=None)
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.OWNER)
     ctx.accessible_cluster_ids = {worker.cluster_id}
     session = MagicMock()
 
@@ -324,7 +324,7 @@ async def test_delete_already_soft_deleted_worker_returns_not_found():
 @pytest.mark.asyncio
 async def test_update_worker_allowed_for_org_admin_in_owning_org():
     worker = _worker(owner_principal_id=10)
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.OWNER)
     session = MagicMock()
     worker_in = WorkerUpdate(name="test-worker", maintenance=None)
 
@@ -344,7 +344,7 @@ async def test_update_worker_allowed_for_org_admin_in_owning_org():
 @pytest.mark.asyncio
 async def test_update_worker_forbidden_for_plain_org_user():
     worker = _worker(owner_principal_id=10)
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.USER)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.MEMBER)
     session = MagicMock()
     worker_in = WorkerUpdate(name="test-worker", maintenance=None)
 
@@ -359,7 +359,7 @@ async def test_update_worker_forbidden_for_plain_org_user():
 async def test_get_worker_privatekey_forbidden_for_plain_org_user():
     """Private key is a write-class secret — same gate as delete/update."""
     worker = _worker(owner_principal_id=10)
-    ctx = _ctx(current_principal_id=10, org_role=OrgRole.USER)
+    ctx = _ctx(current_principal_id=10, org_role=OrgRole.MEMBER)
     session = MagicMock()
 
     with _patch_worker_one_by_id(worker):
@@ -370,7 +370,7 @@ async def test_get_worker_privatekey_forbidden_for_plain_org_user():
 @pytest.mark.asyncio
 async def test_get_worker_privatekey_returns_not_found_for_other_org():
     worker = _worker(owner_principal_id=10)
-    ctx = _ctx(current_principal_id=99, org_role=OrgRole.ADMIN)
+    ctx = _ctx(current_principal_id=99, org_role=OrgRole.OWNER)
     session = MagicMock()
 
     with _patch_worker_one_by_id(worker):


### PR DESCRIPTION
ModelRoutePrincipalLink dropped user_id/principal columns in favor of a single principal_id FK into principals, so listing/replacing a route's user ACL was crashing on AttributeError: user_id when opening Access Settings. Hop through principals (kind == USER) and resolve User via User.principal_id instead.