### PR TITLE
feat: support vllm headless multi-node

### DIFF
--- a/gpustack/policies/candidate_selectors/vllm_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/vllm_resource_fit_selector.py
@@ -39,8 +39,13 @@ from gpustack.utils.command import (
     find_bool_parameter,
     find_parameter,
     find_int_parameter,
+    resolve_executor_backend,
 )
 from gpustack.utils.unit import byte_to_gib
+from gpustack.utils.vllm_topology import (
+    parse_user_parallelism,
+    validate_multinode_topology,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +118,7 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
         )
         dp = find_int_parameter(model.backend_parameters, ["data-parallel-size", "dp"])
         dpl = find_int_parameter(
-            model.backend_parameters, ["--data-parallel-size-local", "dpl"]
+            model.backend_parameters, ["data-parallel-size-local", "dpl"]
         )
 
         if tp or pp or dp:
@@ -128,9 +133,9 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
             if dp:
                 strategies.append("dp")
                 world_size *= dp
-                if dpl:
-                    # NB(thxCode): Indicate how many DP groups(each group owns `-dp` number devices) are there in one worker.
-                    world_size *= dpl
+
+            if dpl:
+                strategies.append("dpl")
 
             return world_size, strategies
 
@@ -632,6 +637,9 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
         worker_count = 0
         device_count_per_worker = 0
 
+        event_message = ListMessageBuilder([])
+        seen_skip_reasons: set[str] = set()
+
         # Loop through worker groups with the same number of GPUs.
         for gpu_count, worker_group in workers_by_gpu_count_dict.items():
             if len(worker_group) < 2:
@@ -677,13 +685,17 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
                         break
 
                 if vram_sum >= self._vram_claim:
-                    return [
-                        _create_candidate(
-                            self._model,
-                            selected_workers,
-                            self._gpu_memory_utilization,
-                        )
-                    ]
+                    candidate, skip_reason = _create_candidate(
+                        self._model,
+                        selected_workers,
+                        self._gpu_memory_utilization,
+                    )
+                    if candidate is None:
+                        if skip_reason and skip_reason not in seen_skip_reasons:
+                            seen_skip_reasons.add(skip_reason)
+                            event_message.append(skip_reason)
+                        continue
+                    return [candidate]
             if vram_sum > largest_vram:
                 workers_combination = selected_workers
                 largest_vram = vram_sum
@@ -691,7 +703,6 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
                 device_count_per_worker = gpu_count
 
         # Nothing can be return, construct scheduling message
-        event_message = ListMessageBuilder([])
         if self._gpu_memory_utilization == 0:
             event_message.append(
                 f"The largest available worker has {byte_to_gib(largest_vram)} GiB of VRAM."
@@ -730,15 +741,75 @@ class VLLMResourceFitSelector(ScheduleCandidatesSelector):
                 msg + " Consider adjusting your tensor-parallel-size value."
             )
 
+        if (
+            resolve_executor_backend(
+                self._model.backend_parameters, self._model.backend_version
+            )
+            == "mp"
+        ):
+            self._validate_native_multinode_arguments()
+
+    def _validate_native_multinode_arguments(self):
+        """
+        Sanity-check user-provided native multi-node parallelism arguments
+        before worker selection. Cross-node-topology invariants (TP divides
+        every node's GPU count, ``workers_per_dp`` fits the cluster, etc.)
+        are enforced later in :func:`cal_multinode_topology` once the
+        deployment metadata is known; here we only catch contradictions
+        detectable from backend_parameters alone.
+        """
+        dp = find_int_parameter(
+            self._model.backend_parameters, ["data-parallel-size", "dp"]
+        )
+        dpl = find_int_parameter(
+            self._model.backend_parameters, ["data-parallel-size-local", "dpl"]
+        )
+
+        if dp is not None and dp <= 0:
+            raise ValueError(
+                f"vLLM multi-node: --data-parallel-size {dp} must be positive."
+            )
+        if dpl is not None and dpl <= 0:
+            raise ValueError(
+                f"vLLM multi-node: --data-parallel-size-local {dpl} must be positive."
+            )
+        if dp is not None and dpl is not None and dp % dpl != 0:
+            raise ValueError(
+                f"vLLM multi-node: --data-parallel-size {dp} must be a multiple "
+                f"of --data-parallel-size-local {dpl}."
+            )
+
 
 def _create_candidate(
     model: Model,
     selected_workers: List[Worker],
     gpu_memory_utilization: float = 0.9,
-) -> ModelInstanceScheduleCandidate:
+) -> Tuple[Optional[ModelInstanceScheduleCandidate], Optional[str]]:
     """
     Create a candidate with all GPUs from the selected workers.
+
+    Returns ``(None, reason)`` when the worker combination fails vLLM's native
+    multi-node topology constraints (e.g. heterogeneous nodes requested for
+    cross-node TP/PP). The outer worker-combination loop skips this group and
+    tries the next one — without raising, because a different combination
+    may still satisfy the requirements.
     """
+    if len(selected_workers) > 1 and (
+        resolve_executor_backend(model.backend_parameters, model.backend_version)
+        == "mp"
+    ):
+        gpu_per_node = [len(w.status.gpu_devices or []) for w in selected_workers]
+        try:
+            validate_multinode_topology(
+                gpu_per_node, parse_user_parallelism(model.backend_parameters)
+            )
+        except ValueError as e:
+            logger.info(
+                f"Skipping worker combination {[w.name for w in selected_workers]} "
+                f"for {model.name}: {e}"
+            )
+            return None, str(e)
+
     main_worker = selected_workers[0]
     vram_claim_main = {
         gpu.index: int(gpu.memory.total * gpu_memory_utilization)
@@ -776,4 +847,4 @@ def _create_candidate(
             )
         )
 
-    return candidate
+    return candidate, None

--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 import aiohttp
 from fastapi import APIRouter, Request, status, HTTPException
 from fastapi.responses import PlainTextResponse, StreamingResponse, RedirectResponse
@@ -10,6 +10,7 @@ from gpustack.api.responses import StreamingResponseWithStatusCode
 from gpustack import envs
 from gpustack.server.services import ModelInstanceService
 from gpustack.server.worker_request import request_to_worker, stream_to_worker
+from gpustack.utils.command import resolve_executor_backend
 from gpustack.worker.logs import LogOptionsDep
 from gpustack.api.exceptions import (
     InternalServerErrorException,
@@ -44,36 +45,47 @@ from gpustack.utils.grafana import resolve_grafana_base_url
 router = APIRouter()
 
 
-# Subordinate-worker display names, keyed by BackendEnum values.
-_SUBORDINATE_DISPLAY_NAMES: Dict[str, str] = {
-    BackendEnum.VLLM: "ray-worker",
-}
+def _is_vllm_ray_subordinate(model_instance: ModelInstance) -> bool:
+    """Whether a vLLM subordinate node is part of the Ray sidecar path.
+
+    Native multi-node (mp) subordinates — regardless of dp_only/mp_only/nested
+    shape — fall through to ``sub-vllm`` because the log viewer doesn't need
+    that level of granularity.
+    """
+    if model_instance.backend != BackendEnum.VLLM:
+        return False
+    model = model_instance.model
+    backend_parameters = model.backend_parameters if model else None
+    backend_version = model.backend_version if model else None
+    return resolve_executor_backend(backend_parameters, backend_version) == "ray"
 
 
-def _default_display_name(backend: Optional[str], is_main_worker: bool) -> str:
+def _default_display_name(model_instance: ModelInstance, is_main_worker: bool) -> str:
     """Resolve the UI display name for the internal 'default' container."""
+    backend = model_instance.backend
+    backend_name = backend.value if hasattr(backend, "value") else backend
     if is_main_worker:
-        return backend or "default"
-    if backend and backend in _SUBORDINATE_DISPLAY_NAMES:
-        return _SUBORDINATE_DISPLAY_NAMES[backend]
+        return backend_name or "default"
+    if _is_vllm_ray_subordinate(model_instance):
+        return "ray-worker"
     # Generic subordinate: "sub-<backend>" or just "subordinate".
-    return f"sub-{backend}" if backend else "subordinate"
+    return f"sub-{backend_name}" if backend_name else "subordinate"
 
 
 def _map_container_display_name(
-    internal_name: str, backend: Optional[str], is_main_worker: bool
+    internal_name: str, model_instance: ModelInstance, is_main_worker: bool
 ) -> str:
     """Forward-map an internal container name to its UI display name."""
     if internal_name != "default":
         return internal_name
-    return _default_display_name(backend, is_main_worker)
+    return _default_display_name(model_instance, is_main_worker)
 
 
 def _unmap_container_display_name(
-    display_name: str, backend: Optional[str], is_main_worker: bool
+    display_name: str, model_instance: ModelInstance, is_main_worker: bool
 ) -> str:
     """Reverse-map a UI display name back to the internal container name."""
-    if display_name == _default_display_name(backend, is_main_worker):
+    if display_name == _default_display_name(model_instance, is_main_worker):
         return "default"
     return display_name
 
@@ -206,7 +218,7 @@ async def get_serving_logs(  # noqa: C901
     if container_name:
         is_main = (worker_id or model_instance.worker_id) == model_instance.worker_id
         container_name = _unmap_container_display_name(
-            container_name, model_instance.backend, is_main
+            container_name, model_instance, is_main
         )
 
     # Build valid worker IDs (main worker + subordinate workers for distributed instances)
@@ -400,7 +412,7 @@ async def get_model_instance_log_options(
         is_main = wo.worker_id == model_instance.worker_id
         for entry in wo.restarts:
             entry.containers = [
-                _map_container_display_name(c, model_instance.backend, is_main)
+                _map_container_display_name(c, model_instance, is_main)
                 for c in entry.containers
             ]
 

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -626,13 +626,14 @@ class ModelInstance(ModelInstanceBase, BaseModelMixin, table=True):
         instance_id: int,
         populate_existing: bool = True,
     ) -> Optional["ModelInstance"]:
-        """Load a model instance with primary/LoRA and draft model_files eagerly loaded."""
+        """Load a model instance with primary/LoRA + draft model_files and model spec eagerly loaded."""
         stmt = (
             select(cls)
             .where(cls.id == instance_id)
             .options(
                 selectinload(cls.model_files),
                 selectinload(cls.draft_model_files),
+                selectinload(cls.model),
             )
         )
         if populate_existing:

--- a/gpustack/utils/command.py
+++ b/gpustack/utils/command.py
@@ -3,8 +3,10 @@ import sys
 import sysconfig
 from os.path import dirname, abspath, join
 import shutil
-from typing import List, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union
 import shlex
+
+from gpustack_runtime.deployer.__utils__ import compare_versions
 
 
 _TRUTHY_VALUES = frozenset({"1", "true", "yes", "on", "t", "y"})
@@ -397,3 +399,54 @@ def flatten_to_argv(parameters: Optional[List[str]]) -> List[str]:
         else:
             tokens.append(stripped)
     return tokens
+
+
+ExecutorBackend = Literal["ray", "mp"]
+
+# vLLM v0.18.0 removed Ray from its default dependencies. Only relevant for
+# user-supplied custom images (see should_default_to_ray for the rationale).
+_VLLM_RAY_DROPPED_FROM_DEFAULTS = "0.18.0"
+
+
+def should_default_to_ray(backend_version: Optional[str]) -> bool:
+    """
+    Whether GPUStack should default to the Ray executor backend when the user
+    does not explicitly choose one.
+
+    gpustack-runner images bundle Ray themselves regardless of vLLM version,
+    so Ray is always available there. The only case where Ray may be absent
+    is user-supplied custom images — identified by a ``-custom`` suffix in
+    ``backend_version`` — running vLLM >= 0.18.0, where upstream dropped Ray
+    from default dependencies. In that case we default to ``mp`` to avoid a
+    startup failure.
+    """
+    if not backend_version or "-custom" not in backend_version:
+        return True
+    try:
+        return compare_versions(backend_version, _VLLM_RAY_DROPPED_FROM_DEFAULTS) < 0
+    except Exception:
+        return True
+
+
+def resolve_executor_backend(
+    backend_parameters: Optional[List[str]],
+    backend_version: Optional[str],
+) -> ExecutorBackend:
+    """
+    Resolve the dispatch branch for vLLM distributed execution.
+
+    Returns ``"ray"`` if GPUStack should take the Ray sidecar path (legacy),
+    ``"mp"`` for the native multi-node headless path (current).
+
+    Precedence:
+    1. User-supplied ``--distributed-executor-backend`` wins. Any explicit value
+       other than ``"mp"`` is routed to the ray branch — GPUStack does not inject
+       its own native topology arguments and leaves the choice to vLLM.
+    2. Otherwise the default depends on ``backend_version`` via
+       :func:`should_default_to_ray`.
+    """
+    user_value = find_parameter(backend_parameters, ["distributed-executor-backend"])
+    if user_value is not None:
+        return "mp" if user_value == "mp" else "ray"
+
+    return "ray" if should_default_to_ray(backend_version) else "mp"

--- a/gpustack/utils/vllm_topology.py
+++ b/gpustack/utils/vllm_topology.py
@@ -1,0 +1,193 @@
+"""Pure topology validation for vLLM native multi-node deployments.
+
+Lives in ``utils`` (not in ``worker.backends``) so scheduler / policies code
+can import these helpers without dragging in worker-only dependencies such as
+``gpustack_runtime.deployer``. Anything that needs a specific node's identity
+(``ModelInstance`` / ``ModelInstanceDeploymentMetadata``) stays on the worker
+side — see ``gpustack.worker.backends.vllm.cal_multinode_topology``.
+"""
+
+from dataclasses import dataclass
+from functools import reduce
+from math import gcd
+from typing import List, Literal, Optional
+
+from gpustack.utils.command import find_int_parameter
+
+
+MultinodeShape = Literal["dp_only", "mp_only", "nested"]
+
+
+@dataclass
+class MultinodeUserParallelism:
+    """User-supplied parallelism hints from backend_parameters.
+
+    Any field left as ``None`` means GPUStack should derive a value from the
+    physical topology. Non-None values are treated as hard constraints and
+    rejected if they contradict the topology.
+    """
+
+    tp: Optional[int] = None
+    pp: Optional[int] = None
+    dp: Optional[int] = None
+    dpl: Optional[int] = None
+
+
+@dataclass
+class ValidatedTopology:
+    """Cluster-level layout that has passed every topology-only validation.
+
+    Captures the shape and per-node DP fragmentation so node-perspective
+    callers can compute their own ``start_rank`` / ``dpl`` without redoing
+    the inference work. Does **not** include node-perspective fields like
+    ``my_idx`` or ``is_follower`` — those are filled in by
+    ``cal_multinode_topology`` for a specific node.
+    """
+
+    shape: MultinodeShape
+    tp: int
+    pp: int
+    dp: int  # cluster total DP ranks
+    dpl_per_node: List[int]  # per-node --data-parallel-size-local values
+    nnodes_within_dp: int  # how many physical nodes share one DP rank
+
+
+def validate_multinode_topology(  # noqa: C901
+    gpu_per_node: List[int],
+    user: Optional[MultinodeUserParallelism] = None,
+) -> ValidatedTopology:
+    """Pure topology validator.
+
+    Runs every check that does not depend on a specific node's identity.
+    Callers (selector at schedule time, ``cal_multinode_topology`` at worker
+    start time) get the same diagnostic ``ValueError`` so error messages are
+    maintained in one place.
+
+    Pivot: ``workers_per_dp = tp * pp`` versus per-node GPU count decides
+    whether a single DP rank fits in one node (``dp_only``) or must span
+    multiple nodes (``mp_only`` / ``nested``).
+    """
+    user = user or MultinodeUserParallelism()
+    nnodes = len(gpu_per_node)
+
+    pp = user.pp or 1
+    if user.tp is not None:
+        tp = user.tp
+    elif user.dp is not None:
+        # vLLM constraint: tp * pp * dp == sum(gpu_per_node). When the user
+        # pins dp (and optionally pp), we can solve for tp instead of falling
+        # back to gcd(gpu_per_node) — which would ignore the user's intent
+        # and almost always conflict with their dp later.
+        total_gpus = sum(gpu_per_node)
+        denom = user.dp * pp
+        if denom == 0 or total_gpus % denom != 0:
+            raise ValueError(
+                f"vLLM multi-node: cannot infer --tensor-parallel-size from "
+                f"--data-parallel-size {user.dp} and --pipeline-parallel-size "
+                f"{pp}: total GPUs {total_gpus} is not a multiple of "
+                f"{user.dp} * {pp} = {denom}."
+            )
+        tp = total_gpus // denom
+    else:
+        tp = reduce(gcd, gpu_per_node)
+
+    if tp <= 0:
+        raise ValueError(
+            f"vLLM multi-node: --tensor-parallel-size {tp} must be positive."
+        )
+    for idx, cnt in enumerate(gpu_per_node):
+        if cnt % tp != 0:
+            raise ValueError(
+                f"vLLM multi-node: --tensor-parallel-size {tp} cannot divide "
+                f"worker[{idx}] {cnt} GPUs (vLLM requires each TP unit fit "
+                f"inside one node)."
+            )
+
+    workers_per_dp = tp * pp
+
+    if workers_per_dp <= min(gpu_per_node):
+        # dp_only: every DP rank fits in one node.
+        dpl_per_node = [g // workers_per_dp for g in gpu_per_node]
+        dp_total = sum(dpl_per_node)
+
+        if user.dp is not None and user.dp != dp_total:
+            raise ValueError(
+                f"vLLM multi-node: --data-parallel-size {user.dp} does not match "
+                f"derived total {dp_total} (per-node DP-Local = {dpl_per_node})."
+            )
+        if user.dpl is not None and any(d != user.dpl for d in dpl_per_node):
+            raise ValueError(
+                f"vLLM multi-node: --data-parallel-size-local {user.dpl} cannot "
+                f"be applied uniformly to a heterogeneous worker group "
+                f"(per-node GPUs = {gpu_per_node}, derived per-node DP-Local = "
+                f"{dpl_per_node}). Remove --data-parallel-size-local from "
+                "backend_parameters and let GPUStack derive it per node."
+            )
+
+        return ValidatedTopology(
+            shape="dp_only",
+            tp=tp,
+            pp=pp,
+            dp=dp_total,
+            dpl_per_node=dpl_per_node,
+            nnodes_within_dp=1,
+        )
+
+    # workers_per_dp > min(gpu_per_node): a DP rank must span multiple nodes.
+    # vLLM requires this layout to be homogeneous because every node receives
+    # the same --data-parallel-size-local value.
+    if len(set(gpu_per_node)) != 1:
+        raise ValueError(
+            f"vLLM multi-node: cross-node TP/PP (workers_per_dp={workers_per_dp} "
+            f"> min node capacity {min(gpu_per_node)}) requires a homogeneous "
+            f"cluster, but workers have differing GPU counts {gpu_per_node}."
+        )
+    # Homogeneous guaranteed by the check above, so any index is equivalent.
+    g_node = gpu_per_node[0]
+    if workers_per_dp % g_node != 0:
+        raise ValueError(
+            f"vLLM multi-node: workers_per_dp={workers_per_dp} cannot evenly "
+            f"distribute across nodes with {g_node} GPUs each."
+        )
+    nnodes_within_dp = workers_per_dp // g_node
+    if nnodes % nnodes_within_dp != 0:
+        raise ValueError(
+            f"vLLM multi-node: cluster size {nnodes} cannot evenly distribute "
+            f"DP ranks that each span {nnodes_within_dp} nodes."
+        )
+    inferred_dp = nnodes // nnodes_within_dp
+
+    if user.dp is not None and user.dp != inferred_dp:
+        raise ValueError(
+            f"vLLM multi-node: --data-parallel-size {user.dp} does not match "
+            f"derived total {inferred_dp} (cluster fits {inferred_dp} DP ranks "
+            f"of {nnodes_within_dp} nodes each)."
+        )
+    if user.dpl is not None and user.dpl != 1:
+        raise ValueError(
+            f"vLLM multi-node: --data-parallel-size-local {user.dpl} is "
+            "invalid in cross-node TP/PP layouts (must be 1 — each node hosts "
+            "at most one DP rank fragment)."
+        )
+
+    shape: MultinodeShape = "mp_only" if inferred_dp == 1 else "nested"
+    return ValidatedTopology(
+        shape=shape,
+        tp=tp,
+        pp=pp,
+        dp=inferred_dp,
+        dpl_per_node=[1] * nnodes,
+        nnodes_within_dp=nnodes_within_dp,
+    )
+
+
+def parse_user_parallelism(
+    backend_parameters: Optional[List[str]],
+) -> MultinodeUserParallelism:
+    """Extract MultinodeUserParallelism from user-provided backend_parameters."""
+    return MultinodeUserParallelism(
+        tp=find_int_parameter(backend_parameters, ["tensor-parallel-size", "tp"]),
+        pp=find_int_parameter(backend_parameters, ["pipeline-parallel-size", "pp"]),
+        dp=find_int_parameter(backend_parameters, ["data-parallel-size", "dp"]),
+        dpl=find_int_parameter(backend_parameters, ["data-parallel-size-local", "dpl"]),
+    )

--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 from gpustack_runtime.deployer import (
@@ -26,14 +27,22 @@ from gpustack.schemas.models import (
 )
 from gpustack.utils import network
 from gpustack.utils.command import (
+    ExecutorBackend,
     find_parameter,
     find_bool_parameter,
     find_int_parameter,
     extend_args_no_exist,
     format_backend_parameters,
+    resolve_executor_backend,
 )
 from gpustack.utils.envs import sanitize_env
 from gpustack.utils.unit import byte_to_gib
+from gpustack.utils.vllm_topology import (
+    MultinodeShape,
+    MultinodeUserParallelism,
+    parse_user_parallelism,
+    validate_multinode_topology,
+)
 from gpustack.worker.backends.base import (
     InferenceServer,
     is_ascend_310p,
@@ -89,6 +98,25 @@ def extend_vllm_mounted_lora_arguments(
             arguments.append(json.dumps(m))
 
 
+@dataclass
+class _VLLMArgsContext:
+    """
+    Derived inputs shared by every `_build_*_arguments` step.
+
+    Computed once per `_build_command_args` invocation so individual builders
+    stay side-effect-free and don't re-evaluate the same predicates.
+    """
+
+    port: int
+    is_distributed: bool
+    executor_backend: ExecutorBackend
+    topology: Optional["MultinodeTopology"]
+    is_omni: bool
+    is_audio: bool
+    entrypoint: Optional[List[str]]
+    deployment_metadata: Optional[ModelInstanceDeploymentMetadata]
+
+
 class VLLMServer(InferenceServer):
     """
     Containerized vLLM inference server backend using gpustack-runtime.
@@ -111,6 +139,7 @@ class VLLMServer(InferenceServer):
 
         env = self._get_configured_env(
             is_distributed=deployment_metadata.distributed,
+            deployment_metadata=deployment_metadata,
         )
 
         # Resolve image first so that backend_version is populated before
@@ -131,6 +160,7 @@ class VLLMServer(InferenceServer):
             port=self._get_serving_port(),
             is_distributed=deployment_metadata.distributed,
             entrypoint=command,
+            deployment_metadata=deployment_metadata,
         )
 
         try:
@@ -201,8 +231,14 @@ class VLLMServer(InferenceServer):
             ports=ports,
         )
 
-        # Adjust run container for distributed follower.
-        if deployment_metadata.distributed_follower:
+        executor_backend = resolve_executor_backend(
+            self._model.backend_parameters, self._model.backend_version
+        )
+
+        # Adjust run container for distributed follower (Ray path only).
+        # For native multi-node followers (mp), --headless and topology args injected
+        # by _build_command_args, so no command swap is needed.
+        if deployment_metadata.distributed_follower and executor_backend == "ray":
             ray_command, ray_command_args, ray_ports = self._build_ray_configuration(
                 is_leader=False,
             )
@@ -218,9 +254,11 @@ class VLLMServer(InferenceServer):
             run_container.execution.args = ray_command_args
             run_container.ports = ray_ports
 
-        # Create sidecar container for distributed leader.
+        # Create sidecar container for distributed leader (Ray path only).
+        # Headless leader runs vLLM directly with DP coordination args; no
+        # ray-head sidecar is required.
         sidecar_container = None
-        if deployment_metadata.distributed_leader:
+        if deployment_metadata.distributed_leader and executor_backend == "ray":
             run_container.mounts.append(
                 ContainerMount(
                     path="/tmp",
@@ -297,7 +335,11 @@ class VLLMServer(InferenceServer):
 
         logger.info(f"Created vLLM container workload: {deployment_metadata.name}")
 
-    def _get_configured_env(self, is_distributed: bool) -> Dict[str, str]:
+    def _get_configured_env(
+        self,
+        is_distributed: bool,
+        deployment_metadata: Optional[ModelInstanceDeploymentMetadata] = None,
+    ) -> Dict[str, str]:
         """
         Get environment variables for vLLM service
         """
@@ -325,7 +367,7 @@ class VLLMServer(InferenceServer):
 
         # Apply distributed environment variables
         if is_distributed:
-            self._set_distributed_env(env)
+            self._set_distributed_env(env, deployment_metadata)
 
         # Apply Ascend-specific environment variables
         if is_ascend(self._get_selected_gpu_devices()):
@@ -375,23 +417,53 @@ class VLLMServer(InferenceServer):
             ram_size = int(vram_claim * extended_kv_cache.ram_ratio)
             env["LMCACHE_MAX_LOCAL_CPU_SIZE"] = str(byte_to_gib(ram_size))
 
-    def _set_distributed_env(self, env: Dict[str, str]):
+    def _resolve_multinode_shape(
+        self,
+        deployment_metadata: ModelInstanceDeploymentMetadata,
+    ) -> Optional[str]:
+        """Best-effort shape lookup, swallowing inference errors. ``None`` if
+        the topology cannot be derived (e.g. user-arg contradictions); the
+        actual failure will surface from the command builder where it can be
+        attributed to a specific instance."""
+        try:
+            return cal_multinode_topology(
+                self._model_instance,
+                deployment_metadata,
+                parse_user_parallelism(self._model.backend_parameters),
+            ).shape
+        except ValueError:
+            return None
+
+    def _set_distributed_env(
+        self,
+        env: Dict[str, str],
+        deployment_metadata: Optional[ModelInstanceDeploymentMetadata] = None,
+    ):
         """
         Set up environment variables for distributed execution.
         """
         # Configure Internal communication IP and port.
         # see https://docs.vllm.ai/en/stable/configuration/env_vars.html.
         env["VLLM_HOST_IP"] = self._worker.ip
-        # During distributed setup,
-        # we must get more than one port here,
-        # so we use ports[-1] for distributed initialization.
-        env["VLLM_PORT"] = str(self._model_instance.ports[-1])
 
-        # Disable Ray logging to stderr by default,
-        # see https://github.com/gpustack/gpustack/issues/4158#issuecomment-3809213348.
-        env["RAY_LOG_TO_STDERR"] = env.pop("RAY_LOG_TO_STDERR", "0")
-        # To reduce verbosity, set Ray backend log level to warning by default.
-        env["RAY_BACKEND_LOG_LEVEL"] = env.pop("RAY_BACKEND_LOG_LEVEL", "warning")
+        executor_backend = resolve_executor_backend(
+            self._model.backend_parameters, self._model.backend_version
+        )
+        if executor_backend == "mp":
+            # VLLM_DP_MASTER_PORT belongs to the DP coordinator path
+            # (vllm-project/vllm#42585). mp_only has dp=1 and no DP master,
+            # so injecting it would bind a port for nobody to use.
+            shape = (
+                self._resolve_multinode_shape(deployment_metadata)
+                if deployment_metadata is not None
+                else None
+            )
+            if shape in ("dp_only", "nested"):
+                env["VLLM_DP_MASTER_PORT"] = str(self._model_instance.ports[-1])
+        else:
+            env["VLLM_PORT"] = str(self._model_instance.ports[-1])
+            env["RAY_LOG_TO_STDERR"] = env.pop("RAY_LOG_TO_STDERR", "0")
+            env["RAY_BACKEND_LOG_LEVEL"] = env.pop("RAY_BACKEND_LOG_LEVEL", "warning")
 
         if is_ascend(self._get_selected_gpu_devices()):
             # See https://vllm-ascend.readthedocs.io/en/latest/tutorials/multi-node_dsv3.2.html.
@@ -498,6 +570,7 @@ class VLLMServer(InferenceServer):
         port: int,
         is_distributed: bool,
         entrypoint: Optional[List[str]] = None,
+        deployment_metadata: Optional[ModelInstanceDeploymentMetadata] = None,
     ) -> Tuple[List[str], List[str]]:
         """
         Build vLLM command arguments for container execution.
@@ -508,109 +581,39 @@ class VLLMServer(InferenceServer):
             added by GPUStack, excluding the entrypoint/model path and
             user-specified backend parameters.
         """
-        arguments = [
-            "vllm",
-            "serve",
-            self._model_path,
-        ]
+        ctx = self._make_args_context(
+            port, is_distributed, entrypoint, deployment_metadata
+        )
 
-        # Allow version-specific command override if configured (before appending extra args)
+        arguments: List[str] = ["vllm", "serve", self._model_path]
         arguments = self.build_versioned_command_args(arguments)
 
-        # Omni modalities
-        omni_enabled = find_bool_parameter(
-            self._model.backend_parameters,
-            ["omni"],
-        )
-        is_omni = is_omni_model(self._model)
-        if is_omni and not omni_enabled:
-            arguments.extend(
-                [
-                    "--omni",
-                ]
-            )
-
-        is_audio = is_audio_model(self._model)
-
-        if not is_omni and not is_audio:
-
-            specified_max_model_len = find_parameter(
+        arguments.extend(self._build_omni_arguments(ctx))
+        arguments.extend(self._build_max_model_len_arguments(ctx))
+        arguments.extend(
+            get_auto_parallelism_arguments(
                 self._model.backend_parameters,
-                ["max-model-len"],
+                self._model_instance,
+                ctx.is_distributed,
+                ctx.deployment_metadata,
+                self._model.backend_version,
             )
-            if specified_max_model_len is None:
-                derived_max_model_len = self._derive_max_model_len()
-                if derived_max_model_len and derived_max_model_len > 8192:
-                    arguments.extend(["--max-model-len", "8192"])
-
-        auto_parallelism_arguments = get_auto_parallelism_arguments(
-            self._model.backend_parameters,
-            self._model_instance,
-            is_distributed,
         )
-        arguments.extend(auto_parallelism_arguments)
-
-        # Add speculative config arguments if needed
-        speculative_config_arguments = self._get_speculative_arguments()
-        arguments.extend(speculative_config_arguments)
-
-        # Suppress high-frequency /metrics access logs by default.
-        access_log_arguments = get_access_log_arguments(
-            self._model.backend_parameters, self._model.backend_version
-        )
-        arguments.extend(access_log_arguments)
-
-        # Expose prefix-cache hits as cached_tokens in OpenAI usage.
-        cache_report_arguments = get_cache_report_arguments(
-            self._model.backend_parameters, self._model.backend_version
-        )
-        arguments.extend(cache_report_arguments)
-
-        if is_distributed:
-            arguments.extend(["--distributed-executor-backend", "ray"])
-            dps = find_int_parameter(
-                self._model.backend_parameters, ["data-parallel-size", "dp"]
+        arguments.extend(self._get_speculative_arguments())
+        arguments.extend(
+            get_access_log_arguments(
+                self._model.backend_parameters, self._model.backend_version
             )
-            if dps and dps > 1:
-                # Prefer to use Ray backend for data parallelism if DP size is specified.
-                dpb = find_parameter(
-                    self._model.backend_parameters, ["data-parallel-backend", "dpb"]
-                )
-                if dpb is None:
-                    arguments.extend(["--data-parallel-backend", "ray"])
-                # Specify a port for DP RPC communication,
-                # we must get more than one port here, see gpustack/worker/serve_manager.py,
-                # so we use ports[1] for DP RPC communication.
-                arguments.extend(
-                    ["--data-parallel-rpc-port", str(self._model_instance.ports[1])]
-                )
-
-        if self._model.extended_kv_cache and self._model.extended_kv_cache.enabled:
-            vendor, _, _ = self._get_device_info()
-            if vendor in {
-                manufacturer_to_backend(ManufacturerEnum.NVIDIA),
-                manufacturer_to_backend(ManufacturerEnum.AMD),
-            }:
-                arguments.extend(
-                    [
-                        "--kv-transfer-config",
-                        '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}',
-                    ]
-                )
-            else:
-                logger.warning(
-                    "Extended KV cache for vLLM is only supported on NVIDIA and AMD GPUs. Skipping LMCache configuration."
-                )
-
-        # For Ascend 310P, we need to enforce eager execution and default dtype to float16
-        if is_ascend_310p(self._get_selected_gpu_devices()):
-            arguments.extend(
-                [
-                    "--enforce-eager",
-                    "--dtype",
-                    "float16",
-                ]
+        )
+        arguments.extend(
+            get_cache_report_arguments(
+                self._model.backend_parameters, self._model.backend_version
             )
+        )
+        arguments.extend(self._build_ray_distributed_arguments(ctx))
+        arguments.extend(self._build_native_multinode_arguments(ctx))
+        arguments.extend(self._build_extended_kv_cache_arguments(ctx))
+        arguments.extend(self._build_ascend_310p_arguments(ctx))
 
         extend_vllm_mounted_lora_arguments(
             arguments,
@@ -623,20 +626,190 @@ class VLLMServer(InferenceServer):
         user_backend_parameters = self._flatten_backend_param()
         arguments.extend(user_backend_parameters)
 
-        # Append immutable arguments to ensure proper operation for accessing.
-        # Only add if not already present in arguments.
         extend_args_no_exist(
             arguments,
             ("--host", self._worker.ip),
-            ("--port", str(port)),
+            ("--port", str(ctx.port)),
             ("--served-model-name", self._model_instance.model_name),
         )
 
         injected = self._get_injected_backend_parameters(
             arguments, user_backend_parameters, entrypoint
         )
-
         return arguments, injected
+
+    def _make_args_context(
+        self,
+        port: int,
+        is_distributed: bool,
+        entrypoint: Optional[List[str]],
+        deployment_metadata: Optional[ModelInstanceDeploymentMetadata],
+    ) -> _VLLMArgsContext:
+        executor_backend = resolve_executor_backend(
+            self._model.backend_parameters, self._model.backend_version
+        )
+        topology: Optional[MultinodeTopology] = None
+        if (
+            is_distributed
+            and executor_backend == "mp"
+            and deployment_metadata is not None
+        ):
+            topology = cal_multinode_topology(
+                self._model_instance,
+                deployment_metadata,
+                parse_user_parallelism(self._model.backend_parameters),
+            )
+        return _VLLMArgsContext(
+            port=port,
+            is_distributed=is_distributed,
+            executor_backend=executor_backend,
+            topology=topology,
+            is_omni=is_omni_model(self._model),
+            is_audio=is_audio_model(self._model),
+            entrypoint=entrypoint,
+            deployment_metadata=deployment_metadata,
+        )
+
+    def _build_omni_arguments(self, ctx: _VLLMArgsContext) -> List[str]:
+        if not ctx.is_omni:
+            return []
+        if find_bool_parameter(self._model.backend_parameters, ["omni"]):
+            return []
+        return ["--omni"]
+
+    def _build_max_model_len_arguments(self, ctx: _VLLMArgsContext) -> List[str]:
+        if ctx.is_omni or ctx.is_audio:
+            return []
+        if (
+            find_parameter(self._model.backend_parameters, ["max-model-len"])
+            is not None
+        ):
+            return []
+        derived_max_model_len = self._derive_max_model_len()
+        if derived_max_model_len and derived_max_model_len > 8192:
+            return ["--max-model-len", "8192"]
+        return []
+
+    def _build_ray_distributed_arguments(self, ctx: _VLLMArgsContext) -> List[str]:
+        """
+        Ray sidecar path only: force --distributed-executor-backend ray and
+        default DP backend to ray when user-specified DP > 1.
+        """
+        if not ctx.is_distributed or ctx.executor_backend != "ray":
+            return []
+
+        arguments: List[str] = ["--distributed-executor-backend", "ray"]
+        dps = find_int_parameter(
+            self._model.backend_parameters, ["data-parallel-size", "dp"]
+        )
+        if dps and dps > 1:
+            dpb = find_parameter(
+                self._model.backend_parameters, ["data-parallel-backend", "dpb"]
+            )
+            if dpb is None:
+                arguments.extend(["--data-parallel-backend", "ray"])
+            # ports[1] is reserved for DP RPC, see gpustack/worker/serve_manager.py.
+            arguments.extend(
+                ["--data-parallel-rpc-port", str(self._model_instance.ports[1])]
+            )
+        return arguments
+
+    def _build_native_multinode_arguments(
+        self,
+        ctx: _VLLMArgsContext,
+    ) -> List[str]:
+        """
+        Native multi-node (non-Ray) path. Dispatches to one of three parameter
+        shapes based on the resolved topology:
+
+        - ``dp_only``  → ``--data-parallel-*`` only; vLLM treats every node as
+          a DP engine head (no PP/TP spans nodes).
+        - ``mp_only``  → ``--nnodes`` + ``--node-rank`` only; a single DP rank
+          is spread across all nodes for cross-node TP/PP.
+        - ``nested``   → both sets; vLLM derives node role internally via
+          ``node_rank % nnodes_within_dp``.
+
+        Followers also carry ``--headless`` to skip the API server. The leader
+        always exposes the HTTP API (handled by --host/--port elsewhere).
+        """
+        if (
+            not ctx.is_distributed
+            or ctx.executor_backend != "mp"
+            or ctx.topology is None
+        ):
+            return []
+
+        topology = ctx.topology
+        leader_ip = self._model_instance.worker_ip
+        arguments: List[str] = []
+        if (
+            find_parameter(
+                self._model.backend_parameters, ["distributed-executor-backend"]
+            )
+            is None
+        ):
+            arguments.extend(["--distributed-executor-backend", "mp"])
+
+        # serve_manager._assign_ports reserves ports[1] for the DP RPC
+        # endpoint (ZMQ) and ports[2] for the PyTorch master endpoint
+        # (TCPStore). The two channels use different protocols and can't
+        # share one port, so each shape consumes the subset it needs.
+        dp_rpc_port = str(self._model_instance.ports[1])
+        master_port = str(self._model_instance.ports[2])
+        if topology.shape == "dp_only":
+            extend_args_no_exist(
+                arguments,
+                ("--data-parallel-start-rank", str(topology.start_rank)),
+                ("--data-parallel-address", leader_ip),
+                ("--data-parallel-rpc-port", dp_rpc_port),
+            )
+        elif topology.shape == "mp_only":
+            extend_args_no_exist(
+                arguments,
+                ("--nnodes", str(topology.nnodes)),
+                ("--node-rank", str(topology.node_rank)),
+                ("--master-addr", leader_ip),
+                ("--master-port", master_port),
+            )
+        else:  # nested
+            extend_args_no_exist(
+                arguments,
+                ("--nnodes", str(topology.nnodes)),
+                ("--node-rank", str(topology.node_rank)),
+                ("--master-addr", leader_ip),
+                ("--master-port", master_port),
+                ("--data-parallel-address", leader_ip),
+                ("--data-parallel-rpc-port", dp_rpc_port),
+            )
+
+        if topology.is_follower:
+            extend_args_no_exist(arguments, "--headless")
+        return arguments
+
+    def _build_extended_kv_cache_arguments(self, ctx: _VLLMArgsContext) -> List[str]:
+        extended = self._model.extended_kv_cache
+        if not (extended and extended.enabled):
+            return []
+
+        vendor, _, _ = self._get_device_info()
+        if vendor not in {
+            manufacturer_to_backend(ManufacturerEnum.NVIDIA),
+            manufacturer_to_backend(ManufacturerEnum.AMD),
+        }:
+            logger.warning(
+                "Extended KV cache for vLLM is only supported on NVIDIA and AMD GPUs. Skipping LMCache configuration."
+            )
+            return []
+
+        return [
+            "--kv-transfer-config",
+            '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}',
+        ]
+
+    def _build_ascend_310p_arguments(self, ctx: _VLLMArgsContext) -> List[str]:
+        if not is_ascend_310p(self._get_selected_gpu_devices()):
+            return []
+        return ["--enforce-eager", "--dtype", "float16"]
 
     def _build_ray_configuration(
         self,
@@ -731,11 +904,126 @@ class VLLMServer(InferenceServer):
         return command, arguments, ports
 
 
+@dataclass
+class MultinodeTopology:
+    """Resolved multi-node deployment topology from one node's perspective.
+
+    Fields:
+      - ``shape``: which set of vLLM arguments to emit (see
+        :py:meth:`VLLMServer._build_native_multinode_arguments`).
+      - ``tp`` / ``pp``: cluster-wide, identical on every node.
+      - ``dp``: total DP rank count across the whole cluster.
+      - ``dpl``: ``--data-parallel-size-local`` value to emit on this node.
+        In ``dp_only`` shape this may differ per node (heterogeneous clusters);
+        in ``mp_only`` / ``nested`` it is always 1.
+      - ``nnodes`` / ``node_rank``: physical cluster size and this node's
+        position in it (0 = leader).
+      - ``start_rank``: ``--data-parallel-start-rank`` to emit in ``dp_only``.
+        In other shapes vLLM derives DP rank internally from
+        ``node_rank % nnodes_within_dp``; we still surface the implied value
+        for diagnostics.
+      - ``is_follower``: whether this node should carry ``--headless``.
+    """
+
+    shape: MultinodeShape
+    tp: int
+    pp: int
+    dp: int
+    dpl: int
+    nnodes: int
+    node_rank: int
+    start_rank: int
+    is_follower: bool
+
+
+def cal_multinode_topology(
+    model_instance: ModelInstance,
+    deployment_metadata: ModelInstanceDeploymentMetadata,
+    user: Optional[MultinodeUserParallelism] = None,
+) -> MultinodeTopology:
+    """Translate user-supplied parallelism hints + physical topology into the
+    vLLM parameter shape this node should emit.
+
+    Delegates cluster-level validation and shape inference to
+    :func:`validate_multinode_topology`, then layers on the node-perspective
+    fields (``my_idx`` / ``start_rank`` / ``is_follower``).
+    """
+    g_main = len(model_instance.gpu_indexes) if model_instance.gpu_indexes else 1
+    subordinate = (
+        model_instance.distributed_servers.subordinate_workers
+        if model_instance.distributed_servers
+        and model_instance.distributed_servers.subordinate_workers
+        else []
+    )
+    gpu_per_node = [g_main] + [len(s.gpu_indexes or []) for s in subordinate]
+    nnodes = len(gpu_per_node)
+
+    # This node's physical rank.
+    if deployment_metadata.distributed_follower:
+        my_idx = (deployment_metadata.distributed_follower_index or 0) + 1
+        is_follower = True
+    else:
+        my_idx = 0
+        is_follower = False
+    if my_idx >= nnodes:
+        raise ValueError(
+            f"vLLM multi-node: follower index {my_idx} out of bounds "
+            f"(cluster has {nnodes} workers)."
+        )
+
+    validated = validate_multinode_topology(gpu_per_node, user)
+
+    if validated.shape == "dp_only":
+        start_rank = sum(validated.dpl_per_node[:my_idx])
+    else:
+        # mp_only / nested: vLLM derives DP rank from node_rank // nnodes_within_dp.
+        start_rank = my_idx // validated.nnodes_within_dp
+
+    return MultinodeTopology(
+        shape=validated.shape,
+        tp=validated.tp,
+        pp=validated.pp,
+        dp=validated.dp,
+        dpl=validated.dpl_per_node[my_idx],
+        nnodes=nnodes,
+        node_rank=my_idx,
+        start_rank=start_rank,
+        is_follower=is_follower,
+    )
+
+
 def get_auto_parallelism_arguments(
     backend_parameters: List[str],
     model_instance: ModelInstance,
     is_distributed: bool,
+    deployment_metadata: Optional[ModelInstanceDeploymentMetadata] = None,
+    backend_version: Optional[str] = None,
 ) -> List[str]:
+    if (
+        is_distributed
+        and deployment_metadata is not None
+        and resolve_executor_backend(backend_parameters, backend_version) == "mp"
+    ):
+        # Native multi-node: derive shape-specific defaults for tp/pp/dp/dpl
+        # so the cluster works out-of-the-box; subordinate workers receive
+        # the same backend_parameters, so any non-None field acts as a hard
+        # cluster-wide constraint.
+        user = parse_user_parallelism(backend_parameters)
+        topology = cal_multinode_topology(model_instance, deployment_metadata, user)
+        derived: List[str] = []
+        if user.tp is None:
+            derived.extend(["--tensor-parallel-size", str(topology.tp)])
+        if user.pp is None and topology.pp > 1:
+            derived.extend(["--pipeline-parallel-size", str(topology.pp)])
+        # dp/dpl are only meaningful when the shape actually emits them
+        # (dp_only and nested). mp_only operates with dp=1, dpl=1 implicit.
+        if topology.shape in ("dp_only", "nested"):
+            if user.dp is None:
+                derived.extend(["--data-parallel-size", str(topology.dp)])
+            if user.dpl is None:
+                derived.extend(["--data-parallel-size-local", str(topology.dpl)])
+        return derived
+
     parallelism = find_parameter(
         backend_parameters,
         [
@@ -752,7 +1040,7 @@ def get_auto_parallelism_arguments(
         return []
 
     if is_distributed:
-        # distributed across multiple workers
+        # distributed across multiple workers (Ray sidecar path)
         (tp, pp) = cal_distributed_parallelism_arguments(model_instance)
         return [
             "--tensor-parallel-size",

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -39,6 +39,7 @@ from gpustack.utils.command import find_int_parameter
 from gpustack.utils.process import terminate_process_tree, add_signal_handlers
 from gpustack.worker.backends.ascend_mindie import AscendMindIEServer
 from gpustack.worker.backends.sglang import SGLangServer
+from gpustack.utils.command import resolve_executor_backend
 from gpustack.worker.backends.vllm import VLLMServer
 from gpustack.worker.backends.vox_box import VoxBoxServer
 from gpustack.worker.backends.custom import CustomServer
@@ -1273,22 +1274,40 @@ class ServeManager:
             mi.ports = [mi.port]
             unavailable_ports.add(mi.port)
 
-            # Additional ports for distributed servers
+            # Additional ports for distributed servers.
+            #
+            # ports[0]: HTTP API (always).
+            # Native (mp) path — both reserved unconditionally, dp_only uses
+            # ports[1], mp_only uses ports[2], nested uses both:
+            #   ports[1]: --data-parallel-rpc-port (DP coordinator ZMQ)
+            #   ports[2]: --master-port (PyTorch torch.distributed TCP store)
+            # Ray path: ports[1] = DP RPC when user-specified dp > 1.
+            # ports[-1]: subordinate workers' connecting port.
             if mi.distributed_servers and mi.distributed_servers.subordinate_workers:
-                # RPC port for DP communication in vLLM backend
                 if backend == BackendEnum.VLLM:
-                    dps = find_int_parameter(
-                        model.backend_parameters,
-                        ["data-parallel-size", "dp"],
+                    executor_backend = resolve_executor_backend(
+                        model.backend_parameters, model.backend_version
                     )
-                    if dps and dps > 1:
-                        dp_connecting_port = network.get_free_port(
+                    if executor_backend == "mp":
+                        # Pre-allocate both DP RPC and PyTorch master ports;
+                        # the two channels use different protocols (ZMQ vs
+                        # TCPStore) and can't share one port in the nested
+                        # shape, so reserving both keeps the layout stable.
+                        cross_port_count = 2
+                    else:
+                        dps = find_int_parameter(
+                            model.backend_parameters,
+                            ["data-parallel-size", "dp"],
+                        )
+                        cross_port_count = 1 if dps and dps > 1 else 0
+                    for _ in range(cross_port_count):
+                        cross_port = network.get_free_port(
                             port_range=self._config.service_port_range,
                             unavailable_ports=unavailable_ports,
                             host=mi.worker_ip,
                         )
-                        mi.ports.append(dp_connecting_port)
-                        unavailable_ports.add(dp_connecting_port)
+                        mi.ports.append(cross_port)
+                        unavailable_ports.add(cross_port)
 
                 # Connecting port for subordinate workers communication
                 connecting_port = network.get_free_port(

--- a/tests/policies/candidate_selectors/vllm/test_vllm_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/vllm/test_vllm_resource_fit_selector.py
@@ -614,6 +614,266 @@ async def test_select_candidates(
 @pytest.mark.parametrize(
     "case_name, m, workers, expected_candidates, final_candidate_index",
     [
+        # Headless mode sentinel (--data-parallel-backend mp) without explicit
+        # TP/DP. Scheduler should fall through the vram-based multi-worker
+        # path exactly like the ray path — sentinel only affects worker-side
+        # command construction.
+        # Check point:
+        # - Headless sentinel does not break auto multi-worker scheduling.
+        (
+            "headless_auto_schedule_16_gpus_2_workers_deepseek_r1",
+            make_model(
+                0,
+                None,
+                "deepseek-ai/DeepSeek-R1",
+                backend_parameters=["--data-parallel-backend=mp"],
+            ),
+            [
+                linux_nvidia_1_4090_24gx1(),
+                linux_nvidia_3_4090_24gx1(),
+                linux_nvidia_22_H100_80gx8(),
+                linux_nvidia_23_H100_80gx8(),
+                linux_nvidia_24_H100_80gx8(),
+                linux_nvidia_25_H100_80gx8(),
+            ],
+            [
+                expected_candidate(
+                    22,
+                    "host22-h100",
+                    [0, 1, 2, 3, 4, 5, 6, 7],
+                    {
+                        0: 77309411328,
+                        1: 77309411328,
+                        2: 77309411328,
+                        3: 77309411328,
+                        4: 77309411328,
+                        5: 77309411328,
+                        6: 77309411328,
+                        7: 77309411328,
+                    },
+                    [
+                        ModelInstanceSubordinateWorker(
+                            worker_id=23,
+                            worker_ip="192.168.50.23",
+                            total_gpus=8,
+                            gpu_indexes=[0, 1, 2, 3, 4, 5, 6, 7],
+                            computed_resource_claim=ComputedResourceClaim(
+                                vram={
+                                    0: 77309411328,
+                                    1: 77309411328,
+                                    2: 77309411328,
+                                    3: 77309411328,
+                                    4: 77309411328,
+                                    5: 77309411328,
+                                    6: 77309411328,
+                                    7: 77309411328,
+                                },
+                            ),
+                        ),
+                    ],
+                )
+            ],
+            0,
+        ),
+        # Issue #5089 regression: TP=8 DP=2 DP-Local=1 in headless mode on a
+        # 2x8 GPU H100 cluster. Prior to the fix --data-parallel-size-local
+        # was parsed only when on the same line as other args, causing the
+        # scheduler to reject otherwise valid candidates.
+        # Check point:
+        # - world_size = TP * DP = 16 (not multiplied by DPL).
+        # - Multi-worker auto-select returns 2x H100 workers, 8 GPU each.
+        (
+            "headless_5089_tp8_dp2_dpl1_2x_h100",
+            make_model(
+                0,
+                None,
+                "deepseek-ai/DeepSeek-R1",
+                backend_parameters=[
+                    "--tensor-parallel-size=8",
+                    "--data-parallel-size=2",
+                    "--data-parallel-size-local=1",
+                    "--data-parallel-backend=mp",
+                ],
+            ),
+            [
+                linux_nvidia_22_H100_80gx8(),
+                linux_nvidia_23_H100_80gx8(),
+            ],
+            [
+                expected_candidate(
+                    22,
+                    "host22-h100",
+                    [0, 1, 2, 3, 4, 5, 6, 7],
+                    {
+                        0: 77309411328,
+                        1: 77309411328,
+                        2: 77309411328,
+                        3: 77309411328,
+                        4: 77309411328,
+                        5: 77309411328,
+                        6: 77309411328,
+                        7: 77309411328,
+                    },
+                    [
+                        ModelInstanceSubordinateWorker(
+                            worker_id=23,
+                            worker_ip="192.168.50.23",
+                            total_gpus=8,
+                            gpu_indexes=[0, 1, 2, 3, 4, 5, 6, 7],
+                            computed_resource_claim=ComputedResourceClaim(
+                                vram={
+                                    0: 77309411328,
+                                    1: 77309411328,
+                                    2: 77309411328,
+                                    3: 77309411328,
+                                    4: 77309411328,
+                                    5: 77309411328,
+                                    6: 77309411328,
+                                    7: 77309411328,
+                                },
+                            ),
+                        ),
+                    ],
+                )
+            ],
+            0,
+        ),
+        # Headless mode scaling to 3 nodes via DP=3 DP-Local=1.
+        # Check point:
+        # - world_size = TP * DP = 24, scheduler picks 3x H100 workers.
+        # - The per-node DP-Local stays 1 (g_per_node=8, tp=8).
+        (
+            "headless_tp8_dp3_dpl1_3x_h100",
+            make_model(
+                0,
+                None,
+                "deepseek-ai/DeepSeek-R1",
+                backend_parameters=[
+                    "--tensor-parallel-size=8",
+                    "--data-parallel-size=3",
+                    "--data-parallel-size-local=1",
+                    "--data-parallel-backend=mp",
+                ],
+            ),
+            [
+                linux_nvidia_22_H100_80gx8(),
+                linux_nvidia_23_H100_80gx8(),
+                linux_nvidia_24_H100_80gx8(),
+            ],
+            [
+                expected_candidate(
+                    22,
+                    "host22-h100",
+                    [0, 1, 2, 3, 4, 5, 6, 7],
+                    {
+                        0: 77309411328,
+                        1: 77309411328,
+                        2: 77309411328,
+                        3: 77309411328,
+                        4: 77309411328,
+                        5: 77309411328,
+                        6: 77309411328,
+                        7: 77309411328,
+                    },
+                    [
+                        ModelInstanceSubordinateWorker(
+                            worker_id=23,
+                            worker_ip="192.168.50.23",
+                            total_gpus=8,
+                            gpu_indexes=[0, 1, 2, 3, 4, 5, 6, 7],
+                            computed_resource_claim=ComputedResourceClaim(
+                                vram={
+                                    0: 77309411328,
+                                    1: 77309411328,
+                                    2: 77309411328,
+                                    3: 77309411328,
+                                    4: 77309411328,
+                                    5: 77309411328,
+                                    6: 77309411328,
+                                    7: 77309411328,
+                                },
+                            ),
+                        ),
+                        ModelInstanceSubordinateWorker(
+                            worker_id=24,
+                            worker_ip="192.168.50.24",
+                            total_gpus=8,
+                            gpu_indexes=[0, 1, 2, 3, 4, 5, 6, 7],
+                            computed_resource_claim=ComputedResourceClaim(
+                                vram={
+                                    0: 77309411328,
+                                    1: 77309411328,
+                                    2: 77309411328,
+                                    3: 77309411328,
+                                    4: 77309411328,
+                                    5: 77309411328,
+                                    6: 77309411328,
+                                    7: 77309411328,
+                                },
+                            ),
+                        ),
+                    ],
+                )
+            ],
+            0,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_select_candidates_headless(
+    config, case_name, m, workers, expected_candidates, final_candidate_index
+):
+    """
+    Auto-scheduling under vLLM headless mode (sentinel `--data-parallel-backend mp`).
+    Verifies that the scheduler still produces correct multi-worker candidates
+    and that the #5089 fix (DP-Local parsing + world_size formula) holds.
+    """
+    with (
+        patch(
+            'gpustack.scheduler.scheduler.BackendFrameworkFilter._has_supported_runners',
+            return_value=(True, []),
+        ),
+        patch(
+            'gpustack.schemas.workers.Worker.all',
+            return_value=workers,
+        ),
+        patch(
+            'gpustack.policies.worker_filters.backend_framework_filter.async_session',
+            return_value=mock_async_session(),
+        ),
+        patch(
+            'gpustack.policies.scorers.placement_scorer.async_session',
+            return_value=mock_async_session(),
+        ),
+        patch(
+            'gpustack.policies.scorers.model_file_locality_scorer.async_session',
+            return_value=mock_async_session(),
+        ),
+    ):
+        m.backend = BackendEnum.VLLM.value
+
+        mis = []
+
+        resource_fit_selector = VLLMResourceFitSelector(config, m, mis)
+        placement_scorer = PlacementScorer(m, mis)
+
+        actual_candidates = await resource_fit_selector.select_candidates(workers)
+        actual_candidates = await placement_scorer.score(actual_candidates)
+        actual_candidate, _ = await scheduler.find_candidate(config, m, workers, mis)
+
+        try:
+            assert len(actual_candidates) == len(expected_candidates)
+            compare_candidates(actual_candidates, expected_candidates)
+            compare_candidates(
+                [actual_candidate], [expected_candidates[final_candidate_index]]
+            )
+        except AssertionError as e:
+            raise AssertionError(f"Test case '{case_name}' failed: {str(e)}") from e
+
+
+@pytest.mark.parametrize(
+    "case_name, m, workers, expected_candidates, final_candidate_index",
+    [
         # Manually select 1 cuda gpu and 1 amd rocm gpu.
         # Check point:
         # - Candidate selection correctness, final candidate should be the cuda gpu.

--- a/tests/worker/backends/test_multinode_topology.py
+++ b/tests/worker/backends/test_multinode_topology.py
@@ -1,0 +1,643 @@
+"""
+Unit tests for vLLM multi-node topology inference.
+
+Covers:
+- world_size formula regression (Issue #5089).
+- ``cal_multinode_topology`` resolver across the three deployment shapes
+  (``dp_only`` / ``mp_only`` / ``nested``).
+- Heterogeneous worker groups (vLLM allows per-node DP-Local).
+- Failure paths: TP/PP that cannot fit, mismatched user-supplied DP, etc.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gpustack.policies.candidate_selectors.vllm_resource_fit_selector import (
+    VLLMResourceFitSelector,
+)
+from gpustack.utils.vllm_topology import (
+    MultinodeUserParallelism,
+    ValidatedTopology,
+    validate_multinode_topology,
+)
+from gpustack.worker.backends.vllm import (
+    MultinodeTopology,
+    cal_multinode_topology,
+)
+
+
+def _model(params):
+    m = MagicMock()
+    m.backend_parameters = params
+    return m
+
+
+def _instance(g_main, *subordinate_gs):
+    mi = MagicMock()
+    mi.gpu_indexes = list(range(g_main))
+    sub = []
+    for g in subordinate_gs:
+        s = MagicMock()
+        s.gpu_indexes = list(range(g))
+        sub.append(s)
+    mi.distributed_servers.subordinate_workers = sub
+    return mi
+
+
+def _meta(role, follower_index=None):
+    """role: 'leader' or 'follower'. follower_index is 0-based."""
+    m = MagicMock()
+    m.distributed_leader = role == "leader"
+    m.distributed_follower = role == "follower"
+    m.distributed_follower_index = follower_index
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Issue #5089 regression
+# ---------------------------------------------------------------------------
+
+
+def test_world_size_5089_multi_line():
+    """Regression: TP=8 DP=2 DP-Local=1 split across tokens yields world_size=16."""
+    params = [
+        "--tensor-parallel-size",
+        "8",
+        "--data-parallel-size",
+        "2",
+        "--data-parallel-size-local",
+        "1",
+    ]
+    world_size, strategies = (
+        VLLMResourceFitSelector.get_world_size_from_backend_parameters(_model(params))
+    )
+    assert world_size == 16
+    assert strategies == ["tp", "dp", "dpl"]
+
+
+def test_world_size_dpl_does_not_multiply():
+    """world_size = TP * PP * DP; DP-Local appears only in strategies."""
+    params = ["--tp", "4", "--dp", "2", "--dpl", "2"]
+    world_size, _ = VLLMResourceFitSelector.get_world_size_from_backend_parameters(
+        _model(params)
+    )
+    assert world_size == 8
+
+
+def test_world_size_only_tp():
+    world_size, strategies = (
+        VLLMResourceFitSelector.get_world_size_from_backend_parameters(
+            _model(["--tensor-parallel-size", "4"])
+        )
+    )
+    assert world_size == 4
+    assert strategies == ["tp"]
+
+
+def test_world_size_tp_pp_dp():
+    world_size, strategies = (
+        VLLMResourceFitSelector.get_world_size_from_backend_parameters(
+            _model(["--tp", "4", "--pp", "2", "--dp", "3"])
+        )
+    )
+    assert world_size == 24
+    assert strategies == ["tp", "pp", "dp"]
+
+
+def test_world_size_no_parallelism():
+    world_size, strategies = (
+        VLLMResourceFitSelector.get_world_size_from_backend_parameters(
+            _model(["--max-model-len", "8192"])
+        )
+    )
+    assert world_size is None
+    assert strategies is None
+
+
+# ---------------------------------------------------------------------------
+# shape == "dp_only" — homogeneous clusters
+# ---------------------------------------------------------------------------
+
+
+def test_dp_only_homogeneous_defaults_leader():
+    """2 nodes x 8 GPU, no user args → TP=8, DP=2, DPL=1, leader start_rank=0."""
+    out = cal_multinode_topology(_instance(8, 8), _meta("leader"))
+    assert out == MultinodeTopology(
+        shape="dp_only",
+        tp=8,
+        pp=1,
+        dp=2,
+        dpl=1,
+        nnodes=2,
+        node_rank=0,
+        start_rank=0,
+        is_follower=False,
+    )
+
+
+def test_dp_only_homogeneous_defaults_follower():
+    """2 nodes x 8 GPU, follower index 0 → start_rank=1 (cumulative DPL)."""
+    out = cal_multinode_topology(_instance(8, 8), _meta("follower", 0))
+    assert out.shape == "dp_only"
+    assert out.start_rank == 1
+    assert out.node_rank == 1
+    assert out.is_follower is True
+
+
+def test_dp_only_user_tp_4_dpl_2():
+    """User TP=4 on 2x8 → per-node DPL=2, DP=4."""
+    out = cal_multinode_topology(
+        _instance(8, 8), _meta("leader"), MultinodeUserParallelism(tp=4)
+    )
+    assert out.shape == "dp_only"
+    assert (out.tp, out.dp, out.dpl, out.start_rank) == (4, 4, 2, 0)
+
+
+def test_dp_only_user_tp_4_follower_start_rank():
+    """User TP=4 on 2x8, follower index 0 → start_rank = leader's DPL = 2."""
+    out = cal_multinode_topology(
+        _instance(8, 8), _meta("follower", 0), MultinodeUserParallelism(tp=4)
+    )
+    assert out.shape == "dp_only"
+    assert (out.tp, out.dp, out.dpl, out.start_rank) == (4, 4, 2, 2)
+
+
+def test_dp_only_single_node():
+    out = cal_multinode_topology(_instance(8), _meta("leader"))
+    # Single-node still resolves to dp_only — there is no PP/TP cross-node split.
+    assert out.shape == "dp_only"
+    assert (out.dp, out.dpl, out.start_rank, out.nnodes) == (1, 1, 0, 1)
+
+
+def test_dp_only_three_nodes_start_ranks():
+    """3 nodes x 8 GPU → start_ranks 0,1,2."""
+    inst = _instance(8, 8, 8)
+    assert cal_multinode_topology(inst, _meta("leader")).start_rank == 0
+    assert cal_multinode_topology(inst, _meta("follower", 0)).start_rank == 1
+    assert cal_multinode_topology(inst, _meta("follower", 1)).start_rank == 2
+
+
+# ---------------------------------------------------------------------------
+# shape == "dp_only" — heterogeneous clusters
+# ---------------------------------------------------------------------------
+
+
+def test_dp_only_heterogeneous_default_tp_gcd():
+    """8 + 4 GPU mix → default TP = gcd(8,4) = 4, per-node DPL = (2, 1)."""
+    inst = _instance(8, 4)
+    leader = cal_multinode_topology(inst, _meta("leader"))
+    assert leader.shape == "dp_only"
+    assert (leader.tp, leader.dp, leader.dpl, leader.start_rank) == (4, 3, 2, 0)
+
+    follower = cal_multinode_topology(inst, _meta("follower", 0))
+    assert follower.shape == "dp_only"
+    assert (follower.dp, follower.dpl, follower.start_rank) == (3, 1, 2)
+
+
+def test_dp_only_heterogeneous_user_tp_overrides():
+    """User TP=2 on 8 + 4 mix → per-node DPL = (4, 2), DP=6."""
+    inst = _instance(8, 4)
+    leader = cal_multinode_topology(
+        inst, _meta("leader"), MultinodeUserParallelism(tp=2)
+    )
+    follower = cal_multinode_topology(
+        inst, _meta("follower", 0), MultinodeUserParallelism(tp=2)
+    )
+    assert (leader.tp, leader.dp, leader.dpl, leader.start_rank) == (2, 6, 4, 0)
+    assert (follower.dp, follower.dpl, follower.start_rank) == (6, 2, 4)
+
+
+def test_dp_only_heterogeneous_rejects_uniform_dpl():
+    with pytest.raises(ValueError, match="heterogeneous worker group"):
+        cal_multinode_topology(
+            _instance(8, 4), _meta("leader"), MultinodeUserParallelism(dpl=1)
+        )
+
+
+def test_dp_only_heterogeneous_tp_must_divide_every_node():
+    with pytest.raises(ValueError, match=r"worker\[1\] 4 GPUs"):
+        cal_multinode_topology(
+            _instance(8, 4), _meta("leader"), MultinodeUserParallelism(tp=8)
+        )
+
+
+# ---------------------------------------------------------------------------
+# shape == "mp_only" — PP/TP spans multiple nodes, dp == 1
+# ---------------------------------------------------------------------------
+
+
+def test_mp_only_pp_across_two_nodes_leader():
+    """TP=8 PP=2 on 2x8 GPU → workers_per_dp=16 > g_per_node=8 → mp_only."""
+    inst = _instance(8, 8)
+    out = cal_multinode_topology(
+        inst, _meta("leader"), MultinodeUserParallelism(tp=8, pp=2)
+    )
+    assert out == MultinodeTopology(
+        shape="mp_only",
+        tp=8,
+        pp=2,
+        dp=1,
+        dpl=1,
+        nnodes=2,
+        node_rank=0,
+        start_rank=0,
+        is_follower=False,
+    )
+
+
+def test_mp_only_pp_across_two_nodes_follower():
+    inst = _instance(8, 8)
+    out = cal_multinode_topology(
+        inst, _meta("follower", 0), MultinodeUserParallelism(tp=8, pp=2)
+    )
+    assert out.shape == "mp_only"
+    assert out.node_rank == 1
+    assert out.is_follower is True
+
+
+def test_mp_only_pp_three_nodes():
+    """TP=4 PP=3 on 3x4 GPU."""
+    inst = _instance(4, 4, 4)
+    out = cal_multinode_topology(
+        inst, _meta("follower", 1), MultinodeUserParallelism(tp=4, pp=3)
+    )
+    assert out.shape == "mp_only"
+    assert out.nnodes == 3 and out.node_rank == 2
+
+
+def test_mp_only_rejects_heterogeneous():
+    """mp_only requires every node to contribute the same GPU count.
+
+    Uses TP=4 PP=4 so both nodes pass the TP-divides-GPU check first, then
+    the cross-node branch's homogeneity check is what fires.
+    """
+    inst = _instance(8, 4)
+    with pytest.raises(ValueError, match="homogeneous"):
+        cal_multinode_topology(
+            inst, _meta("leader"), MultinodeUserParallelism(tp=4, pp=4)
+        )
+
+
+def test_mp_only_rejects_dp_gt_1_without_capacity():
+    """workers_per_dp=16 > capacity=8 → nnodes_within_dp=2; cluster only has 2 nodes,
+    so a single DP rank fills the cluster — dp=2 is impossible to fit."""
+    inst = _instance(8, 8)
+    with pytest.raises(ValueError, match="does not match"):
+        cal_multinode_topology(
+            inst,
+            _meta("leader"),
+            MultinodeUserParallelism(tp=8, pp=2, dp=2),
+        )
+
+
+# ---------------------------------------------------------------------------
+# shape == "nested" — DP rank spans multiple nodes, dp > 1
+# ---------------------------------------------------------------------------
+
+
+def test_nested_dp_2_pp_2():
+    """TP=4 PP=2 DP=2 on 4x4 GPU → workers_per_dp=8 > 4 → nested."""
+    inst = _instance(4, 4, 4, 4)
+    leader = cal_multinode_topology(
+        inst, _meta("leader"), MultinodeUserParallelism(tp=4, pp=2, dp=2)
+    )
+    assert leader == MultinodeTopology(
+        shape="nested",
+        tp=4,
+        pp=2,
+        dp=2,
+        dpl=1,
+        nnodes=4,
+        node_rank=0,
+        start_rank=0,
+        is_follower=False,
+    )
+
+    follower2 = cal_multinode_topology(
+        inst, _meta("follower", 1), MultinodeUserParallelism(tp=4, pp=2, dp=2)
+    )
+    # node_rank=2, nnodes_within_dp=2 → node_rank_within_dp=0 → DP rank 1 head.
+    assert follower2.shape == "nested"
+    assert follower2.node_rank == 2
+    # vLLM derives DP rank from node_rank // nnodes_within_dp internally;
+    # we surface it here for diagnostics but do not emit --data-parallel-start-rank.
+    assert follower2.start_rank == 1
+
+
+def test_nested_rejects_non_divisible_nnodes():
+    """3 nodes, workers_per_dp=8, capacity=4 → nnodes_within_dp=2 but 3 % 2 != 0."""
+    inst = _instance(4, 4, 4)
+    with pytest.raises(ValueError, match="cannot evenly distribute"):
+        cal_multinode_topology(
+            inst, _meta("leader"), MultinodeUserParallelism(tp=4, pp=2, dp=2)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Generic failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_tp_not_divisor():
+    with pytest.raises(ValueError, match=r"worker\[0\] 8 GPUs"):
+        cal_multinode_topology(
+            _instance(8, 8), _meta("leader"), MultinodeUserParallelism(tp=3)
+        )
+
+
+def test_dp_only_dp_mismatch():
+    # Single-dp without tp now goes through tp inference (16 % 5 != 0),
+    # so the failure is "cannot infer" rather than "does not match".
+    with pytest.raises(ValueError, match="cannot infer"):
+        cal_multinode_topology(
+            _instance(8, 8), _meta("leader"), MultinodeUserParallelism(dp=5)
+        )
+
+
+def test_dp_only_explicit_tp_dp_mismatch():
+    # When the user pins tp explicitly, dp inference is skipped and we fall
+    # back to the original dp_total consistency check.
+    with pytest.raises(ValueError, match="does not match"):
+        cal_multinode_topology(
+            _instance(8, 8),
+            _meta("leader"),
+            MultinodeUserParallelism(tp=8, dp=5),
+        )
+
+
+def test_dp_only_user_dpl_consistent():
+    out = cal_multinode_topology(
+        _instance(8, 8), _meta("leader"), MultinodeUserParallelism(tp=8, dpl=1)
+    )
+    assert out.shape == "dp_only"
+    assert (out.tp, out.dp, out.dpl, out.start_rank) == (8, 2, 1, 0)
+
+
+def test_follower_index_out_of_bounds():
+    with pytest.raises(ValueError, match="out of bounds"):
+        cal_multinode_topology(_instance(8, 8), _meta("follower", 5))
+
+
+# ---------------------------------------------------------------------------
+# validate_multinode_topology — pure function exposed to selector
+# ---------------------------------------------------------------------------
+
+
+def test_validate_dp_only_homogeneous():
+    out = validate_multinode_topology([8, 8])
+    assert out == ValidatedTopology(
+        shape="dp_only",
+        tp=8,
+        pp=1,
+        dp=2,
+        dpl_per_node=[1, 1],
+        nnodes_within_dp=1,
+    )
+
+
+def test_validate_dp_only_heterogeneous_dpl_per_node():
+    """Heterogeneous cluster: dpl_per_node should differ per node."""
+    out = validate_multinode_topology([8, 4], MultinodeUserParallelism(tp=4))
+    assert out.shape == "dp_only"
+    assert out.dpl_per_node == [2, 1]
+    assert out.dp == 3
+
+
+def test_validate_mp_only():
+    out = validate_multinode_topology([8, 8], MultinodeUserParallelism(tp=8, pp=2))
+    assert out == ValidatedTopology(
+        shape="mp_only",
+        tp=8,
+        pp=2,
+        dp=1,
+        dpl_per_node=[1, 1],
+        nnodes_within_dp=2,
+    )
+
+
+def test_validate_nested():
+    out = validate_multinode_topology(
+        [4, 4, 4, 4], MultinodeUserParallelism(tp=4, pp=2, dp=2)
+    )
+    assert out == ValidatedTopology(
+        shape="nested",
+        tp=4,
+        pp=2,
+        dp=2,
+        dpl_per_node=[1, 1, 1, 1],
+        nnodes_within_dp=2,
+    )
+
+
+@pytest.mark.parametrize(
+    "gpu_per_node,user,expected_match",
+    [
+        # tp doesn't divide a node's GPU count.
+        ([8, 8], MultinodeUserParallelism(tp=3), r"worker\[0\] 8 GPUs"),
+        # User pins both tp and dp inconsistently.
+        ([8, 8], MultinodeUserParallelism(tp=8, dp=5), "does not match"),
+        # Heterogeneous cross-node TP/PP.
+        ([8, 4], MultinodeUserParallelism(tp=4, pp=4), "homogeneous"),
+        # nnodes_within_dp doesn't divide cluster size.
+        (
+            [4, 4, 4],
+            MultinodeUserParallelism(tp=4, pp=2, dp=2),
+            "cannot evenly distribute",
+        ),
+        # User dpl != 1 in cross-node layout.
+        (
+            [8, 8],
+            MultinodeUserParallelism(tp=8, pp=2, dpl=2),
+            "must be 1",
+        ),
+    ],
+)
+def test_validate_rejects(gpu_per_node, user, expected_match):
+    with pytest.raises(ValueError, match=expected_match):
+        validate_multinode_topology(gpu_per_node, user)
+
+
+def test_validate_default_tp_uses_gcd():
+    """No user TP → default to gcd(gpu_per_node)."""
+    out = validate_multinode_topology([8, 4])
+    assert out.tp == 4
+    assert out.dpl_per_node == [2, 1]
+
+
+def test_validate_returns_tp_for_inference_by_caller():
+    """selector can read out.tp to learn what GPUStack inferred."""
+    out = validate_multinode_topology([16, 16], MultinodeUserParallelism())
+    assert out.tp == 16
+    assert out.shape == "dp_only"
+
+
+# ---------------------------------------------------------------------------
+# tp inference from user-supplied dp (vLLM-aligned semantics)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_infers_tp_from_dp_only():
+    """Cluster=[8, 8] + --dp 4 → tp=4 (16 GPUs / 4 DP ranks)."""
+    out = validate_multinode_topology([8, 8], MultinodeUserParallelism(dp=4))
+    assert out.tp == 4
+    assert out.dp == 4
+    assert out.shape == "dp_only"
+    assert out.dpl_per_node == [2, 2]
+
+
+def test_validate_infers_tp_from_dp_with_pp():
+    """Cluster=[8, 8] + --dp 1 --pp 2 → tp=8, mp_only across both nodes."""
+    out = validate_multinode_topology([8, 8], MultinodeUserParallelism(dp=1, pp=2))
+    assert out.tp == 8
+    assert out.pp == 2
+    assert out.dp == 1
+    assert out.shape == "mp_only"
+    assert out.nnodes_within_dp == 2
+
+
+def test_validate_infers_tp_yields_nested():
+    """Cluster=[4, 4, 4, 4] + --dp 2 --pp 2 → tp=4, nested layout."""
+    out = validate_multinode_topology(
+        [4, 4, 4, 4], MultinodeUserParallelism(dp=2, pp=2)
+    )
+    assert out.tp == 4
+    assert out.shape == "nested"
+    assert out.nnodes_within_dp == 2
+
+
+def test_validate_rejects_dp_not_dividing_total_gpus():
+    """Cluster=[8, 8] + --dp 3 → 16 % 3 != 0 → reject before further checks."""
+    with pytest.raises(ValueError, match="cannot infer"):
+        validate_multinode_topology([8, 8], MultinodeUserParallelism(dp=3))
+
+
+def test_validate_explicit_tp_overrides_dp_inference():
+    """Explicit tp wins; dp is only consistency-checked, not used to infer tp.
+
+    With tp=8 the inferred dp_total is 2; user.dp=2 must agree.
+    """
+    out = validate_multinode_topology([8, 8], MultinodeUserParallelism(tp=8, dp=2))
+    assert out.tp == 8
+    assert out.dp == 2
+
+
+def test_validate_explicit_tp_with_inconsistent_dp_still_rejects():
+    """Regression: tp explicit + dp explicit but inconsistent → reject by
+    existing dp-mismatch check (not by the new inference branch)."""
+    with pytest.raises(ValueError, match="does not match"):
+        validate_multinode_topology([8, 8], MultinodeUserParallelism(tp=8, dp=5))
+
+
+# ---------------------------------------------------------------------------
+# selector ``_create_candidate`` topology gating
+# ---------------------------------------------------------------------------
+
+
+def _mock_worker(name, gpu_count, total_memory=80 * 1024**3):
+    """Build a worker mock just rich enough for _create_candidate."""
+    worker = MagicMock()
+    worker.id = hash(name) & 0xFFFF
+    worker.name = name
+    worker.ip = "10.0.0.1"
+    worker.ifname = "eth0"
+    gpus = []
+    for i in range(gpu_count):
+        gpu = MagicMock()
+        gpu.index = i
+        gpu.memory.total = total_memory
+        gpu.type = "nvidia"
+        gpus.append(gpu)
+    worker.status.gpu_devices = gpus
+    return worker
+
+
+def _mock_model(backend_parameters=None, backend_version="0.18.0"):
+    model = MagicMock()
+    model.backend = "vLLM"
+    model.backend_parameters = backend_parameters
+    model.backend_version = backend_version
+    model.name = "test-model"
+    model.categories = None
+    # _create_candidate → get_computed_ram_claim consults extended_kv_cache;
+    # leaving it as a MagicMock would trip ``ram_size > 0``.
+    model.extended_kv_cache = None
+    return model
+
+
+def test_create_candidate_returns_none_on_topology_failure():
+    """Heterogeneous cluster requested for cross-node TP/PP → selector should
+    skip the worker combination by returning None plus an explanatory reason."""
+    from gpustack.policies.candidate_selectors.vllm_resource_fit_selector import (
+        _create_candidate,
+    )
+
+    model = _mock_model(
+        ["--distributed-executor-backend", "mp", "--tp", "4", "--pp", "4"]
+    )
+    workers = [_mock_worker("a", 8), _mock_worker("b", 4)]
+    candidate, reason = _create_candidate(model, workers)
+    assert candidate is None
+    assert reason is not None
+    assert "homogeneous" in reason
+
+
+def test_create_candidate_tp_unfittable_returns_reason():
+    """Cluster=[1,1] + tp=2 → vLLM forbids cross-node TP; reason surfaces it.
+
+    Regression: this is the user-reported scenario where the UI used to show
+    "no suitable workers" without explaining the parameter is impossible.
+    """
+    from gpustack.policies.candidate_selectors.vllm_resource_fit_selector import (
+        _create_candidate,
+    )
+
+    model = _mock_model(["--distributed-executor-backend", "mp", "--tp", "2"])
+    workers = [_mock_worker("a", 1), _mock_worker("b", 1)]
+    candidate, reason = _create_candidate(model, workers)
+    assert candidate is None
+    assert "cannot divide" in reason
+
+
+def test_create_candidate_returns_candidate_when_topology_fits():
+    """Homogeneous cluster with valid cross-node TP/PP → candidate created."""
+    from gpustack.policies.candidate_selectors.vllm_resource_fit_selector import (
+        _create_candidate,
+    )
+
+    model = _mock_model(
+        ["--distributed-executor-backend", "mp", "--tp", "8", "--pp", "2"]
+    )
+    workers = [_mock_worker("a", 8), _mock_worker("b", 8)]
+    candidate, reason = _create_candidate(model, workers)
+    assert candidate is not None
+    assert reason is None
+    assert len(candidate.subordinate_workers) == 1
+
+
+def test_create_candidate_skips_topology_check_for_ray_backend():
+    """Ray-path candidates don't go through native topology validation."""
+    from gpustack.policies.candidate_selectors.vllm_resource_fit_selector import (
+        _create_candidate,
+    )
+
+    # Heterogeneous would fail mp topology, but Ray path bypasses the check.
+    model = _mock_model(
+        ["--distributed-executor-backend", "ray", "--tp", "4", "--pp", "4"]
+    )
+    workers = [_mock_worker("a", 8), _mock_worker("b", 4)]
+    candidate, reason = _create_candidate(model, workers)
+    assert candidate is not None
+    assert reason is None
+
+
+def test_create_candidate_skips_topology_check_for_single_worker():
+    """Single-worker schedule is not multi-node — no topology validation."""
+    from gpustack.policies.candidate_selectors.vllm_resource_fit_selector import (
+        _create_candidate,
+    )
+
+    model = _mock_model(["--distributed-executor-backend", "mp"])
+    candidate, reason = _create_candidate(model, [_mock_worker("a", 8)])
+    assert candidate is not None
+    assert reason is None


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5037

1. Use the `--distributed-executor-backend=mp` parameter as a switch for headless mode. When set, it will skip Ray's startup configuration and automatically calculate the parallel parameter configuration for headless mode.
2. Split the method `_build_command_args` of vllm backend into focused helpers, to improve the readability.