### PR TITLE
chore: remove pinned vllm version for qwen3.5

### DIFF
--- a/gpustack/assets/model-catalog-modelscope.yaml
+++ b/gpustack/assets/model-catalog-modelscope.yaml
@@ -511,7 +511,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-0.8B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -551,7 +550,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-2B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -592,7 +590,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-4B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -633,7 +630,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-9B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -644,7 +640,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-9B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -659,7 +654,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-9B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -700,7 +694,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-27B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -712,7 +705,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-27B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -756,7 +748,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-35B-A3B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -768,7 +759,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-35B-A3B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -782,7 +772,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-35B-A3B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -828,7 +817,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-122B-A10B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -840,7 +828,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-122B-A10B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -884,7 +871,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-397B-A17B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -896,7 +882,6 @@ model_sets:
       source: model_scope
       model_scope_model_id: Qwen/Qwen3.5-397B-A17B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768

--- a/gpustack/assets/model-catalog.yaml
+++ b/gpustack/assets/model-catalog.yaml
@@ -489,7 +489,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-0.8B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -529,7 +528,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-2B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -570,7 +568,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-4B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -611,7 +608,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-9B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -622,7 +618,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-9B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -637,7 +632,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-9B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -678,7 +672,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-27B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -690,7 +683,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-27B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -734,7 +726,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-35B-A3B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -746,7 +737,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-35B-A3B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -760,7 +750,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-35B-A3B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -807,7 +796,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-122B-A10B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -819,7 +807,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-122B-A10B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -863,7 +850,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-397B-A17B
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768
@@ -875,7 +861,6 @@ model_sets:
       source: huggingface
       huggingface_repo_id: Qwen/Qwen3.5-397B-A17B-FP8
       backend: vLLM
-      backend_version: 0.17.1
       backend_parameters:
         - --reasoning-parser=qwen3
         - --max-model-len=32768


### PR DESCRIPTION
Related: https://github.com/gpustack/gpustack/issues/4969

Run Qwen3.5 with the default (v0.20.1+) vLLM versions.
For Ascend, SGLang 0.5.9 is kept because it's still better than vllm-ascend 0.18.0 running Qwen3.5:

<img width="3326" height="660" alt="e6d6083b393a121580d5bc5b643d95ee" src="https://github.com/user-attachments/assets/d31c590b-205c-45ea-b138-656d8a394239" />
