### PR TITLE
fix: detect fresh install via data_dir snapshot for server role

### DIFF
--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -228,6 +228,7 @@ class Config(WorkerConfig, BaseSettings):
     _set_worker_fields = {}
     _derive_gateway_token = None
     _jwt_secret_key_user_provided = False
+    _data_dir_was_fresh = False
 
     model_config = SettingsConfigDict(
         env_prefix="GPUSTACK_", protected_namespaces=('settings_',), extra="allow"
@@ -248,6 +249,12 @@ class Config(WorkerConfig, BaseSettings):
 
         # common options
         self.data_dir = prepare_dir(self.data_dir, self.get_data_dir())
+        # Snapshot data_dir emptiness before any init step writes into it
+        # (e.g., prepare_jwt_secret_key, make_dirs). _is_both_role() reads
+        # this to decide if this is a fresh v2.0.1+ install.
+        self._data_dir_was_fresh = not os.path.isdir(self.data_dir) or not os.listdir(
+            self.data_dir
+        )
         self.cache_dir = prepare_dir(
             self.cache_dir, os.path.join(self.data_dir, "cache")
         )
@@ -757,9 +764,14 @@ class Config(WorkerConfig, BaseSettings):
         Determine if the server is running in both server and worker mode. If the
         `enable_worker` flag is set to True, the server is running in both modes. If the
         `disable_worker` flag is set to True, the server is running in server-only mode.
-        If neither flag is set, the presence of a `bootstrap_version` file in the data
-        directory is checked. If the file does not exist, it indicates that the server was
-        installed using a version that defaults to running in both modes.
+
+        If neither flag is set, decide by data_dir state:
+        - An empty/missing data_dir indicates a fresh install, which defaults to
+          server-only mode (the v2.0.1+ default).
+        - Otherwise fall back to checking the `bootstrap_version` file: its
+          presence marks a data_dir that was first initialized by v2.0.1+
+          (server-only default); its absence on a non-empty data_dir means a
+          legacy v2.0.0 install that defaults to both modes.
 
         Returns:
             bool: True if running in both server and worker mode, False otherwise.
@@ -771,9 +783,9 @@ class Config(WorkerConfig, BaseSettings):
         elif self.disable_worker:
             return False
 
-        # As of v2.0.1, a `bootstrap_version` file is created in data_dir.
-        # If the file exists, it indicates that the server was installed
-        # using a version that defaults to running server-only mode.
+        if self._data_dir_was_fresh:
+            return False
+
         bootstrap_version_path = os.path.join(self.data_dir, "bootstrap_version")
         if os.path.exists(bootstrap_version_path):
             return False

--- a/tests/config/test_server_role.py
+++ b/tests/config/test_server_role.py
@@ -1,0 +1,42 @@
+from gpustack.config.config import Config
+
+
+def test_is_both_role_false_when_data_dir_missing(tmp_path):
+    # data_dir does not exist yet -> fresh install -> server-only
+    cfg = Config(data_dir=str(tmp_path / "nonexistent"))
+
+    assert cfg._data_dir_was_fresh is True
+    assert cfg._is_both_role() is False
+
+
+def test_is_both_role_false_when_data_dir_empty(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    cfg = Config(data_dir=str(data_dir))
+
+    assert cfg._data_dir_was_fresh is True
+    assert cfg._is_both_role() is False
+
+
+def test_is_both_role_false_when_bootstrap_version_present(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "bootstrap_version").write_text("2.0.1")
+
+    cfg = Config(data_dir=str(data_dir))
+
+    assert cfg._data_dir_was_fresh is False
+    assert cfg._is_both_role() is False
+
+
+def test_is_both_role_true_for_legacy_data_dir(tmp_path):
+    # Non-empty data_dir without bootstrap_version simulates a v2.0.0 install.
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "legacy_marker").write_text("")
+
+    cfg = Config(data_dir=str(data_dir))
+
+    assert cfg._data_dir_was_fresh is False
+    assert cfg._is_both_role() is True


### PR DESCRIPTION
Related: https://github.com/gpustack/gpustack/issues/5181

Notice the following warning logs in server-only container:
```
2026-05-19 16:22:12.636337+08:00 - gpustack.utils.ephemeral_ports - WARNING - gpustack port ranges (service_port_range=40000-40063, ray_port_range=41000-41999) overlap the kernel ephemeral port range 32768-60999 and are not reserved. Ray or inference servers may fail to bind when the kernel transiently assigns one of these ports as an outbound ephemeral port. Failed to auto-reserve ([Errno 30] Read-only file system: '/proc/sys/net/ipv4/ip_local_reserved_ports'). Run on each worker host:
    echo 'net.ipv4.ip_local_reserved_ports = 40000-40063,41000-41999' | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
```

It's expected to run on workers, however in prerun, server_role() returns both for server-only.


`bootstrap_version` is written by the initial alembic migration, which runs after prerun. On the first start of a fresh v2.0.1+ install, prerun queried `server_role()` before the file existed and fell back to BOTH, triggering ephemeral port reservation (and a noisy warning when /proc is read-only) on what the user intended as a server-only deploy.

Snapshot data_dir emptiness in `Config.check_all` right after data_dir is resolved (before `prepare_jwt_secret_key` and `make_dirs` write into it), then have `_is_both_role()` treat a fresh data_dir as server-only. Existing data_dirs still fall back to the `bootstrap_version` check so v2.0.0 installs (with or without external DB) continue to default to BOTH.