### PR TITLE
refactor: group name field

### DIFF
--- a/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
+++ b/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
@@ -338,9 +338,6 @@ def upgrade() -> None:
     # 5. Principal-specific constraints / indexes on the renamed table.
     # ------------------------------------------------------------------
     with op.batch_alter_table('principals', schema=None) as batch_op:
-        batch_op.create_unique_constraint(
-            'uix_principals_name', ['name']
-        )
         batch_op.create_foreign_key(
             'fk_principals_parent_principal_id_principals',
             'principals',
@@ -349,20 +346,37 @@ def upgrade() -> None:
             ondelete='CASCADE',
         )
 
-    # Group display names are globally unique among active groups.
+    # ``principals.name`` uniqueness is partitioned by kind:
+    # - GROUP has its own namespace — IdP-supplied group names
+    #   commonly coincide with admin-chosen Org names; forcing the
+    #   two to be globally unique would break OIDC/SAML group sync
+    #   the moment an admin happens to name an Org the same as an
+    #   IdP group.
+    # - USER / ORG / SYSTEM share one namespace — admin-curated kinds
+    #   that have always shared one. Most lookups already scope by
+    #   kind (platform-Org resolution, default-cluster SYSTEM
+    #   resolution, the ``<owner-name>/<route>`` URL resolver), but
+    #   ``get_by_username`` (login) does not and relies on this
+    #   shared partition to avoid mis-resolving a login to an ORG row.
+    #
     # Postgres supports partial unique indexes natively. MySQL has
-    # no equivalent — a plain (non-unique) index supports lookups
-    # and uniqueness is enforced in the route handlers.
+    # no equivalent — fall back to a single plain (non-unique) index
+    # for lookup performance; uniqueness within each partition is
+    # enforced by the create routes (``create_user`` /
+    # ``create_organization`` / ``_insert_group_or_refetch``).
     if dialect == 'postgresql':
         op.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS uix_principals_group_display_name "
-            "ON principals (display_name) "
+            "CREATE UNIQUE INDEX IF NOT EXISTS uix_principals_non_group_name "
+            "ON principals (name) "
+            "WHERE kind <> 'GROUP' AND deleted_at IS NULL"
+        )
+        op.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uix_principals_group_name "
+            "ON principals (name) "
             "WHERE kind = 'GROUP' AND deleted_at IS NULL"
         )
     else:
-        op.create_index(
-            'ix_principals_group_display_name', 'principals', ['display_name']
-        )
+        op.create_index('ix_principals_name', 'principals', ['name'])
 
     # ------------------------------------------------------------------
     # 6. New related tables.

--- a/gpustack/routes/cluster_access.py
+++ b/gpustack/routes/cluster_access.py
@@ -97,6 +97,7 @@ async def _resolve_principal_views(
                 cluster_id=r.cluster_id,
                 principal_id=r.principal_id,
                 principal_type=kind,
+                principal_name=p.name if p else None,
                 principal_display_name=p.display_name if p else None,
                 principal_parent_id=parent,
                 granted_by=r.granted_by,

--- a/gpustack/routes/me_orgs.py
+++ b/gpustack/routes/me_orgs.py
@@ -36,10 +36,11 @@ async def list_my_orgs(session: SessionDep, user: CurrentUserDep):
     Group-membership).
 
     "Personal" is no longer a stored Org row. After the principals
-    refactor it's the user's own USER-principal (pre-refactor flag
-    ``is_personal=True`` is now ``kind == USER`` rendered by
-    ``OrganizationPublic.from_principal``). Synthesizing it here keeps
-    the OrgSwitcher render path unchanged on the UI side.
+    refactor it's the user's own USER-principal, rendered through
+    ``OrganizationPublic.from_principal`` with ``is_personal=True``.
+    The DTO passes the user's real ``name`` / ``display_name`` through
+    unmodified; the UI is responsible for substituting its localized
+    "Personal" label when ``is_personal`` is set.
     """
     items: List[MyOrganization] = []
 

--- a/gpustack/routes/model_route_principals.py
+++ b/gpustack/routes/model_route_principals.py
@@ -40,9 +40,11 @@ class PrincipalView(BaseModel):
     route_id: int
     principal_type: PrincipalType
     principal_id: int
-    # Resolved at read time from the joined principals row's
-    # ``display_name`` column so the client can render a label without
-    # an extra lookup.
+    # Stable identifier and optional human label from the joined
+    # principals row. UI renders ``display_name || name``; both are
+    # sent so the client can show them side-by-side or disambiguate
+    # equal display names.
+    principal_name: Optional[str] = None
     principal_display_name: Optional[str] = None
 
 
@@ -76,12 +78,14 @@ async def _validate_principal(
 def _row_to_view(
     row: ModelRoutePrincipalLink,
     kind: PrincipalType,
+    name: Optional[str] = None,
     display_name: Optional[str] = None,
 ) -> PrincipalView:
     return PrincipalView(
         route_id=row.route_id,
         principal_type=kind,
         principal_id=row.principal_id,
+        principal_name=name,
         principal_display_name=display_name,
     )
 
@@ -96,18 +100,18 @@ async def _resolve_views(
             select(Principal).where(Principal.id.in_(principal_ids))
         )
         by_id = {p.id: p for p in result.all()}
-    return [
-        _row_to_view(
-            r,
-            (
-                by_id[r.principal_id].kind
-                if r.principal_id in by_id
-                else PrincipalType.USER
-            ),
-            by_id[r.principal_id].display_name if r.principal_id in by_id else None,
+    out: List[PrincipalView] = []
+    for r in rows:
+        p = by_id.get(r.principal_id)
+        out.append(
+            _row_to_view(
+                r,
+                p.kind if p else PrincipalType.USER,
+                p.name if p else None,
+                p.display_name if p else None,
+            )
         )
-        for r in rows
-    ]
+    return out
 
 
 @router.get("/{id}/principals", response_model=List[PrincipalView])

--- a/gpustack/routes/organization_members.py
+++ b/gpustack/routes/organization_members.py
@@ -160,10 +160,12 @@ async def _enrich_with_labels(
     org_principal_id: int,
     rows: List[PrincipalMembership],
 ) -> List[OrganizationMembershipPublic]:
-    """Resolve display labels for each membership row.
+    """Resolve identity fields for each membership row.
 
-    Every label lives on the ``principals`` row's ``display_name``
-    column for both USER and GROUP members.
+    Sends both ``Principal.name`` (stable identifier) and
+    ``Principal.display_name`` (optional human label); the UI picks
+    which to render. GROUP rows commonly have only ``name``; USER
+    rows commonly have both.
     """
     member_ids = {r.member_principal_id for r in rows}
     if not member_ids:
@@ -199,6 +201,7 @@ def _to_public(
     return OrganizationMembershipPublic(
         principal_id=p.id,
         principal_kind=p.kind,
+        principal_name=p.name,
         principal_display_name=p.display_name,
         principal_description=p.description,
         organization_id=organization_id,

--- a/gpustack/routes/organizations.py
+++ b/gpustack/routes/organizations.py
@@ -93,9 +93,18 @@ async def create_organization(session: SessionDep, org_in: OrganizationCreate):
     except ValueError as e:
         raise InvalidException(message=str(e))
 
-    existing = await Principal.one_by_fields(
-        session, {"name": org_in.name, "deleted_at": None}
-    )
+    # USER / ORG / SYSTEM share one name namespace (see partitioning
+    # rationale on ``Principal.name``); a GROUP with the same name is
+    # in a separate partition and does not block Org creation.
+    existing = (
+        await session.exec(
+            select(Principal).where(
+                Principal.name == org_in.name,
+                Principal.kind != PrincipalType.GROUP,
+                Principal.deleted_at.is_(None),
+            )
+        )
+    ).first()
     if existing:
         raise AlreadyExistsException(
             message=f"Organization with name '{org_in.name}' already exists"

--- a/gpustack/routes/user_groups.py
+++ b/gpustack/routes/user_groups.py
@@ -128,19 +128,17 @@ async def create_group(session: SessionDep, body: UserGroupCreate):
         session,
         {
             "kind": PrincipalType.GROUP,
-            "display_name": body.display_name,
+            "name": body.name,
             "deleted_at": None,
         },
     )
     if existing:
-        raise AlreadyExistsException(
-            message=f"Group '{body.display_name}' already exists"
-        )
+        raise AlreadyExistsException(message=f"Group '{body.name}' already exists")
 
     try:
         group = Principal(
             kind=PrincipalType.GROUP,
-            display_name=body.display_name,
+            name=body.name,
             description=body.description,
         )
         created = await Principal.create(session, group)
@@ -158,19 +156,17 @@ async def create_group(session: SessionDep, body: UserGroupCreate):
 async def update_group(session: SessionDep, group_id: int, body: UserGroupUpdate):
     group = await _load_group(session, group_id)
 
-    if body.display_name != group.display_name:
+    if body.name != group.name:
         clash = await Principal.one_by_fields(
             session,
             {
                 "kind": PrincipalType.GROUP,
-                "display_name": body.display_name,
+                "name": body.name,
                 "deleted_at": None,
             },
         )
         if clash and clash.id != group.id:
-            raise AlreadyExistsException(
-                message=f"Group '{body.display_name}' already exists"
-            )
+            raise AlreadyExistsException(message=f"Group '{body.name}' already exists")
 
     try:
         await group.update(session, body.model_dump(exclude_unset=True))

--- a/gpustack/routes/users.py
+++ b/gpustack/routes/users.py
@@ -120,7 +120,18 @@ async def list_user_memberships(session: SessionDep, id: int):
 
 @router.post("", response_model=UserPublic)
 async def create_user(session: SessionDep, user_in: UserCreate):
-    existing = await User.one_by_field(session, "name", user_in.username)
+    # USER / ORG / SYSTEM share one name namespace (see partitioning
+    # rationale on ``Principal.name``); a GROUP with the same name is
+    # in a separate partition and does not block USER creation.
+    existing = (
+        await session.exec(
+            select(Principal).where(
+                Principal.name == user_in.username,
+                Principal.kind != PrincipalType.GROUP,
+                Principal.deleted_at.is_(None),
+            )
+        )
+    ).first()
     if existing:
         raise AlreadyExistsException(message=f"User {user_in.username} already exists")
 

--- a/gpustack/schemas/cluster_access.py
+++ b/gpustack/schemas/cluster_access.py
@@ -66,9 +66,14 @@ class ClusterAccessPublic(SQLModel):
     # second principals lookup. Resolved server-side from the principals
     # row.
     principal_type: PrincipalType
-    # Human-readable label for the principal — the ``display_name``
-    # column on the principals row, populated for every kind. Server
-    # has the join cheaply.
+    # Stable identifier and human label, taken verbatim from the
+    # principals row. The UI renders ``display_name`` when set and
+    # falls back to ``name`` otherwise (e.g. GROUP rows commonly have
+    # only ``name``, ORG rows may have only ``name``). Both are sent
+    # so the UI can render them side-by-side ("Engineering @eng-team"
+    # style) or use ``name`` to disambiguate when ``display_name``
+    # collides.
+    principal_name: Optional[str] = None
     principal_display_name: Optional[str] = None
     # For GROUP principals, the parent ORG. NULL for USER and ORG.
     principal_parent_id: Optional[int] = None

--- a/gpustack/schemas/organizations.py
+++ b/gpustack/schemas/organizations.py
@@ -31,11 +31,14 @@ from gpustack.schemas.principals import (
 # hyphen).
 name_pattern = r'^[a-z](?:[a-z0-9\-]*[a-z0-9])?$'
 
-# "Personal" is the conceptual user-self namespace (no longer a separate
-# Org row); "Global" is the UI label for admin-curated Platform rows
-# (e.g. inference backends with owner_principal_id IS NULL). Letting users
-# create regular Orgs with these names would collide with built-in UX
-# slots. Match case-insensitively after trimming whitespace.
+# "Personal" is the UI label for the user-self namespace (USER
+# principal rendered via ``OrganizationPublic.from_principal`` with
+# ``is_personal=True``); "Global" is the UI label for admin-curated
+# Platform rows (e.g. inference backends with owner_principal_id IS
+# NULL). Backend never emits these strings as a real Org's
+# ``display_name``, but letting an admin create a regular Org named
+# "Personal" / "Global" would visually collide with those built-in
+# UX slots. Match case-insensitively after trimming whitespace.
 RESERVED_ORG_DISPLAY_NAMES = {"personal", "global", "system", "system-toolkit"}
 RESERVED_ORG_NAMES = {"personal", "global", "system", "system-toolkit"}
 # Legacy user-principal name pattern — keep humans from grabbing the
@@ -113,15 +116,17 @@ class OrganizationPublic(SQLModel):
     def from_principal(cls, p: Principal) -> "OrganizationPublic":
         """Render a Principal row as the Organization shape.
 
-        For USER principals, surface ``display_name="Personal"`` so the
-        OrgSwitcher renders the canonical label instead of the user's
-        own display name.
+        ``name`` and ``display_name`` are passed through verbatim from
+        the principal row; the client decides the rendered label. For
+        USER principals (the Personal slot), ``is_personal=True`` flags
+        the row so the UI can substitute its localized "Personal"
+        label instead of the user's own ``display_name``.
         """
         is_personal = p.kind == PrincipalType.USER
         return cls(
             id=p.id,
             name=p.name,
-            display_name="Personal" if is_personal else p.display_name,
+            display_name=p.display_name,
             description=p.description,
             is_personal=is_personal,
             created_at=p.created_at,
@@ -137,15 +142,18 @@ class OrganizationMembershipPublic(SQLModel):
 
     USER and GROUP principals are peer-level in the new identity
     model, so the membership API treats them uniformly: identity
-    fields (``principal_id``, ``principal_kind``,
+    fields (``principal_id``, ``principal_kind``, ``principal_name``,
     ``principal_display_name``, ``principal_description``) come off
-    the ``principals`` row. ``principal_display_name`` is the human
-    label (the ``display_name`` column) — what cluster-access /
-    ACL pickers / the members list render.
+    the ``principals`` row. ``principal_name`` is the stable
+    identifier; ``principal_display_name`` is the optional human
+    label. The UI is expected to render ``display_name || name``;
+    both are sent so the UI can show them side-by-side or use
+    ``name`` to disambiguate equal ``display_name`` values.
     """
 
     principal_id: int
     principal_kind: str
+    principal_name: Optional[str] = None
     principal_display_name: Optional[str] = None
     principal_description: Optional[str] = None
     organization_id: int

--- a/gpustack/schemas/principals.py
+++ b/gpustack/schemas/principals.py
@@ -42,7 +42,6 @@ from sqlmodel import (
     Integer,
     Relationship,
     SQLModel,
-    UniqueConstraint,
 )
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -162,11 +161,21 @@ class PrincipalBase(SQLModel):
         sa_column=Column(SQLEnum(PrincipalType), nullable=False),
     )
 
-    # Stable identifier for the principal. Globally unique among
-    # non-NULL values. Matches the k8s convention where
-    # ``metadata.name`` is the URL-safe identifier — the upcoming GPU
-    # service API and k8s namespace plumbing both key off this
-    # column directly.
+    # Stable identifier for the principal. Uniqueness is partitioned:
+    # GROUP has its own namespace; USER / ORG / SYSTEM share one. The
+    # GROUP partition exists because IdP-supplied group names commonly
+    # coincide with admin-chosen Org names — forcing them globally
+    # unique would break OIDC/SAML group sync the moment an admin
+    # happens to name an Org the same as an IdP group. The shared
+    # namespace for the admin-curated kinds is conservative: most
+    # name lookups already scope by kind (``init_platform_principal_id``
+    # → ORG, ``get_default_cluster_principal`` → SYSTEM, the
+    # ``<owner-name>/<route>`` URL resolver → ORG), but
+    # ``get_by_username`` (login) does not, and relies on USER / ORG /
+    # SYSTEM not colliding to avoid mis-resolving a login to an ORG
+    # row. Matches the k8s convention where ``metadata.name`` is the
+    # URL-safe identifier — the upcoming GPU service API and k8s
+    # namespace plumbing both key off this column directly.
     #
     # * USER: the login name (what the legacy schema called
     #   ``username``). Not used as a URL prefix — USER-owned model
@@ -174,8 +183,9 @@ class PrincipalBase(SQLModel):
     #   uniqueness check.
     # * ORG: user-supplied URL-safe identifier; appears as the
     #   ``<owner-name>/<route-name>`` prefix in inference URLs.
-    # * GROUP: NULL (groups have no canonical identifier; their
-    #   ``display_name`` is uniquely indexed instead).
+    # * GROUP: admin- or IdP-supplied identifier. Not used in URLs
+    #   (groups are not route-owners), so format is unconstrained
+    #   beyond the global uniqueness check.
     name: Optional[str] = Field(default=None, nullable=True)
 
     # Human-readable display label. For USER this was the legacy
@@ -258,15 +268,22 @@ class Principal(PrincipalBase, BaseModelMixin, table=True):
 
     __tablename__ = 'principals'
     __table_args__ = (
-        UniqueConstraint('name', name='uix_principals_name'),
-        # Group display names are globally unique among active groups.
-        # Postgres supports partial unique indexes — declared here for
-        # autogenerate parity with the migration. MySQL has no partial
-        # index, so the migration creates a plain non-unique index and
-        # the route handlers enforce uniqueness in code.
+        # Two partial unique indexes — see the ``name`` field comment
+        # for the partitioning rationale (non-GROUP kinds share one
+        # namespace; GROUP has its own). Both are declared here for
+        # autogenerate parity with the migration. On MySQL the
+        # migration falls back to a single plain (non-unique) index
+        # since partial indexes are unsupported; uniqueness within
+        # each partition is then enforced by the create routes.
         Index(
-            'uix_principals_group_display_name',
-            'display_name',
+            'uix_principals_non_group_name',
+            'name',
+            unique=True,
+            postgresql_where=text("kind <> 'GROUP' AND deleted_at IS NULL"),
+        ),
+        Index(
+            'uix_principals_group_name',
+            'name',
             unique=True,
             postgresql_where=text("kind = 'GROUP' AND deleted_at IS NULL"),
         ),
@@ -406,8 +423,12 @@ async def init_platform_principal_id(session: AsyncSession) -> int:
     Idempotent. Callable from tests.
     """
     global _PLATFORM_PRINCIPAL_ID, _PLATFORM_PRINCIPAL_ID_INITIALIZED
-    p = await Principal.one_by_field(
-        session=session, field='name', value=PLATFORM_PRINCIPAL_NAME
+    # Platform principal is always an ORG — scope by kind so an
+    # IdP-synced GROUP that happens to be named 'default' can't shadow
+    # it under the partitioned name uniqueness model.
+    p = await Principal.one_by_fields(
+        session=session,
+        fields={'kind': PrincipalType.ORG, 'name': PLATFORM_PRINCIPAL_NAME},
     )
     if p is None:
         raise RuntimeError(

--- a/gpustack/schemas/user_groups.py
+++ b/gpustack/schemas/user_groups.py
@@ -22,9 +22,7 @@ from gpustack.schemas.users import AuthProviderEnum
 
 
 class UserGroupUpdate(SQLModel):
-    # Groups have no URL-safe ``name`` column; ``display_name`` is
-    # what the IdP supplies and what's uniquely indexed.
-    display_name: str = Field(nullable=False)
+    name: str = Field(nullable=False)
     description: Optional[str] = Field(default=None, nullable=True)
 
 
@@ -34,7 +32,7 @@ class UserGroupCreate(UserGroupUpdate):
 
 class UserGroupListParams(ListParams):
     sortable_fields: ClassVar[List[str]] = [
-        "display_name",
+        "name",
         "created_at",
         "updated_at",
     ]
@@ -42,7 +40,7 @@ class UserGroupListParams(ListParams):
 
 class UserGroupPublic(SQLModel):
     id: int
-    display_name: str
+    name: str
     description: Optional[str] = None
     # Count of active users in this group — denormalized on the
     # response so admin listings can render "Members" at a glance
@@ -62,7 +60,7 @@ class UserGroupPublic(SQLModel):
     ) -> "UserGroupPublic":
         return cls(
             id=p.id,
-            display_name=p.display_name,
+            name=p.name,
             description=p.description,
             member_count=member_count,
             source=p.source,

--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -200,9 +200,15 @@ async def get_default_cluster_principal(session: AsyncSession) -> Optional[Princ
     # silently fan out per row). Bootstrap callers
     # (``Server._migrate_legacy_token`` / ``_ensure_registration_token``)
     # need the related Cluster row, so eager-load it here.
-    return await Principal.one_by_field(
+    # Default cluster principal is SYSTEM kind. Scope by kind so a
+    # GROUP that happens to share the same ``name`` (different
+    # partition under the partitioned name uniqueness model) can't
+    # shadow it.
+    return await Principal.one_by_fields(
         session=session,
-        field="name",
-        value=default_cluster_principal_name,
+        fields={
+            "kind": PrincipalType.SYSTEM,
+            "name": default_cluster_principal_name,
+        },
         options=[selectinload(Principal.cluster)],
     )

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -234,21 +234,25 @@ async def _insert_group_or_refetch(
 
     Wraps the insert in a SAVEPOINT (``session.begin_nested``) so the
     surrounding sync transaction survives an ``IntegrityError`` from
-    a unique-constraint collision. The collision can come from the
-    partial unique index on Postgres, or from an application-layer
-    pre-check race on MySQL — either way we just re-read the row the
-    winner inserted.
+    the ``uix_principals_group_name`` partial unique index when two
+    concurrent first-time logins push the same group name — we just
+    re-read the row the winner inserted. On MySQL the partial unique
+    index isn't supported; the migration falls back to a plain index
+    and the SAVEPOINT acts purely as defensive scaffolding (the race
+    window is wider but real conflicts still resolve via the
+    re-fetch).
     """
     grp = Principal(
         kind=PrincipalType.GROUP,
-        # GROUPs have no ``name`` (the URL-safe identifier) — only a
-        # ``display_name`` that's unique among active groups via the
-        # partial index. The IdP-supplied group name lands here.
-        display_name=name,
+        # IdP-supplied group name; unique within the GROUP partition
+        # (``uix_principals_group_name`` on PG, app-layer pre-check on
+        # MySQL). A non-GROUP principal with the same ``name`` lives
+        # in a separate partition and does not conflict.
+        name=name,
         # Tag the Group with the provider that brought it into
         # existence. UI uses this to badge IdP-managed rows; sync
-        # doesn't condition on it (matching is by display_name
-        # regardless of source).
+        # doesn't condition on it (matching is by name regardless of
+        # source).
         source=provider,
         created_at=now,
         updated_at=now,
@@ -264,7 +268,7 @@ async def _insert_group_or_refetch(
                 select(Principal).where(
                     Principal.kind == PrincipalType.GROUP,
                     Principal.deleted_at.is_(None),
-                    Principal.display_name == name,
+                    Principal.name == name,
                 )
             )
         ).first()
@@ -335,24 +339,23 @@ async def sync_user_group_memberships(
                 select(Principal).where(
                     Principal.kind == PrincipalType.GROUP,
                     Principal.deleted_at.is_(None),
-                    Principal.display_name.in_(wanted_names),
+                    Principal.name.in_(wanted_names),
                 )
             )
         ).all()
-        existing_by_name = {p.display_name: p for p in existing}
+        existing_by_name = {p.name: p for p in existing}
 
         now = datetime.now(timezone.utc).replace(tzinfo=None)
         for name in wanted_names:
             grp = existing_by_name.get(name)
             if grp is None:
-                # Race-tolerant create: a concurrent first-time login of
-                # another user can be inserting the same group name. On
-                # Postgres the partial unique index aborts the loser
-                # with IntegrityError; on MySQL the window is wider
-                # (no DB-level unique index — see migration notes) but
-                # the SAVEPOINT lets us recover in both cases. The
-                # SAVEPOINT scopes the failure to the insert so the
-                # surrounding sync transaction stays alive.
+                # Race-tolerant create: a concurrent first-time login
+                # of another user can be inserting the same group name.
+                # On PG the ``uix_principals_group_name`` partial
+                # unique index aborts the loser with IntegrityError;
+                # on MySQL there's no partial unique so the window is
+                # wider but the SAVEPOINT-wrapped insert still lets us
+                # re-read the winner's row.
                 grp = await _insert_group_or_refetch(session, name, provider, now)
             desired_group_ids.add(grp.id)
 
@@ -561,7 +564,20 @@ class ModelRouteService:
         if "/" in name:
             owner_name, _, rest = name.partition("/")
             if rest:
-                owner = await Principal.one_by_field(self.session, "name", owner_name)
+                # Route owners are always ORG principals — USER /
+                # SYSTEM / GROUP never own routes. Scope the lookup
+                # accordingly so a same-named non-ORG principal (e.g.
+                # a GROUP under the partitioned name model) can't be
+                # mis-resolved as the URL prefix owner.
+                owner = (
+                    await self.session.exec(
+                        select(Principal).where(
+                            Principal.name == owner_name,
+                            Principal.kind == PrincipalType.ORG,
+                            Principal.deleted_at.is_(None),
+                        )
+                    )
+                ).first()
                 if owner is not None:
                     route = await ModelRoute.one_by_fields(
                         self.session,
@@ -606,7 +622,20 @@ class ModelRouteService:
         if "/" in name:
             owner_name, _, rest = name.partition("/")
             if rest:
-                owner = await Principal.one_by_field(self.session, "name", owner_name)
+                # Route owners are always ORG principals — USER /
+                # SYSTEM / GROUP never own routes. Scope the lookup
+                # accordingly so a same-named non-ORG principal (e.g.
+                # a GROUP under the partitioned name model) can't be
+                # mis-resolved as the URL prefix owner.
+                owner = (
+                    await self.session.exec(
+                        select(Principal).where(
+                            Principal.name == owner_name,
+                            Principal.kind == PrincipalType.ORG,
+                            Principal.deleted_at.is_(None),
+                        )
+                    )
+                ).first()
                 if owner is not None:
                     owner_principal_id = owner.id
                     raw_name = rest

--- a/tests/api/test_group_sync.py
+++ b/tests/api/test_group_sync.py
@@ -68,12 +68,12 @@ def test_coerce_non_string_scalar_is_empty():
 # ---- sync_user_group_memberships -------------------------------------------
 
 
-def _principal(id: int, display_name: str) -> Principal:
+def _principal(id: int, name: str) -> Principal:
     """Make a Group-principal Mock that quacks like a real row."""
     p = MagicMock(spec=Principal)
     p.id = id
     p.kind = PrincipalType.GROUP
-    p.display_name = display_name
+    p.name = name
     p.deleted_at = None
     return p
 
@@ -101,7 +101,8 @@ def _session(exec_results, *, flush_raises=None):
 
     ``flush_raises``: optional list, one entry per ``flush`` call. A
     non-None entry is raised as the side effect of that call. Lets a
-    test simulate an ``IntegrityError`` from the partial unique index.
+    test simulate an ``IntegrityError`` from
+    ``uix_principals_group_name``.
 
     Also mocks ``begin_nested`` as an async context manager so the
     SAVEPOINT-wrapped insert path in ``sync_user_group_memberships``

--- a/tests/api/test_p2_routes.py
+++ b/tests/api/test_p2_routes.py
@@ -121,13 +121,9 @@ def test_can_manage_member_cannot_manage():
 
 
 @pytest.mark.asyncio
-async def test_create_organization_rejects_duplicate_name(monkeypatch):
-    session = MagicMock()
-    monkeypatch.setattr(
-        organizations_route.Principal,
-        "one_by_fields",
-        AsyncMock(return_value=_principal(display_name="Existing", name="acme")),
-    )
+async def test_create_organization_rejects_duplicate_name():
+    # Non-GROUP principal already holding the name → reject.
+    session = _session_returning(_principal(display_name="Existing", name="acme"))
     with pytest.raises(AlreadyExistsException):
         await organizations_route.create_organization(
             session=session,
@@ -251,7 +247,7 @@ async def test_remove_only_owner_blocked_for_group_owner(monkeypatch):
     """
     org = _principal(id=10, display_name="Acme", name="acme")
     group = _principal(
-        id=300, kind=PrincipalType.GROUP, display_name="gpu-admins", name=None
+        id=300, kind=PrincipalType.GROUP, display_name=None, name="gpu-admins"
     )
     membership = MagicMock(spec=PrincipalMembership)
     membership.parent_principal_id = 10
@@ -392,8 +388,8 @@ async def test_create_group_rejects_duplicate_name(monkeypatch):
     existing = _principal(
         id=5,
         kind=PrincipalType.GROUP,
-        display_name="team-a",
-        name=None,
+        display_name=None,
+        name="team-a",
     )
     monkeypatch.setattr(
         user_groups_route.Principal,
@@ -403,7 +399,7 @@ async def test_create_group_rejects_duplicate_name(monkeypatch):
     with pytest.raises(AlreadyExistsException):
         await user_groups_route.create_group(
             session=MagicMock(),
-            body=user_groups_route.UserGroupCreate(display_name="team-a"),
+            body=user_groups_route.UserGroupCreate(name="team-a"),
         )
 
 
@@ -412,8 +408,8 @@ async def test_add_group_members_rejects_missing_user(monkeypatch):
     group = _principal(
         id=5,
         kind=PrincipalType.GROUP,
-        display_name="team-a",
-        name=None,
+        display_name=None,
+        name="team-a",
     )
     monkeypatch.setattr(
         user_groups_route.Principal,

--- a/tests/api/test_p4_routes.py
+++ b/tests/api/test_p4_routes.py
@@ -1,5 +1,6 @@
 """Unit tests for P4 (ALLOWED_PRINCIPALS extension) route logic."""
 
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -24,11 +25,13 @@ def _route(id: int = 1):
 def _principal(
     id: int = 5,
     kind: PrincipalType = PrincipalType.ORG,
-    display_name: str = "principal",
+    name: str = "principal",
+    display_name: Optional[str] = None,
 ):
     p = MagicMock(spec=Principal)
     p.id = id
     p.kind = kind
+    p.name = name
     p.display_name = display_name
     p.deleted_at = None
     return p


### PR DESCRIPTION
…splay labels

Three related cleanups bundled together, all flowing from the recent ``slug/name → name/display_name`` rename:

1. GROUP identifier moves from ``display_name`` to ``name``

   Aligns Group with the k8s ``metadata.name`` convention now used for USER and ORG. The single field a user (or IdP) supplies when creating a group — what Keycloak's group API calls ``name`` and what the OIDC ``groups`` claim emits as bare strings — lands in ``Principal.name``, not ``Principal.display_name``.

   - GROUP rows write the identifier to ``principals.name``; uniqueness is enforced by the existing global ``uix_principals_name`` constraint. The GROUP-specific partial unique index (``uix_principals_group_display_name`` on PG / ``ix_principals_group_display_name`` on MySQL) and its application-layer dedup workaround for MySQL are removed.
   - ``Principal.display_name`` for GROUP is now usually NULL; the column stays available for a future "alternate display label".
   - ``UserGroupCreate`` / ``UserGroupUpdate`` / ``UserGroupPublic``: JSON field ``display_name`` → ``name``; sortable fields and the list-route search field follow.
   - ``_insert_group_or_refetch`` and ``sync_user_group_memberships`` write/lookup IdP-supplied names against ``Principal.name``; the SAVEPOINT recovery path keys off ``uix_principals_name``.

2. Cross-kind DTOs expose both ``principal_name`` and ``principal_display_name``

   ``OrganizationMembershipPublic`` / ``ClusterAccessPublic`` / ``PrincipalView`` were collapsing both columns into a single ``principal_display_name`` with a server-side ``display_name or name`` fallback. That hid information the UI may want (secondary labels, disambiguating equal display names), scattered the fallback rule across four call sites, and was inconsistent with ``UserPublic`` / ``OrganizationPublic`` / ``UserGroupPublic`` which already expose both columns. The three DTOs now carry both fields; the three route handlers pass ``p.name`` / ``p.display_name`` through verbatim. UI renders ``display_name || name``.

3. ``OrganizationPublic.from_principal`` stops synthesizing ``display_name="Personal"``

   The DTO was overriding ``display_name`` with the literal English string ``"Personal"`` when rendering a USER principal as the OrgSwitcher's Personal slot. That fabricated a value not in storage and hardcoded a UI label on a backend DTO. The ``is_personal`` flag already discriminates the row; the UI substitutes its localized "Personal" / "个人" / etc. label conditional on that flag. ``RESERVED_ORG_DISPLAY_NAMES`` still contains ``"personal"`` — the collision is now purely visual (admin creating an Org named "Personal" would render indistinguishably from the synthesized slot), so the reservation stays even though backend no longer emits the string.

Tests:

- ``test_group_sync._principal()`` helper renames its kwarg to ``name``; the ``test_p2_routes`` GROUP fixtures flip ``display_name`` / ``name`` accordingly. ``UserGroupCreate`` is constructed with ``name=`` in route tests.
- ``test_p4_routes._principal()`` helper seeds ``p.name`` so ``PrincipalView`` validation passes (previously a MagicMock placeholder pydantic rejected as non-string).