### PR TITLE
refactor(chart): move imagePullSecrets to global, align with higress-core

### DIFF
--- a/charts/gpustack-chart/templates/_helper.tpl
+++ b/charts/gpustack-chart/templates/_helper.tpl
@@ -96,19 +96,9 @@ tls:
 {{- end -}}
 
 
-{{- define "image_pull_secret_create_name" -}}
-gpustack-image-pull-secret
-{{- end -}}
-
-
 {{- define "image_pull_secrets" -}}
-{{- $names := list -}}
-{{- range .Values.imagePullSecrets.existingSecrets -}}
-{{- $names = append $names . -}}
-{{- end -}}
-{{- $names = append $names (include "image_pull_secret_create_name" .) -}}
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{- range $names }}
-  - name: {{ . }}
+{{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end -}}

--- a/charts/gpustack-chart/templates/image-pull-secret.yaml
+++ b/charts/gpustack-chart/templates/image-pull-secret.yaml
@@ -1,7 +1,24 @@
-{{- $c := .Values.imagePullSecrets.credentials -}}
-{{- if and $c.username $c.password -}}
+{{- /*
+Create the canonical `gpustack-image-pull-secret` Secret only when one of:
+  1. Credentials are provided (the user wants the chart to bake a dockerconfigjson).
+  2. The default `global.imagePullSecrets` list still references the canonical
+     name (i.e. the user hasn't fully swapped to externally managed Secrets).
+Otherwise skip — avoids leaking an empty, unreferenced Secret when the user
+points `global.imagePullSecrets` at Secrets they manage themselves.
+*/ -}}
+{{- $canonicalName := "gpustack-image-pull-secret" -}}
+{{- $c := (.Values.imagePullSecret | default dict).credentials | default dict -}}
+{{- $hasCredentials := and $c.username $c.password -}}
+{{- $referenced := false -}}
+{{- range .Values.global.imagePullSecrets -}}
+{{- if eq .name $canonicalName -}}
+{{- $referenced = true -}}
+{{- end -}}
+{{- end -}}
+{{- if or $hasCredentials $referenced -}}
+{{- if $hasCredentials -}}
 {{- if contains ":" ($c.username | toString) -}}
-{{- fail "imagePullSecrets.credentials.username must not contain ':' (used as the auth field separator)" -}}
+{{- fail "imagePullSecret.credentials.username must not contain ':' (used as the auth field separator)" -}}
 {{- end -}}
 {{- $registry := default "docker.io" $c.registry -}}
 {{- $email := default "" $c.email -}}
@@ -10,7 +27,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "image_pull_secret_create_name" . }}
+  name: {{ $canonicalName }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "chart_labels" . | indent 4 }}
@@ -21,11 +38,12 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "image_pull_secret_create_name" . }}
+  name: {{ $canonicalName }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "chart_labels" . | indent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ `{"auths":{}}` | b64enc }}
+{{- end -}}
 {{- end -}}

--- a/charts/gpustack-chart/values.yaml
+++ b/charts/gpustack-chart/values.yaml
@@ -9,29 +9,37 @@ registrationToken: null
 # `global.hub` is the container registry host (e.g. docker.io).
 # For air-gapped or private registry installs, override:
 #   --set global.hub=myregistry.example.com
+#
+# `global.imagePullSecrets` is the list of Secret references attached to every
+# pod created by this chart and propagated to sub-charts (higress-core,
+# gpustack-enterprise) that follow the same convention. Defaults to a single
+# entry pointing at the canonical `gpustack-image-pull-secret` that this chart
+# auto-creates (see `imagePullSecret` below).
+#
+# To reference your own pre-existing Secrets, replace the list entirely:
+#   global:
+#     imagePullSecrets:
+#       - name: my-existing-secret
+#       - name: another-secret
+# When the list no longer references `gpustack-image-pull-secret` and no
+# credentials are provided below, the chart skips creating the canonical
+# Secret to avoid leaving an unused resource behind.
 global:
   hub: docker.io
-# Image pull secrets for the gpustack server, worker, and higress-plugins images.
-# The chart always creates a docker-registry Secret named "gpustack-image-pull-secret".
-# Two ways to populate it, which may be combined:
-#   1. Reference existing Secrets in the release namespace by name:
-#        imagePullSecrets:
-#          existingSecrets:
-#            - my-existing-secret
-#   2. Provide registry credentials; the auto-created Secret will contain the auth:
-#        imagePullSecrets:
-#          credentials:
-#            registry: docker.io
-#            username: myuser
-#            password: mypassword
-#            email: ""      # optional
-#
-# When no credentials are provided, the auto-created Secret contains an empty
-# {"auths":{}} and is harmless. The Secret is also pre-wired into the bundled
-# higress-core sub-chart (see higress-core.gateway.imagePullSecrets and
-# higress-core.controller.imagePullSecrets below).
-imagePullSecrets:
-  existingSecrets: []
+  imagePullSecrets:
+    - name: gpustack-image-pull-secret
+
+# Auto-creation of the canonical `gpustack-image-pull-secret` docker-registry
+# Secret. The Secret is created when either:
+#   - `credentials.username` and `credentials.password` are set (populated
+#     `.dockerconfigjson`), or
+#   - `global.imagePullSecrets` above still references the canonical name
+#     (created with an empty `{"auths":{}}` — harmless to reference, useful as
+#     a placeholder when no credentials are needed).
+# If the user fully swaps `global.imagePullSecrets` to externally managed
+# Secrets AND provides no credentials here, the canonical Secret is not
+# created.
+imagePullSecret:
   credentials:
     registry: docker.io
     username: null


### PR DESCRIPTION
Pod-level refs move to `global.imagePullSecrets` (list of `{name: ...}`) so they propagate to sub-charts like `global.hub` does. Auto-creation knob renamed to `imagePullSecret` and only fires when credentials are set or the default list still references the canonical name.