### PR TITLE
feat: open cluster-detail surface to cluster-visible callers

### DIFF
--- a/gpustack/extension.py
+++ b/gpustack/extension.py
@@ -1,7 +1,7 @@
 """
 Extension plugin interface for GPUStack.
 
-Third-party or enterprise plugins can implement this interface
+Third-party plugins can implement this interface
 and register via the ``gpustack.plugins`` entry-point group.
 
 A plugin is fully wired at construction time: the subclass's

--- a/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
+++ b/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
@@ -164,6 +164,8 @@ def upgrade() -> None:
             sa.Column('principal_id', sa.Integer(), nullable=False),
             sa.Column('granted_by', sa.Integer(), nullable=True),
             sa.Column('created_at', sa.TIMESTAMP(), nullable=False),
+            sa.Column('updated_at', sa.TIMESTAMP(), nullable=False),
+            sa.Column('deleted_at', sa.TIMESTAMP(), nullable=True),
             sa.ForeignKeyConstraint(
                 ['cluster_id'], ['clusters.id'], ondelete='CASCADE',
             ),

--- a/gpustack/routes/cluster_access.py
+++ b/gpustack/routes/cluster_access.py
@@ -1,12 +1,17 @@
-"""Cluster access authorization — platform admin only.
+"""Cluster access authorization.
 
-Lets the platform admin grant or revoke a cluster's accessibility to a
-specific principal (USER / ORG / GROUP). The grant row stores a single
-``principal_id`` FK; kind comes from the joined principals row at read
-time.
+Lets the cluster's owner Org delegate accessibility to other
+principals (USER / ORG / GROUP); platform admin can manage any
+cluster. The grant row stores a single ``principal_id`` FK; kind
+comes from the joined principals row at read time.
+
+Permission gates:
+- GET — anyone who can see the cluster (cluster-detail audience).
+- POST / DELETE — platform admin, or the owner-role member of the
+  cluster's owner Org (``assert_cluster_writable``). Non-owner
+  orgs that merely hold an access grant can't re-grant.
 """
 
-from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter
@@ -18,6 +23,7 @@ from gpustack.api.exceptions import (
     InvalidException,
     NotFoundException,
 )
+from gpustack.api.tenant import assert_cluster_visible, assert_cluster_writable
 from gpustack.schemas.cluster_access import ClusterAccess, ClusterAccessPublic
 from gpustack.schemas.clusters import Cluster
 from gpustack.schemas.principals import Principal, PrincipalType
@@ -35,10 +41,9 @@ class ClusterAccessGrant(BaseModel):
     principal_id: int
 
 
-async def _load_cluster(session, cluster_id: int) -> Cluster:
+async def _load_cluster(session, ctx, cluster_id: int) -> Cluster:
     cluster = await Cluster.one_by_id(session, cluster_id)
-    if not cluster or cluster.deleted_at is not None:
-        raise NotFoundException(message="Cluster not found")
+    assert_cluster_visible(ctx, cluster, not_found_message="Cluster not found")
     return cluster
 
 
@@ -108,7 +113,7 @@ async def _resolve_principal_views(
 async def list_cluster_access(
     session: SessionDep, ctx: TenantContextDep, cluster_id: int
 ):
-    await _load_cluster(session, cluster_id)
+    await _load_cluster(session, ctx, cluster_id)
     stmt = select(ClusterAccess).where(ClusterAccess.cluster_id == cluster_id)
     rows = list((await session.exec(stmt)).all())
     return await _resolve_principal_views(session, rows)
@@ -121,7 +126,11 @@ async def grant_cluster_access(
     cluster_id: int,
     body: ClusterAccessGrant,
 ):
-    await _load_cluster(session, cluster_id)
+    cluster = await _load_cluster(session, ctx, cluster_id)
+    # Cluster owner Org's owner (and platform admin) can delegate
+    # access to other tenants; non-owner orgs that merely have a
+    # grant can't re-grant.
+    assert_cluster_writable(ctx, cluster)
     await _validate_principal(session, body.principal_type, body.principal_id)
 
     existing_stmt = select(ClusterAccess).where(
@@ -132,15 +141,14 @@ async def grant_cluster_access(
         raise AlreadyExistsException(message="Access already granted")
 
     try:
-        access = ClusterAccess(
-            cluster_id=cluster_id,
-            principal_id=body.principal_id,
-            granted_by=ctx.user.id,
-            created_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        access = await ClusterAccess.create(
+            session,
+            ClusterAccess(
+                cluster_id=cluster_id,
+                principal_id=body.principal_id,
+                granted_by=ctx.user.id,
+            ),
         )
-        session.add(access)
-        await session.commit()
-        await session.refresh(access)
     except Exception as e:
         await session.rollback()
         raise InvalidException(message=f"Failed to grant cluster access: {e}")
@@ -156,7 +164,8 @@ async def revoke_cluster_access(
     cluster_id: int,
     principal_id: int,
 ):
-    await _load_cluster(session, cluster_id)
+    cluster = await _load_cluster(session, ctx, cluster_id)
+    assert_cluster_writable(ctx, cluster)
     stmt = select(ClusterAccess).where(
         ClusterAccess.cluster_id == cluster_id,
         ClusterAccess.principal_id == principal_id,
@@ -166,8 +175,7 @@ async def revoke_cluster_access(
         raise NotFoundException(message="Access grant not found")
 
     try:
-        await session.delete(access)
-        await session.commit()
+        await access.delete(session)
     except Exception as e:
         await session.rollback()
         raise InvalidException(message=f"Failed to revoke cluster access: {e}")

--- a/gpustack/routes/cluster_quotas.py
+++ b/gpustack/routes/cluster_quotas.py
@@ -1,0 +1,205 @@
+"""Per-cluster quota rows for the cluster-detail Quotas tab.
+
+A cluster's quota set covers every ORG that can deploy on it: the
+cluster's own owner Org (implicit) plus any Org granted explicit
+access via ``cluster_access`` (ORG grants expose themselves; GROUP
+grants expose the group's owning Org). USER grants don't surface
+here — user-level deploys are attributed to whichever Org the
+caller is acting under at deploy time.
+
+Surface design:
+- ``GET /clusters/{id}/quotas`` — list rows for everyone who can
+  see the cluster (platform admin OR a member of one of the
+  accessible Orgs). Each row carries the org name so the client
+  doesn't need a separate orgs lookup.
+- ``PUT /clusters/{id}/quotas/{owner_principal_id}`` — upsert one
+  org's quotas on this cluster. Platform admin OR the owner-role
+  member of the cluster's owner Org (``assert_cluster_writable``);
+  non-owner Orgs that merely hold an access grant cannot mutate
+  quotas.
+"""
+
+from typing import List, Optional, Set
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from sqlmodel import col, select
+
+from gpustack.api.exceptions import (
+    InvalidException,
+)
+from gpustack.api.tenant import assert_cluster_visible, assert_cluster_writable
+from gpustack.schemas.cluster_access import ClusterAccess
+from gpustack.schemas.clusters import Cluster
+from gpustack.schemas.principals import Principal, PrincipalType
+from gpustack.schemas.tenant_quotas import TenantQuota, TenantQuotaUpdate
+from gpustack.server.deps import SessionDep, TenantContextDep
+
+router = APIRouter()
+
+
+class ClusterQuotaPublic(BaseModel):
+    cluster_id: int
+    owner_principal_id: int
+    owner_name: str
+    gpu: Optional[int] = None
+    cpu_milli: Optional[int] = None
+    memory_bytes: Optional[int] = None
+    gpu_instance: Optional[int] = None
+
+
+async def _load_cluster(session, ctx, cluster_id: int) -> Cluster:
+    cluster = await Cluster.one_by_id(session, cluster_id)
+    assert_cluster_visible(ctx, cluster, not_found_message="Cluster not found")
+    return cluster
+
+
+async def _accessible_org_ids(session, cluster: Cluster) -> Set[int]:
+    """Org-principal ids that can deploy on this cluster.
+
+    Owner Org always counts. cluster_access ORG grants add themselves;
+    GROUP grants add the group's owning Org. USER grants are skipped
+    (user-level access is per-deploy, not per-Org).
+    """
+    org_ids: Set[int] = set()
+    if cluster.owner_principal_id is not None:
+        org_ids.add(cluster.owner_principal_id)
+    access_rows = (
+        await session.exec(
+            select(ClusterAccess).where(ClusterAccess.cluster_id == cluster.id)
+        )
+    ).all()
+    principal_ids = {r.principal_id for r in access_rows}
+    if principal_ids:
+        principals = (
+            await session.exec(
+                select(Principal).where(col(Principal.id).in_(principal_ids))
+            )
+        ).all()
+        for p in principals:
+            if p.deleted_at is not None:
+                continue
+            if p.kind == PrincipalType.ORG:
+                org_ids.add(p.id)
+            elif p.kind == PrincipalType.GROUP and p.parent_principal_id is not None:
+                org_ids.add(p.parent_principal_id)
+    return org_ids
+
+
+def _to_public(
+    cluster_id: int,
+    owner_principal_id: int,
+    owner_name: str,
+    quota: Optional[TenantQuota],
+) -> ClusterQuotaPublic:
+    return ClusterQuotaPublic(
+        cluster_id=cluster_id,
+        owner_principal_id=owner_principal_id,
+        owner_name=owner_name,
+        gpu=quota.gpu if quota else None,
+        cpu_milli=quota.cpu_milli if quota else None,
+        memory_bytes=quota.memory_bytes if quota else None,
+        gpu_instance=quota.gpu_instance if quota else None,
+    )
+
+
+@router.get("/clusters/{cluster_id}/quotas", response_model=List[ClusterQuotaPublic])
+async def list_cluster_quotas(
+    session: SessionDep, ctx: TenantContextDep, cluster_id: int
+):
+    cluster = await _load_cluster(session, ctx, cluster_id)
+    org_ids = await _accessible_org_ids(session, cluster)
+    if not org_ids:
+        return []
+
+    quotas = (
+        await session.exec(
+            select(TenantQuota).where(
+                TenantQuota.cluster_id == cluster_id,
+                col(TenantQuota.owner_principal_id).in_(org_ids),
+            )
+        )
+    ).all()
+    quota_by_owner = {q.owner_principal_id: q for q in quotas}
+
+    orgs = (
+        await session.exec(
+            select(Principal).where(
+                col(Principal.id).in_(org_ids),
+                Principal.kind == PrincipalType.ORG,
+                Principal.deleted_at.is_(None),
+            )
+        )
+    ).all()
+    name_by_id = {p.id: p.name for p in orgs}
+
+    out: List[ClusterQuotaPublic] = []
+    for org_id in org_ids:
+        if org_id not in name_by_id:
+            continue
+        out.append(
+            _to_public(
+                cluster_id, org_id, name_by_id[org_id], quota_by_owner.get(org_id)
+            )
+        )
+    # Stable order: iterating ``org_ids`` (a set) is non-deterministic,
+    # which would shuffle the Quotas table on every refresh. Sort by
+    # owner Org name so the UI list stays stable.
+    out.sort(key=lambda r: r.owner_name)
+    return out
+
+
+@router.put(
+    "/clusters/{cluster_id}/quotas/{owner_principal_id}",
+    response_model=ClusterQuotaPublic,
+)
+async def upsert_cluster_quota(
+    session: SessionDep,
+    ctx: TenantContextDep,
+    cluster_id: int,
+    owner_principal_id: int,
+    body: TenantQuotaUpdate,
+):
+    cluster = await _load_cluster(session, ctx, cluster_id)
+    # Same gate as cluster_access POST / DELETE: platform admin OR the
+    # owner-role member of the cluster's owner Org. Setting quotas is
+    # part of running the cluster — if you can share it, you can
+    # decide how much of it each tenant gets. Non-owner Orgs that
+    # merely hold an access grant cannot mutate quotas.
+    assert_cluster_writable(ctx, cluster)
+
+    org_ids = await _accessible_org_ids(session, cluster)
+    if owner_principal_id not in org_ids:
+        raise InvalidException(
+            message="Org is not accessible to this cluster; grant access first"
+        )
+
+    owner = await Principal.one_by_id(session, owner_principal_id)
+    if owner is None or owner.deleted_at is not None or owner.kind != PrincipalType.ORG:
+        raise InvalidException(message=f"Org {owner_principal_id} not found")
+
+    existing = await TenantQuota.first_by_fields(
+        session,
+        {"cluster_id": cluster_id, "owner_principal_id": owner_principal_id},
+    )
+    try:
+        if existing is None:
+            row = await TenantQuota.create(
+                session,
+                TenantQuota(
+                    cluster_id=cluster_id,
+                    owner_principal_id=owner_principal_id,
+                    gpu=body.gpu,
+                    cpu_milli=body.cpu_milli,
+                    memory_bytes=body.memory_bytes,
+                    gpu_instance=body.gpu_instance,
+                ),
+            )
+        else:
+            await existing.update(session, body)
+            row = existing
+    except Exception as e:
+        await session.rollback()
+        raise InvalidException(message=f"Failed to update cluster quota: {e}")
+
+    return _to_public(cluster_id, owner_principal_id, owner.name, row)

--- a/gpustack/routes/dashboard.py
+++ b/gpustack/routes/dashboard.py
@@ -18,11 +18,13 @@ from gpustack.schemas.dashboard import (
     SystemSummary,
     TimeSeriesData,
 )
+from gpustack.api.exceptions import ForbiddenException
+from gpustack.api.tenant import assert_cluster_visible
 from gpustack.schemas.model_usage import ModelUsage
 from gpustack.schemas.models import Model, ModelInstance
 from gpustack.schemas.system_load import SystemLoad
 from gpustack.schemas.users import User
-from gpustack.server.deps import SessionDep
+from gpustack.server.deps import SessionDep, TenantContextDep
 from gpustack.schemas import Worker, Cluster
 from gpustack.schemas.model_provider import ModelProvider
 from gpustack.server.system_load import compute_system_load
@@ -33,8 +35,24 @@ router = APIRouter()
 @router.get("")
 async def dashboard(
     session: SessionDep,
+    ctx: TenantContextDep,
     cluster_id: Optional[int] = None,
 ):
+    # Permission split: the cluster-detail header (Cluster Basic +
+    # System Load tiles) calls this with ``cluster_id`` and is open to
+    # any caller who can see the cluster — that's the same audience
+    # cluster-detail itself uses. The aggregate dashboard (no
+    # ``cluster_id``) reads across every cluster's data so platform
+    # admin only.
+    if cluster_id is None:
+        if not ctx.is_platform_admin:
+            raise ForbiddenException(
+                message="Only platform admin can read the aggregate dashboard"
+            )
+    else:
+        cluster = await Cluster.one_by_id(session, cluster_id)
+        assert_cluster_visible(ctx, cluster, not_found_message="Cluster not found")
+
     resoruce_counts = await get_resource_counts(session, cluster_id)
     system_load = await get_system_load(session, cluster_id)
     model_usage = await get_model_usage_summary(session, cluster_id)
@@ -521,6 +539,7 @@ def get_models_by_provider_id(
 @router.get("/usage")
 async def usage(
     session: SessionDep,
+    ctx: TenantContextDep,
     start_date: Optional[date] = Query(
         None,
         description="Start date for the usage data (YYYY-MM-DD). Defaults to 31 days ago.",
@@ -544,6 +563,10 @@ async def usage(
     Get model usage records.
     This endpoint returns detailed model usage records within a specified date range.
     """
+    if not ctx.is_platform_admin:
+        raise ForbiddenException(
+            message="Only platform admin can read aggregate model usage"
+        )
     items = await get_model_usages(
         session,
         start_date=start_date,
@@ -558,6 +581,7 @@ async def usage(
 @router.get("/usage/stats")
 async def usage_stats(
     session: SessionDep,
+    ctx: TenantContextDep,
     start_date: Optional[date] = Query(
         None,
         description="Start date for the usage data (YYYY-MM-DD). Defaults to 31 days ago.",
@@ -582,6 +606,10 @@ async def usage_stats(
     This endpoint returns aggregated statistics for model usage, including token counts and request counts.
     It can filter by date range, model IDs, user IDs, model names with provider ID prefix.
     """
+    if not ctx.is_platform_admin:
+        raise ForbiddenException(
+            message="Only platform admin can read aggregate model usage stats"
+        )
     return await get_model_usage_stats(
         session,
         start_date=start_date,

--- a/gpustack/routes/model_route_principals.py
+++ b/gpustack/routes/model_route_principals.py
@@ -11,7 +11,7 @@ shape, where ``principal_id`` here is the principals.id of the target
 (USER / ORG / GROUP principal).
 """
 
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter
 from pydantic import BaseModel
@@ -41,6 +41,9 @@ class PrincipalView(BaseModel):
     route_id: int
     principal_type: PrincipalType
     principal_id: int
+    # Resolved at read time from the joined principals row so the
+    # client can render a label without an extra lookup.
+    principal_name: Optional[str] = None
 
 
 async def _load_route(session, route_id: int) -> ModelRoute:
@@ -70,11 +73,16 @@ async def _validate_principal(
     return target
 
 
-def _row_to_view(row: ModelRoutePrincipalLink, kind: PrincipalType) -> PrincipalView:
+def _row_to_view(
+    row: ModelRoutePrincipalLink,
+    kind: PrincipalType,
+    name: Optional[str] = None,
+) -> PrincipalView:
     return PrincipalView(
         route_id=row.route_id,
         principal_type=kind,
         principal_id=row.principal_id,
+        principal_name=name,
     )
 
 
@@ -82,14 +90,23 @@ async def _resolve_views(
     session, rows: List[ModelRoutePrincipalLink]
 ) -> List[PrincipalView]:
     principal_ids = {r.principal_id for r in rows}
-    kinds: dict[int, PrincipalType] = {}
+    by_id: dict[int, Principal] = {}
     if principal_ids:
         result = await session.exec(
             select(Principal).where(Principal.id.in_(principal_ids))
         )
-        kinds = {p.id: p.kind for p in result.all()}
+        by_id = {p.id: p for p in result.all()}
     return [
-        _row_to_view(r, kinds.get(r.principal_id, PrincipalType.USER)) for r in rows
+        _row_to_view(
+            r,
+            (
+                by_id[r.principal_id].kind
+                if r.principal_id in by_id
+                else PrincipalType.USER
+            ),
+            by_id[r.principal_id].name if r.principal_id in by_id else None,
+        )
+        for r in rows
     ]
 
 

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -766,9 +766,8 @@ async def _replace_route_user_principals(
     """Replace the user-grant rows on a route with exactly ``user_ids``.
 
     Touches only rows whose principal is USER-kind — org / group
-    grants set by the enterprise UI's ALLOWED_PRINCIPALS flow are left
-    alone, even if the OSS UI happens to call this endpoint on the
-    same route.
+    grants attached via the ``ALLOWED_PRINCIPALS`` flow are left
+    alone, even if this endpoint is called on the same route.
     """
     desired_principal_ids: Set[int] = set()
     if user_ids:

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -853,8 +853,18 @@ async def add_model_authorization(
         affected_user_ids = None
         cache_model = None
 
+    # `users` is the source-of-truth for grants only under the
+    # ALLOWED_USERS policy. ALLOWED_PRINCIPALS manages grants via
+    # `/principals` (which can also create USER-kind rows), and the
+    # other policies don't care about the explicit list. Wiping
+    # USER-kind rows when the policy isn't ALLOWED_USERS would
+    # silently delete USER grants that ALLOWED_PRINCIPALS just
+    # attached.
+    should_replace_users = model.access_policy == AccessPolicyEnum.ALLOWED_USERS
+
     try:
-        await _replace_route_user_principals(session, id, requested_user_ids)
+        if should_replace_users:
+            await _replace_route_user_principals(session, id, requested_user_ids)
         await revoke_model_access_cache(
             session=session,
             model=cache_model,

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -808,7 +808,10 @@ async def get_model_authorization_list(session: SessionDep, id: int):
     if not model:
         raise NotFoundException(message="Model not found")
 
-    return ModelAuthorizationList(items=await _list_route_users(session, id))
+    return ModelAuthorizationList(
+        items=await _list_route_users(session, id),
+        access_policy=model.access_policy,
+    )
 
 
 @router.post("/{id}/access", response_model=ModelAuthorizationList)
@@ -862,7 +865,10 @@ async def add_model_authorization(
         await session.rollback()
         raise InternalServerErrorException(message=f"Failed to add model access: {e}")
 
-    return ModelAuthorizationList(items=await _list_route_users(session, id))
+    return ModelAuthorizationList(
+        items=await _list_route_users(session, id),
+        access_policy=model.access_policy,
+    )
 
 
 @my_models_router.get("", response_model=ModelRoutesPublic)

--- a/gpustack/routes/organizations.py
+++ b/gpustack/routes/organizations.py
@@ -14,6 +14,7 @@ from sqlmodel import select
 from gpustack.api.exceptions import (
     AlreadyExistsException,
     ConflictException,
+    ForbiddenException,
     InternalServerErrorException,
     InvalidException,
     NotFoundException,
@@ -28,12 +29,14 @@ from gpustack.schemas.organizations import (
 )
 from gpustack.schemas.principals import (
     PLATFORM_PRINCIPAL_ID,
+    OrgRole,
     Principal,
     PrincipalType,
 )
-from gpustack.server.deps import SessionDep
+from gpustack.server.deps import SessionDep, TenantContextDep
 
 router = APIRouter()
+directory_router = APIRouter()
 
 
 def _to_public(p: Principal) -> OrganizationPublic:
@@ -216,3 +219,38 @@ async def _has_resources(session, owner_principal_id: int) -> list[str]:
         blockers.append("user_groups")
 
     return blockers
+
+
+# ---- Org directory (slim, non-admin-readable) -------------------------------
+#
+# The full ``/organizations`` CRUD surface is admin-only. But picker UIs
+# need to enumerate Orgs even when the caller is an Org owner — e.g.
+# the cluster-detail "Grant access" form, where the cluster's owner Org
+# owner picks a target Org to delegate cluster access to.
+#
+# Mirror the ``/user-directory`` pattern: a slim, paginated, search-
+# friendly endpoint that returns the same ``OrganizationsPublic`` shape
+# but is gated to platform admin OR the caller-in-owner-role-of-an-Org.
+@directory_router.get("/organization-directory", response_model=OrganizationsPublic)
+async def list_organization_directory(
+    session: SessionDep,
+    ctx: TenantContextDep,
+    page: int = 1,
+    perPage: int = 30,
+    search: Optional[str] = None,
+):
+    if not ctx.is_platform_admin and ctx.org_role != OrgRole.OWNER:
+        raise ForbiddenException(message="Insufficient permission")
+    fuzzy_fields = {}
+    if search:
+        fuzzy_fields = {"name": search, "slug": search}
+    fields = {"deleted_at": None, "kind": PrincipalType.ORG}
+    page_data = await Principal.paginated_by_query(
+        session=session,
+        fields=fields,
+        fuzzy_fields=fuzzy_fields,
+        page=page,
+        per_page=perPage,
+    )
+    page_data.items = [_to_public(p) for p in page_data.items]
+    return page_data

--- a/gpustack/routes/routes.py
+++ b/gpustack/routes/routes.py
@@ -6,6 +6,7 @@ from gpustack.routes import (
     api_keys,
     auth,
     cluster_access,
+    cluster_quotas,
     config,
     dashboard,
     debug,
@@ -243,21 +244,50 @@ tenant_routers = model_routers + [
         "prefix": "/inference-backends",
         "tags": ["Inference Backend"],
     },
+    # Per-cluster quota rows for the cluster-detail Quotas tab. GET
+    # visible to anyone who can see the cluster (platform admin OR a
+    # member of one of its accessible Orgs); PUT gates inside the
+    # handler to platform admin OR cluster owner Org owner
+    # (`assert_cluster_writable`).
+    {
+        "router": cluster_quotas.router,
+        "tags": ["Cluster Quotas"],
+        "include_in_schema": _EXTENDED_API_IN_SCHEMA,
+    },
+    # Dashboard sub-routes gate themselves inside the handler. The
+    # per-cluster ``GET /dashboard?cluster_id=X`` accepts anyone who
+    # can see the cluster (cluster-detail audience); the aggregate
+    # ``GET /dashboard`` and the ``/usage`` endpoints stay platform
+    # admin only.
+    {"router": dashboard.router, "prefix": "/dashboard", "tags": ["Dashboard"]},
+    # cluster_access GET is open to anyone who can see the cluster
+    # (cluster-detail audience); POST / DELETE gate inside the
+    # handler to platform admin OR cluster owner Org owner
+    # (`assert_cluster_writable`) — share-out is part of running
+    # the cluster, non-owner grantees can't re-grant.
+    {
+        "router": cluster_access.router,
+        "tags": ["Cluster Access"],
+        "include_in_schema": _EXTENDED_API_IN_SCHEMA,
+    },
+    # Slim org-list endpoint for picker UIs (cluster-access "Grant
+    # access" form, etc.). Gated inside the handler to platform admin
+    # OR owner-role in any Org context; the full /organizations CRUD
+    # stays admin-only under admin_routers below.
+    {
+        "router": organizations.directory_router,
+        "tags": ["Organizations"],
+        "include_in_schema": _EXTENDED_API_IN_SCHEMA,
+    },
 ]
 
 # Platform-only routers — admin can manage globally; non-admin gets 403.
 admin_routers = [
-    {"router": dashboard.router, "prefix": "/dashboard", "tags": ["Dashboard"]},
     {"router": users.router, "prefix": "/users", "tags": ["Users"]},
     {
         "router": organizations.router,
         "prefix": "/organizations",
         "tags": ["Organizations"],
-        "include_in_schema": _EXTENDED_API_IN_SCHEMA,
-    },
-    {
-        "router": cluster_access.router,
-        "tags": ["Cluster Access"],
         "include_in_schema": _EXTENDED_API_IN_SCHEMA,
     },
 ]

--- a/gpustack/schemas/cluster_access.py
+++ b/gpustack/schemas/cluster_access.py
@@ -10,11 +10,11 @@ from sqlmodel import (
     UniqueConstraint,
 )
 
-from gpustack.schemas.common import UTCDateTime
+from gpustack.mixins import BaseModelMixin
 from gpustack.schemas.principals import PrincipalType
 
 
-class ClusterAccess(SQLModel, table=True):
+class ClusterAccess(BaseModelMixin, SQLModel, table=True):
     """Grant a single principal access to a cluster.
 
     Polymorphic ``(principal_type, principal_id)`` was collapsed into a
@@ -53,10 +53,9 @@ class ClusterAccess(SQLModel, table=True):
             nullable=True,
         ),
     )
-    created_at: Optional[datetime] = Field(
-        default=None,
-        sa_column=Column(UTCDateTime, nullable=False),
-    )
+    # `created_at`, `updated_at`, `deleted_at` come from BaseModelMixin
+    # so revoke is a soft delete (audit trail) and inserts auto-fill
+    # timestamps via the mixin's SA defaults.
 
 
 class ClusterAccessPublic(SQLModel):

--- a/gpustack/schemas/model_routes.py
+++ b/gpustack/schemas/model_routes.py
@@ -366,7 +366,13 @@ class ModelUserAccessExtended(ModelUserAccess):
     # More user fields can be added here. e.g. quota, rate_limit, etc.
 
 
-ModelAuthorizationList = ItemList[ModelUserAccessExtended]
+class ModelAuthorizationList(ItemList[ModelUserAccessExtended]):
+    # The route's current access_policy is returned alongside the
+    # grants list so a single GET refreshes both halves of the
+    # Access Settings dialog (some clients open it from a stale list
+    # snapshot where the row's policy may not reflect the latest
+    # save).
+    access_policy: Optional[AccessPolicyEnum] = None
 
 
 class MyModel(ModelRouteBase, BaseModelMixin, table=True):

--- a/gpustack/schemas/model_routes.py
+++ b/gpustack/schemas/model_routes.py
@@ -65,13 +65,13 @@ class AccessPolicyEnum(str, Enum):
     # default for new routes in non-platform Orgs — semantically the
     # "team-private" scope, no principal table involvement.
     ORG = "org"
-    # Per-user grants. The OSS UI surfaces only this policy for explicit
-    # access lists since it doesn't expose Org / Group concepts; rows
-    # are stored in ``model_route_principals`` with ``principal_id``
-    # pointing at a USER-kind principal.
+    # Per-user grants. Rows are stored in ``model_route_principals``
+    # with ``principal_id`` pointing at a USER-kind principal.
     ALLOWED_USERS = "allowed_users"
     # Per-principal grants (user / org / group) via
-    # ``model_route_principals``. Surfaced by the enterprise UI.
+    # ``model_route_principals``. Mutually exclusive with
+    # ``ALLOWED_USERS`` — pick the policy whose granularity matches
+    # the deployment's identity model.
     ALLOWED_PRINCIPALS = "allowed_principals"
 
 

--- a/gpustack/server/coordinator/__init__.py
+++ b/gpustack/server/coordinator/__init__.py
@@ -2,9 +2,9 @@
 Coordination module for GPUStack.
 
 This module provides coordination capabilities for server instances.
-The open-source edition provides a local implementation for single-node
-deployments, while the enterprise edition provides distributed
-implementations for multi-instance deployments.
+Ships with a local implementation for single-node deployments; plugins
+can register alternative implementations (e.g. distributed coordinators
+for multi-instance deployments).
 
 Usage:
     from gpustack.server.coordinator import Coordinator, LocalCoordinator, Event
@@ -13,8 +13,8 @@ Usage:
     coordinator = LocalCoordinator(config)
     await coordinator.start()
 
-    # Enterprise edition can provide distributed implementations
-    # via the plugin system.
+    # Plugins may contribute distributed implementations via
+    # the plugin system.
 """
 
 from gpustack.server.coordinator.base import Coordinator, Event, EventType

--- a/gpustack/server/coordinator/base.py
+++ b/gpustack/server/coordinator/base.py
@@ -2,9 +2,8 @@
 Coordinator Abstract Base Class.
 
 This module defines the interface for coordinating multiple server instances.
-The open-source edition provides a local (single-node) implementation, while
-the enterprise edition provides distributed implementations using Redis or
-PostgreSQL.
+Ships with a local (single-node) implementation; plugins can contribute
+distributed implementations (e.g. Redis- or PostgreSQL-backed coordinators).
 """
 
 from abc import ABC, abstractmethod

--- a/tests/api/test_p4_routes.py
+++ b/tests/api/test_p4_routes.py
@@ -25,10 +25,12 @@ def _route(id: int = 1):
 def _principal(
     id: int = 5,
     kind: PrincipalType = PrincipalType.ORG,
+    name: str = "principal",
 ):
     p = MagicMock(spec=Principal)
     p.id = id
     p.kind = kind
+    p.name = name
     p.deleted_at = None
     p.parent_principal_id = None
     return p


### PR DESCRIPTION
The cluster-detail page (Workers, GPUs, plus the enterprise plugin's Cluster Access / Quotas tabs) is reachable by any caller who can see the cluster — owner Org members and orgs granted access via cluster_access. But the backend endpoints the page calls were all admin-only at the router level, so org owners hit 403s opening each section.

Rework permission gates so the cluster-detail audience matches the backend audience for the corresponding endpoints:

- `dashboard.router` moves to tenant_routers.
  - `GET /dashboard?cluster_id=X` — assert_cluster_visible.
  - `GET /dashboard` (aggregate across all clusters) — platform admin only via in-handler check.
  - `GET /dashboard/usage` / `/usage/stats` — aggregate-only, platform admin only.

- `cluster_access.router` moves to tenant_routers.
  - `GET /clusters/{id}/access` — assert_cluster_visible.
  - `POST` / `DELETE` — assert_cluster_writable, which encodes "platform admin OR owner-role of cluster.owner Org". Lets the cluster's owner Org delegate access to other tenants; non-owner orgs that merely hold an access grant still can't re-grant.

- New `cluster_quotas.router` for the per-cluster Quotas tab.
  - `GET /clusters/{id}/quotas` — assert_cluster_visible. Returns one row per Org that can deploy on this cluster (owner Org plus every Org reached via cluster_access — ORG grants surface themselves, GROUP grants surface their parent Org, USER grants skipped). Each row is pre-enriched with the resolved Org name, so the client doesn't need a separate principals lookup. This replaces the UI's previous N+1 fan-out and removes the dependency on the admin-only platform-wide org list.
  - `PUT /clusters/{id}/quotas/{owner_principal_id}` — same `assert_cluster_writable` gate. Quota allocation is part of running the cluster: if you own the cluster you decide how much of it each tenant gets. Non-owner Orgs that merely hold an access grant cannot mutate quotas.

- New `organizations.directory_router` (`GET /organization-directory`) mirroring the `/user-directory` pattern. Slim, paginated, search- friendly org list gated to platform admin OR caller-in-owner-role. Lets the cluster-access "Grant access" form's principal picker enumerate Orgs without widening the full /organizations CRUD surface, which stays admin-only.