### PR TITLE
feat(k8s): add k8s_values config and multi GPU vendor manifest support

### DIFF
--- a/gpustack/k8s/daemonset.jinja
+++ b/gpustack/k8s/daemonset.jinja
@@ -1,21 +1,30 @@
+{%- for worker in config.workers %}
 ---
-# DaemonSet
+# DaemonSet for {{ worker.name }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: gpustack-worker
-  name: gpustack-worker
+    app: {{ worker.ds_name }}
+    {%- if config.multi_vendor_mode %}
+    app.kubernetes.io/component: worker
+    gpustack.io/runtime: {{ worker.name }}
+    {%- endif %}
+  name: {{ worker.ds_name }}
   namespace: {{ config.namespace }}
 spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: gpustack-worker
+      app: {{ worker.ds_name }}
   template:
     metadata:
       labels:
-        app: gpustack-worker
+        app: {{ worker.ds_name }}
+        {%- if config.multi_vendor_mode %}
+        app.kubernetes.io/component: worker
+        gpustack.io/runtime: {{ worker.name }}
+        {%- endif %}
     spec:
       containers:
         - env:
@@ -46,7 +55,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {%- if config.runtime == 'hygon' %}
+            {%- if worker.runtime == 'hygon' %}
             - name: ROCM_PATH
               value: /opt/dtk
             - name: ROCM_SMI_LIB_PATH
@@ -75,12 +84,12 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-            {%- if config.runtime == 'amd' %}
+            {%- if worker.runtime == 'amd' %}
             - name: gpustack-amd-driver
               mountPath: /opt/rocm
               readOnly: true
             {%- endif %}
-            {%- if config.runtime == 'ascend' %}
+            {%- if worker.runtime == 'ascend' %}
             - name: gpustack-ascend-driver
               mountPath: /usr/local/Ascend/driver
               readOnly: true
@@ -88,7 +97,7 @@ spec:
               mountPath: /usr/local/Ascend/ascend-toolkit
               readOnly: true
             {%- endif %}
-            {%- if config.runtime == 'hygon' %}
+            {%- if worker.runtime == 'hygon' %}
             - name: gpustack-hygon-driver
               mountPath: /opt/hyhal
               readOnly: true
@@ -96,7 +105,7 @@ spec:
               mountPath: /opt/dtk
               readOnly: true
             {%- endif %}
-            {%- if config.runtime == 'metax' %}
+            {%- if worker.runtime == 'metax' %}
             - name: gpustack-metax-driver
               mountPath: /opt/mxdriver
               readOnly: true
@@ -104,25 +113,25 @@ spec:
               mountPath: /opt/maca
               readOnly: true
             {%- endif %}
-            {%- if config.runtime == 'iluvatar' %}
+            {%- if worker.runtime == 'iluvatar' %}
             - name: gpustack-iluvatar-toolkit
               mountPath: /usr/local/corex
               readOnly: true
             {%- endif %}
-            {%- if config.runtime == 'cambricon' %}
+            {%- if worker.runtime == 'cambricon' %}
             - name: gpustack-cambricon-bin
               mountPath: /usr/bin/cnmon
             - name: gpustack-cambricon-toolkit
               mountPath: /usr/local/neuware
               readOnly: true
             {%- endif %}
-            {%- if config.runtime == 'thead' %}
+            {%- if worker.runtime == 'thead' %}
             - name: gpustack-thead-toolkit
               mountPath: /usr/local/PPU_SDK
               readOnly: true
             {%- endif %}
-            {%- if config.k8s_volume_mounts %}
-            {%- for vm in config.k8s_volume_mounts %}
+            {%- if config.k8s_options and config.k8s_options.volume_mounts %}
+            {%- for vm in config.k8s_options.volume_mounts %}
             - name: {{ vm.name | to_yaml }}
               mountPath: {{ vm.mount_path | to_yaml }}
               readOnly: {{ vm.read_only | lower }}
@@ -154,7 +163,7 @@ spec:
             failureThreshold: 5
             successThreshold: 1
       volumes:
-        {%- if config.runtime == 'ascend' %}
+        {%- if worker.runtime == 'ascend' %}
         - name: gpustack-ascend-driver
           hostPath:
             path: /usr/local/Ascend/driver
@@ -164,13 +173,13 @@ spec:
             path: /usr/local/Ascend/ascend-toolkit
             type: DirectoryOrCreate
         {%- endif %}
-        {%- if config.runtime == 'amd' %}
+        {%- if worker.runtime == 'amd' %}
         - name: gpustack-amd-driver
           hostPath:
             path: /opt/rocm
             type: DirectoryOrCreate
         {%- endif %}
-        {%- if config.runtime == 'hygon' %}
+        {%- if worker.runtime == 'hygon' %}
         - name: gpustack-hygon-driver
           hostPath:
             path: /opt/hyhal
@@ -180,7 +189,7 @@ spec:
             path: /opt/dtk
             type: DirectoryOrCreate
         {%- endif %}
-        {%- if config.runtime == 'metax' %}
+        {%- if worker.runtime == 'metax' %}
         - name: gpustack-metax-driver
           hostPath:
             path: /opt/mxdriver
@@ -190,13 +199,13 @@ spec:
             path: /opt/maca
             type: DirectoryOrCreate
         {%- endif %}
-        {%- if config.runtime == 'iluvatar' %}
+        {%- if worker.runtime == 'iluvatar' %}
         - name: gpustack-iluvatar-toolkit
           hostPath:
             path: /usr/local/corex
             type: DirectoryOrCreate
         {%- endif %}
-        {%- if config.runtime == 'cambricon' %}
+        {%- if worker.runtime == 'cambricon' %}
         - name: gpustack-cambricon-bin
           hostPath:
             path: /usr/bin/cnmon
@@ -206,27 +215,58 @@ spec:
             path: /usr/local/neuware
             type: DirectoryOrCreate
         {%- endif %}
-        {%- if config.runtime == 'thead' %}
+        {%- if worker.runtime == 'thead' %}
         - name: gpustack-thead-toolkit
           hostPath:
             path: /usr/local/PPU_SDK
             type: DirectoryOrCreate
         {%- endif %}
-        {%- if config.k8s_volume_mounts %}
-        {%- for vm in config.k8s_volume_mounts %}
+        {%- if config.k8s_options and config.k8s_options.volume_mounts %}
+        {%- for vm in config.k8s_options.volume_mounts %}
         - name: {{ vm.name | to_yaml }}
           {{ vm.volume_source | to_yaml | indent(10) }}
         {%- endfor %}
         {%- endif %}
+      {%- if config.multi_vendor_mode %}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: worker
+              namespaceSelector: {}
+        {%- if worker.is_cpu and worker.cpu_exclusion_keys %}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                {%- for key in worker.cpu_exclusion_keys %}
+                  - key: {{ key }}
+                    operator: DoesNotExist
+                {%- endfor %}
+        {%- endif %}
+      {%- endif %}
+      {%- if worker.node_selector %}
+      nodeSelector:
+        {{ worker.node_selector | to_yaml | indent(8) }}
+      {%- endif %}
+      {%- if config.image_pull_secrets %}
+      imagePullSecrets:
+      {%- for ips in config.image_pull_secrets %}
+        - name: {{ ips.name }}
+      {%- endfor %}
+      {%- endif %}
       hostNetwork: true
       hostIPC: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: gpustack-worker
-      {%- if config.runtime in ['nvidia', 'mthreads'] %}
-      runtimeClassName: {{ config.runtime }}
+      {%- if worker.runtime in ['nvidia', 'mthreads'] %}
+      runtimeClassName: {{ worker.runtime }}
       {%- endif %}
   updateStrategy:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
+{%- endfor %}

--- a/gpustack/k8s/image_pull_secrets.jinja
+++ b/gpustack/k8s/image_pull_secrets.jinja
@@ -1,0 +1,30 @@
+{#-
+  Materialise each K8sOptions.image_credentials entry as a
+  kubernetes.io/dockerconfigjson Secret. The Secret is mirrored into the
+  operator namespace whenever it differs from the worker namespace so the
+  operator Deployment / bootstrap Job can pull from the same registry.
+-#}
+{%- for ips in config.image_pull_secrets %}
+---
+# Image pull secret for {{ ips.registry }} (worker namespace)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ ips.name }}
+  namespace: {{ config.namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ ips.dockerconfigjson_b64 }}
+{%- if config.system_namespace and config.system_namespace != config.namespace %}
+---
+# Image pull secret for {{ ips.registry }} (system/operator namespace)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ ips.name }}
+  namespace: {{ config.system_namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ ips.dockerconfigjson_b64 }}
+{%- endif %}
+{%- endfor %}

--- a/gpustack/k8s/manifest_template.py
+++ b/gpustack/k8s/manifest_template.py
@@ -1,13 +1,61 @@
 import jinja2
 import base64
+import json
 import yaml
-from typing import List, Optional
+from typing import Dict, List, Optional
+from pydantic import BaseModel, ConfigDict
 
 from gpustack.gpu_instances.cluster_apis_util import get_namespace_name
 from gpustack.utils.compat_importlib import pkg_resources
-from gpustack.schemas.clusters import ClusterRegistrationTokenPublic
-from gpustack.schemas.clusters import K8sVolumeMount
+from gpustack.schemas.clusters import ClusterRegistrationTokenPublic, K8sOptions
 from gpustack_runtime.detector import ManufacturerEnum
+
+
+CPU_WORKER_NAME = "cpu"
+WORKER_DS_BASENAME = "gpustack-worker"
+IMAGE_PULL_SECRET_NAME_PREFIX = "gpustack-image-pull-secret"
+
+
+class ImagePullSecretRenderSpec(BaseModel):
+    """
+    One materialised ``kubernetes.io/dockerconfigjson`` Secret derived from
+    a single ``K8sOptions.image_credentials`` entry. The name is index-based
+    so the same name is rendered into both the Secret (image_pull_secrets.jinja)
+    and each worker DaemonSet's imagePullSecrets list.
+    """
+
+    name: str
+    registry: str
+    dockerconfigjson_b64: str
+
+
+class WorkerRenderSpec(BaseModel):
+    """
+    Per-DaemonSet render data, one entry per worker variant. The CPU worker
+    is always emitted and keeps the legacy ``gpustack-worker`` name so
+    existing clusters can in-place update without a DaemonSet selector
+    mutation. Each requested GPU vendor adds a ``gpustack-worker-<vendor>``
+    worker alongside it.
+
+    The grouping mirrors how Helm chart values are typically organized
+    (``.Values.worker.*``), so a future chart migration maps 1:1 onto these
+    entries.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str
+    ds_name: str
+    # Runtime tag consumed by per-vendor jinja branches (volume mounts /
+    # volumes / runtimeClassName / vendor-specific env). Empty string for
+    # the CPU worker so none of those branches activate.
+    runtime: str = ""
+    is_cpu: bool = False
+    node_selector: Optional[Dict[str, str]] = None
+    # Vendor node labels the CPU worker must avoid (DoesNotExist
+    # matchExpression). Populated only for the CPU worker; derived from
+    # all configured ``gpu_vendor_overrides[*].node_selector`` keys.
+    cpu_exclusion_keys: List[str] = []
 
 
 class TemplateConfig(ClusterRegistrationTokenPublic):
@@ -23,9 +71,19 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
     namespace: Optional[str] = None
     cluster_suffix: Optional[str] = None
     cluster_owner_principal_name: Optional[str] = None
-    runtime_enum: Optional[ManufacturerEnum] = None
-    runtime: Optional[str] = None
-    k8s_volume_mounts: Optional[List[K8sVolumeMount]] = None
+    runtimes: Optional[List[ManufacturerEnum]] = None
+    k8s_options: Optional[K8sOptions] = None
+    workers: List[WorkerRenderSpec] = []
+    # Pre-computed Secret render data, one per K8sOptions.image_credentials
+    # entry. Both image_pull_secrets.jinja (Secret resource) and the
+    # daemonset.jinja imagePullSecrets reference iterate this list, so the
+    # Secret name is the single source of truth.
+    image_pull_secrets: List[ImagePullSecretRenderSpec] = []
+    # True when 2+ distinct GPU runtimes are requested. Switches the jinja
+    # templates from the v1-compatible single-DaemonSet output to the
+    # multi-DaemonSet output (per-vendor DS + always-on CPU DS + safety nets
+    # like podAntiAffinity and CPU nodeAffinity DoesNotExist).
+    multi_vendor_mode: bool = False
 
     def render(self) -> str:
         def b64encode(value):
@@ -53,6 +111,9 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
         with pkg_resources.path("gpustack.k8s", "manifests.jinja") as manifest_path:
             with manifest_path.open(encoding="utf-8") as f:
                 template_data = f.read()
+        with pkg_resources.path("gpustack.k8s", "image_pull_secrets.jinja") as ips_path:
+            with ips_path.open(encoding="utf-8") as f:
+                ips_data = f.read()
         with pkg_resources.path("gpustack.k8s", "daemonset.jinja") as daemon_set_path:
             with daemon_set_path.open(encoding="utf-8") as f:
                 daemon_set_data = f.read()
@@ -62,13 +123,11 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
         env = jinja2.Environment()
         env.filters["b64encode"] = b64encode
         env.filters["to_yaml"] = to_yaml
-        template = env.from_string(template_data)
-        rendered = template.render(config=self)
-        template_daemonset = env.from_string(daemon_set_data)
-        daemon_set = template_daemonset.render(config=self)
-        template_operator = env.from_string(operator_data)
-        operator = template_operator.render(config=self)
-        return "\n".join([rendered, daemon_set, operator])
+        rendered = env.from_string(template_data).render(config=self)
+        image_pull_secrets = env.from_string(ips_data).render(config=self)
+        daemon_set = env.from_string(daemon_set_data).render(config=self)
+        operator = env.from_string(operator_data).render(config=self)
+        return "\n".join([rendered, image_pull_secrets, daemon_set, operator])
 
     def __init__(
         self, registration: Optional[ClusterRegistrationTokenPublic] = None, **data
@@ -89,6 +148,130 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
             self.namespace = f"gpustack-system-{self.cluster_suffix}"
         elif self.namespace is None:
             self.namespace = "gpustack-system"
-        self.runtime = (
-            self.runtime_enum.value if self.runtime_enum is not None else None
+        self.image_pull_secrets = self._build_image_pull_secrets()
+        self.workers = self._build_workers()
+
+    def _build_image_pull_secrets(self) -> List[ImagePullSecretRenderSpec]:
+        if self.k8s_options is None or not self.k8s_options.image_credentials:
+            return []
+        specs: List[ImagePullSecretRenderSpec] = []
+        for i, cred in enumerate(self.k8s_options.image_credentials):
+            # Credentials without both username and password become a
+            # placeholder Secret with an empty auths map — same shape that
+            # the gpustack Helm chart's canonical pull-secret uses when no
+            # credentials are configured. The Secret is still referenced
+            # from imagePullSecrets so users can later patch it in-cluster
+            # without re-applying the manifest.
+            if cred.username and cred.password:
+                auth = base64.b64encode(
+                    f"{cred.username}:{cred.password}".encode("utf-8")
+                ).decode("utf-8")
+                dockerconfigjson = json.dumps(
+                    {
+                        "auths": {
+                            cred.registry: {
+                                "username": cred.username,
+                                "password": cred.password,
+                                "auth": auth,
+                            }
+                        }
+                    }
+                )
+            else:
+                dockerconfigjson = json.dumps({"auths": {}})
+            specs.append(
+                ImagePullSecretRenderSpec(
+                    name=f"{IMAGE_PULL_SECRET_NAME_PREFIX}-{i}",
+                    registry=cred.registry,
+                    dockerconfigjson_b64=base64.b64encode(
+                        dockerconfigjson.encode("utf-8")
+                    ).decode("utf-8"),
+                )
+            )
+        return specs
+
+    def _build_workers(self) -> List[WorkerRenderSpec]:
+        gpu_runtimes: List[ManufacturerEnum] = []
+        seen: set = set()
+        for r in self.runtimes or []:
+            # UNKNOWN is the "no GPU detected" sentinel — covered by the
+            # legacy worker, so don't emit a separate vendor worker for it.
+            if r == ManufacturerEnum.UNKNOWN:
+                continue
+            if r in seen:
+                continue
+            seen.add(r)
+            gpu_runtimes.append(r)
+
+        self.multi_vendor_mode = len(gpu_runtimes) >= 2
+
+        if not self.multi_vendor_mode:
+            # 0 or 1 GPU runtime → emit ONE DaemonSet under the legacy name
+            # ``gpustack-worker`` with that runtime's vendor blocks. Output
+            # is byte-compatible with v1 single-vendor manifests (no
+            # additional labels, no podAntiAffinity, no nodeAffinity). The
+            # CPU worker concept does not exist in this mode.
+            runtime = gpu_runtimes[0] if gpu_runtimes else None
+            resolved = (
+                self.k8s_options.resolve_for(runtime)
+                if self.k8s_options is not None
+                else None
+            )
+            return [
+                WorkerRenderSpec(
+                    name=runtime.value if runtime else CPU_WORKER_NAME,
+                    ds_name=WORKER_DS_BASENAME,
+                    runtime=runtime.value if runtime else "",
+                    is_cpu=runtime is None,
+                    node_selector=(resolved.node_selector if resolved else None),
+                )
+            ]
+
+        # 2+ GPU runtimes → multi-vendor mode: a per-vendor DS plus the
+        # always-present CPU DS, with the full safety-net set.
+        workers: List[WorkerRenderSpec] = []
+        for runtime in gpu_runtimes:
+            resolved = (
+                self.k8s_options.resolve_for(runtime)
+                if self.k8s_options is not None
+                else None
+            )
+            workers.append(
+                WorkerRenderSpec(
+                    name=runtime.value,
+                    ds_name=f"{WORKER_DS_BASENAME}-{runtime.value}",
+                    runtime=runtime.value,
+                    is_cpu=False,
+                    node_selector=(resolved.node_selector if resolved else None),
+                )
+            )
+
+        cpu_resolved = (
+            self.k8s_options.resolve_for(None) if self.k8s_options is not None else None
         )
+        workers.append(
+            WorkerRenderSpec(
+                name=CPU_WORKER_NAME,
+                ds_name=WORKER_DS_BASENAME,
+                runtime="",
+                is_cpu=True,
+                node_selector=(cpu_resolved.node_selector if cpu_resolved else None),
+                cpu_exclusion_keys=_collect_vendor_label_keys(self.k8s_options),
+            )
+        )
+        return workers
+
+
+def _collect_vendor_label_keys(k8s_options: Optional[K8sOptions]) -> List[str]:
+    """
+    Union of all label keys declared under any ``gpu_vendor_overrides[*].node_selector``.
+    The CPU DS uses these as DoesNotExist matchExpressions so it avoids any
+    node the user has marked as belonging to a specific vendor.
+    """
+    if k8s_options is None or k8s_options.gpu_vendor_overrides is None:
+        return []
+    keys: set = set()
+    for override in k8s_options.gpu_vendor_overrides.values():
+        if override.node_selector:
+            keys.update(override.node_selector.keys())
+    return sorted(keys)

--- a/gpustack/k8s/manifests.jinja
+++ b/gpustack/k8s/manifests.jinja
@@ -48,7 +48,11 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    {%- if config.multi_vendor_mode %}
+    app.kubernetes.io/component: worker
+    {%- else %}
     app: gpustack-worker
+    {%- endif %}
   ports:
     - name: api
       port: 10150

--- a/gpustack/k8s/operator.jinja
+++ b/gpustack/k8s/operator.jinja
@@ -123,6 +123,16 @@ data:
         spec:
           serviceAccountName: gpustack-operator-worker
           restartPolicy: Always
+          {%- if config.image_pull_secrets %}
+          imagePullSecrets:
+          {%- for ips in config.image_pull_secrets %}
+            - name: {{ ips.name }}
+          {%- endfor %}
+          {%- endif %}
+          {%- if config.k8s_options and config.k8s_options.node_selector %}
+          nodeSelector:
+            {{ config.k8s_options.node_selector | to_yaml | indent(12) }}
+          {%- endif %}
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -249,6 +259,16 @@ spec:
   template:
     spec:
       serviceAccountName: gpustack-operator-worker
+      {%- if config.image_pull_secrets %}
+      imagePullSecrets:
+      {%- for ips in config.image_pull_secrets %}
+        - name: {{ ips.name }}
+      {%- endfor %}
+      {%- endif %}
+      {%- if config.k8s_options and config.k8s_options.node_selector %}
+      nodeSelector:
+        {{ config.k8s_options.node_selector | to_yaml | indent(8) }}
+      {%- endif %}
       containers:
       - name: main
         image: {{ config.operator_image }}

--- a/gpustack/migrations/versions/2026_03_10_1600-8bf38a6bb3b5_v2_2_0_database_changes.py
+++ b/gpustack/migrations/versions/2026_03_10_1600-8bf38a6bb3b5_v2_2_0_database_changes.py
@@ -48,12 +48,15 @@ def upgrade() -> None:
         *proxy_mode_to_add,
     )
 
-    ### k8s volume mount
-    if not column_exists('clusters', 'k8s_volume_mounts'):
+    ### k8s deployment values (imagePullSecrets, nodeSelector, volumeMounts,
+    ### gpuVendorOverrides). Container for every K8s pod-spec knob the
+    ### cluster needs; subsumed the previous standalone k8s_volume_mounts
+    ### column before that field shipped.
+    if not column_exists('clusters', 'k8s_options'):
         with op.batch_alter_table('clusters', schema=None) as batch_op:
             batch_op.add_column(
                 sa.Column(
-                    'k8s_volume_mounts',
+                    'k8s_options',
                     gpustack.schemas.common.JSON(),
                     nullable=True,
                 )
@@ -602,9 +605,9 @@ def downgrade() -> None:
         *proxy_mode_to_add,
     )
 
-    ### k8s volume mount
+    ### k8s deployment values
     with op.batch_alter_table('clusters', schema=None) as batch_op:
-        batch_op.drop_column('k8s_volume_mounts')
+        batch_op.drop_column('k8s_options')
     ### end
 
     ### custom API_KEY

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -1,7 +1,7 @@
 import math
 import random
 import secrets
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 from urllib.parse import urlencode
 
 import aiohttp
@@ -243,27 +243,31 @@ def create_update_check(
             message=f"server_url is required for provider {provider}"
         )
     if provider == ClusterProvider.Kubernetes:
-        # check for volume mounts
-        if input.k8s_volume_mounts is None or len(input.k8s_volume_mounts) < 1:
+        # check for volume mounts (now nested under k8s_options)
+        volume_mounts = (
+            input.k8s_options.volume_mounts if input.k8s_options is not None else None
+        )
+        if volume_mounts is None or len(volume_mounts) < 1:
             # at least one volume mount is required, and the default one is for gpustack data dir.
             raise InvalidException(
-                message="At least one k8s_volume_mount is required, and the default one is for gpustack data dir."
+                message="At least one k8s_options.volume_mount is required, and the default one is for gpustack data dir."
             )
         if (
-            input.k8s_volume_mounts[0].volume_source is None
-            or input.k8s_volume_mounts[0].volume_source.host_path is None
+            volume_mounts[0].volume_source is None
+            or volume_mounts[0].volume_source.host_path is None
         ):
             raise InvalidException(
-                message="The first k8s_volume_mount must be for gpustack data dir with hostPath volume source."
+                message="The first k8s_options.volume_mount must be for gpustack data dir with hostPath volume source."
             )
 
 
 def enforce_data_dir_mounts(input: Union[ClusterCreate, ClusterUpdate]):
     """
-    Assuming the first item of k8s_volume_mounts is for gpustack data dir, enforce that it is always present and has the correct settings.
+    Assuming the first item of k8s_options.volume_mounts is for gpustack data dir,
+    enforce that it is always present and has the correct settings.
     """
     # the first volume must exist as it's validated in create_update_check, and it must be for gpustack data dir, so we enforce it here.
-    data_dir_mount = input.k8s_volume_mounts[0]
+    data_dir_mount = input.k8s_options.volume_mounts[0]
     data_dir_mount.name = "gpustack-data-dir"
     data_dir_mount.mount_path = "/var/lib/gpustack"
     data_dir_mount.read_only = False
@@ -499,6 +503,97 @@ async def create_worker_pool(
         raise InternalServerErrorException(message=f"Failed to create worker pool: {e}")
 
 
+def _validate_multi_vendor_overrides(
+    requested_runtimes: Optional[List[ManufacturerEnum]],
+    k8s_options,
+) -> None:
+    """
+    When 2+ distinct GPU runtimes are requested, each must have a configured
+    ``gpu_vendor_overrides[<runtime>].node_selector``. The override's keys
+    drive the CPU worker's DoesNotExist node-affinity, without which the CPU
+    DS and the vendor DSes would compete for the same nodes and the wrong
+    vendor's hostPath mounts could land on incompatible hardware.
+    """
+    if not requested_runtimes:
+        return
+
+    distinct: List[ManufacturerEnum] = []
+    seen: set = set()
+    for r in requested_runtimes:
+        if r == ManufacturerEnum.UNKNOWN:
+            continue
+        if r in seen:
+            continue
+        seen.add(r)
+        distinct.append(r)
+
+    if len(distinct) < 2:
+        return
+
+    overrides = (
+        k8s_options.gpu_vendor_overrides
+        if k8s_options is not None and k8s_options.gpu_vendor_overrides
+        else {}
+    )
+    missing = [
+        r.value
+        for r in distinct
+        if r not in overrides
+        or overrides[r].node_selector is None
+        or len(overrides[r].node_selector) == 0
+    ]
+    if missing:
+        raise InvalidException(
+            message=(
+                "Multi-vendor manifest requires "
+                "k8s_options.gpuVendorOverrides[<runtime>].nodeSelector "
+                f"to be configured for each requested runtime. Missing: {', '.join(missing)}."
+            )
+        )
+
+    # Two vendors using an identical nodeSelector means both DSes target the
+    # same node set; podAntiAffinity would let one DS arbitrarily win each
+    # node and leave the other Pending forever.
+    duplicates: List[str] = []
+    for i, r1 in enumerate(distinct):
+        for r2 in distinct[i + 1 :]:
+            if overrides[r1].node_selector == overrides[r2].node_selector:
+                duplicates.append(f"{r1.value}+{r2.value}")
+    if duplicates:
+        raise InvalidException(
+            message=(
+                "Multi-vendor manifest cannot use the same nodeSelector for "
+                "different runtimes — each vendor must scope to a distinct "
+                f"node set. Conflicting pairs: {', '.join(duplicates)}."
+            )
+        )
+
+    # Base nodeSelector keys must not also appear in any vendor override.
+    # The CPU worker collects all override keys into DoesNotExist match
+    # expressions, so a key shared with the base would make CPU DS
+    # simultaneously require and forbid it — never schedulable.
+    base_keys = (
+        set(k8s_options.node_selector.keys())
+        if k8s_options is not None and k8s_options.node_selector
+        else set()
+    )
+    if base_keys:
+        override_keys: set = set()
+        for ov in overrides.values():
+            if ov.node_selector:
+                override_keys.update(ov.node_selector.keys())
+        clashing = sorted(base_keys & override_keys)
+        if clashing:
+            raise InvalidException(
+                message=(
+                    "Multi-vendor manifest cannot reuse k8s_options.nodeSelector "
+                    "keys inside gpuVendorOverrides[*].nodeSelector — the CPU "
+                    "worker would simultaneously require and forbid the key. "
+                    f"Conflicting keys: {', '.join(clashing)}."
+                )
+            )
+
+
 def get_registration_from_cluster(
     request: Request, cluster: Cluster
 ) -> ClusterRegistrationTokenPublic:
@@ -537,8 +632,14 @@ async def get_cluster_manifests(
     request: Request,
     session: SessionDep,
     id: int,
-    runtime: Optional[ManufacturerEnum] = Query(
-        None, description="Optional runtime to include in the manifest"
+    runtime: Optional[List[ManufacturerEnum]] = Query(
+        None,
+        description=(
+            "GPU vendor runtimes to include in the manifest. Repeat the "
+            "parameter for multiple vendors (e.g. ?runtime=nvidia&runtime=ascend). "
+            "The CPU worker DaemonSet is always rendered regardless of this "
+            "parameter."
+        ),
     ),
 ):
     cluster = await Cluster.one_by_id(session, id)
@@ -558,13 +659,15 @@ async def get_cluster_manifests(
             )
         )
 
+    _validate_multi_vendor_overrides(runtime, cluster.k8s_options)
+
     config = TemplateConfig(
         registration=get_registration_from_cluster(request, cluster),
         cluster_suffix=cluster.hashed_suffix,
         cluster_owner_principal_name=principal.name,
         namespace=getattr(cluster.worker_config, "namespace", None),
-        runtime_enum=runtime,
-        k8s_volume_mounts=cluster.k8s_volume_mounts,
+        runtimes=runtime,
+        k8s_options=cluster.k8s_options,
     )
     yaml_content = config.render()
     return Response(

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 from urllib.parse import urlparse
 from enum import Enum
@@ -23,6 +24,8 @@ from sqlmodel import (
 )
 import sqlalchemy as sa
 from typing import TYPE_CHECKING
+
+from gpustack_runtime.detector import ManufacturerEnum
 
 from gpustack.schemas.config import (
     SensitivePredefinedConfig,
@@ -69,6 +72,32 @@ class Volume(BaseModel):
         if not all(c in allowed_chars for c in v):
             raise ValueError("Volume name contains invalid characters")
         return v
+
+
+class ImageCredential(BaseModel):
+    """
+    A docker registry credential. At manifest render time each entry is
+    materialized into a ``kubernetes.io/dockerconfigjson`` Secret named
+    ``gpustack-image-pull-secret-<index>`` in the worker namespace, which
+    every worker DaemonSet then references via ``imagePullSecrets``.
+
+    ``username`` / ``password`` are optional so a credential entry can act
+    as a placeholder Secret for a public or pre-configured registry — the
+    rendered ``.dockerconfigjson`` falls back to an empty ``{"auths":{}}``
+    payload when either is missing, matching the gpustack Helm chart
+    convention.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    registry: str = PydanticField(
+        ...,
+        description="Docker registry host (e.g. docker.io, registry.example.com).",
+    )
+    username: Optional[str] = None
+    password: Optional[str] = PydanticField(
+        default=None,
+        description="Registry password / access token. Stored as-is — handle as a secret.",
+    )
 
 
 class HostPathVolumeSource(BaseModel):
@@ -137,8 +166,6 @@ class K8sVolumeMount(BaseModel):
             return v
         if len(v) > 63:
             raise ValueError("Volume name must be less than 64 characters")
-        import re
-
         if not re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", v):
             raise ValueError(
                 "Volume name must be a valid DNS-1123 label (e.g. 'my-name', or '123-abc'); "
@@ -146,6 +173,100 @@ class K8sVolumeMount(BaseModel):
                 "and must start and end with an alphanumeric character."
             )
         return v
+
+
+class K8sOptionsOverride(BaseModel):
+    """
+    Per-vendor override layered on top of K8sOptions at manifest render time.
+    Only carries fields that are genuinely vendor-scoped — currently just
+    nodeSelector, since vendor node labels (e.g. nvidia.com/gpu,
+    huawei.com/Ascend910) differ per runtime. Registry-scoped fields like
+    imageCredentials stay cluster-level on K8sOptions.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    node_selector: Optional[Dict[str, str]] = PydanticField(
+        default=None,
+        alias="nodeSelector",
+    )
+
+
+class K8sOptions(BaseModel):
+    """
+    All Kubernetes-side deployment knobs for a cluster's worker DaemonSets:
+    pod spec primitives (imageCredentials, nodeSelector, volumeMounts) plus
+    per-vendor overrides. Top-level on the cluster (parallel to
+    ``worker_config``) so K8s deployment concerns are isolated from worker
+    process behaviour; structure mirrors how Helm chart values are usually
+    organised under ``worker.*`` for future chart migration.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    image_credentials: Optional[List[ImageCredential]] = PydanticField(
+        default=None,
+        alias="imageCredentials",
+        description=(
+            "Docker registry credentials. Each entry becomes a "
+            "kubernetes.io/dockerconfigjson Secret named "
+            "``gpustack-image-pull-secret-<index>`` in the worker namespace "
+            "and is referenced from every worker DaemonSet's imagePullSecrets."
+        ),
+    )
+    node_selector: Optional[Dict[str, str]] = PydanticField(
+        default=None,
+        alias="nodeSelector",
+        description="Pod spec nodeSelector labels applied to manifests rendered for the cluster.",
+    )
+    volume_mounts: Optional[List[K8sVolumeMount]] = PydanticField(
+        default=None,
+        alias="volumeMounts",
+        description=(
+            "Pod spec volumes and volumeMounts applied to every worker "
+            "DaemonSet. The first entry is reserved for the gpustack data "
+            "dir; the route layer enforces that invariant."
+        ),
+    )
+    gpu_vendor_overrides: Optional[Dict[ManufacturerEnum, K8sOptionsOverride]] = (
+        PydanticField(
+            default=None,
+            alias="gpuVendorOverrides",
+            description=(
+                "Per-vendor (runtime) overrides layered on top of the base values "
+                "when rendering manifests for that runtime. nodeSelector merges by "
+                "key with override winning."
+            ),
+        )
+    )
+
+    def resolve_for(self, runtime: Optional[ManufacturerEnum]) -> "K8sOptions":
+        """
+        Return a flattened K8sOptions with the matching vendor override merged
+        on top of the base values. The returned instance has gpu_vendor_overrides
+        unset so consumers (e.g. jinja templates) see a single layer.
+        """
+        override: Optional[K8sOptionsOverride] = None
+        if runtime is not None and self.gpu_vendor_overrides:
+            override = self.gpu_vendor_overrides.get(runtime)
+
+        if override is None:
+            return K8sOptions(
+                image_credentials=self.image_credentials,
+                node_selector=self.node_selector,
+                volume_mounts=self.volume_mounts,
+            )
+
+        merged_node_selector: Optional[Dict[str, str]] = None
+        if self.node_selector or override.node_selector:
+            merged_node_selector = {
+                **(self.node_selector or {}),
+                **(override.node_selector or {}),
+            }
+
+        return K8sOptions(
+            image_credentials=self.image_credentials,
+            node_selector=merged_node_selector,
+            volume_mounts=self.volume_mounts,
+        )
 
 
 class CloudOptions(BaseModel):
@@ -332,11 +453,11 @@ class ClusterUpdate(SQLModel):
             )
         ),
     )
-    k8s_volume_mounts: Optional[List[K8sVolumeMount]] = Field(
+    k8s_options: Optional[K8sOptions] = Field(
         default=None,
         sa_column=Column(
             pydantic_column_type(
-                List[K8sVolumeMount],
+                K8sOptions,
                 exclude_none=True,
                 exclude_unset=True,
                 exclude_defaults=True,

--- a/tests/k8s/test_template_render.py
+++ b/tests/k8s/test_template_render.py
@@ -1,0 +1,446 @@
+import yaml
+from gpustack_runtime.detector import ManufacturerEnum
+
+from gpustack.k8s.manifest_template import (
+    CPU_WORKER_NAME,
+    WORKER_DS_BASENAME,
+    TemplateConfig,
+)
+from gpustack.schemas.clusters import ClusterRegistrationTokenPublic
+from gpustack.schemas.clusters import (
+    HostPathVolumeSource,
+    ImageCredential,
+    K8sOptions,
+    K8sOptionsOverride,
+    K8sVolumeMount,
+    VolumeSource,
+)
+
+
+def _registration():
+    return ClusterRegistrationTokenPublic(
+        token="t",
+        server_url="http://server",
+        image="gpustack/gpustack:test",
+        env={"GPUSTACK_TOKEN": "t"},
+        args=[],
+        operator_image="gpustack/gpustack-operator:test",
+    )
+
+
+def _config(**kwargs):
+    return TemplateConfig(
+        registration=_registration(),
+        cluster_suffix="abc",
+        cluster_owner_principal_name="alice",
+        **kwargs,
+    )
+
+
+def _render_docs(**kwargs):
+    return [d for d in yaml.safe_load_all(_config(**kwargs).render()) if d]
+
+
+def _daemonsets(docs):
+    return {d["metadata"]["name"]: d for d in docs if d.get("kind") == "DaemonSet"}
+
+
+def _pod_spec(ds):
+    return ds["spec"]["template"]["spec"]
+
+
+# ---------------------------------------------------------------------------
+# Single-vendor / no-runtime mode — must stay byte-compatible with v1
+# (one DaemonSet named gpustack-worker, no extra labels, no affinity).
+# ---------------------------------------------------------------------------
+
+
+def test_no_runtime_renders_single_legacy_daemonset():
+    cfg = _config()
+    assert cfg.multi_vendor_mode is False
+    dses = _daemonsets([d for d in yaml.safe_load_all(cfg.render()) if d])
+    assert list(dses.keys()) == [WORKER_DS_BASENAME]
+    ds = dses[WORKER_DS_BASENAME]
+    assert ds["spec"]["template"]["metadata"]["labels"] == {"app": WORKER_DS_BASENAME}
+    assert "affinity" not in _pod_spec(ds)
+
+
+def test_single_runtime_renders_single_legacy_daemonset_with_vendor_blocks():
+    cfg = _config(runtimes=[ManufacturerEnum.NVIDIA])
+    assert cfg.multi_vendor_mode is False
+    docs = [d for d in yaml.safe_load_all(cfg.render()) if d]
+    dses = _daemonsets(docs)
+    assert list(dses.keys()) == [WORKER_DS_BASENAME]
+    ds = dses[WORKER_DS_BASENAME]
+    # Pod labels remain legacy single-label so apply does not trigger an
+    # unnecessary rolling update on existing v1 clusters.
+    assert ds["spec"]["template"]["metadata"]["labels"] == {"app": WORKER_DS_BASENAME}
+    # No podAntiAffinity / nodeAffinity in single-vendor mode.
+    assert "affinity" not in _pod_spec(ds)
+    # Vendor specifics still apply.
+    assert _pod_spec(ds).get("runtimeClassName") == "nvidia"
+
+
+def test_single_runtime_ascend_keeps_vendor_volume_mounts():
+    docs = _render_docs(runtimes=[ManufacturerEnum.ASCEND])
+    ds = _daemonsets(docs)[WORKER_DS_BASENAME]
+    mounts = _pod_spec(ds)["containers"][0].get("volumeMounts") or []
+    assert {m["name"] for m in mounts} == {
+        "gpustack-ascend-driver",
+        "gpustack-ascend-toolkit",
+    }
+
+
+def test_single_vendor_service_uses_legacy_selector():
+    docs = _render_docs(runtimes=[ManufacturerEnum.NVIDIA])
+    svc = next(d for d in docs if d.get("kind") == "Service")
+    assert svc["spec"]["selector"] == {"app": WORKER_DS_BASENAME}
+
+
+def test_unknown_runtime_falls_back_to_single_legacy_daemonset():
+    """UNKNOWN is treated as no GPU → emit only the legacy CPU DS."""
+    cfg = _config(runtimes=[ManufacturerEnum.UNKNOWN])
+    assert cfg.multi_vendor_mode is False
+    dses = _daemonsets([d for d in yaml.safe_load_all(cfg.render()) if d])
+    assert list(dses.keys()) == [WORKER_DS_BASENAME]
+
+
+def test_repeated_runtime_collapses_to_single_vendor_mode():
+    cfg = _config(runtimes=[ManufacturerEnum.NVIDIA, ManufacturerEnum.NVIDIA])
+    assert cfg.multi_vendor_mode is False
+    dses = _daemonsets([d for d in yaml.safe_load_all(cfg.render()) if d])
+    assert list(dses.keys()) == [WORKER_DS_BASENAME]
+
+
+def test_single_runtime_merges_base_and_override_node_selector():
+    values = K8sOptions(
+        node_selector={"env": "prod"},
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            )
+        },
+    )
+    docs = _render_docs(runtimes=[ManufacturerEnum.NVIDIA], k8s_options=values)
+    ds = _daemonsets(docs)[WORKER_DS_BASENAME]
+    assert _pod_spec(ds)["nodeSelector"] == {
+        "env": "prod",
+        "nvidia.com/gpu": "true",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Multi-vendor mode — per-vendor DS + always-on CPU DS + safety nets.
+# ---------------------------------------------------------------------------
+
+
+def _multi_vendor_values():
+    return K8sOptions(
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            ),
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(
+                node_selector={"huawei.com/Ascend910": "true"}
+            ),
+        }
+    )
+
+
+def test_multi_vendor_emits_cpu_plus_each_vendor_daemonset():
+    cfg = _config(
+        runtimes=[ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options=_multi_vendor_values(),
+    )
+    assert cfg.multi_vendor_mode is True
+    docs = [d for d in yaml.safe_load_all(cfg.render()) if d]
+    dses = _daemonsets(docs)
+    assert set(dses.keys()) == {
+        WORKER_DS_BASENAME,
+        f"{WORKER_DS_BASENAME}-nvidia",
+        f"{WORKER_DS_BASENAME}-ascend",
+    }
+
+
+def test_multi_vendor_all_daemonsets_have_pod_anti_affinity():
+    docs = _render_docs(
+        runtimes=[ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options=_multi_vendor_values(),
+    )
+    for ds in _daemonsets(docs).values():
+        terms = _pod_spec(ds)["affinity"]["podAntiAffinity"][
+            "requiredDuringSchedulingIgnoredDuringExecution"
+        ]
+        assert len(terms) == 1
+        term = terms[0]
+        assert term["topologyKey"] == "kubernetes.io/hostname"
+        assert term["labelSelector"]["matchLabels"] == {
+            "app.kubernetes.io/component": "worker"
+        }
+        assert term["namespaceSelector"] == {}
+
+
+def test_multi_vendor_cpu_ds_has_node_affinity_does_not_exist():
+    docs = _render_docs(
+        runtimes=[ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options=_multi_vendor_values(),
+    )
+    cpu_ds = _daemonsets(docs)[WORKER_DS_BASENAME]
+    exprs = _pod_spec(cpu_ds)["affinity"]["nodeAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ]["nodeSelectorTerms"][0]["matchExpressions"]
+    assert {e["key"] for e in exprs} == {
+        "nvidia.com/gpu",
+        "huawei.com/Ascend910",
+    }
+    assert {e["operator"] for e in exprs} == {"DoesNotExist"}
+
+
+def test_multi_vendor_gpu_ds_has_no_node_affinity():
+    docs = _render_docs(
+        runtimes=[ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options=_multi_vendor_values(),
+    )
+    nvidia_ds = _daemonsets(docs)[f"{WORKER_DS_BASENAME}-nvidia"]
+    assert "nodeAffinity" not in _pod_spec(nvidia_ds).get("affinity", {})
+
+
+def test_multi_vendor_pod_labels_include_common_component_and_runtime_tag():
+    docs = _render_docs(
+        runtimes=[ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options=_multi_vendor_values(),
+    )
+    dses = _daemonsets(docs)
+    nvidia_labels = dses[f"{WORKER_DS_BASENAME}-nvidia"]["spec"]["template"][
+        "metadata"
+    ]["labels"]
+    assert nvidia_labels["app.kubernetes.io/component"] == "worker"
+    assert nvidia_labels["gpustack.io/runtime"] == "nvidia"
+    assert nvidia_labels["app"] == f"{WORKER_DS_BASENAME}-nvidia"
+
+    cpu_labels = dses[WORKER_DS_BASENAME]["spec"]["template"]["metadata"]["labels"]
+    assert cpu_labels["gpustack.io/runtime"] == CPU_WORKER_NAME
+    assert cpu_labels["app"] == WORKER_DS_BASENAME
+
+
+def test_multi_vendor_service_uses_common_component_label():
+    docs = _render_docs(
+        runtimes=[ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options=_multi_vendor_values(),
+    )
+    svc = next(d for d in docs if d.get("kind") == "Service")
+    assert svc["spec"]["selector"] == {"app.kubernetes.io/component": "worker"}
+
+
+def test_image_credentials_materialise_to_dockerconfigjson_secrets():
+    """Each ImageCredential renders a kubernetes.io/dockerconfigjson Secret
+    in the worker namespace, with a deterministic index-based name."""
+    import base64
+    import json
+
+    values = K8sOptions(
+        image_credentials=[
+            ImageCredential(
+                registry="harbor.example.com",
+                username="alice",
+                password="s3cret",
+            ),
+            ImageCredential(registry="ghcr.io", username="bob", password="token-xyz"),
+        ],
+    )
+    docs = _render_docs(k8s_options=values)
+    secrets = {
+        d["metadata"]["name"]: d
+        for d in docs
+        if d.get("kind") == "Secret"
+        and d["metadata"]["name"].startswith("gpustack-image-pull-secret-")
+        and d["metadata"]["namespace"] == "gpustack-system-abc"
+    }
+    assert set(secrets.keys()) == {
+        "gpustack-image-pull-secret-0",
+        "gpustack-image-pull-secret-1",
+    }
+    s0 = secrets["gpustack-image-pull-secret-0"]
+    assert s0["type"] == "kubernetes.io/dockerconfigjson"
+    decoded = json.loads(base64.b64decode(s0["data"][".dockerconfigjson"]))
+    assert "harbor.example.com" in decoded["auths"]
+    assert decoded["auths"]["harbor.example.com"]["username"] == "alice"
+    assert decoded["auths"]["harbor.example.com"]["password"] == "s3cret"
+    # The `auth` field is the base64 of "username:password"
+    expected_auth = base64.b64encode(b"alice:s3cret").decode()
+    assert decoded["auths"]["harbor.example.com"]["auth"] == expected_auth
+
+
+def test_image_credentials_mirror_into_system_namespace_when_distinct():
+    """The operator components live in config.system_namespace; mirror the
+    Secrets there too so they can pull from the same registry."""
+    values = K8sOptions(
+        image_credentials=[
+            ImageCredential(
+                registry="harbor.example.com",
+                username="alice",
+                password="s3cret",
+            )
+        ]
+    )
+    docs = _render_docs(k8s_options=values)
+    secrets = [
+        d
+        for d in docs
+        if d.get("kind") == "Secret"
+        and d["metadata"]["name"] == "gpustack-image-pull-secret-0"
+    ]
+    namespaces = sorted(s["metadata"]["namespace"] for s in secrets)
+    # cluster_suffix='abc' → worker ns = gpustack-system-abc, system ns = gpustack-system
+    assert namespaces == ["gpustack-system", "gpustack-system-abc"]
+
+
+def test_image_credentials_referenced_by_all_worker_daemonsets():
+    values = K8sOptions(
+        image_credentials=[
+            ImageCredential(
+                registry="harbor.example.com",
+                username="alice",
+                password="s3cret",
+            ),
+            ImageCredential(registry="ghcr.io", username="bob", password="token-xyz"),
+        ],
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            ),
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(
+                node_selector={"huawei.com/Ascend910": "true"}
+            ),
+        },
+    )
+    docs = _render_docs(
+        runtimes=[ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options=values,
+    )
+    expected_refs = [
+        {"name": "gpustack-image-pull-secret-0"},
+        {"name": "gpustack-image-pull-secret-1"},
+    ]
+    for ds in _daemonsets(docs).values():
+        assert _pod_spec(ds).get("imagePullSecrets") == expected_refs
+
+
+def test_image_credentials_without_username_password_emit_placeholder_secret():
+    """An ImageCredential without username/password renders a placeholder
+    Secret with an empty ``auths`` map — useful for pre-creating a Secret
+    reference that the user (or another controller) patches in-cluster."""
+    import base64
+    import json
+
+    values = K8sOptions(
+        image_credentials=[ImageCredential(registry="docker.io")],
+    )
+    docs = _render_docs(k8s_options=values)
+    secret = next(
+        d
+        for d in docs
+        if d.get("kind") == "Secret"
+        and d["metadata"]["name"] == "gpustack-image-pull-secret-0"
+        and d["metadata"]["namespace"] == "gpustack-system-abc"
+    )
+    decoded = json.loads(base64.b64decode(secret["data"][".dockerconfigjson"]))
+    assert decoded == {"auths": {}}
+    # The Secret is still referenced by worker DSes so users can patch in
+    # credentials post-install without re-applying the manifest.
+    ds = _daemonsets(docs)[WORKER_DS_BASENAME]
+    assert _pod_spec(ds)["imagePullSecrets"] == [
+        {"name": "gpustack-image-pull-secret-0"}
+    ]
+
+
+def test_image_credentials_with_only_username_falls_back_to_placeholder():
+    """Half-configured credentials (username without password, or vice
+    versa) fall back to the empty-auths placeholder rather than producing
+    a broken auth entry."""
+    import base64
+    import json
+
+    values = K8sOptions(
+        image_credentials=[ImageCredential(registry="docker.io", username="alice")],
+    )
+    docs = _render_docs(k8s_options=values)
+    secret = next(
+        d
+        for d in docs
+        if d.get("kind") == "Secret"
+        and d["metadata"]["name"] == "gpustack-image-pull-secret-0"
+        and d["metadata"]["namespace"] == "gpustack-system-abc"
+    )
+    decoded = json.loads(base64.b64decode(secret["data"][".dockerconfigjson"]))
+    assert decoded == {"auths": {}}
+
+
+def test_no_image_credentials_emits_no_secret_or_reference():
+    docs = _render_docs(k8s_options=K8sOptions())
+    image_secrets = [
+        d
+        for d in docs
+        if d.get("kind") == "Secret"
+        and d["metadata"]["name"].startswith("gpustack-image-pull-secret-")
+    ]
+    assert image_secrets == []
+    for ds in _daemonsets(docs).values():
+        assert "imagePullSecrets" not in _pod_spec(ds)
+
+
+def test_user_volume_mounts_flow_through_via_k8s_options():
+    """K8sOptions now carries the cluster's volumeMounts (previously the
+    top-level k8s_volume_mounts field). Each rendered DS should pick them
+    up."""
+    values = K8sOptions(
+        volume_mounts=[
+            K8sVolumeMount(
+                name="data-dir",
+                mount_path="/var/lib/gpustack",
+                volume_source=VolumeSource(
+                    host_path=HostPathVolumeSource(
+                        path="/var/lib/gpustack", type="DirectoryOrCreate"
+                    )
+                ),
+            )
+        ]
+    )
+    docs = _render_docs(runtimes=[ManufacturerEnum.NVIDIA], k8s_options=values)
+    ds = _daemonsets(docs)[WORKER_DS_BASENAME]
+    mount_names = {
+        m["name"] for m in (_pod_spec(ds)["containers"][0].get("volumeMounts") or [])
+    }
+    volume_names = {v["name"] for v in (_pod_spec(ds).get("volumes") or [])}
+    assert "data-dir" in mount_names
+    assert "data-dir" in volume_names
+
+
+def test_multi_vendor_volume_mounts_applied_only_to_owning_vendor():
+    docs = _render_docs(
+        runtimes=[ManufacturerEnum.ASCEND, ManufacturerEnum.AMD],
+        k8s_options=K8sOptions(
+            gpu_vendor_overrides={
+                ManufacturerEnum.ASCEND: K8sOptionsOverride(
+                    node_selector={"huawei.com/Ascend910": "true"}
+                ),
+                ManufacturerEnum.AMD: K8sOptionsOverride(
+                    node_selector={"amd.com/gpu": "true"}
+                ),
+            }
+        ),
+    )
+    dses = _daemonsets(docs)
+
+    def mount_names(ds):
+        return {
+            m["name"]
+            for m in (_pod_spec(ds)["containers"][0].get("volumeMounts") or [])
+        }
+
+    assert mount_names(dses[f"{WORKER_DS_BASENAME}-ascend"]) == {
+        "gpustack-ascend-driver",
+        "gpustack-ascend-toolkit",
+    }
+    assert mount_names(dses[f"{WORKER_DS_BASENAME}-amd"]) == {"gpustack-amd-driver"}
+    assert mount_names(dses[WORKER_DS_BASENAME]) == set()

--- a/tests/k8s/test_validate_multi_vendor.py
+++ b/tests/k8s/test_validate_multi_vendor.py
@@ -1,0 +1,172 @@
+import pytest
+from gpustack_runtime.detector import ManufacturerEnum
+
+from gpustack.api.exceptions import InvalidException
+from gpustack.routes.clusters import _validate_multi_vendor_overrides
+from gpustack.schemas.clusters import K8sOptions, K8sOptionsOverride
+
+
+def test_no_runtimes_skips_validation():
+    _validate_multi_vendor_overrides(None, None)
+    _validate_multi_vendor_overrides([], None)
+
+
+def test_single_runtime_skips_validation_even_without_override():
+    # Single-vendor mode does not require a vendor override.
+    _validate_multi_vendor_overrides([ManufacturerEnum.NVIDIA], None)
+
+
+def test_repeated_same_runtime_treated_as_single_vendor():
+    _validate_multi_vendor_overrides(
+        [ManufacturerEnum.NVIDIA, ManufacturerEnum.NVIDIA], None
+    )
+
+
+def test_unknown_excluded_from_distinct_count():
+    # UNKNOWN + NVIDIA distinct count = 1, so single-vendor → no validation.
+    _validate_multi_vendor_overrides(
+        [ManufacturerEnum.UNKNOWN, ManufacturerEnum.NVIDIA], None
+    )
+
+
+def test_multi_vendor_without_k8s_options_raises():
+    with pytest.raises(InvalidException) as exc:
+        _validate_multi_vendor_overrides(
+            [ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+            None,
+        )
+    assert "nvidia" in exc.value.message
+    assert "ascend" in exc.value.message
+
+
+def test_multi_vendor_with_partial_overrides_raises():
+    k8s_options = K8sOptions(
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            )
+        }
+    )
+    with pytest.raises(InvalidException) as exc:
+        _validate_multi_vendor_overrides(
+            [ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+            k8s_options,
+        )
+    assert "ascend" in exc.value.message
+    assert "nvidia" not in exc.value.message
+
+
+def test_multi_vendor_with_empty_override_node_selector_raises():
+    """An override entry without a populated node_selector does not satisfy
+    the requirement — the CPU DS still gets no exclusion key from it."""
+    k8s_options = K8sOptions(
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            ),
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(),
+        }
+    )
+    with pytest.raises(InvalidException) as exc:
+        _validate_multi_vendor_overrides(
+            [ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+            k8s_options,
+        )
+    assert "ascend" in exc.value.message
+
+
+def test_multi_vendor_with_all_overrides_passes():
+    k8s_options = K8sOptions(
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            ),
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(
+                node_selector={"huawei.com/Ascend910": "true"}
+            ),
+        }
+    )
+    _validate_multi_vendor_overrides(
+        [ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options,
+    )
+
+
+def test_multi_vendor_duplicate_override_node_selector_raises():
+    """Two vendors with identical nodeSelector dicts target the same node
+    set — podAntiAffinity would let one DS win each node and the other
+    would stay Pending forever."""
+    k8s_options = K8sOptions(
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(node_selector={"gpu": "true"}),
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(node_selector={"gpu": "true"}),
+        }
+    )
+    with pytest.raises(InvalidException) as exc:
+        _validate_multi_vendor_overrides(
+            [ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+            k8s_options,
+        )
+    assert "nvidia+ascend" in exc.value.message or "ascend+nvidia" in exc.value.message
+
+
+def test_multi_vendor_partial_key_overlap_is_allowed():
+    """Overrides may share a key (e.g. a shared zone constraint) as long
+    as the dicts are not fully equal — different values still scope each
+    vendor to a distinct node set."""
+    k8s_options = K8sOptions(
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"gpu-type": "nvidia", "zone": "a"}
+            ),
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(
+                node_selector={"gpu-type": "ascend", "zone": "a"}
+            ),
+        }
+    )
+    _validate_multi_vendor_overrides(
+        [ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options,
+    )
+
+
+def test_multi_vendor_base_key_in_override_raises():
+    """A base nodeSelector key reused in any vendor override creates a
+    self-contradicting CPU DS (requires X AND DoesNotExist X)."""
+    k8s_options = K8sOptions(
+        node_selector={"gpu": "true"},
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"gpu": "true", "nvidia.com/gpu": "true"}
+            ),
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(
+                node_selector={"huawei.com/Ascend910": "true"}
+            ),
+        },
+    )
+    with pytest.raises(InvalidException) as exc:
+        _validate_multi_vendor_overrides(
+            [ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+            k8s_options,
+        )
+    assert "gpu" in exc.value.message
+
+
+def test_multi_vendor_disjoint_base_and_override_keys_passes():
+    """Base provides shared constraint, overrides provide vendor-only
+    keys — no clash."""
+    k8s_options = K8sOptions(
+        node_selector={"env": "prod"},
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            ),
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(
+                node_selector={"huawei.com/Ascend910": "true"}
+            ),
+        },
+    )
+    _validate_multi_vendor_overrides(
+        [ManufacturerEnum.NVIDIA, ManufacturerEnum.ASCEND],
+        k8s_options,
+    )

--- a/tests/k8s/test_values_resolve.py
+++ b/tests/k8s/test_values_resolve.py
@@ -1,0 +1,127 @@
+from gpustack_runtime.detector import ManufacturerEnum
+
+from gpustack.schemas.clusters import (
+    ImageCredential,
+    K8sOptions,
+    K8sOptionsOverride,
+)
+
+
+def _cred(registry):
+    return ImageCredential(registry=registry, username="u", password="p")
+
+
+def test_resolve_no_runtime_strips_overrides():
+    values = K8sOptions(
+        node_selector={"env": "prod"},
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            )
+        },
+    )
+    out = values.resolve_for(None)
+    assert out.node_selector == {"env": "prod"}
+    assert out.gpu_vendor_overrides is None
+
+
+def test_resolve_runtime_without_matching_override_returns_base():
+    values = K8sOptions(
+        node_selector={"env": "prod"},
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            )
+        },
+    )
+    out = values.resolve_for(ManufacturerEnum.AMD)
+    assert out.node_selector == {"env": "prod"}
+    assert out.gpu_vendor_overrides is None
+
+
+def test_resolve_node_selector_merge_override_wins_per_key():
+    values = K8sOptions(
+        node_selector={"env": "prod", "zone": "a"},
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"zone": "b", "nvidia.com/gpu": "true"}
+            )
+        },
+    )
+    out = values.resolve_for(ManufacturerEnum.NVIDIA)
+    assert out.node_selector == {
+        "env": "prod",
+        "zone": "b",
+        "nvidia.com/gpu": "true",
+    }
+
+
+def test_resolve_passes_through_base_image_credentials():
+    """image_credentials is registry-scoped, not vendor-scoped — base flows through unchanged."""
+    values = K8sOptions(
+        image_credentials=[_cred("harbor.example.com"), _cred("ghcr.io")],
+        gpu_vendor_overrides={
+            ManufacturerEnum.NVIDIA: K8sOptionsOverride(
+                node_selector={"nvidia.com/gpu": "true"}
+            )
+        },
+    )
+    out = values.resolve_for(ManufacturerEnum.NVIDIA)
+    assert [c.registry for c in out.image_credentials] == [
+        "harbor.example.com",
+        "ghcr.io",
+    ]
+    assert out.node_selector == {"nvidia.com/gpu": "true"}
+
+
+def test_resolve_with_only_override_node_selector():
+    values = K8sOptions(
+        gpu_vendor_overrides={
+            ManufacturerEnum.ASCEND: K8sOptionsOverride(
+                node_selector={"huawei.com/Ascend910": "true"}
+            )
+        },
+    )
+    out = values.resolve_for(ManufacturerEnum.ASCEND)
+    assert out.node_selector == {"huawei.com/Ascend910": "true"}
+    assert out.image_credentials is None
+
+
+def test_resolve_empty_override_block_leaves_base_intact():
+    values = K8sOptions(
+        node_selector={"env": "prod"},
+        image_credentials=[_cred("harbor.example.com")],
+        gpu_vendor_overrides={ManufacturerEnum.NVIDIA: K8sOptionsOverride()},
+    )
+    out = values.resolve_for(ManufacturerEnum.NVIDIA)
+    assert out.node_selector == {"env": "prod"}
+    assert [c.registry for c in out.image_credentials] == ["harbor.example.com"]
+
+
+def test_resolve_no_gpu_vendor_overrides_field():
+    values = K8sOptions(node_selector={"env": "prod"})
+    out = values.resolve_for(ManufacturerEnum.NVIDIA)
+    assert out.node_selector == {"env": "prod"}
+    assert out.gpu_vendor_overrides is None
+
+
+def test_resolve_by_alias_payload_round_trip():
+    payload = {
+        "imageCredentials": [
+            {
+                "registry": "harbor.example.com",
+                "username": "alice",
+                "password": "s3cret",
+            }
+        ],
+        "nodeSelector": {"env": "prod"},
+        "gpuVendorOverrides": {
+            "nvidia": {
+                "nodeSelector": {"nvidia.com/gpu": "true"},
+            }
+        },
+    }
+    values = K8sOptions.model_validate(payload)
+    out = values.resolve_for(ManufacturerEnum.NVIDIA)
+    assert [c.registry for c in out.image_credentials] == ["harbor.example.com"]
+    assert out.node_selector == {"env": "prod", "nvidia.com/gpu": "true"}


### PR DESCRIPTION
- Introduce K8sValues (imagePullSecrets, nodeSelector, volumeMounts, gpuVendorOverrides) as top-level cluster.k8s_values, parallel to worker_config; absorbs the unreleased k8s_volume_mounts column so the shape is fully owned by one container before shipping.
- Render per-vendor DaemonSets (gpustack-worker-<vendor>) when 2+ distinct runtimes are requested. CPU fallback keeps the legacy gpustack-worker name and spec for single-vendor / no-runtime calls so v1 manifest output stays byte-compatible (no new labels, no affinity, legacy Service selector).
- Multi-vendor mode adds safety nets: required podAntiAffinity with topologyKey=hostname and namespaceSelector={} (cross-namespace hostPort protection), and CPU DS nodeAffinity DoesNotExist for vendor label keys collected from gpuVendorOverrides.
- Route layer rejects multi-vendor calls when:
  * any requested runtime is missing k8s_values.gpuVendorOverrides[<runtime>].nodeSelector — without it the CPU DS and vendor DSes would compete for the same nodes;
  * two vendor overrides share an identical nodeSelector — both DSes would target the same node set and podAntiAffinity would leave one Pending forever (typical copy-paste mistake);
  * a base nodeSelector key also appears in any vendor override — the CPU worker would simultaneously require and forbid that key and never schedule.
- Move K8s pod-spec data types (K8sValues, K8sVolumeMount, VolumeSource, ...) from schemas/config.py to schemas/clusters.py — they are cluster-scoped, not worker process config.