### PR TITLE
feat: route shared GPU service access via system/authenticated group

### DIFF
--- a/gpustack/api/tenant.py
+++ b/gpustack/api/tenant.py
@@ -38,11 +38,13 @@ from gpustack.api.exceptions import (
 )
 from gpustack.schemas.api_keys import ApiKey
 from gpustack.schemas.cluster_access import ClusterAccess
+from gpustack.schemas.clusters import Cluster
 from gpustack.schemas.principals import (
     OrgRole,
     Principal,
     PrincipalMembership,
     PrincipalType,
+    get_authenticated_principal_id,
 )
 from gpustack.schemas.users import User
 from gpustack.server.db import get_session
@@ -70,6 +72,11 @@ class TenantContext:
     current_principal_id: Optional[int]
     org_role: Optional[OrgRole]
     accessible_cluster_ids: Set[int] = field(default_factory=set)
+    # Owner-Org principal ids of the clusters in ``accessible_cluster_ids``.
+    # Surfaces "which Orgs run infra I'm allowed to touch" — used by
+    # cluster-bound resource visibility (PV types, future analogs)
+    # without re-querying ``clusters`` per call.
+    accessible_cluster_owner_ids: Set[int] = field(default_factory=set)
     # True when ``current_principal_id`` is the user's own
     # USER-principal (personal scope) rather than an ORG-principal.
     # Lets endpoints treat the "owner of a one-member namespace" case
@@ -200,19 +207,51 @@ async def _accessible_clusters(
     user_principal_id: int,
     org_principal_id: Optional[int],
     group_principal_ids: List[int],
-) -> Set[int]:
-    """Cluster ids reachable from any of: org, user, or any joined group."""
-    principal_ids = [user_principal_id, *group_principal_ids]
+) -> tuple[Set[int], Set[int]]:
+    """Cluster ids + their owner-principal ids reachable from any of:
+    org, user, joined group, or the built-in ``system/authenticated``
+    group.
+
+    ``system/authenticated`` is always part of the lookup set — every
+    authenticated caller is an implicit member of it. ClusterAccess
+    rows written against it become global grants that any logged-in
+    user inherits. Default-Org clusters use this mechanism:
+    ``create_cluster`` seeds one such row per Default-Org cluster,
+    which UI surfaces as an "Everyone" grant that admin can revoke or
+    re-apply.
+
+    Returns ``(cluster_ids, owner_principal_ids)`` so downstream code
+    (PV-type visibility, etc.) can scope cluster-bound resources by
+    "Orgs whose infrastructure I can use" without re-querying
+    ``clusters``.
+    """
+    principal_ids = [
+        user_principal_id,
+        *group_principal_ids,
+        # Async getter so CLI / offline call sites that never ran
+        # ``_init_data`` fail loudly (init raises) rather than silently
+        # use the uninitialised sentinel ``0`` — which would make the
+        # IN-clause skip every ``system/authenticated`` grant.
+        await get_authenticated_principal_id(session),
+    ]
     if org_principal_id is not None:
         principal_ids.append(org_principal_id)
 
-    if not principal_ids:
-        return set()
-
-    stmt = select(ClusterAccess.cluster_id).where(
-        ClusterAccess.principal_id.in_(principal_ids),
+    stmt = (
+        select(Cluster.id, Cluster.owner_principal_id)
+        .join(ClusterAccess, ClusterAccess.cluster_id == Cluster.id)
+        .where(
+            ClusterAccess.principal_id.in_(principal_ids),
+            Cluster.deleted_at.is_(None),
+        )
     )
-    return set((await session.exec(stmt)).all())
+    cluster_ids: Set[int] = set()
+    owner_ids: Set[int] = set()
+    for cid, oid in (await session.exec(stmt)).all():
+        cluster_ids.add(cid)
+        if oid is not None:
+            owner_ids.add(oid)
+    return cluster_ids, owner_ids
 
 
 def _resolve_requested_principal_id(
@@ -264,6 +303,7 @@ async def get_tenant_context(
 
     org_role: Optional[OrgRole] = None
     accessible_cluster_ids: Set[int] = set()
+    accessible_cluster_owner_ids: Set[int] = set()
     current_is_personal_scope = False
 
     if current_principal_id is not None and user.kind != PrincipalType.SYSTEM:
@@ -275,7 +315,10 @@ async def get_tenant_context(
         if current_principal_id == user.id:
             current_is_personal_scope = True
             group_ids = await _user_group_principal_ids(session, user.id)
-            accessible_cluster_ids = await _accessible_clusters(
+            (
+                accessible_cluster_ids,
+                accessible_cluster_owner_ids,
+            ) = await _accessible_clusters(
                 session,
                 user.id,
                 None,
@@ -293,7 +336,10 @@ async def get_tenant_context(
                 )
 
             group_ids = await _user_group_principal_ids(session, user.id)
-            accessible_cluster_ids = await _accessible_clusters(
+            (
+                accessible_cluster_ids,
+                accessible_cluster_owner_ids,
+            ) = await _accessible_clusters(
                 session,
                 user.id,
                 current_principal_id,
@@ -324,6 +370,7 @@ async def get_tenant_context(
         current_principal_id=current_principal_id,
         org_role=org_role,
         accessible_cluster_ids=accessible_cluster_ids,
+        accessible_cluster_owner_ids=accessible_cluster_owner_ids,
         current_is_personal_scope=current_is_personal_scope,
     )
     request.state.tenant_context = ctx
@@ -511,8 +558,9 @@ def assert_org_owned_writable(
     resource: Any,
     *,
     resource_label: str = "resource",
+    allow_member: bool = False,
 ) -> None:
-    """403 if the caller can't mutate an org-owned infrastructure row.
+    """403 if the caller can't mutate an org-owned row.
 
     Used for clusters / cloud_credentials / worker_pools / inference
     backends — anything with a nullable ``owner_principal_id`` and these
@@ -529,6 +577,13 @@ def assert_org_owned_writable(
       and admin-in-act-as cannot mutate Global rows directly. Resource
       handlers redirect such writes to the caller's own row instead.
     - **Other principal's row**: never writable for non-admin.
+
+    ``allow_member`` (default False) keeps infra-level writes
+    (cluster, cloud_credential, worker_pool, inference_backend, PV
+    type, template) gated on the OWNER role. Workload-level rows
+    (GPU instance, SSH key, persistent volume) set it True so an Org
+    Member can manage workloads scoped to the Org they belong to —
+    consistent with how Personal-scope users manage their own.
     """
     if bypass_tenant_filter(ctx):
         return
@@ -544,9 +599,14 @@ def assert_org_owned_writable(
                 "current organization"
             )
         )
-    # Platform admin acting-as the Org passes the role check unconditionally;
-    # for non-admin we require Org owner.
-    if not ctx.is_platform_admin and ctx.org_role != OrgRole.OWNER:
+    # Platform admin acting-as the Org passes the role check unconditionally.
+    # ``allow_member=True`` accepts any Org role AND Personal scope (the
+    # user managing their own USER-principal namespace). ``allow_member=False``
+    # is the infra-level gate: only Admin or Org Owner — Personal scope has
+    # no Org-role ladder, so it falls on the non-OWNER side here too.
+    if ctx.is_platform_admin or allow_member:
+        return
+    if ctx.current_is_personal_scope or ctx.org_role != OrgRole.OWNER:
         raise OrgRoleError(
             message=(
                 f"Insufficient organization role to modify this " f"{resource_label}"
@@ -566,12 +626,22 @@ def validate_owner_principal(
     ctx: TenantContext,
     *,
     resource_label: str = "resource",
+    allow_member: bool = False,
 ) -> None:
     """Decide whether the caller can create a row owned by
     ``input_owner_principal_id``.
 
     - Platform admin: any value (including NULL = global)
     - Org owner: must equal ``current_principal_id``; can't create global
+    - Personal scope: must equal the caller's own USER-principal id.
+      No Org-role ladder applies — the user owns their own namespace.
+
+    ``allow_member`` (default False) keeps infra-level creates
+    (cluster, cloud_credential, worker_pool, inference_backend, PV
+    type, template) gated on the OWNER role. Workload-level rows
+    (GPU instance, SSH key, persistent volume) set it True so an Org
+    Member can spin up workloads in the Org they belong to — same
+    permission ladder as Personal scope, just stamped on the Org.
     """
     if ctx.is_platform_admin:
         return
@@ -586,7 +656,14 @@ def validate_owner_principal(
         raise InvalidException(
             message="owner_principal_id must match the current organization"
         )
-    if ctx.org_role != OrgRole.OWNER:
+    # ``allow_member=True`` accepts any Org role AND Personal scope (the
+    # user creating in their own USER-principal namespace).
+    # ``allow_member=False`` is the infra-level gate: only Admin or Org
+    # Owner — Personal scope has no Org-role ladder, so it falls on the
+    # non-OWNER side here too.
+    if allow_member:
+        return
+    if ctx.current_is_personal_scope or ctx.org_role != OrgRole.OWNER:
         raise InvalidException(
             message=(f"Insufficient organization role to create a " f"{resource_label}")
         )

--- a/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
+++ b/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
@@ -78,6 +78,8 @@ import gpustack  # noqa: F401  (keeps SQLModel registrations side-effect-loaded)
 import gpustack.utils.sql_enum as sql_enum
 from gpustack.migrations.utils import column_exists, table_exists
 from gpustack.schemas.principals import (
+    AUTHENTICATED_PRINCIPAL_DISPLAY_NAME,
+    AUTHENTICATED_PRINCIPAL_NAME,
     AuthProviderEnum,
     PLATFORM_PRINCIPAL_NAME,
 )
@@ -1138,6 +1140,91 @@ def upgrade() -> None:
     # PG, leave the type in place — dropping an enum still referenced
     # by historical migrations would re-fail on a future ``alembic
     # downgrade``; an orphaned enum type is harmless.
+
+    # ------------------------------------------------------------------
+    # 18. Seed ``system/authenticated`` + backfill Default-Org grants.
+    # ------------------------------------------------------------------
+    # ``system/authenticated`` is the built-in GROUP principal that
+    # ``_accessible_clusters`` treats as implicitly containing every
+    # authenticated caller. A ``cluster_access`` row granting it is
+    # therefore a global grant.
+    #
+    # Default-Org clusters default to "shared with all users" — the
+    # ``create_cluster`` route now seeds that row at create time. Here
+    # we cover the upgrade case: every Default-Org cluster that
+    # pre-dates this revision gets the same row, idempotent via the
+    # ``NOT EXISTS`` guard and the composite UNIQUE on
+    # ``(cluster_id, principal_id)``.
+
+    # 18a. Seed the GROUP principal. Lives in the GROUP name
+    # partition (its own partial uniqueness index, set up above), so
+    # it can't collide with the admin-curated USER / ORG / SYSTEM rows
+    # in the other partition.
+    op.execute(
+        sa.text(
+            f"""
+            INSERT INTO principals
+                (kind, name, display_name, description,
+                 is_admin, is_active,
+                 source,
+                 created_at, updated_at, deleted_at)
+            SELECT
+                'GROUP', :name, :display_name, :desc,
+                {bool_false}, {bool_true},
+                'Local',
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL
+            WHERE NOT EXISTS (
+                SELECT 1 FROM principals
+                WHERE kind = 'GROUP' AND name = :name
+            )
+            """
+        ).bindparams(
+            name=AUTHENTICATED_PRINCIPAL_NAME,
+            display_name=AUTHENTICATED_PRINCIPAL_DISPLAY_NAME,
+            desc=(
+                'Built-in group containing every authenticated principal. '
+                'Grant access to this principal to share a resource with all users.'
+            ),
+        )
+    )
+
+    authenticated_id = bind.execute(
+        sa.text(
+            "SELECT id FROM principals "
+            "WHERE kind = 'GROUP' AND name = :name AND deleted_at IS NULL"
+        ).bindparams(name=AUTHENTICATED_PRINCIPAL_NAME)
+    ).scalar()
+    if authenticated_id is None:
+        raise RuntimeError(
+            f"Authenticated principal not found by name="
+            f"{AUTHENTICATED_PRINCIPAL_NAME!r} after seed; "
+            "backfill cannot continue"
+        )
+
+    # 18b. Backfill ``cluster_access`` rows for every existing
+    # Default-Org cluster. ``platform_id`` was resolved in step 3.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO cluster_access
+                (cluster_id, principal_id, granted_by,
+                 created_at, updated_at, deleted_at)
+            SELECT c.id, :authenticated_id, NULL,
+                   CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL
+            FROM clusters c
+            WHERE c.owner_principal_id = :platform_id
+              AND c.deleted_at IS NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM cluster_access ca
+                WHERE ca.cluster_id = c.id
+                  AND ca.principal_id = :authenticated_id
+              )
+            """
+        ).bindparams(
+            authenticated_id=authenticated_id,
+            platform_id=platform_id,
+        )
+    )
 
 
 def downgrade() -> None:

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -50,7 +50,12 @@ from gpustack.schemas.clusters import (
     WorkerPool,
     CloudOptions,
 )
-from gpustack.schemas.principals import PrincipalType, platform_principal_id
+from gpustack.schemas.cluster_access import ClusterAccess
+from gpustack.schemas.principals import (
+    PrincipalType,
+    get_authenticated_principal_id,
+    platform_principal_id,
+)
 from gpustack.schemas.users import system_name_prefix
 from gpustack.schemas.api_keys import ApiKey
 from gpustack.security import get_secret_hash, API_KEY_PREFIX
@@ -98,6 +103,26 @@ def _is_cluster_visible(cluster: Cluster, ctx: TenantContext) -> bool:
     return False
 
 
+def _is_cluster_manageable(cluster: Cluster, ctx: TenantContext) -> bool:
+    """Manageability mirror: drops cross-Org grants. Bypass for admin
+    in "All" mode (sees everything regardless)."""
+    if bypass_tenant_filter(ctx):
+        return True
+    return (
+        ctx.current_principal_id is not None
+        and cluster.owner_principal_id == ctx.current_principal_id
+    )
+
+
+def _cluster_manageable_conditions(ctx: TenantContext) -> List[Any]:
+    """SQL twin of :func:`_is_cluster_manageable`."""
+    if bypass_tenant_filter(ctx):
+        return []
+    if ctx.current_principal_id is None:
+        return [Cluster.id == -1]
+    return [Cluster.owner_principal_id == ctx.current_principal_id]
+
+
 @router.get("", response_model=ClustersPublic, response_model_exclude_none=True)
 async def get_clusters(
     session: SessionDep,
@@ -105,7 +130,19 @@ async def get_clusters(
     params: ClusterListParams = Depends(),
     name: str = None,
     search: str = None,
+    mine: bool = False,
 ):
+    """List clusters.
+
+    Default visibility is "everything the caller can use" — own-Org
+    clusters plus clusters granted via ``cluster_access``. Pickers
+    (e.g. GPU-instance create) use this default.
+
+    ``mine=true`` restricts to clusters owned by the caller's current
+    principal — drops grants from other Orgs, so management pages
+    don't surface read-only rows the caller can't actually edit.
+    Platform admin still sees everything (bypass).
+    """
     fuzzy_fields = {}
     if search:
         fuzzy_fields = {"name": search}
@@ -114,13 +151,24 @@ async def get_clusters(
     if name:
         fields = {"name": name}
 
+    extra_conditions = (
+        _cluster_manageable_conditions(ctx)
+        if mine
+        else cluster_visibility_conditions(ctx, Cluster)
+    )
+
     if params.watch:
+        filter_func = (
+            (lambda c: _is_cluster_manageable(c, ctx))
+            if mine
+            else (lambda c: _is_cluster_visible(c, ctx))
+        )
         return StreamingResponse(
             Cluster.streaming(
                 fields=fields,
                 fuzzy_fields=fuzzy_fields,
                 options=CLUSTER_LOAD_OPTIONS,
-                filter_func=lambda c: _is_cluster_visible(c, ctx),
+                filter_func=filter_func,
             ),
             media_type="text/event-stream",
         )
@@ -134,7 +182,7 @@ async def get_clusters(
             fields=fields,
             fuzzy_fields=fuzzy_fields,
             options=CLUSTER_LOAD_OPTIONS,
-            extra_conditions=cluster_visibility_conditions(ctx, Cluster),
+            extra_conditions=extra_conditions,
         )
 
         if not items:
@@ -367,6 +415,20 @@ async def create_cluster(
         await cluster.save(session=session, auto_commit=False)
         to_create_apikey.user_id = cluster_principal.id
         await ApiKey.create(session=session, source=to_create_apikey, auto_commit=False)
+        # Default-Org clusters default to "shared with everyone" — seed
+        # an explicit ClusterAccess grant against ``system/authenticated``
+        # so the policy is visible (and revocable) from the UI's
+        # cluster-access view rather than baked into request resolution.
+        if cluster.owner_principal_id == platform_principal_id():
+            await ClusterAccess.create(
+                session=session,
+                source=ClusterAccess(
+                    cluster_id=cluster.id,
+                    principal_id=await get_authenticated_principal_id(session),
+                    granted_by=ctx.user.id,
+                ),
+                auto_commit=False,
+            )
         await session.commit()
         await session.refresh(cluster)
         return cluster

--- a/gpustack/routes/gpu_instance_persistent_volume_types.py
+++ b/gpustack/routes/gpu_instance_persistent_volume_types.py
@@ -38,24 +38,54 @@ async def get_gpu_instance_persistent_volume_types(
     ctx: TenantContextDep,
     params: GPUInstancePersistentVolumeTypeListParams = Depends(),
     search: Optional[str] = None,
+    mine: bool = False,
 ):
-    owner_principal_id = ctx.current_principal_id or platform_principal_id()
-    if bypass_tenant_filter(ctx):
-        owner_principal_id = None
+    """List PV types.
 
-    fields: dict = {}
-    if owner_principal_id is not None:
-        fields["owner_principal_id"] = owner_principal_id
+    Default visibility unions the caller's own types with types owned
+    by every Org whose cluster the caller can use — covers Default-Org
+    "Everyone" grants and cross-Org cluster grants, so PV-create
+    pickers find any type referenceable from a cluster they target.
 
+    ``mine=true`` restricts to types owned by the caller's current
+    principal — drops cross-Org rows so the Storage Type management
+    page doesn't surface read-only types from other Orgs that
+    happened to grant the caller a cluster.
+    """
     fuzzy_fields: dict = {}
     if search:
         fuzzy_fields["name"] = search
 
+    extra_conditions: list = []
+    filter_func = lambda row: is_visible(row, ctx)  # noqa: E731
+    if not bypass_tenant_filter(ctx):
+        if mine:
+            if ctx.current_principal_id is None:
+                extra_conditions = [GPUInstancePersistentVolumeType.id == -1]
+            else:
+                extra_conditions = [
+                    GPUInstancePersistentVolumeType.owner_principal_id
+                    == ctx.current_principal_id
+                ]
+            filter_func = lambda row: is_manageable(row, ctx)  # noqa: E731
+        else:
+            owner_ids = set(ctx.accessible_cluster_owner_ids)
+            if ctx.current_principal_id is not None:
+                owner_ids.add(ctx.current_principal_id)
+            if not owner_ids:
+                # No avenue; force empty result rather than leak.
+                extra_conditions = [GPUInstancePersistentVolumeType.id == -1]
+            else:
+                extra_conditions = [
+                    GPUInstancePersistentVolumeType.owner_principal_id.in_(owner_ids)
+                ]
+
     if params.watch:
         return StreamingResponse(
             GPUInstancePersistentVolumeType.streaming(
-                fields=fields,
+                fields={},
                 fuzzy_fields=fuzzy_fields,
+                filter_func=filter_func,
             ),
             media_type="text/event-stream",
         )
@@ -63,11 +93,12 @@ async def get_gpu_instance_persistent_volume_types(
     async with async_session() as session:
         return await GPUInstancePersistentVolumeType.paginated_by_query(
             session=session,
-            fields=fields,
+            fields={},
             fuzzy_fields=fuzzy_fields,
             order_by=params.order_by,
             page=params.page,
             per_page=params.perPage,
+            extra_conditions=extra_conditions,
         )
 
 
@@ -92,12 +123,15 @@ async def create_gpu_instance_persistent_volume_type(
     ctx: TenantContextDep,
     create_obj: GPUInstancePersistentVolumeTypeCreate,
 ):
+    if create_obj.owner_principal_id is None:
+        create_obj.owner_principal_id = (
+            ctx.current_principal_id or platform_principal_id()
+        )
     validate_owner_principal(
         create_obj.owner_principal_id,
         ctx,
         resource_label="GPU instance persistent volume type",
     )
-    create_obj.owner_principal_id = ctx.current_principal_id or platform_principal_id()
 
     _validate_create_obj(create_obj)
 
@@ -175,7 +209,29 @@ def ensure_writable(obj, ctx: TenantContext):
 def is_visible(obj, ctx: TenantContext) -> bool:
     if bypass_tenant_filter(ctx):
         return True
-    return ctx.current_principal_id == obj.owner_principal_id
+    # Caller's own Org always sees its PV types.
+    if (
+        ctx.current_principal_id is not None
+        and obj.owner_principal_id == ctx.current_principal_id
+    ):
+        return True
+    # PV types owned by an Org whose cluster the caller can use —
+    # covers Default-Org "Everyone" grants and cross-Org cluster
+    # grants (Org1 grants its cluster to Org2 → Org2 can pick Org1's
+    # PV types when provisioning storage on that cluster).
+    return obj.owner_principal_id in ctx.accessible_cluster_owner_ids
+
+
+def is_manageable(obj, ctx: TenantContext) -> bool:
+    """Manageability mirror of :func:`is_visible`: drops cross-Org rows
+    that came in via cluster-access. Bypass for admin in "All" mode.
+    """
+    if bypass_tenant_filter(ctx):
+        return True
+    return (
+        ctx.current_principal_id is not None
+        and obj.owner_principal_id == ctx.current_principal_id
+    )
 
 
 @asynccontextmanager

--- a/gpustack/routes/gpu_instance_persistent_volumes.py
+++ b/gpustack/routes/gpu_instance_persistent_volumes.py
@@ -16,6 +16,7 @@ from gpustack.api.tenant import (
     assert_org_owned_writable,
     validate_owner_principal,
 )
+from sqlmodel import select
 from gpustack.gpu_instances import validate_k8s_object_name
 
 from gpustack.schemas import (
@@ -93,14 +94,18 @@ async def create_gpu_instance_persistent_volume(
     ctx: TenantContextDep,
     create_obj: GPUInstancePersistentVolumeCreate,
 ):
+    if create_obj.owner_principal_id is None:
+        create_obj.owner_principal_id = (
+            ctx.current_principal_id or platform_principal_id()
+        )
     validate_owner_principal(
         create_obj.owner_principal_id,
         ctx,
         resource_label="GPU instance persistent volume",
+        allow_member=True,
     )
-    create_obj.owner_principal_id = ctx.current_principal_id or platform_principal_id()
 
-    persistent_volume_type_id = await _validate_create_obj(session, create_obj)
+    persistent_volume_type_id = await _validate_create_obj(session, ctx, create_obj)
 
     source = _build_create_source(create_obj, ctx.user.id, persistent_volume_type_id)
     async with handle_error(
@@ -168,7 +173,12 @@ def ensure_visible(obj, ctx: TenantContext):
 def ensure_writable(obj, ctx: TenantContext):
     if obj is None:
         raise NotFoundException(message="GPU instance persistent volume not found")
-    assert_org_owned_writable(ctx, obj, resource_label="GPU instance persistent volume")
+    assert_org_owned_writable(
+        ctx,
+        obj,
+        resource_label="GPU instance persistent volume",
+        allow_member=True,
+    )
     return obj
 
 
@@ -190,16 +200,16 @@ async def handle_error(message: str):
 
 async def _validate_create_obj(
     session: AsyncSession,
+    ctx: TenantContext,
     create_obj: GPUInstancePersistentVolumeCreate,
 ) -> int:
     validate_k8s_object_name(create_obj.name)
 
-    pvt = await GPUInstancePersistentVolumeType.first_by_fields(
-        session=session,
-        fields={
-            "owner_principal_id": create_obj.owner_principal_id,
-            "name": create_obj.spec.type_,
-        },
+    pvt = await resolve_pv_type_for_ctx(
+        session,
+        ctx,
+        owner_principal_id=create_obj.owner_principal_id,
+        name=create_obj.spec.type_,
     )
     if pvt is None:
         raise InvalidException(
@@ -210,6 +220,51 @@ async def _validate_create_obj(
         )
 
     return pvt.id
+
+
+async def resolve_pv_type_for_ctx(
+    session: AsyncSession,
+    ctx: TenantContext,
+    *,
+    owner_principal_id: int,
+    name: str,
+) -> Optional[GPUInstancePersistentVolumeType]:
+    """Resolve a PV type by name from any Org the caller can use:
+
+    - the PV's own owner principal (caller's own types), and
+    - any Org that owns a cluster the caller has access to
+      (covers Default-Org "Everyone" grants and cross-Org cluster
+      grants — Org1 grants its cluster to Org2 → Org2's user can
+      reference Org1's PV types by name when provisioning).
+
+    Returns the first matching row, or ``None`` if no Org in the
+    accessible set defines a type with that name. ``ctx`` may bypass
+    tenant scoping (admin / SYSTEM); in that case lookup is unscoped.
+    """
+    # Always scope by ``owner_principal_id`` — even for admin in
+    # "All" mode. Two Orgs can independently define a PV type with
+    # the same name; without the scope the lookup picks an
+    # arbitrary one and the resulting PV would silently bind to the
+    # wrong Org's storage backend. Tenant scoping is otherwise
+    # unbounded here (admin / SYSTEM bypass): they may resolve a
+    # type from any Org, but only the one matching the PV being
+    # created.
+    if bypass_tenant_filter(ctx):
+        stmt = select(GPUInstancePersistentVolumeType).where(
+            GPUInstancePersistentVolumeType.name == name,
+            GPUInstancePersistentVolumeType.owner_principal_id == owner_principal_id,
+        )
+        return (await session.exec(stmt)).first()
+
+    owner_ids = set(ctx.accessible_cluster_owner_ids)
+    owner_ids.add(owner_principal_id)
+    if not owner_ids:
+        return None
+    stmt = select(GPUInstancePersistentVolumeType).where(
+        GPUInstancePersistentVolumeType.name == name,
+        GPUInstancePersistentVolumeType.owner_principal_id.in_(owner_ids),
+    )
+    return (await session.exec(stmt)).first()
 
 
 def _build_create_source(

--- a/gpustack/routes/gpu_instance_ssh_public_keys.py
+++ b/gpustack/routes/gpu_instance_ssh_public_keys.py
@@ -90,10 +90,16 @@ async def create_gpu_instance_ssh_public_key(
     ctx: TenantContextDep,
     create_obj: GPUInstanceSSHPublicKeyCreate,
 ):
+    if create_obj.owner_principal_id is None:
+        create_obj.owner_principal_id = (
+            ctx.current_principal_id or platform_principal_id()
+        )
     validate_owner_principal(
-        create_obj.owner_principal_id, ctx, resource_label="GPU instance SSH public key"
+        create_obj.owner_principal_id,
+        ctx,
+        resource_label="GPU instance SSH public key",
+        allow_member=True,
     )
-    create_obj.owner_principal_id = ctx.current_principal_id or platform_principal_id()
 
     _validate_create_obj(create_obj)
 
@@ -162,7 +168,9 @@ def ensure_visible(obj, ctx: TenantContext):
 def ensure_writable(obj, ctx: TenantContext):
     if obj is None:
         raise NotFoundException(message="GPU instance SSH public key not found")
-    assert_org_owned_writable(ctx, obj, resource_label="GPU instance SSH public key")
+    assert_org_owned_writable(
+        ctx, obj, resource_label="GPU instance SSH public key", allow_member=True
+    )
     return obj
 
 

--- a/gpustack/routes/gpu_instance_templates.py
+++ b/gpustack/routes/gpu_instance_templates.py
@@ -38,7 +38,21 @@ async def get_gpu_instance_templates(
     params: GPUInstanceTemplateListParams = Depends(),
     manufacturer: Optional[str] = None,
     search: Optional[str] = None,
+    mine: bool = False,
 ):
+    """List templates visible to the caller.
+
+    Default visibility is "everything the caller may use": Global
+    templates plus templates owned by the caller's current principal.
+    GPU-instance create pickers use this default so users can launch
+    from a Global preset.
+
+    ``mine=true`` restricts to rows the caller's scope actually owns
+    — drops Global rows for non-admin callers, so the Templates
+    management page doesn't surface admin-curated rows the caller
+    can't edit. Platform admin still sees Global rows under ``mine``
+    (they can edit them).
+    """
     fields: dict = {}
     if manufacturer:
         fields["manufacturer"] = manufacturer
@@ -47,12 +61,19 @@ async def get_gpu_instance_templates(
     if search:
         fuzzy_fields["name"] = search
 
+    extra_conditions = manageable_conditions(ctx) if mine else visible_conditions(ctx)
+
     if params.watch:
+        filter_func = (
+            (lambda tmpl: is_manageable(tmpl, ctx))
+            if mine
+            else (lambda tmpl: is_visible(tmpl, ctx))
+        )
         return StreamingResponse(
             GPUInstanceTemplate.streaming(
                 fields=fields,
                 fuzzy_fields=fuzzy_fields,
-                filter_func=lambda tmpl: is_visible(tmpl, ctx),
+                filter_func=filter_func,
             ),
             media_type="text/event-stream",
         )
@@ -65,7 +86,7 @@ async def get_gpu_instance_templates(
             order_by=params.order_by,
             page=params.page,
             per_page=params.perPage,
-            extra_conditions=visible_conditions(ctx),
+            extra_conditions=extra_conditions,
         )
 
 
@@ -90,10 +111,18 @@ async def create_gpu_instance_template(
     ctx: TenantContextDep,
     create_obj: GPUInstanceTemplateCreate,
 ):
+    if create_obj.owner_principal_id is None:
+        create_obj.owner_principal_id = ctx.current_principal_id
     validate_owner_principal(
-        create_obj.owner_principal_id, ctx, resource_label="GPU instance template"
+        create_obj.owner_principal_id,
+        ctx,
+        resource_label="GPU instance template",
+        # Templates are a user-curated resource per principal (Personal,
+        # Org). The Org-Member ladder applies; only Global templates
+        # (``owner_principal_id IS NULL``) stay admin-only, enforced by
+        # the ``None`` branch inside ``validate_owner_principal``.
+        allow_member=True,
     )
-    create_obj.owner_principal_id = ctx.current_principal_id
 
     _validate_create_obj(create_obj)
 
@@ -175,7 +204,12 @@ def ensure_visible(obj, ctx: TenantContext):
 def ensure_writable(obj, ctx: TenantContext):
     if obj is None:
         raise NotFoundException(message="GPU instance template not found")
-    assert_org_owned_writable(ctx, obj, resource_label="GPU instance template")
+    # Org Member ladder for principal-owned templates; the Global ones
+    # (``owner_principal_id IS NULL``) stay admin-only via the ``None``
+    # branch inside ``assert_org_owned_writable``.
+    assert_org_owned_writable(
+        ctx, obj, resource_label="GPU instance template", allow_member=True
+    )
     return obj
 
 
@@ -184,6 +218,18 @@ def is_visible(obj, ctx: TenantContext) -> bool:
         return True
     if obj.owner_principal_id is None:
         return True
+    return ctx.current_principal_id == obj.owner_principal_id
+
+
+def is_manageable(obj, ctx: TenantContext) -> bool:
+    """Manageability mirror of :func:`is_visible`: drops Global rows
+    (owner ``None``) for non-admin callers — they can't edit those,
+    so the management list page hides them.
+    """
+    if bypass_tenant_filter(ctx):
+        return True
+    if obj.owner_principal_id is None:
+        return False
     return ctx.current_principal_id == obj.owner_principal_id
 
 
@@ -200,6 +246,19 @@ def visible_conditions(ctx: TenantContext) -> list:
         )
 
     return [or_(*or_clauses)]
+
+
+def manageable_conditions(ctx: TenantContext) -> list:
+    """SQL twin of :func:`is_manageable`. Non-admin callers get scoped
+    strictly to their own current-principal rows; admin (bypass) sees
+    everything.
+    """
+    if bypass_tenant_filter(ctx):
+        return []
+    if ctx.current_principal_id is None:
+        # No principal context; force empty rather than leak globals.
+        return [GPUInstanceTemplate.id == -1]
+    return [GPUInstanceTemplate.owner_principal_id == ctx.current_principal_id]
 
 
 @asynccontextmanager

--- a/gpustack/routes/gpu_instances.py
+++ b/gpustack/routes/gpu_instances.py
@@ -16,11 +16,11 @@ from gpustack.api.tenant import (
     validate_owner_principal,
 )
 from gpustack.gpu_instances import validate_k8s_object_name
+from gpustack.routes.gpu_instance_persistent_volumes import resolve_pv_type_for_ctx
 
 from gpustack.schemas import (
     GPUInstance,
     GPUInstancePersistentVolume,
-    GPUInstancePersistentVolumeType,
     GPUInstanceUpdate,
     GPUInstancePublic,
     GPUInstanceListParams,
@@ -94,12 +94,18 @@ async def create_gpu_instance(
     ctx: TenantContextDep,
     create_obj: GPUInstanceCreate,
 ):
+    if create_obj.owner_principal_id is None:
+        create_obj.owner_principal_id = (
+            ctx.current_principal_id or platform_principal_id()
+        )
     validate_owner_principal(
-        create_obj.owner_principal_id, ctx, resource_label="GPU instance"
+        create_obj.owner_principal_id,
+        ctx,
+        resource_label="GPU instance",
+        allow_member=True,
     )
-    create_obj.owner_principal_id = ctx.current_principal_id or platform_principal_id()
 
-    persistent_volume_id = await _validate_create_obj(session, ctx.user.id, create_obj)
+    persistent_volume_id = await _validate_create_obj(session, ctx, create_obj)
 
     source = _build_create_source(create_obj, ctx.user.id, persistent_volume_id)
     async with handle_error(
@@ -171,7 +177,9 @@ def ensure_visible(obj, ctx: TenantContext):
 def ensure_writable(obj, ctx: TenantContext):
     if obj is None:
         raise NotFoundException(message="GPU instance not found")
-    assert_org_owned_writable(ctx, obj, resource_label="GPU instance")
+    assert_org_owned_writable(
+        ctx, obj, resource_label="GPU instance", allow_member=True
+    )
     return obj
 
 
@@ -193,7 +201,7 @@ async def handle_error(message: str):
 
 async def _validate_create_obj(
     session: AsyncSession,
-    creator_id: int,
+    ctx: TenantContext,
     create_obj: GPUInstanceCreate,
 ) -> Optional[int]:
     """Enforce create-time invariants that aren't expressible in the schema:
@@ -283,12 +291,11 @@ async def _validate_create_obj(
                 ),
             )
 
-        pvt = await GPUInstancePersistentVolumeType.first_by_fields(
-            session=session,
-            fields={
-                "owner_principal_id": create_obj.owner_principal_id,
-                "name": template.spec.type_,
-            },
+        pvt = await resolve_pv_type_for_ctx(
+            session,
+            ctx,
+            owner_principal_id=create_obj.owner_principal_id,
+            name=template.spec.type_,
         )
         if pvt is None:
             raise InvalidException(
@@ -302,7 +309,7 @@ async def _validate_create_obj(
             name=template.name,
             spec=template.spec,
             owner_principal_id=create_obj.owner_principal_id,
-            creator_id=creator_id,
+            creator_id=ctx.user.id,
             persistent_volume_type_id=pvt.id,
         )
         created = await GPUInstancePersistentVolume.create(

--- a/gpustack/routes/me_orgs.py
+++ b/gpustack/routes/me_orgs.py
@@ -16,6 +16,7 @@ from gpustack.schemas.principals import (
     Principal,
     PrincipalMembership,
     PrincipalType,
+    get_authenticated_principal_id,
 )
 from gpustack.server.deps import CurrentUserDep, SessionDep, TenantContextDep
 
@@ -148,7 +149,16 @@ async def list_my_clusters_in_org(
     )
     group_principal_ids = list((await session.exec(group_stmt)).all())
 
-    principal_ids = [user_principal_id, org_id, *group_principal_ids]
+    # ``system/authenticated`` covers Default-Org "shared with all
+    # users" grants (and any future admin-applied global grant) on the
+    # same code path as explicit principal grants — every authenticated
+    # caller is an implicit member.
+    principal_ids = [
+        user_principal_id,
+        org_id,
+        await get_authenticated_principal_id(session),
+        *group_principal_ids,
+    ]
     cluster_id_stmt = select(ClusterAccess.cluster_id).where(
         ClusterAccess.principal_id.in_(principal_ids)
     )

--- a/gpustack/routes/user_groups.py
+++ b/gpustack/routes/user_groups.py
@@ -28,6 +28,8 @@ from gpustack.schemas.principals import (
     Principal,
     PrincipalMembership,
     PrincipalType,
+    RESERVED_PRINCIPAL_NAME_PREFIX,
+    is_reserved_principal_name,
 )
 from gpustack.schemas.user_groups import (
     UserGroupCreate,
@@ -48,8 +50,22 @@ class GroupMembershipCreate(BaseModel):
 
 
 async def _load_group(session, group_id: int) -> Principal:
+    """Load a user-curated group by id.
+
+    Built-in reserved groups (``system/`` prefix) are deliberately
+    hidden from the Group-CRUD surface — admins shouldn't be able to
+    rename / delete them, and the Groups list page has no useful
+    rendering for them (Members is always 0 since membership is
+    implicit). They're still consumed by cluster_access / ACL views,
+    which render principal_kind=GROUP grants directly.
+    """
     group = await Principal.one_by_id(session, group_id)
-    if not group or group.deleted_at is not None or group.kind != PrincipalType.GROUP:
+    if (
+        not group
+        or group.deleted_at is not None
+        or group.kind != PrincipalType.GROUP
+        or is_reserved_principal_name(group.name)
+    ):
         raise NotFoundException(message="Group not found")
     return group
 
@@ -86,12 +102,24 @@ async def list_groups(
     ctx: TenantContextDep,
     params: UserGroupListParams = Depends(),
     search: Optional[str] = None,
+    include_reserved: bool = False,
 ):
     """List all groups. Visible to any authenticated user — Group names
     are global identifiers in the system; rendering an Org's
     group-memberships needs to be able to enumerate candidate groups.
+
+    By default reserved built-in groups (``system/…``) are excluded:
+    the Groups CRUD page would render them as 0-member editable rows
+    that the server then rejects on write. ACL pickers (cluster_access
+    grant, model-route ACL, …) pass ``include_reserved=true`` so
+    ``system/authenticated`` shows up and can be granted to.
     """
     fuzzy_fields = {"name": search} if search else {}
+    extra_conditions = []
+    if not include_reserved:
+        extra_conditions.append(
+            Principal.name.not_like(f"{RESERVED_PRINCIPAL_NAME_PREFIX}%"),
+        )
     page = await Principal.paginated_by_query(
         session=session,
         fields={
@@ -102,6 +130,7 @@ async def list_groups(
         page=params.page,
         per_page=params.perPage,
         order_by=params.order_by,
+        extra_conditions=extra_conditions,
     )
     counts = await _bulk_member_counts(session, [g.id for g in page.items])
     page.items = [
@@ -124,6 +153,16 @@ async def get_group(session: SessionDep, ctx: TenantContextDep, group_id: int):
     dependencies=[Depends(require_platform_admin)],
 )
 async def create_group(session: SessionDep, body: UserGroupCreate):
+    if is_reserved_principal_name(body.name):
+        # ``system/`` is reserved for built-in principals
+        # (``system/authenticated``, ``system/cluster-…``, …) that the
+        # server seeds itself.
+        raise InvalidException(
+            message=(
+                f"Group name must not start with "
+                f"'{RESERVED_PRINCIPAL_NAME_PREFIX}' (reserved prefix)"
+            )
+        )
     existing = await Principal.one_by_fields(
         session,
         {
@@ -157,6 +196,13 @@ async def update_group(session: SessionDep, group_id: int, body: UserGroupUpdate
     group = await _load_group(session, group_id)
 
     if body.name != group.name:
+        if is_reserved_principal_name(body.name):
+            raise InvalidException(
+                message=(
+                    f"Group name must not start with "
+                    f"'{RESERVED_PRINCIPAL_NAME_PREFIX}' (reserved prefix)"
+                )
+            )
         clash = await Principal.one_by_fields(
             session,
             {

--- a/gpustack/schemas/principals.py
+++ b/gpustack/schemas/principals.py
@@ -72,6 +72,33 @@ class AuthProviderEnum(str, Enum):
 # resources default to it.
 PLATFORM_PRINCIPAL_NAME = 'default'
 
+# Canonical ``name`` of the built-in "all authenticated users" group
+# principal. Shares the ``system/`` reserved prefix with
+# ``system/cluster-…`` / ``system/worker-…`` so every built-in
+# reserved-name principal follows one convention. Every authenticated
+# request is treated as a member of this group at auth-context
+# resolution time, without a backing ``principal_memberships`` row.
+# ClusterAccess (and any future ACL table) can grant to this
+# principal_id, and the grant takes effect for every authenticated
+# user. Lazy-seeded on server startup by
+# :func:`init_authenticated_principal_id` so no schema migration is
+# required.
+AUTHENTICATED_PRINCIPAL_NAME = 'system/authenticated'
+AUTHENTICATED_PRINCIPAL_DISPLAY_NAME = 'All Authenticated Users'
+
+# Names starting with this prefix are reserved for internal /
+# built-in principals (``system/cluster-…``, ``system/worker-…``,
+# ``system/authenticated``). Group-CRUD routes hide and lock these
+# rows so admins can't accidentally rename / delete them; cluster_access
+# / ACL surfaces continue to render them for revoke flows.
+RESERVED_PRINCIPAL_NAME_PREFIX = 'system/'
+
+
+def is_reserved_principal_name(name: Optional[str]) -> bool:
+    """Return True if ``name`` is in the reserved built-in namespace."""
+    return bool(name) and name.startswith(RESERVED_PRINCIPAL_NAME_PREFIX)
+
+
 # Module-private mutable resolved at server startup by
 # :func:`init_platform_principal_id`. Used to be exported as
 # ``PLATFORM_PRINCIPAL_ID`` (a hardcoded ``1`` baked into schema
@@ -83,6 +110,7 @@ PLATFORM_PRINCIPAL_NAME = 'default'
 # the runtime update. Underscore prefix discourages that import path;
 # every reader goes through :func:`platform_principal_id`.
 _PLATFORM_PRINCIPAL_ID: int = 1
+_AUTHENTICATED_PRINCIPAL_ID: int = 0
 
 
 def platform_principal_id() -> int:
@@ -94,6 +122,17 @@ def platform_principal_id() -> int:
     ``_PLATFORM_PRINCIPAL_ID`` directly.
     """
     return _PLATFORM_PRINCIPAL_ID
+
+
+def authenticated_principal_id() -> int:
+    """Sync getter for the ``system/authenticated`` group principal id.
+
+    Used by ``_accessible_clusters`` (and any future ACL resolver) to
+    union grants written against this group with the caller's direct /
+    group / org grants — every authenticated principal is an implicit
+    member, so the row applies universally.
+    """
+    return _AUTHENTICATED_PRINCIPAL_ID
 
 
 # Public alias for ``default_factory=`` on SQLModel fields. Identical
@@ -412,6 +451,7 @@ class PrincipalMembership(PrincipalMembershipBase, BaseModelMixin, table=True):
 # --------------------------------------------------------------------
 
 _PLATFORM_PRINCIPAL_ID_INITIALIZED: bool = False
+_AUTHENTICATED_PRINCIPAL_ID_INITIALIZED: bool = False
 
 
 async def init_platform_principal_id(session: AsyncSession) -> int:
@@ -439,6 +479,30 @@ async def init_platform_principal_id(session: AsyncSession) -> int:
     return p.id
 
 
+async def init_authenticated_principal_id(session: AsyncSession) -> int:
+    """Resolve and bind the ``system/authenticated`` group principal id.
+
+    The row is seeded by the shared-GPU-services migration alongside
+    the cluster_access backfill — same pattern as the platform
+    principal — so this is a read-only resolver. Raises if absent so
+    a missing seed surfaces loudly instead of letting auth-resolution
+    silently widen.
+    """
+    global _AUTHENTICATED_PRINCIPAL_ID, _AUTHENTICATED_PRINCIPAL_ID_INITIALIZED
+    p = await Principal.one_by_fields(
+        session=session,
+        fields={'kind': PrincipalType.GROUP, 'name': AUTHENTICATED_PRINCIPAL_NAME},
+    )
+    if p is None:
+        raise RuntimeError(
+            f"Authenticated principal not found by name="
+            f"{AUTHENTICATED_PRINCIPAL_NAME!r}; database may be uninitialized"
+        )
+    _AUTHENTICATED_PRINCIPAL_ID = p.id
+    _AUTHENTICATED_PRINCIPAL_ID_INITIALIZED = True
+    return p.id
+
+
 async def get_platform_principal_id(session: AsyncSession) -> int:
     """Read the platform principal's id, resolving by name if startup
     init has not been performed yet (tests, scripts).
@@ -448,8 +512,20 @@ async def get_platform_principal_id(session: AsyncSession) -> int:
     return await init_platform_principal_id(session)
 
 
+async def get_authenticated_principal_id(session: AsyncSession) -> int:
+    """Read the ``system/authenticated`` principal id, seeding it on
+    first call. Counterpart to :func:`get_platform_principal_id`.
+    """
+    if _AUTHENTICATED_PRINCIPAL_ID_INITIALIZED:
+        return _AUTHENTICATED_PRINCIPAL_ID
+    return await init_authenticated_principal_id(session)
+
+
 def _reset_platform_principal_for_tests() -> None:
     """Test hook — clears the initialised flag and resets the value."""
     global _PLATFORM_PRINCIPAL_ID, _PLATFORM_PRINCIPAL_ID_INITIALIZED
+    global _AUTHENTICATED_PRINCIPAL_ID, _AUTHENTICATED_PRINCIPAL_ID_INITIALIZED
     _PLATFORM_PRINCIPAL_ID = 1
     _PLATFORM_PRINCIPAL_ID_INITIALIZED = False
+    _AUTHENTICATED_PRINCIPAL_ID = 0
+    _AUTHENTICATED_PRINCIPAL_ID_INITIALIZED = False

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -23,7 +23,13 @@ from gpustack.schemas.users import (
     get_default_cluster_principal,
     default_cluster_principal_name,
 )
-from gpustack.schemas.principals import Principal, PrincipalType, platform_principal_id
+from gpustack.schemas.principals import (
+    Principal,
+    PrincipalType,
+    init_authenticated_principal_id,
+    init_platform_principal_id,
+    platform_principal_id,
+)
 from gpustack.schemas.models import Model, ModelInstance
 from gpustack.schemas.api_keys import ApiKey
 from gpustack.schemas.workers import Worker
@@ -630,6 +636,10 @@ class Server:
         # MAX(users.id), so every downstream init step that defaults to
         # ``platform_principal_id()`` needs the live value bound.
         await self._init_platform_principal_id(session)
+        # ``system/authenticated`` is seeded lazily on first call —
+        # bind it at startup so the resolver returns a real id before
+        # the first request lands on ``_accessible_clusters``.
+        await self._init_authenticated_principal_id(session)
 
         init_data_funcs = [
             self._init_user,
@@ -667,9 +677,10 @@ class Server:
         )
 
     async def _init_platform_principal_id(self, session: AsyncSession):
-        from gpustack.schemas.principals import init_platform_principal_id
-
         await init_platform_principal_id(session)
+
+    async def _init_authenticated_principal_id(self, session: AsyncSession):
+        await init_authenticated_principal_id(session)
 
     async def _init_user(self, session: AsyncSession):
         # Skip bootstrap when any non-system admin already exists, so that

--- a/tests/api/test_tenant.py
+++ b/tests/api/test_tenant.py
@@ -11,10 +11,19 @@ from gpustack.api.tenant import (
     require_org_role,
     require_platform_admin,
 )
+from gpustack.schemas import principals as principals_module
 from gpustack.schemas.principals import (
     OrgRole,
     PrincipalType,
 )
+
+
+# Pre-seed the cached ``system/authenticated`` principal id so the
+# ``get_authenticated_principal_id`` async helper short-circuits via
+# its cache and doesn't try to query the mock session (which only
+# queues canned results for the specific calls the tests model).
+principals_module._AUTHENTICATED_PRINCIPAL_ID = 9999
+principals_module._AUTHENTICATED_PRINCIPAL_ID_INITIALIZED = True
 
 
 def _request(api_key=None):
@@ -76,6 +85,14 @@ def _session_returning(*scalar_lists):
     return session
 
 
+def _cluster_rows(*pairs):
+    """Helper for ``_accessible_clusters`` mock results: pass tuples of
+    ``(cluster_id, owner_principal_id)`` matching the joined-row shape
+    the function unpacks.
+    """
+    return list(pairs)
+
+
 # ---- _resolve_requested_principal_id ---------------------------------------
 
 
@@ -134,7 +151,7 @@ async def test_member_uses_team_org_via_header():
     session = _session_returning(
         [OrgRole.MEMBER],  # _resolve_effective_org_role (direct ∪ via-group)
         [11, 12],  # _user_group_principal_ids (all groups, no org filter)
-        [101, 102],  # _accessible_clusters
+        _cluster_rows((101, 5), (102, 5)),  # _accessible_clusters
         _principal(id=5, kind=PrincipalType.ORG),  # org existence check
     )
 
@@ -149,6 +166,7 @@ async def test_member_uses_team_org_via_header():
     assert ctx.current_principal_id == 5
     assert ctx.org_role == OrgRole.MEMBER
     assert ctx.accessible_cluster_ids == {101, 102}
+    assert ctx.accessible_cluster_owner_ids == {5}
     assert ctx.current_is_personal_scope is False
 
 
@@ -163,7 +181,7 @@ async def test_member_inherits_role_via_group_membership():
         # direct ∪ via-group — only via-group has a row.
         [OrgRole.OWNER],
         [42],  # _user_group_principal_ids
-        [101],  # _accessible_clusters
+        _cluster_rows((101, 5)),  # _accessible_clusters
         _principal(id=5, kind=PrincipalType.ORG),
     )
 
@@ -187,7 +205,7 @@ async def test_personal_scope_short_circuits():
     request = _request()
     session = _session_returning(
         [],  # _user_group_principal_ids
-        [],  # _accessible_clusters
+        _cluster_rows(),  # _accessible_clusters
     )
 
     ctx = await get_tenant_context(
@@ -200,6 +218,7 @@ async def test_personal_scope_short_circuits():
     assert ctx.current_principal_id == 100
     assert ctx.current_is_personal_scope is True
     assert ctx.org_role is None
+    assert ctx.accessible_cluster_owner_ids == set()
 
 
 @pytest.mark.asyncio
@@ -224,7 +243,7 @@ async def test_platform_admin_can_act_in_org_without_membership():
     session = _session_returning(
         [],  # union: no membership; admin still passes
         [],  # _user_group_principal_ids
-        [],  # _accessible_clusters
+        _cluster_rows(),  # _accessible_clusters
         _principal(id=7, kind=PrincipalType.ORG),
     )
 
@@ -247,7 +266,7 @@ async def test_api_key_overrides_header():
     session = _session_returning(
         [OrgRole.MEMBER],  # union: direct membership in org 42
         [],
-        [],
+        _cluster_rows(),  # _accessible_clusters
         _principal(id=42, kind=PrincipalType.ORG),
     )
 

--- a/tests/routers/test_workers.py
+++ b/tests/routers/test_workers.py
@@ -213,6 +213,10 @@ def _ctx(*, is_platform_admin=False, current_principal_id=None, org_role=None):
         current_principal_id=current_principal_id,
         org_role=org_role,
         accessible_cluster_ids=set(),
+        accessible_cluster_owner_ids=set(),
+        # These worker tests all set up Org scope (current_principal_id
+        # is an Org id), never Personal scope — keep the flag False.
+        current_is_personal_scope=False,
     )
 
 


### PR DESCRIPTION
Add a built-in system/authenticated GROUP principal. Every authenticated caller is an implicit member, so a ClusterAccess row written against it is a global grant — revocable from the cluster-access UI rather than baked into request resolution. Default-Org cluster create now seeds one such grant, and a startup backfill applies it to pre-existing Default-Org clusters (idempotent: respects soft-deleted rows so admin revokes survive). The Groups CRUD page hides and locks system/-prefixed principals so the row doesn't surface as an editable group with 0 members.

PV-type visibility broadens with it: types are visible from the caller's own Org plus every Org that owns a cluster the caller can use. Surfaces admin-configured types in Personal scope, and lets Org2 users pick Org1's PV types after Org1 grants its cluster to Org2.

Also fix "Only platform admin can create global X" on GPU instance / SSH key / PV / PV type / template create — default owner_principal_id to ctx.current_principal_id before validating, matching cluster-create order.