### PR TITLE
feat: add consumer principal to model usage

### DIFF
--- a/gpustack/migrations/versions/2026_03_10_1600-8bf38a6bb3b5_v2_2_0_database_changes.py
+++ b/gpustack/migrations/versions/2026_03_10_1600-8bf38a6bb3b5_v2_2_0_database_changes.py
@@ -364,8 +364,12 @@ def upgrade() -> None:
             # audit-survival reasons as the other id columns on this table:
             # ``ON DELETE SET NULL`` on the live Principal would erase the
             # historical owner attribution that breakdown / billing relies
-            # on. Sourced at flush time from the model / api_key owner.
+            # on. Sourced at flush time from the model.
             sa.Column('owner_principal_id', sa.Integer(), nullable=True),
+            # Consumer tenant scope snapshot, denormalized from the API key
+            # owner. This can differ from owner_principal_id for cross-Org
+            # shared model usage.
+            sa.Column('consumer_principal_id', sa.Integer(), nullable=True),
             sa.Column('provider_id', sa.Integer(), nullable=True),
             sa.Column('provider_name', sa.String(255), nullable=True),
             sa.Column('provider_type', sa.String(255), nullable=True),
@@ -404,6 +408,12 @@ def upgrade() -> None:
         )
         op.create_index(
             f'ix_{table_name}_user_id', table_name, ['user_id'], unique=False
+        )
+        op.create_index(
+            f'ix_{table_name}_consumer_principal_id',
+            table_name,
+            ['consumer_principal_id'],
+            unique=False,
         )
         op.create_index(
             f'ix_{table_name}_api_key_id',

--- a/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
+++ b/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
@@ -697,6 +697,65 @@ def upgrade() -> None:
                     ondelete='SET NULL',
                 )
 
+    # model_usages also needs a consumer-side tenant pointer for "usage made
+    # with this Org's API keys" views. It intentionally differs from
+    # owner_principal_id when Org A calls a deployment shared by Org B.
+    if not column_exists('model_usages', 'consumer_principal_id'):
+        with op.batch_alter_table('model_usages', schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column('consumer_principal_id', sa.Integer(), nullable=True)
+            )
+            batch_op.create_foreign_key(
+                'fk_model_usages_consumer_principal_id_principals',
+                'principals',
+                ['consumer_principal_id'],
+                ['id'],
+                ondelete='SET NULL',
+            )
+            batch_op.create_index(
+                'ix_model_usages_consumer_principal_id',
+                ['consumer_principal_id'],
+                unique=False,
+            )
+
+    for tbl in (
+        'model_usages',
+        'model_usage_details',
+        'model_usage_details_archive',
+    ):
+        if not table_exists(tbl) or not column_exists(tbl, 'consumer_principal_id'):
+            continue
+        if dialect == 'mysql':
+            op.execute(
+                sa.text(
+                    f"""
+                    UPDATE {tbl} mu
+                    JOIN api_keys ak ON ak.access_key = mu.access_key
+                    SET mu.consumer_principal_id = ak.owner_principal_id
+                    WHERE mu.consumer_principal_id IS NULL
+                    """
+                )
+            )
+        else:
+            op.execute(
+                sa.text(
+                    f"""
+                    UPDATE {tbl}
+                    SET consumer_principal_id = (
+                        SELECT api_keys.owner_principal_id
+                        FROM api_keys
+                        WHERE api_keys.access_key = {tbl}.access_key
+                    )
+                    WHERE consumer_principal_id IS NULL
+                      AND EXISTS (
+                        SELECT 1
+                        FROM api_keys
+                        WHERE api_keys.access_key = {tbl}.access_key
+                      )
+                    """
+                )
+            )
+
     # model_files only had worker_id; add cluster_id for direct
     # cluster_access-based filtering.
     if not column_exists('model_files', 'cluster_id'):
@@ -1003,9 +1062,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    bind = op.get_bind()
-    dialect = bind.dialect.name
-
     # Splitting principals back into a USER-only ``users`` table is not
     # mechanical: ORG/GROUP rows have ids in the same space as the
     # original users, and FK definitions on legacy tables (api_keys,

--- a/gpustack/routes/api_keys.py
+++ b/gpustack/routes/api_keys.py
@@ -23,7 +23,7 @@ from gpustack.schemas.api_keys import (
     ApiKeysPublic,
     ApiKeyUpdate,
 )
-from gpustack.schemas.principals import PrincipalType
+from gpustack.schemas.principals import OrgRole, PrincipalType
 from gpustack.schemas.users import User
 from gpustack.server.services import APIKeyService
 from gpustack.utils.api_keys import get_masked_api_key_value
@@ -68,6 +68,42 @@ def _is_hidden_api_key(api_key: ApiKey) -> bool:
     return _is_system_owned(api_key)
 
 
+def _can_manage_org_api_keys(ctx) -> bool:
+    if ctx.user.is_admin:
+        return True
+    return ctx.current_principal_id is not None and ctx.org_role == OrgRole.OWNER
+
+
+def _api_key_list_fields(ctx, user_id: Optional[str]) -> dict:
+    """Build list filters for the caller's API key management scope.
+
+    Org owners manage all API keys in the current Org. Regular members only
+    manage their own keys in that Org. Platform admins keep the historical
+    cross-org behavior: no org context lists their own keys unless user_id is
+    supplied, with "*" meaning all users.
+    """
+    user = ctx.user
+    fields = {}
+    if ctx.current_principal_id is not None:
+        fields["owner_principal_id"] = ctx.current_principal_id
+
+    if _can_manage_org_api_keys(ctx):
+        if user_id is None:
+            if user.is_admin and ctx.current_principal_id is None:
+                fields["user_id"] = user.id
+            return fields
+        if user_id == "*":
+            return fields
+        try:
+            fields["user_id"] = int(user_id)
+        except ValueError:
+            raise InvalidException(message="user_id must be an integer or '*'")
+        return fields
+
+    fields["user_id"] = user.id
+    return fields
+
+
 @router.get("", response_model=ApiKeysPublic)
 async def get_api_keys(
     session: SessionDep,
@@ -78,20 +114,7 @@ async def get_api_keys(
     ),
     search: str = None,
 ):
-    user = ctx.user
-    fields = {"user_id": user.id}
-    if user.is_admin and user_id is not None:
-        if user_id == "*":
-            fields = {}
-        else:
-            try:
-                fields = {"user_id": int(user_id)}
-            except ValueError:
-                raise InvalidException(message="user_id must be an integer or '*'")
-    # Tenant filter: scope keys to the current org context unless the platform
-    # admin is explicitly browsing across orgs (no header / no api key org).
-    if ctx.current_principal_id is not None:
-        fields["owner_principal_id"] = ctx.current_principal_id
+    fields = _api_key_list_fields(ctx, user_id)
 
     fuzzy_fields = {}
     if search:
@@ -203,7 +226,7 @@ async def create_api_key(
 
 def _api_key_in_scope(api_key: ApiKey, ctx) -> bool:
     """An api_key is in the caller's scope if the caller is its owner, or a
-    platform admin acting either across all orgs or in the key's org.
+    platform/org admin acting either across all orgs or in the key's org.
     """
     user = ctx.user
     if api_key.user_id == user.id and (
@@ -214,6 +237,12 @@ def _api_key_in_scope(api_key: ApiKey, ctx) -> bool:
     if user.is_admin and (
         ctx.current_principal_id is None
         or api_key.owner_principal_id == ctx.current_principal_id
+    ):
+        return True
+    if (
+        ctx.current_principal_id is not None
+        and ctx.org_role == OrgRole.OWNER
+        and api_key.owner_principal_id == ctx.current_principal_id
     ):
         return True
     return False

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -1,7 +1,8 @@
 import logging
 import secrets
+from sqlalchemy import true
 from sqlalchemy.orm import selectinload
-from sqlmodel import col, or_, select
+from sqlmodel import col, func, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from typing import Any, Callable, List, Optional, Set, Tuple, Union, Dict
 from fastapi import APIRouter, Depends, Query
@@ -329,6 +330,9 @@ async def _get_model_routes(
                 extra_conditions.extend(_model_route_grant_conditions(ctx))
             else:
                 extra_conditions.extend(tenant_list_conditions(ctx, ModelRoute))
+        my_model_sql_filter = _append_my_model_conditions(
+            extra_conditions, target_class, my_model_sql_filter
+        )
         if my_model_sql_filter is not None:
             extra_conditions.append(my_model_sql_filter)
         if categories:
@@ -344,6 +348,50 @@ async def _get_model_routes(
             order_by=params.order_by,
             extra_conditions=extra_conditions,
         )
+
+
+def _append_my_model_conditions(extra_conditions, target_class, visibility_filter):
+    """Push the MyModel dedup subquery into ``extra_conditions`` and
+    return ``None`` to signal the visibility filter has been absorbed
+    into the subquery (don't double-apply on the outer query). For
+    non-MyModel targets, return ``visibility_filter`` unchanged so the
+    caller's downstream branch handles it as before.
+    """
+    if target_class is not MyModel:
+        return visibility_filter
+    extra_conditions.append(_my_model_dedup_condition(visibility_filter))
+    return None
+
+
+def _my_model_dedup_condition(visibility_filter):
+    """Collapse multi-chain ``(user, route)`` rows down to one in the
+    MyModel list path. The view emits one row per (user, route,
+    granting-principal) chain by contract; without this, ``COUNT(*)``
+    counts chains instead of routes and the page slice can drop chains
+    arbitrarily.
+
+    Ranking happens inside the visibility-filtered chain set —
+    otherwise ``rn=1`` could land on a chain the caller's scope would
+    have dropped, hiding the route entirely. ``MIN(via_principal_id)``
+    is used as a deterministic tiebreak; the surviving ``via_*`` is
+    arbitrary among the visible chains, matching the agreed semantics
+    of "one row per route, via 任取一条". ``_get_model_route`` orders
+    by the same key so detail and list agree on which chain to surface.
+    """
+    ranked = (
+        select(
+            MyModel.pid,
+            func.row_number()
+            .over(
+                partition_by=[MyModel.id, MyModel.user_id],
+                order_by=[col(MyModel.via_principal_id).asc()],
+            )
+            .label("rn"),
+        )
+        .where(visibility_filter if visibility_filter is not None else true())
+        .subquery()
+    )
+    return col(MyModel.pid).in_(select(ranked.c.pid).where(ranked.c.rn == 1))
 
 
 @router.get("/{id}", response_model=ModelRoutePublic, response_model_exclude_none=True)
@@ -373,7 +421,10 @@ async def _get_model_route(
     # The MyModel view emits one row per (user, route, granting-principal)
     # chain; ``one_by_fields`` would .first() back an arbitrary row that
     # might be filtered out by the caller's context. Push the same
-    # visibility predicate as the list path into the query.
+    # visibility predicate as the list path into the query, and order
+    # by ``via_principal_id`` so the chain we surface here matches the
+    # one ``_get_model_routes`` picked via ``ROW_NUMBER() ... ORDER BY
+    # via_principal_id ASC`` (see :func:`_my_model_dedup_condition`).
     if target_class is MyModel and ctx is not None:
         vis = _my_model_visibility_sql(ctx)
         stmt = select(MyModel)
@@ -381,6 +432,7 @@ async def _get_model_route(
             stmt = stmt.where(getattr(MyModel, key) == value)
         if vis is not None:
             stmt = stmt.where(vis)
+        stmt = stmt.order_by(col(MyModel.via_principal_id).asc())
         existing = (await session.exec(stmt.limit(1))).first()
     else:
         existing = await target_class.one_by_fields(

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -3,7 +3,7 @@ import secrets
 from sqlalchemy.orm import selectinload
 from sqlmodel import col, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
-from typing import List, Optional, Set, Tuple, Union, Dict
+from typing import Any, Callable, List, Optional, Set, Tuple, Union, Dict
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
 from gpustack.schemas.model_routes import (
@@ -79,6 +79,176 @@ async def get_model_routes(
     )
 
 
+def _model_route_grant_conditions(ctx: TenantContext) -> list:
+    """OR-set making a ``ModelRoute`` list query mirror what a member of
+    the current Org would see — owner-equality PLUS PUBLIC/AUTHED PLUS
+    any grant from ``model_route_principals`` that names the current
+    principal. Used in place of ``tenant_list_conditions`` on the
+    consumption path (admin act-as ``my-models``); the management
+    endpoint (``GET /model-routes``) keeps the narrower owner filter so
+    it stays a "manage what you own" view.
+    """
+    if ctx.current_principal_id is None:
+        return []
+    grant_exists = (
+        select(ModelRoutePrincipalLink.id)
+        .where(
+            ModelRoutePrincipalLink.route_id == ModelRoute.id,
+            ModelRoutePrincipalLink.principal_id == ctx.current_principal_id,
+            ModelRoutePrincipalLink.deleted_at.is_(None),
+        )
+        .exists()
+    )
+    return [
+        or_(
+            col(ModelRoute.access_policy).in_(
+                (AccessPolicyEnum.PUBLIC, AccessPolicyEnum.AUTHED)
+            ),
+            ModelRoute.owner_principal_id == ctx.current_principal_id,
+            grant_exists,
+        )
+    ]
+
+
+async def _model_route_visible_to_ctx(
+    session: AsyncSession,
+    ctx: TenantContext,
+    route: ModelRoute,
+) -> bool:
+    """Single-row mirror of :func:`_model_route_grant_conditions`."""
+    if ctx.current_principal_id is None:
+        return True
+    if route.access_policy in (AccessPolicyEnum.PUBLIC, AccessPolicyEnum.AUTHED):
+        return True
+    if route.owner_principal_id == ctx.current_principal_id:
+        return True
+    stmt = (
+        select(ModelRoutePrincipalLink.id)
+        .where(
+            ModelRoutePrincipalLink.route_id == route.id,
+            ModelRoutePrincipalLink.principal_id == ctx.current_principal_id,
+            ModelRoutePrincipalLink.deleted_at.is_(None),
+        )
+        .limit(1)
+    )
+    return (await session.exec(stmt)).first() is not None
+
+
+def _my_model_visibility_sql(ctx: TenantContext):
+    """SQL predicate partitioning ``MyModel`` rows by the caller's context.
+
+    The view emits one row per (user, route, granting-principal) chain.
+    Personal scope shows only USER/GROUP-mediated grants plus PUBLIC /
+    AUTHED; Org act-as shows only grants tied to that specific Org plus
+    PUBLIC / AUTHED. Returns ``None`` when no filtering applies
+    (platform admin in All mode shouldn't reach the MyModel path; for
+    safety we treat a missing context as no-op).
+    """
+    if ctx.current_principal_id is None:
+        return None
+    if ctx.current_is_personal_scope:
+        return or_(
+            MyModel.via_principal_id.is_(None),
+            MyModel.via_principal_kind.in_(("USER", "GROUP")),
+        )
+    return or_(
+        MyModel.via_principal_id.is_(None),
+        MyModel.via_principal_id == ctx.current_principal_id,
+    )
+
+
+def _my_model_visibility_predicate(
+    ctx: TenantContext,
+) -> Optional[Callable[[Any], bool]]:
+    """Python mirror of :func:`_my_model_visibility_sql` for the
+    streaming path, which can't push WHERE clauses past the event bus.
+    """
+    if ctx.current_principal_id is None:
+        return None
+    if ctx.current_is_personal_scope:
+
+        def _ok(data: Any) -> bool:
+            return getattr(data, "via_principal_id", None) is None or getattr(
+                data, "via_principal_kind", None
+            ) in ("USER", "GROUP")
+
+        return _ok
+    org_id = ctx.current_principal_id
+
+    def _ok(data: Any) -> bool:
+        return (
+            getattr(data, "via_principal_id", None) is None
+            or getattr(data, "via_principal_id", None) == org_id
+        )
+
+    return _ok
+
+
+async def _fetch_granted_route_ids(ctx: TenantContext) -> Set[int]:
+    """Snapshot the set of route IDs granted to ``current_principal_id``
+    via ``model_route_principals``. Used by the streaming path to keep
+    the SSE filter sync; the snapshot can drift if grants change while
+    a stream is open, but ``ModelRoute`` events don't fire on grant
+    edits either, so clients reconnect to refresh.
+    """
+    async with async_session() as session:
+        return set(
+            (
+                await session.exec(
+                    select(ModelRoutePrincipalLink.route_id).where(
+                        ModelRoutePrincipalLink.principal_id
+                        == ctx.current_principal_id,
+                        ModelRoutePrincipalLink.deleted_at.is_(None),
+                    )
+                )
+            ).all()
+        )
+
+
+async def _build_route_grant_stream_filter(
+    ctx: Optional[TenantContext],
+    target_class,
+    include_grants: bool,
+) -> Optional[Callable[[Any], bool]]:
+    """Streaming counterpart to :func:`_model_route_grant_conditions`.
+    Returns ``None`` when no grant filtering applies (non-grants path,
+    non-ModelRoute target, or admin "All" mode without a principal).
+    """
+    if (
+        ctx is None
+        or target_class is not ModelRoute
+        or not include_grants
+        or ctx.current_principal_id is None
+    ):
+        return None
+    granted_route_ids = await _fetch_granted_route_ids(ctx)
+    return _model_route_grant_predicate(ctx, granted_route_ids)
+
+
+def _model_route_grant_predicate(
+    ctx: TenantContext, granted_route_ids: Set[int]
+) -> Callable[[Any], bool]:
+    """Python mirror of :func:`_model_route_grant_conditions` for the
+    streaming path. ``granted_route_ids`` is snapshotted at stream start
+    — ``ModelRoute`` events don't fire on ``model_route_principals``
+    changes, so a mid-stream grant edit isn't observable here either
+    way; clients reconnect to refresh.
+    """
+    current_principal_id = ctx.current_principal_id
+
+    def _ok(data: Any) -> bool:
+        if getattr(data, "access_policy", None) in (
+            AccessPolicyEnum.PUBLIC,
+            AccessPolicyEnum.AUTHED,
+        ):
+            return True
+        if getattr(data, "owner_principal_id", None) == current_principal_id:
+            return True
+        return getattr(data, "id", None) in granted_route_ids
+
+    return _ok
+
+
 async def _get_model_routes(
     params: ModelRouteListParams,
     name: str = None,
@@ -88,6 +258,7 @@ async def _get_model_routes(
     owner_principal_id: Optional[int] = None,
     target_class: Union[ModelRoute, MyModel] = ModelRoute,
     ctx: Optional[TenantContext] = None,
+    include_grants: bool = False,
 ):
     fuzzy_fields = {}
     if search:
@@ -103,21 +274,48 @@ async def _get_model_routes(
         fields["owner_principal_id"] = owner_principal_id
 
     # Apply tenant scoping to the streaming path too. Skipped for the MyModel
-    # view which handles visibility through its own SQL view definition.
+    # view which handles visibility through its own SQL view definition,
+    # and for the grants-inclusive consumption path which needs an OR
+    # against ``model_route_principals`` that a single field-equality
+    # can't express.
     if (
         ctx is not None
         and target_class is ModelRoute
+        and not include_grants
         and ctx.current_principal_id is not None
         and "owner_principal_id" not in fields
     ):
         fields["owner_principal_id"] = ctx.current_principal_id
 
+    my_model_sql_filter = None
+    my_model_stream_filter: Optional[Callable[[Any], bool]] = None
+    if target_class is MyModel and ctx is not None:
+        my_model_sql_filter = _my_model_visibility_sql(ctx)
+        my_model_stream_filter = _my_model_visibility_predicate(ctx)
+
     if params.watch:
+        # Snapshot grant-mediated route ids only on the streaming path —
+        # the paginated branch below pushes the same predicate into SQL
+        # via ``_model_route_grant_conditions`` and doesn't need the
+        # extra round-trip.
+        route_grant_stream_filter = await _build_route_grant_stream_filter(
+            ctx, target_class, include_grants
+        )
+
+        def _stream_filter(data: Any) -> bool:
+            if my_model_stream_filter is not None and not my_model_stream_filter(data):
+                return False
+            if route_grant_stream_filter is not None and not route_grant_stream_filter(
+                data
+            ):
+                return False
+            return categories_filter(data, categories)
+
         return StreamingResponse(
             target_class.streaming(
                 fields=fields,
                 fuzzy_fields=fuzzy_fields,
-                filter_func=lambda data: categories_filter(data, categories),
+                filter_func=_stream_filter,
             ),
             media_type="text/event-stream",
         )
@@ -127,7 +325,12 @@ async def _get_model_routes(
         # Apply tenant scoping when caller passed a TenantContext. Per-user
         # visibility for ModelRoute is via the model_route_principals table.
         if ctx is not None and target_class is ModelRoute:
-            extra_conditions.extend(tenant_list_conditions(ctx, ModelRoute))
+            if include_grants:
+                extra_conditions.extend(_model_route_grant_conditions(ctx))
+            else:
+                extra_conditions.extend(tenant_list_conditions(ctx, ModelRoute))
+        if my_model_sql_filter is not None:
+            extra_conditions.append(my_model_sql_filter)
         if categories:
             conditions = build_category_conditions(session, target_class, categories)
             extra_conditions.append(or_(*conditions))
@@ -159,24 +362,43 @@ async def _get_model_route(
     user_id: Optional[int] = None,
     owner_principal_id: Optional[int] = None,
     ctx: Optional[TenantContext] = None,
+    include_grants: bool = False,
 ):
     fields = {"id": id}
     if user_id is not None:
         fields["user_id"] = user_id
     if owner_principal_id is not None:
         fields["owner_principal_id"] = owner_principal_id
-    existing = await target_class.one_by_fields(
-        session=session,
-        fields=fields,
-    )
+
+    # The MyModel view emits one row per (user, route, granting-principal)
+    # chain; ``one_by_fields`` would .first() back an arbitrary row that
+    # might be filtered out by the caller's context. Push the same
+    # visibility predicate as the list path into the query.
+    if target_class is MyModel and ctx is not None:
+        vis = _my_model_visibility_sql(ctx)
+        stmt = select(MyModel)
+        for key, value in fields.items():
+            stmt = stmt.where(getattr(MyModel, key) == value)
+        if vis is not None:
+            stmt = stmt.where(vis)
+        existing = (await session.exec(stmt.limit(1))).first()
+    else:
+        existing = await target_class.one_by_fields(
+            session=session,
+            fields=fields,
+        )
     if not existing or existing.deleted_at is not None:
         raise NotFoundException(f"ModelAccess with id '{id}' not found.")
     if ctx is not None and target_class is ModelRoute:
-        assert_resource_visible(
-            ctx,
-            existing,
-            not_found_message=f"ModelAccess with id '{id}' not found.",
-        )
+        if include_grants:
+            if not await _model_route_visible_to_ctx(session, ctx, existing):
+                raise NotFoundException(f"ModelAccess with id '{id}' not found.")
+        else:
+            assert_resource_visible(
+                ctx,
+                existing,
+                not_found_message=f"ModelAccess with id '{id}' not found.",
+            )
     return existing
 
 
@@ -954,21 +1176,26 @@ async def get_my_models(
 ):
     """List the model routes available to the calling user.
 
-    For non-admin users: visibility is governed by `non_admin_user_models`,
-    which already encodes PUBLIC/AUTHED/ORG/ALLOWED_PRINCIPALS semantics. We do NOT additionally filter by current_principal_id — routes
-    published cross-org via ALLOWED_PRINCIPALS would otherwise be hidden.
-    For platform admins: optionally filter by org if a context was provided.
+    Non-admin: read the ``non_admin_user_models`` view (one row per
+    user × route × granting-principal) and partition it by the
+    request's ``current_principal_id`` — Personal scope sees only
+    USER/GROUP-mediated grants plus PUBLIC/AUTHED; Org act-as sees
+    only grants tied to that Org plus PUBLIC/AUTHED.
+
+    Platform admin: list the live ``model_routes`` table. With an Org
+    context set, the act-as filter matches what a member of that Org
+    would see; without one, return everything (the "All" view).
     """
     user = ctx.user
     user_id = None
     target_class = ModelRoute
-    owner_principal_id = None
     if not user.is_admin:
         target_class = MyModel
         user_id = user.id
-    else:
-        # Admin can opt into a per-org view by setting the org context.
-        owner_principal_id = ctx.current_principal_id
+    # Admin act-as: match what an org member would see (own + PUBLIC /
+    # AUTHED + cross-tenant grants), not just routes whose ``owner`` is
+    # this org. Admin "All" mode (no current_principal_id) keeps
+    # bypassing tenant filters via ``include_grants`` returning [].
 
     return await _get_model_routes(
         params=params,
@@ -976,7 +1203,8 @@ async def get_my_models(
         categories=categories,
         target_class=target_class,
         user_id=user_id,
-        owner_principal_id=owner_principal_id,
+        ctx=ctx,
+        include_grants=user.is_admin,
     )
 
 
@@ -989,17 +1217,15 @@ async def get_my_model(
     user = ctx.user
     user_id = None
     target_class = ModelRoute
-    owner_principal_id = None
     if not user.is_admin:
         target_class = MyModel
         user_id = user.id
-    else:
-        owner_principal_id = ctx.current_principal_id
 
     return await _get_model_route(
         session=session,
         id=id,
         user_id=user_id,
-        owner_principal_id=owner_principal_id,
         target_class=target_class,
+        ctx=ctx,
+        include_grants=user.is_admin,
     )

--- a/gpustack/routes/openai.py
+++ b/gpustack/routes/openai.py
@@ -34,7 +34,8 @@ from gpustack.schemas.model_routes import (
 )
 from gpustack.schemas.principals import Principal, platform_principal_id
 from gpustack.schemas.workers import Worker
-from gpustack.server.deps import SessionDep, CurrentUserDep
+from gpustack.routes.model_routes import _my_model_visibility_sql
+from gpustack.server.deps import SessionDep, CurrentUserDep, TenantContextDep
 from gpustack.server.services import (
     ModelInstanceService,
     ModelRouteService,
@@ -90,6 +91,7 @@ def get_legacy_api_router() -> APIRouter:
 async def list_models(
     user: CurrentUserDep,
     session: SessionDep,
+    ctx: TenantContextDep,
     categories: List[str] = Query(
         [],
         description="Model categories to filter by.",
@@ -104,6 +106,15 @@ async def list_models(
     if target_class == MyModel:
         # Non-admin users should only see their own private models when filtering by categories.
         statement = statement.where(target_class.user_id == user.id)
+        # Apply the same Personal vs Org-act-as partition as
+        # ``/v2/my-models``: otherwise the Playground happily lists
+        # (and lets the user invoke) a model that the My Models page
+        # — under the same view — has hidden. Org-mediated grants
+        # surface only in the matching Org context; user/group
+        # grants surface in Personal.
+        vis = _my_model_visibility_sql(ctx)
+        if vis is not None:
+            statement = statement.where(vis)
 
     if categories:
         conditions = build_category_conditions(session, target_class, categories)

--- a/gpustack/routes/usage.py
+++ b/gpustack/routes/usage.py
@@ -386,13 +386,20 @@ def _apply_usage_scope_and_filters(
     scope: str,
     org_id: Optional[int] = None,
 ) -> Select:
-    # ``self`` view always restricts to the caller's own rows. ``all``
-    # view restricts by owner_principal_id when one is in context (platform
-    # admin in cross-org "All" mode has org_id=None and sees everything).
+    # ``self`` scope always restricts to the caller's own rows and
+    # current Org. ``all`` scope restricts to the current Org unless
+    # platform admin is in cross-org "All" mode. The Org dimension is
+    # the consumer side (API-key owner), which answers "what did this
+    # Org spend" — the only question the Usage page surfaces today. A
+    # symmetric provider view (rows whose model / deployment is owned
+    # by this Org) is deferred until there's an actual product surface
+    # for it.
     if scope == USAGE_SCOPE_SELF:
         statement = statement.where(ModelUsage.user_id == user.id)
+        if org_id is not None:
+            statement = statement.where(ModelUsage.consumer_principal_id == org_id)
     elif org_id is not None:
-        statement = statement.where(ModelUsage.owner_principal_id == org_id)
+        statement = statement.where(ModelUsage.consumer_principal_id == org_id)
 
     for group_by, items in [
         (USAGE_GROUP_BY_USER, filters.users),
@@ -510,9 +517,13 @@ async def get_usage_meta(
     base_statement = _base_statement()
     if scope == USAGE_SCOPE_SELF:
         base_statement = base_statement.where(ModelUsage.user_id == user.id)
+        if ctx.current_principal_id is not None:
+            base_statement = base_statement.where(
+                ModelUsage.consumer_principal_id == ctx.current_principal_id
+            )
     elif ctx.current_principal_id is not None:
         base_statement = base_statement.where(
-            ModelUsage.owner_principal_id == ctx.current_principal_id
+            ModelUsage.consumer_principal_id == ctx.current_principal_id
         )
 
     user_options: List[UsageFilterOption] = []

--- a/gpustack/schemas/model_routes.py
+++ b/gpustack/schemas/model_routes.py
@@ -408,6 +408,13 @@ class MyModel(ModelRouteBase, BaseModelMixin, table=True):
     pid: str
     id: int
     user_id: int = Field(default=0)
+    # Records which principal granted this (user, route) row visibility.
+    # NULL on PUBLIC/AUTHED rows (not principal-mediated). The kind is
+    # stored as plain text — see ``model_user_after_create_view_stmt``
+    # for why it isn't the ``principaltype`` enum. Server-side only;
+    # not surfaced via ``MyModelPublic``.
+    via_principal_id: Optional[int] = None
+    via_principal_kind: Optional[str] = None
 
 
 class MyModelPublic(ModelRoutePublic):

--- a/gpustack/schemas/model_usage.py
+++ b/gpustack/schemas/model_usage.py
@@ -53,8 +53,16 @@ class ModelUsage(SQLModel, ActiveRecordMixin, table=True):
     access_key: Optional[str] = Field(default=None)
     api_key_is_custom: Optional[bool] = Field(default=None)
     # Tenant scope. Denormalized from the api_key/model used for the request.
-    # NULL = global (admin acting in "All" mode).
+    # This is the model/deployment owner principal.
+    # NULL = global (admin acting in "All" mode)
     owner_principal_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(Integer, ForeignKey("principals.id", ondelete="SET NULL")),
+    )
+    # Consumer tenant scope, denormalized from the API key used for the request.
+    # This can differ from owner_principal_id when one Org calls another Org's
+    # shared models.
+    consumer_principal_id: Optional[int] = Field(
         default=None,
         sa_column=Column(Integer, ForeignKey("principals.id", ondelete="SET NULL")),
     )

--- a/gpustack/schemas/model_usage_details.py
+++ b/gpustack/schemas/model_usage_details.py
@@ -46,6 +46,10 @@ class ModelUsageDetails(SQLModel, BaseModelMixin, table=True):
     # Tenant scope snapshot. FK-less for the same audit-survival reason
     # as the other id columns — see class docstring.
     owner_principal_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
+    # Consumer tenant scope snapshot, denormalized from the API key owner.
+    consumer_principal_id: Optional[int] = Field(
+        default=None, sa_column=Column(Integer)
+    )
     provider_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
     provider_name: Optional[str] = Field(default=None)
     provider_type: Optional[str] = Field(default=None)
@@ -103,6 +107,10 @@ class ModelUsageDetailsArchive(SQLModel, BaseModelMixin, table=True):
     # Tenant scope snapshot. FK-less for the same audit-survival reason
     # as the other id columns — see class docstring.
     owner_principal_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
+    # Consumer tenant scope snapshot, denormalized from the API key owner.
+    consumer_principal_id: Optional[int] = Field(
+        default=None, sa_column=Column(Integer)
+    )
     provider_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
     provider_name: Optional[str] = Field(default=None)
     provider_type: Optional[str] = Field(default=None)

--- a/gpustack/schemas/stmt.py
+++ b/gpustack/schemas/stmt.py
@@ -214,11 +214,6 @@ WHERE group_pm.deleted_at IS NULL
 
 def model_user_after_create_view_stmt(db_type: str) -> str:
     sql_false = '0' if db_type == "sqlite" else 'FALSE'
-    pid = (
-        "CONCAT(m.id, ':', u.id)"
-        if db_type == "mysql"
-        else "CAST(m.id AS TEXT) || ':' || CAST(u.id AS TEXT)"
-    )
     # MySQL's CAST(... AS TEXT) is invalid; CHAR is the canonical
     # variable-length text target there. PG / openGauss / sqlite all
     # accept TEXT.
@@ -227,6 +222,27 @@ def model_user_after_create_view_stmt(db_type: str) -> str:
     # servers / OceanBase compat modes want ``SIGNED``. PG / openGauss
     # both accept ``INTEGER``.
     int_type = "SIGNED" if db_type == "mysql" else "INTEGER"
+
+    def _pid(via_expr: str) -> str:
+        # ``pid`` keys identity-map lookups on MyModel, so it has to be
+        # genuinely unique per emitted row. ``route_id:user_id`` alone
+        # collides whenever a (user, route) is covered by multiple
+        # grant chains; folding ``via_principal_id`` into the suffix
+        # restores uniqueness. ``IFNULL`` / ``COALESCE`` are mandatory:
+        # both ``CONCAT(...)`` (MySQL) and ``||`` (PG / openGauss /
+        # sqlite) propagate NULL through the whole expression, so a raw
+        # NULL via on the PUBLIC/AUTHED branch would make pid itself
+        # NULL.
+        if db_type == "mysql":
+            return (
+                f"CONCAT(m.id, ':', u.id, ':', "
+                f"IFNULL(CAST({via_expr} AS CHAR), ''))"
+            )
+        return (
+            f"CAST(m.id AS TEXT) || ':' || CAST(u.id AS TEXT) "
+            f"|| ':' || COALESCE(CAST({via_expr} AS TEXT), '')"
+        )
+
     # 4-branch UNION ALL — each branch is a straight index join, so the
     # planner doesn't have to materialize every (user, route) pair to
     # then OR-filter EXISTS subqueries against it. ``mrp.deleted_at IS
@@ -246,9 +262,15 @@ def model_user_after_create_view_stmt(db_type: str) -> str:
     # grants aren't principal-mediated. The kind is normalized to TEXT
     # so PG's native ``principaltype`` enum doesn't poison the UNION's
     # column type inference.
+    #
+    # The view's contract is one row per chain — multi-chain (user,
+    # route) collapse to "one row per route" is the API layer's job
+    # (see ``_get_model_routes``), because the visibility filter
+    # discriminates by chain ``via_principal_kind`` and would drop the
+    # wrong chain if the view picked one up front.
     return f'''
 CREATE VIEW non_admin_user_models AS
-SELECT {pid} AS pid,
+SELECT {_pid("NULL")} AS pid,
        u.id AS user_id,
        CAST(NULL AS {int_type}) AS via_principal_id,
        CAST(NULL AS {text_type}) AS via_principal_kind,
@@ -261,7 +283,7 @@ WHERE u.kind = 'USER' AND u.deleted_at IS NULL
 
 UNION ALL
 
-SELECT {pid} AS pid,
+SELECT {_pid("m.owner_principal_id")} AS pid,
        u.id AS user_id,
        m.owner_principal_id AS via_principal_id,
        CAST('ORG' AS {text_type}) AS via_principal_kind,
@@ -277,7 +299,7 @@ WHERE u.kind = 'USER' AND u.deleted_at IS NULL
 
 UNION ALL
 
-SELECT {pid} AS pid,
+SELECT {_pid("u.id")} AS pid,
        u.id AS user_id,
        u.id AS via_principal_id,
        CAST('USER' AS {text_type}) AS via_principal_kind,
@@ -294,7 +316,7 @@ WHERE u.kind = 'USER' AND u.deleted_at IS NULL
 
 UNION ALL
 
-SELECT {pid} AS pid,
+SELECT {_pid("mrp.principal_id")} AS pid,
        u.id AS user_id,
        mrp.principal_id AS via_principal_id,
        CAST(pr.kind AS {text_type}) AS via_principal_kind,

--- a/gpustack/schemas/stmt.py
+++ b/gpustack/schemas/stmt.py
@@ -219,6 +219,14 @@ def model_user_after_create_view_stmt(db_type: str) -> str:
         if db_type == "mysql"
         else "CAST(m.id AS TEXT) || ':' || CAST(u.id AS TEXT)"
     )
+    # MySQL's CAST(... AS TEXT) is invalid; CHAR is the canonical
+    # variable-length text target there. PG / openGauss / sqlite all
+    # accept TEXT.
+    text_type = "CHAR" if db_type == "mysql" else "TEXT"
+    # MySQL only accepts ``INTEGER`` as a CAST target from 8.0.17; older
+    # servers / OceanBase compat modes want ``SIGNED``. PG / openGauss
+    # both accept ``INTEGER``.
+    int_type = "SIGNED" if db_type == "mysql" else "INTEGER"
     # 4-branch UNION ALL — each branch is a straight index join, so the
     # planner doesn't have to materialize every (user, route) pair to
     # then OR-filter EXISTS subqueries against it. ``mrp.deleted_at IS
@@ -230,9 +238,21 @@ def model_user_after_create_view_stmt(db_type: str) -> str:
     # ALLOWED_USERS branch becomes ``mrp.principal_id = u.id`` (the
     # user's USER-principal id IS the user's id) instead of joining
     # through the now-removed ``users.principal_id`` column.
+    #
+    # ``via_principal_id`` / ``via_principal_kind`` record which principal
+    # granted this (user, route) row visibility, so the API layer can
+    # partition results into Personal vs Org-scoped views without
+    # re-deriving the chain. NULL on the PUBLIC/AUTHED branch — those
+    # grants aren't principal-mediated. The kind is normalized to TEXT
+    # so PG's native ``principaltype`` enum doesn't poison the UNION's
+    # column type inference.
     return f'''
 CREATE VIEW non_admin_user_models AS
-SELECT {pid} AS pid, u.id AS user_id, m.*
+SELECT {pid} AS pid,
+       u.id AS user_id,
+       CAST(NULL AS {int_type}) AS via_principal_id,
+       CAST(NULL AS {text_type}) AS via_principal_kind,
+       m.*
 FROM principals u
 CROSS JOIN model_routes m
 WHERE u.kind = 'USER' AND u.deleted_at IS NULL
@@ -241,7 +261,11 @@ WHERE u.kind = 'USER' AND u.deleted_at IS NULL
 
 UNION ALL
 
-SELECT {pid} AS pid, u.id AS user_id, m.*
+SELECT {pid} AS pid,
+       u.id AS user_id,
+       m.owner_principal_id AS via_principal_id,
+       CAST('ORG' AS {text_type}) AS via_principal_kind,
+       m.*
 FROM principals u
 JOIN principal_users pu
   ON pu.user_id = u.id
@@ -253,7 +277,11 @@ WHERE u.kind = 'USER' AND u.deleted_at IS NULL
 
 UNION ALL
 
-SELECT {pid} AS pid, u.id AS user_id, m.*
+SELECT {pid} AS pid,
+       u.id AS user_id,
+       u.id AS via_principal_id,
+       CAST('USER' AS {text_type}) AS via_principal_kind,
+       m.*
 FROM principals u
 JOIN model_route_principals mrp
   ON mrp.principal_id = u.id
@@ -266,12 +294,18 @@ WHERE u.kind = 'USER' AND u.deleted_at IS NULL
 
 UNION ALL
 
-SELECT {pid} AS pid, u.id AS user_id, m.*
+SELECT {pid} AS pid,
+       u.id AS user_id,
+       mrp.principal_id AS via_principal_id,
+       CAST(pr.kind AS {text_type}) AS via_principal_kind,
+       m.*
 FROM principals u
 JOIN principal_users pu ON pu.user_id = u.id
 JOIN model_route_principals mrp
   ON mrp.principal_id = pu.principal_id
   AND mrp.deleted_at IS NULL
+JOIN principals pr
+  ON pr.id = mrp.principal_id
 JOIN model_routes m
   ON m.id = mrp.route_id
   AND m.access_policy = 'ALLOWED_PRINCIPALS'

--- a/gpustack/schemas/usage.py
+++ b/gpustack/schemas/usage.py
@@ -121,9 +121,9 @@ class UsageBaseRequest(BaseModel):
     end_date: Date
     filters: UsageFilterRequest = Field(default_factory=UsageFilterRequest)
     # See USAGE_SCOPE_* constants. Defaults to "all" so that managers /
-    # admins who omit the parameter get the org-wide provider view; the
-    # endpoint downgrades to "self" automatically when the caller has
-    # no managerial role (and rejects the request if they explicitly
+    # admins who omit the parameter get the org-wide view; the endpoint
+    # downgrades to "self" automatically when the caller has no
+    # managerial role (and rejects the request if they explicitly
     # asked for "all").
     scope: str = USAGE_SCOPE_ALL
 

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -433,7 +433,11 @@ async def distribute_models_to_user(
     ]:
         for user_id in ids:
             my_model = MyModel(
-                pid=f"{model_id}:{user_id}",
+                # Match the view's pid layout (``route_id:user_id:via``).
+                # The publisher doesn't know the granting chain, so the
+                # via suffix is empty — same shape as the PUBLIC/AUTHED
+                # branch of ``non_admin_user_models``.
+                pid=f"{model_id}:{user_id}:",
                 user_id=user_id,
                 **model_dict,
             )

--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -324,6 +324,7 @@ async def create_or_update_model_usage(
             "model_route_id": metric.model_route_id,
             "access_key": metric.access_key,
             "operation": metric.operation,
+            "consumer_principal_id": metric.consumer_principal_id,
             "date": metric.date,
         },
     )
@@ -432,6 +433,7 @@ def _build_metric_snapshot(
                     "api_key_name": api_key.name,
                     "access_key": api_key.access_key,
                     "api_key_is_custom": api_key.is_custom,
+                    "consumer_principal_id": api_key.owner_principal_id,
                 }
             )
         if model_route_id is not None:

--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -123,7 +123,11 @@ def _resolve_metric_datetime(
 def _make_buffer_key(metric: ModelUsageMetrics) -> str:
     # Include the completion-anchored date so streams that cross midnight
     # accumulate into the correct billing-period rollup instead of being
-    # merged with the next day's traffic.
+    # merged with the next day's traffic. ``organization_id`` is included
+    # to match the DB upsert key in ``create_or_update_model_usage`` —
+    # otherwise the same user calling from different Org contexts within
+    # one flush window would merge in memory but split on write, losing
+    # tokens.
     metric_date, _ = _resolve_metric_datetime(metric)
     operation = metric.operation.value if metric.operation else ""
     return ".".join(
@@ -134,6 +138,7 @@ def _make_buffer_key(metric: ModelUsageMetrics) -> str:
             metric.model,
             metric.user_id,
             metric.access_key,
+            metric.organization_id,
             metric.model_route_id,
             operation,
             metric_date.isoformat(),
@@ -465,6 +470,19 @@ def _build_metric_snapshot(
     snapshot.setdefault("provider_type", metric.provider_type)
     snapshot.setdefault("access_key", metric.access_key)
     snapshot.setdefault("api_key_is_custom", None)
+    # The api_key path above stamps ``consumer_principal_id`` from
+    # ``api_key.owner_principal_id`` whenever a key is present. For
+    # cookie-authed traffic (no api_key) the gateway plugin still
+    # provides the active tenant via the wire-format
+    # ``organization_id`` header — parse it back to int so the row
+    # carries its Org scope. Direct-to-gpustack cookie calls don't
+    # populate this field and land NULL; that's by design (no Org
+    # context known at that path).
+    if "consumer_principal_id" not in snapshot and metric.organization_id:
+        try:
+            snapshot["consumer_principal_id"] = int(metric.organization_id)
+        except (TypeError, ValueError):
+            pass
     return snapshot
 
 

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -676,6 +676,36 @@ class ModelRouteService:
             if target.model_id is not None
         ]
 
+    @locked_cached()
+    async def get_by_name(self, name: str) -> Optional[ModelRoute]:
+        """Resolve a request model name to its ``ModelRoute`` row.
+
+        Mirrors the ``<owner-name>/<route>`` prefix handling from
+        :meth:`get_model_auth_info_by_name` so the OpenAI proxy can
+        attribute requests to the route they entered through regardless
+        of whether Higress's ``modelMapping`` has rewritten the name yet.
+        """
+        if "/" in name:
+            owner_name, _, rest = name.partition("/")
+            if rest:
+                owner = (
+                    await self.session.exec(
+                        select(Principal).where(
+                            Principal.name == owner_name,
+                            Principal.kind == PrincipalType.ORG,
+                            Principal.deleted_at.is_(None),
+                        )
+                    )
+                ).first()
+                if owner is not None:
+                    route = await ModelRoute.one_by_fields(
+                        self.session,
+                        {"name": rest, "owner_principal_id": owner.id},
+                    )
+                    if route is not None:
+                        return route
+        return await ModelRoute.one_by_field(self.session, "name", name)
+
     async def update(
         self,
         model_route: ModelRoute,
@@ -689,6 +719,7 @@ class ModelRouteService:
         for name in names:
             await delete_cache_by_key(self.get_model_auth_info_by_name, name)
             await delete_cache_by_key(self.resolve_route_targets, name)
+            await delete_cache_by_key(self.get_by_name, name)
         return result
 
     async def delete(self, model_route: ModelRoute, auto_commit: bool = True):
@@ -700,6 +731,7 @@ class ModelRouteService:
         for name in names:
             await delete_cache_by_key(self.get_model_auth_info_by_name, name)
             await delete_cache_by_key(self.resolve_route_targets, name)
+            await delete_cache_by_key(self.get_by_name, name)
         return result
 
 

--- a/gpustack/utils/usage_snapshots.py
+++ b/gpustack/utils/usage_snapshots.py
@@ -133,6 +133,7 @@ def build_model_usage_snapshot(
                 "api_key_name": api_key.name,
                 "access_key": api_key.access_key,
                 "api_key_is_custom": api_key.is_custom,
+                "consumer_principal_id": api_key.owner_principal_id,
             }
         )
     if model_route_id is not None:

--- a/tests/routers/test_usage.py
+++ b/tests/routers/test_usage.py
@@ -9,6 +9,7 @@ from gpustack.routes.usage import (
     get_usage_breakdown,
     get_usage_meta,
 )
+from gpustack.schemas.principals import OrgRole
 from gpustack.schemas.users import User
 from gpustack.schemas.usage import (
     UsageBreakdownRequest,
@@ -38,6 +39,14 @@ def _ctx_for(user):
     ctx.is_platform_admin = bool(getattr(user, "is_admin", False))
     ctx.current_principal_id = None if ctx.is_platform_admin else 1
     ctx.org_role = None
+    ctx.current_is_personal_scope = False
+    return ctx
+
+
+def _org_owner_ctx(user, org_id=1):
+    ctx = _ctx_for(user)
+    ctx.current_principal_id = org_id
+    ctx.org_role = OrgRole.OWNER
     return ctx
 
 
@@ -504,6 +513,38 @@ async def test_get_usage_breakdown_defaults_regular_user_to_self_scope():
 
     executed_sql = str(session.exec.call_args_list[0].args[0])
     assert "model_usages.user_id =" in executed_sql
+    assert "model_usages.consumer_principal_id =" in executed_sql
+
+
+@pytest.mark.asyncio
+async def test_get_usage_breakdown_org_owner_scopes_by_consumer_principal():
+    """Org owner with default ``scope=all`` must filter the org
+    dimension by the API-key owner (``consumer_principal_id``), not
+    the deployment owner. A pure consumer (Org that only uses models
+    granted from elsewhere) would otherwise see an empty page even
+    though their members are actively spending."""
+    session = MagicMock()
+    session.exec = AsyncMock(
+        side_effect=[
+            _mock_exec_result([SimpleNamespace()]),
+            _mock_exec_result([0]),
+            _mock_exec_result([]),
+        ]
+    )
+    user = User(id=2, name="owner", is_admin=False)
+    request = UsageBreakdownRequest(
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 2),
+        group_by=["route"],
+    )
+
+    await get_usage_breakdown(
+        session=session, user=user, ctx=_org_owner_ctx(user), request=request
+    )
+
+    executed_sql = str(session.exec.call_args_list[0].args[0])
+    assert "model_usages.consumer_principal_id =" in executed_sql
+    assert "model_usages.owner_principal_id =" not in executed_sql
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_api_keys.py
+++ b/tests/routes/test_api_keys.py
@@ -1,0 +1,99 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gpustack.routes import api_keys
+from gpustack.schemas.api_keys import ApiKey, ApiKeyListParams, ApiKeysPublic
+from gpustack.schemas.common import Pagination
+from gpustack.schemas.principals import OrgRole
+from gpustack.schemas.users import User
+
+
+def _ctx(*, user_id=1, is_admin=False, current_principal_id=10, org_role=None):
+    return SimpleNamespace(
+        user=User(id=user_id, name=f"user-{user_id}", is_admin=is_admin),
+        current_principal_id=current_principal_id,
+        org_role=org_role,
+    )
+
+
+@pytest.mark.asyncio
+async def test_org_owner_lists_all_api_keys_in_current_org(monkeypatch):
+    captured = {}
+
+    async def fake_paginated_by_query(**kwargs):
+        captured["fields"] = kwargs["fields"]
+        return ApiKeysPublic(
+            items=[],
+            pagination=Pagination(page=1, perPage=100, total=0, totalPage=0),
+        )
+
+    monkeypatch.setattr(ApiKey, "paginated_by_query", fake_paginated_by_query)
+
+    await api_keys.get_api_keys(
+        session=object(),
+        ctx=_ctx(org_role=OrgRole.OWNER),
+        params=ApiKeyListParams(),
+        user_id=None,
+    )
+
+    assert captured["fields"] == {"owner_principal_id": 10}
+
+
+@pytest.mark.asyncio
+async def test_org_member_lists_only_own_api_keys_in_current_org(monkeypatch):
+    captured = {}
+
+    async def fake_paginated_by_query(**kwargs):
+        captured["fields"] = kwargs["fields"]
+        return ApiKeysPublic(
+            items=[],
+            pagination=Pagination(page=1, perPage=100, total=0, totalPage=0),
+        )
+
+    monkeypatch.setattr(ApiKey, "paginated_by_query", fake_paginated_by_query)
+
+    await api_keys.get_api_keys(
+        session=object(),
+        ctx=_ctx(user_id=2, org_role=OrgRole.MEMBER),
+        params=ApiKeyListParams(),
+        user_id=None,
+    )
+
+    assert captured["fields"] == {"owner_principal_id": 10, "user_id": 2}
+
+
+@pytest.mark.asyncio
+async def test_org_owner_can_delete_other_users_api_key_in_current_org(monkeypatch):
+    deleted = {}
+    api_key = ApiKey(
+        id=5,
+        name="team-key",
+        user_id=2,
+        owner_principal_id=10,
+        access_key="access",
+        hashed_secret_key="secret",
+        created_at=datetime(2026, 1, 1),
+        updated_at=datetime(2026, 1, 1),
+    )
+
+    monkeypatch.setattr(ApiKey, "one_by_id", AsyncMock(return_value=api_key))
+
+    class FakeAPIKeyService:
+        def __init__(self, session):
+            self.session = session
+
+        async def delete(self, api_key):
+            deleted["api_key_id"] = api_key.id
+
+    monkeypatch.setattr(api_keys, "APIKeyService", FakeAPIKeyService)
+
+    await api_keys.delete_api_key(
+        session=object(),
+        ctx=_ctx(user_id=1, org_role=OrgRole.OWNER),
+        id=5,
+    )
+
+    assert deleted["api_key_id"] == 5

--- a/tests/routes/test_model_routes.py
+++ b/tests/routes/test_model_routes.py
@@ -1,16 +1,44 @@
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import true
 
 from gpustack.api.exceptions import InvalidException
+from gpustack.api.tenant import TenantContext
 from gpustack.routes import model_routes
 from gpustack.schemas.common import Pagination
 from gpustack.schemas.model_routes import (
+    AccessPolicyEnum,
+    ModelRoute,
     ModelRouteListParams,
     ModelRoutesPublic,
     MyModel,
 )
+from gpustack.schemas.principals import Principal, PrincipalType
+
+
+def _ctx(
+    user_id: int, current_principal_id: int, is_admin: bool = False
+) -> TenantContext:
+    user = Principal(
+        id=user_id,
+        name=f"u{user_id}",
+        kind=PrincipalType.USER,
+        is_admin=is_admin,
+    )
+    return TenantContext(
+        user=user,
+        is_platform_admin=is_admin,
+        current_principal_id=current_principal_id,
+        org_role=None,
+        current_is_personal_scope=current_principal_id == user_id,
+    )
+
+
+def _compile(expr) -> str:
+    """Render a SQLAlchemy expression to a literal string for assertions."""
+    return str(expr.compile(compile_kwargs={"literal_binds": True}))
 
 
 @pytest.mark.asyncio
@@ -91,3 +119,326 @@ def test_assert_target_tenant_aligned_skips_when_either_owner_null():
         target_kind="ModelProvider",
         target_id=11,
     )
+
+
+# ----------------------------------------------------------------------
+# MyModel visibility — partition by Personal vs Org act-as
+# ----------------------------------------------------------------------
+
+
+def test_my_model_visibility_sql_personal_scope():
+    """Personal view: PUBLIC/AUTHED (NULL via) + USER/GROUP grants only —
+    Org-mediated grants must be excluded."""
+    ctx = _ctx(user_id=7, current_principal_id=7)
+    sql = _compile(model_routes._my_model_visibility_sql(ctx))
+    assert "via_principal_id IS NULL" in sql
+    assert "via_principal_kind IN ('USER', 'GROUP')" in sql
+    # No specific principal-id equality — this branch is kind-based.
+    assert "via_principal_id =" not in sql
+
+
+def test_my_model_visibility_sql_org_act_as():
+    """Org act-as view: only grants tied to the active org (plus PUBLIC /
+    AUTHED). User/Group-mediated grants don't bleed into the org view."""
+    ctx = _ctx(user_id=7, current_principal_id=42)
+    sql = _compile(model_routes._my_model_visibility_sql(ctx))
+    assert "via_principal_id IS NULL" in sql
+    assert "via_principal_id = 42" in sql
+    assert "via_principal_kind" not in sql
+
+
+def test_my_model_visibility_predicate_personal():
+    """Mirror :func:`_my_model_visibility_sql` for the streaming path —
+    Personal scope keeps PUBLIC/AUTHED and USER/GROUP rows, drops ORG."""
+    pred = model_routes._my_model_visibility_predicate(_ctx(7, 7))
+    assert pred(SimpleNamespace(via_principal_id=None, via_principal_kind=None))
+    assert pred(SimpleNamespace(via_principal_id=7, via_principal_kind="USER"))
+    assert pred(SimpleNamespace(via_principal_id=99, via_principal_kind="GROUP"))
+    assert not pred(SimpleNamespace(via_principal_id=42, via_principal_kind="ORG"))
+
+
+def test_my_model_visibility_predicate_org_act_as():
+    pred = model_routes._my_model_visibility_predicate(_ctx(7, 42))
+    assert pred(SimpleNamespace(via_principal_id=None, via_principal_kind=None))
+    assert pred(SimpleNamespace(via_principal_id=42, via_principal_kind="ORG"))
+    # Personal grants belong to the user's Personal view, not org 42's.
+    assert not pred(SimpleNamespace(via_principal_id=7, via_principal_kind="USER"))
+    # And another org's grant must not leak into this org's view.
+    assert not pred(SimpleNamespace(via_principal_id=43, via_principal_kind="ORG"))
+
+
+def test_my_model_visibility_returns_none_without_context():
+    """No current_principal_id => no extra filter (defensive bypass)."""
+    user = Principal(id=7, name="u7", kind=PrincipalType.USER, is_admin=True)
+    ctx = TenantContext(
+        user=user,
+        is_platform_admin=True,
+        current_principal_id=None,
+        org_role=None,
+    )
+    assert model_routes._my_model_visibility_sql(ctx) is None
+    assert model_routes._my_model_visibility_predicate(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_get_model_routes_applies_my_model_visibility_filter(monkeypatch):
+    """End-to-end through ``_get_model_routes``: the SQL OR predicate
+    must show up in ``extra_conditions`` when target is MyModel + ctx
+    has a current_principal_id."""
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_async_session():
+        yield object()
+
+    async def fake_paginated_by_query(**kwargs):
+        captured["extra_conditions"] = kwargs["extra_conditions"]
+        captured["fields"] = kwargs["fields"]
+        return ModelRoutesPublic(
+            items=[],
+            pagination=Pagination(page=1, perPage=24, total=0, totalPage=0),
+        )
+
+    monkeypatch.setattr(model_routes, "async_session", fake_async_session)
+    monkeypatch.setattr(MyModel, "paginated_by_query", fake_paginated_by_query)
+
+    await model_routes._get_model_routes(
+        params=ModelRouteListParams(page=1, perPage=24),
+        target_class=MyModel,
+        user_id=7,
+        ctx=_ctx(user_id=7, current_principal_id=42),
+    )
+
+    rendered = " ".join(_compile(c) for c in captured["extra_conditions"])
+    assert "via_principal_id IS NULL" in rendered
+    assert "via_principal_id = 42" in rendered
+    # Fields filter for the user is still enforced.
+    assert captured["fields"]["user_id"] == 7
+
+
+# ----------------------------------------------------------------------
+# Admin act-as parity — ``ModelRoute`` with ``include_grants=True``
+# ----------------------------------------------------------------------
+
+
+def test_model_route_grant_conditions_includes_owner_public_and_grants():
+    """Admin act-as should see: owner-equality OR PUBLIC/AUTHED OR an
+    explicit grant in ``model_route_principals`` — the same set a non-
+    admin member of that org would see via the ``non_admin_user_models``
+    view. Owner-only is too narrow."""
+    ctx = _ctx(user_id=99, current_principal_id=42, is_admin=True)
+    conds = model_routes._model_route_grant_conditions(ctx)
+    assert len(conds) == 1
+    rendered = _compile(conds[0])
+    assert "access_policy IN ('PUBLIC', 'AUTHED')" in rendered
+    assert "owner_principal_id = 42" in rendered
+    # The EXISTS subquery links the route to model_route_principals.
+    assert "model_route_principals" in rendered
+    assert "principal_id = 42" in rendered
+
+
+def test_model_route_grant_conditions_empty_without_principal():
+    """All-mode admin (no current_principal_id) gets no filter — caller
+    is expected to skip the helper or use it as a no-op."""
+    user = Principal(id=99, name="admin", kind=PrincipalType.USER, is_admin=True)
+    ctx = TenantContext(
+        user=user,
+        is_platform_admin=True,
+        current_principal_id=None,
+        org_role=None,
+    )
+    assert model_routes._model_route_grant_conditions(ctx) == []
+
+
+@pytest.mark.asyncio
+async def test_get_model_routes_admin_act_as_uses_grant_conditions(monkeypatch):
+    """When the my-models admin branch calls ``_get_model_routes`` with
+    ``include_grants=True``, the broader OR set replaces the narrow
+    owner-equality filter and the field-level owner injection is
+    skipped — otherwise the OR would be ANDed with owner=x and degrade
+    to owner-only."""
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_async_session():
+        yield object()
+
+    async def fake_paginated_by_query(**kwargs):
+        captured["extra_conditions"] = kwargs["extra_conditions"]
+        captured["fields"] = kwargs["fields"]
+        return ModelRoutesPublic(
+            items=[],
+            pagination=Pagination(page=1, perPage=24, total=0, totalPage=0),
+        )
+
+    async def fake_fetch_granted_route_ids(ctx):
+        return set()
+
+    monkeypatch.setattr(model_routes, "async_session", fake_async_session)
+    monkeypatch.setattr(ModelRoute, "paginated_by_query", fake_paginated_by_query)
+    monkeypatch.setattr(
+        model_routes, "_fetch_granted_route_ids", fake_fetch_granted_route_ids
+    )
+
+    await model_routes._get_model_routes(
+        params=ModelRouteListParams(page=1, perPage=24),
+        target_class=ModelRoute,
+        ctx=_ctx(user_id=99, current_principal_id=42, is_admin=True),
+        include_grants=True,
+    )
+
+    assert "owner_principal_id" not in captured["fields"]
+    rendered = " ".join(_compile(c) for c in captured["extra_conditions"])
+    assert "access_policy IN ('PUBLIC', 'AUTHED')" in rendered
+    assert "owner_principal_id = 42" in rendered
+    assert "model_route_principals" in rendered
+
+
+@pytest.mark.asyncio
+async def test_get_model_routes_admin_management_keeps_owner_narrow(monkeypatch):
+    """``include_grants=False`` (the management path on
+    ``/v1/model-routes``) keeps the historical owner-only filter — admins
+    managing routes shouldn't be looking at routes they don't own just
+    because someone granted them access."""
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_async_session():
+        yield object()
+
+    async def fake_paginated_by_query(**kwargs):
+        captured["fields"] = kwargs["fields"]
+        captured["extra_conditions"] = kwargs["extra_conditions"]
+        return ModelRoutesPublic(
+            items=[],
+            pagination=Pagination(page=1, perPage=24, total=0, totalPage=0),
+        )
+
+    monkeypatch.setattr(model_routes, "async_session", fake_async_session)
+    monkeypatch.setattr(ModelRoute, "paginated_by_query", fake_paginated_by_query)
+
+    await model_routes._get_model_routes(
+        params=ModelRouteListParams(page=1, perPage=24),
+        target_class=ModelRoute,
+        ctx=_ctx(user_id=99, current_principal_id=42, is_admin=True),
+    )
+
+    # Owner gets pinned via the fields dict (used by both watch and
+    # paginated paths), not via an OR predicate.
+    assert captured["fields"].get("owner_principal_id") == 42
+    rendered = " ".join(_compile(c) for c in captured["extra_conditions"])
+    assert "model_route_principals" not in rendered
+
+
+def test_model_route_grant_predicate_owner_public_and_grant():
+    """Streaming mirror of the grant OR-set: PUBLIC/AUTHED or owner-match
+    or a snapshotted grant id must all let the event through; everything
+    else is dropped."""
+    ctx = _ctx(user_id=99, current_principal_id=42, is_admin=True)
+    pred = model_routes._model_route_grant_predicate(ctx, {17, 18})
+    # PUBLIC / AUTHED: visible regardless of owner.
+    assert pred(
+        SimpleNamespace(
+            id=1, access_policy=AccessPolicyEnum.PUBLIC, owner_principal_id=999
+        )
+    )
+    assert pred(
+        SimpleNamespace(
+            id=2, access_policy=AccessPolicyEnum.AUTHED, owner_principal_id=999
+        )
+    )
+    # Owner-equality on the current principal.
+    assert pred(
+        SimpleNamespace(
+            id=3, access_policy=AccessPolicyEnum.ALLOWED_USERS, owner_principal_id=42
+        )
+    )
+    # Snapshotted grant.
+    assert pred(
+        SimpleNamespace(
+            id=17,
+            access_policy=AccessPolicyEnum.ALLOWED_PRINCIPALS,
+            owner_principal_id=999,
+        )
+    )
+    # Foreign + private + not granted: dropped.
+    assert not pred(
+        SimpleNamespace(
+            id=99,
+            access_policy=AccessPolicyEnum.ALLOWED_PRINCIPALS,
+            owner_principal_id=999,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_model_routes_admin_act_as_watch_applies_grant_filter(monkeypatch):
+    """Streaming path for admin act-as my-models: the watch SSE filter
+    must apply the same OR-set the paginated path uses — owner /
+    PUBLIC/AUTHED / snapshotted grant — instead of emitting every
+    ``ModelRoute`` globally."""
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_async_session():
+        yield object()
+
+    async def fake_fetch_granted_route_ids(ctx):
+        return {17}
+
+    def fake_streaming(fields=None, fuzzy_fields=None, filter_func=None):
+        captured["fields"] = fields
+        captured["filter_func"] = filter_func
+
+        async def _empty():
+            return
+            yield ""  # pragma: no cover
+
+        return _empty()
+
+    monkeypatch.setattr(model_routes, "async_session", fake_async_session)
+    monkeypatch.setattr(
+        model_routes, "_fetch_granted_route_ids", fake_fetch_granted_route_ids
+    )
+    monkeypatch.setattr(ModelRoute, "streaming", fake_streaming)
+
+    await model_routes._get_model_routes(
+        params=ModelRouteListParams(page=1, perPage=24, watch=True),
+        target_class=ModelRoute,
+        ctx=_ctx(user_id=99, current_principal_id=42, is_admin=True),
+        include_grants=True,
+    )
+
+    flt = captured["filter_func"]
+    assert flt is not None
+    # Cross-Org private route with no grant: dropped (the pre-fix bug
+    # would have let this through).
+    assert not flt(
+        SimpleNamespace(
+            id=5,
+            access_policy=AccessPolicyEnum.ALLOWED_PRINCIPALS,
+            owner_principal_id=999,
+        )
+    )
+    # PUBLIC / owner / snapshotted grant: visible.
+    assert flt(
+        SimpleNamespace(
+            id=6, access_policy=AccessPolicyEnum.PUBLIC, owner_principal_id=999
+        )
+    )
+    assert flt(
+        SimpleNamespace(
+            id=7, access_policy=AccessPolicyEnum.ALLOWED_USERS, owner_principal_id=42
+        )
+    )
+    assert flt(
+        SimpleNamespace(
+            id=17,
+            access_policy=AccessPolicyEnum.ALLOWED_PRINCIPALS,
+            owner_principal_id=999,
+        )
+    )
+    # The narrow field-equality filter must NOT be applied — it would
+    # AND with the OR predicate and drop PUBLIC/AUTHED + foreign-owned
+    # grants entirely.
+    assert "owner_principal_id" not in captured["fields"]

--- a/tests/server/test_metrics_collector.py
+++ b/tests/server/test_metrics_collector.py
@@ -54,12 +54,14 @@ def test_make_buffer_key():
         model_route_id=9,
         completed_at=_FIXED_COMPLETED_AT_MS,
     )
-    assert _make_buffer_key(m) == f"1..qwen3-0.6b.2.abc.9..{_FIXED_DATE_ISO}"
+    # Segment order: model_id, provider_id, model, user_id, access_key,
+    # organization_id, model_route_id, operation, date.
+    assert _make_buffer_key(m) == f"1..qwen3-0.6b.2.abc..9..{_FIXED_DATE_ISO}"
 
 
 def test_make_buffer_key_none_fields():
     m = ModelUsageMetrics(model="qwen3-0.6b", completed_at=_FIXED_COMPLETED_AT_MS)
-    assert _make_buffer_key(m) == f"..qwen3-0.6b.....{_FIXED_DATE_ISO}"
+    assert _make_buffer_key(m) == f"..qwen3-0.6b......{_FIXED_DATE_ISO}"
 
 
 def test_make_buffer_key_route_separates_otherwise_identical_metrics():
@@ -76,6 +78,24 @@ def test_make_buffer_key_route_separates_otherwise_identical_metrics():
     assert _make_buffer_key(
         ModelUsageMetrics(**base, model_route_id=1)
     ) != _make_buffer_key(ModelUsageMetrics(**base, model_route_id=2))
+
+
+def test_make_buffer_key_organization_separates_otherwise_identical_metrics():
+    """Same user / api_key / route called from two Org contexts within
+    one flush window must stay separate — the DB upsert key in
+    ``create_or_update_model_usage`` includes ``consumer_principal_id``,
+    so merging in memory and splitting on write would lose tokens."""
+    base = dict(
+        model="qwen3-0.6b",
+        model_id=1,
+        user_id=2,
+        access_key="abc",
+        model_route_id=9,
+        completed_at=_FIXED_COMPLETED_AT_MS,
+    )
+    assert _make_buffer_key(
+        ModelUsageMetrics(**base, organization_id="1")
+    ) != _make_buffer_key(ModelUsageMetrics(**base, organization_id="2"))
 
 
 def test_accumulate_new_entry():


### PR DESCRIPTION

  - **`refactor: track consumer principal for model usage`** — Adds
    `consumer_principal_id` to `model_usages` /
    `model_usage_details` / `model_usage_details_archive`,
    denormalized from `api_keys.owner_principal_id` at flush time
    with a back-fill for historical rows. The Usage API switches its
    Org dimension to filter on this column so an Org sees what its
    keys actually consumed (including across Org boundaries) rather
    than what its deployments served. Both Org owners and members
    share this single consumer view; a symmetric provider view is
    deferred until there's product surface for it. No `view`
    query parameter is exposed.

  - **`feat: allow org owners to manage org API keys`** — Org
    owners couldn't list / delete keys other members of their Org
    created — the surface was platform-admin only. Promote them to
    the same management scope, gated to the current Org. Platform
    admin "All" mode is unchanged.

  - **`fix: scope my-models by current principal context`** —
    `non_admin_user_models` now records `via_principal_id` /
    `via_principal_kind` on each row, so `GET /my-models`
    can partition by the request's Org context: Personal scope
    surfaces USER/GROUP-mediated grants plus PUBLIC/AUTHED, Org
    act-as surfaces grants tied to that specific Org plus
    PUBLIC/AUTHED. Admin act-as for `GET /my-models` also goes
    through a grants-inclusive predicate so it matches what a
    non-admin member of the same Org would see; the management
    endpoint (`GET /v1/model-routes`) keeps the narrow owner-only
    filter.

  - **`fix: add missing ModelRouteService.get_by_name`** — The
    OpenAI proxy called `model_route_service.get_by_name` to stamp
    `request.state.model_route_id`, but the method was never
    defined; every Playground request hit `AttributeError` in disabled gateway mode.

  - **`fix(usage): stamp consumer_principal_id from gateway
    organization_id`** — The wasm token-usage plugin emits
    `organization_id` (raw `X-Organization-Id`); the flush-time
    snapshot now parses it back to int and fills the DB column
    when the api_key path didn't supply one. `_make_buffer_key`
    includes `organization_id` so two metrics from the same user
    but different Org contexts within one flush window don't merge
    in memory and split on the DB upsert.

  - **`fix: apply MyModel visibility filter to /v1/models`** —
    `/v1/models` (the OpenAI-compatible listing the Playground
    uses) read the MyModel view without the Personal/Org partition
    that `GET /my-models` applies, so a user in Personal view could
    see (and invoke) a model granted to one of their Orgs. Layer
    the same predicate onto the listing.
