### PR TITLE
feat: enforce same-Org alignment between routes and their targets

### DIFF
--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -203,7 +203,7 @@ async def create_model_route(
         )
     source = input.model_dump(exclude={"targets"})
     targets = input.targets or []
-    await validate_targets(session, targets)
+    await validate_targets(session, targets, route_owner_principal_id=target_org_id)
     source["targets"] = len(targets)
     # Stamp the route's owning org from the caller's tenant context.
     # ModelRouteBase defaults `owner_principal_id` to PLATFORM_PRINCIPAL_ID
@@ -294,6 +294,7 @@ async def update_model_route(
                 targets=input.targets,
                 auto_commit=False,
                 new_route_name=input.name if input.name != existing.name else None,
+                route_owner_principal_id=existing.owner_principal_id,
             )
             input_data["targets"] = target_count
         await ModelRouteService(session).update(
@@ -367,6 +368,7 @@ async def add_model_route_targets(
         route_id=route.id,
         route_name=route.name,
         new_route_name=None,
+        route_owner_principal_id=route.owner_principal_id,
         targets=targets,
         auto_commit=False,
     )
@@ -390,6 +392,7 @@ async def batch_handle_targets(
     targets: List[ModelRouteTargetUpdateItem],
     auto_commit: bool = True,
     new_route_name: Optional[str] = None,
+    route_owner_principal_id: Optional[int] = None,
 ) -> Tuple[int, List[ModelRouteTarget]]:
     existing_targets = await ModelRouteTarget.all_by_field(
         session=session,
@@ -417,7 +420,11 @@ async def batch_handle_targets(
     ]
     target_count -= len(to_delete_target_ids)
 
-    fallback_index = await validate_targets(session=session, targets=targets)
+    fallback_index = await validate_targets(
+        session=session,
+        targets=targets,
+        route_owner_principal_id=route_owner_principal_id,
+    )
     if fallback_index is not None:
         fallback_target = targets[fallback_index]
         if fallback_target.id is None:
@@ -542,9 +549,46 @@ async def create_model_route_targets(
     return created_targets
 
 
+def _assert_target_tenant_aligned(
+    route_owner_principal_id: Optional[int],
+    target_owner_principal_id: Optional[int],
+    target_kind: str,
+    target_id: int,
+) -> None:
+    """Routes are GPUStack's only cross-tenant sharing surface — a
+    deployment (Model / ModelProvider) has no permission primitive of
+    its own, so it lives within one Org's boundary and must only be
+    referenced from routes in the same Org. Cross-Org targeting that
+    bypasses this is a misconfiguration: usage attribution
+    (``ModelUsage.owner_principal_id``) is sourced from the model's
+    owner, so a cross-Org target silently drifts the row's tenant scope
+    away from the route's caller.
+
+    A NULL target owner (e.g. legacy provider rows that predate
+    multi-tenancy) is treated as global and allowed everywhere — the
+    strict rule kicks in only when the target explicitly carries an
+    owner. A route with no owner (also legacy / platform fallback) is
+    similarly skipped.
+    """
+    if route_owner_principal_id is None:
+        return
+    if target_owner_principal_id is None:
+        return
+    if target_owner_principal_id == route_owner_principal_id:
+        return
+    raise InvalidException(
+        f"{target_kind} {target_id} belongs to principal "
+        f"{target_owner_principal_id}; a route owned by principal "
+        f"{route_owner_principal_id} may only target resources in the "
+        f"same Org. Cross-Org sharing must be done by exposing this Org's "
+        f"own route (via access policy), not by retargeting across Orgs."
+    )
+
+
 async def validate_targets(
     session: SessionDep,
     targets: List[ModelRouteTargetUpdateItem],
+    route_owner_principal_id: Optional[int] = None,
 ) -> Optional[int]:
     fallback_index: Optional[int] = None
     for index, target in enumerate(targets):
@@ -566,10 +610,22 @@ async def validate_targets(
                     f"ModelProvider with id '{target.provider_id}' not found."
                 )
             validate_provider_model_name(provider, target.provider_model_name)
+            _assert_target_tenant_aligned(
+                route_owner_principal_id,
+                getattr(provider, "owner_principal_id", None),
+                "ModelProvider",
+                target.provider_id,
+            )
         elif target.model_id is not None:
             model = await Model.one_by_id(session=session, id=target.model_id)
             if model is None or model.deleted_at is not None:
                 raise NotFoundException(f"Model with id '{target.model_id}' not found.")
+            _assert_target_tenant_aligned(
+                route_owner_principal_id,
+                getattr(model, "owner_principal_id", None),
+                "Model",
+                target.model_id,
+            )
     return fallback_index
 
 
@@ -645,6 +701,13 @@ async def update_model_route_target(
     )
     if not existing or existing.deleted_at is not None:
         raise NotFoundException(f"ModelRouteTarget with id '{id}' not found.")
+    # Resolve the owning route's tenant so validate_targets can enforce
+    # tenant alignment — a target swap (e.g. pointing at a different
+    # model) must still satisfy "route and target share an Org".
+    parent_route = await ModelRoute.one_by_id(session=session, id=existing.route_id)
+    if parent_route is None:
+        raise NotFoundException(f"ModelRoute with id '{existing.route_id}' not found.")
+    route_owner_principal_id = parent_route.owner_principal_id
     # don't need to update fallback_status_codes here, handled in set-fallback target
     targets = [
         ModelRouteTargetUpdateItem.model_validate(
@@ -655,7 +718,9 @@ async def update_model_route_target(
             }
         )
     ]
-    await validate_targets(session, targets)
+    await validate_targets(
+        session, targets, route_owner_principal_id=route_owner_principal_id
+    )
     try:
         await update_model_route_targets(
             session=session,

--- a/tests/routes/test_model_routes.py
+++ b/tests/routes/test_model_routes.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 import pytest
 from sqlalchemy import true
 
+from gpustack.api.exceptions import InvalidException
 from gpustack.routes import model_routes
 from gpustack.schemas.common import Pagination
 from gpustack.schemas.model_routes import (
@@ -50,3 +51,43 @@ async def test_get_model_routes_filters_categories_on_target_class(monkeypatch):
     assert captured["categories"] == ["image"]
     assert captured["fields"]["user_id"] == 123
     assert captured["extra_conditions"]
+
+
+def test_assert_target_tenant_aligned_same_org():
+    # Same Org is always allowed.
+    model_routes._assert_target_tenant_aligned(
+        route_owner_principal_id=2,
+        target_owner_principal_id=2,
+        target_kind="Model",
+        target_id=10,
+    )
+
+
+def test_assert_target_tenant_aligned_cross_org_rejected():
+    """Routes are the only cross-tenant sharing surface; targeting a
+    resource that lives in a different Org must fail at validation time
+    rather than silently drift usage attribution to the wrong tenant."""
+    with pytest.raises(InvalidException):
+        model_routes._assert_target_tenant_aligned(
+            route_owner_principal_id=2,
+            target_owner_principal_id=3,
+            target_kind="Model",
+            target_id=10,
+        )
+
+
+def test_assert_target_tenant_aligned_skips_when_either_owner_null():
+    # NULL on either side is treated as "global / legacy" — strict
+    # equality only kicks in when both sides explicitly carry an owner.
+    model_routes._assert_target_tenant_aligned(
+        route_owner_principal_id=None,
+        target_owner_principal_id=3,
+        target_kind="Model",
+        target_id=10,
+    )
+    model_routes._assert_target_tenant_aligned(
+        route_owner_principal_id=2,
+        target_owner_principal_id=None,
+        target_kind="ModelProvider",
+        target_id=11,
+    )


### PR DESCRIPTION
In GPUStack's tenancy model, deployments (Model / ModelProvider) have no permission primitive of their own — they live within one Org's boundary, and routes are the sole cross-tenant sharing surface (via access policy on the route itself). Previously ``validate_targets`` checked existence and provider model names only, allowing a route in Org A to silently target a model in Org B; this drifts usage attribution (``ModelUsage.owner_principal_id`` is sourced from the model) away from the route's caller without any error path.

* Add ``_assert_target_tenant_aligned`` and pipe a ``route_owner_principal_id`` parameter through ``validate_targets``.
* All three call sites — ``create_model_route``, ``batch_handle_targets`` (used by route update / add-target), and the single-target update path — now resolve the owning route's principal and pass it in.
* NULL owner on either side is treated as legacy/global and skipped, so the check only kicks in once both ends explicitly carry an Org.