### PR TITLE
fix: keep ``username`` / ``full_name`` on the Users API wire

### DIFF
--- a/gpustack/routes/users.py
+++ b/gpustack/routes/users.py
@@ -189,15 +189,19 @@ async def update_user(session: SessionDep, id: int, user_in: UserUpdate):
         raise ConflictException(message="Cannot deactivate the only admin user")
 
     try:
-        # ``by_alias=True`` maps the wire-level ``username`` / ``full_name``
-        # back onto the Principal columns ``name`` / ``display_name``
-        # for the storage write — see :class:`UserBase`. ``exclude_none=True``
-        # so omitting an optional field (e.g. ``full_name``) on the
-        # PUT request leaves the stored value alone rather than
-        # clobbering it with NULL; matches :func:`update_user_me`.
-        # Password + require-change flag live on the ``user_passwords``
-        # row, handled separately.
-        update_data = user_in.model_dump(by_alias=True, exclude_none=True)
+        # ``exclude_none=True`` so omitting an optional field (e.g.
+        # ``full_name``) on the PUT request leaves the stored value
+        # alone rather than clobbering it with NULL; matches
+        # :func:`update_user_me`. Wire-level ``username`` /
+        # ``full_name`` are mapped back onto the Principal columns
+        # ``name`` / ``display_name`` for the storage write — see
+        # :class:`UserBase`. Password + require-change flag live on
+        # the ``user_passwords`` row, handled separately.
+        update_data = user_in.model_dump(exclude_none=True)
+        if "username" in update_data:
+            update_data["name"] = update_data.pop("username")
+        if "full_name" in update_data:
+            update_data["display_name"] = update_data.pop("full_name")
         update_data.pop("password", None)
         update_data.pop("source", None)
         require_change = update_data.pop("require_password_change", False)
@@ -292,7 +296,9 @@ async def update_user_me(
     session: SessionDep, user: CurrentUserDep, user_in: UserSelfUpdate
 ):
     try:
-        update_data = user_in.model_dump(by_alias=True, exclude_none=True)
+        update_data = user_in.model_dump(exclude_none=True)
+        if "full_name" in update_data:
+            update_data["display_name"] = update_data.pop("full_name")
         plain = update_data.pop("password", None)
         await UserService(session).update(user, update_data)
         if plain:

--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -11,11 +11,15 @@ rows. SYSTEM-context call sites should construct / query
 
 Pydantic DTOs (``UserCreate``, ``UserUpdate``, ``UserPublic``, …) stay
 here — they're API-surface shapes, not table mappings. They expose
-``username`` and ``full_name`` JSON keys for backward compat, aliased
-to the underlying ``name`` / ``display_name`` columns via Pydantic
-``validation_alias`` + ``serialization_alias``. ORG / GROUP-only
-columns (``description``, ``kind``, ``parent_principal_id``) aren't
-on the user wire surface.
+``username`` and ``full_name`` JSON keys for backward compat;
+``validation_alias`` lets ``UserPublic.model_validate(principal)``
+read directly off the underlying ``name`` / ``display_name`` columns
+without an explicit conversion step. The wire→storage rename on
+writes is handled in the route handlers (see ``routes/users.py``)
+rather than via ``serialization_alias``, so FastAPI's default
+``response_model_by_alias=True`` doesn't leak the storage column
+names into responses. ORG / GROUP-only columns (``description``,
+``kind``, ``parent_principal_id``) aren't on the user wire surface.
 
 Re-exports ``AuthProviderEnum`` so existing
 ``from gpustack.schemas.users import AuthProviderEnum`` callers keep
@@ -87,7 +91,11 @@ class UserBase(SQLModel):
     Principal columns ``name`` and ``display_name``; the
     ``validation_alias`` on each lets
     ``UserPublic.model_validate(principal)`` read directly off a
-    ``Principal`` row without an explicit conversion step.
+    ``Principal`` row without an explicit conversion step. No
+    ``serialization_alias`` is set — FastAPI's default
+    ``response_model_by_alias=True`` would otherwise emit the storage
+    column names on the wire. Route handlers map wire→storage
+    explicitly when writing back to the Principal row.
     """
 
     # ``populate_by_name=True`` so callers can still construct DTOs via
@@ -98,14 +106,12 @@ class UserBase(SQLModel):
 
     username: str = PField(
         validation_alias=AliasChoices('username', 'name'),
-        serialization_alias='name',
     )
     is_admin: bool = False
     is_active: bool = True
     full_name: Optional[str] = PField(
         default=None,
         validation_alias=AliasChoices('full_name', 'display_name'),
-        serialization_alias='display_name',
     )
     avatar_url: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)
@@ -132,7 +138,7 @@ class UserSelfUpdate(SQLModel):
 
     Wire field name stays ``full_name``; persisted as ``display_name``
     on the Principal row (see :class:`UserBase` for the alias
-    rationale).
+    rationale). The route handler maps wire→storage explicitly.
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -140,7 +146,6 @@ class UserSelfUpdate(SQLModel):
     full_name: Optional[str] = PField(
         default=None,
         validation_alias=AliasChoices('full_name', 'display_name'),
-        serialization_alias='display_name',
     )
     avatar_url: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)


### PR DESCRIPTION
The recent Principal slug/name → name/display_name rename intended to leave the Users API JSON keys unchanged. ``UserBase`` set ``serialization_alias='name'`` / ``'display_name'`` on ``username`` / ``full_name`` so that ``model_dump(by_alias=True)`` in the update routes could remap into Principal columns — but FastAPI defaults ``response_model_by_alias=True``, so the same alias leaked onto every Users-API response and the wire returned ``name`` / ``display_name`` instead.

Drop the ``serialization_alias`` from ``UserBase`` / ``UserSelfUpdate``. ``validation_alias=AliasChoices('username', 'name')`` stays so ``UserPublic.model_validate(principal)`` still reads the storage columns. ``update_user`` and ``update_user_me`` now rename ``username`` → ``name`` / ``full_name`` → ``display_name`` explicitly before handing the dict to ``UserService.update``, matching the manual mapping that ``create_user`` already used.