### PR TITLE
fix(model-files): clear stale .lock file when resetting a model file

### DIFF
--- a/gpustack/routes/model_files.py
+++ b/gpustack/routes/model_files.py
@@ -18,6 +18,8 @@ from gpustack.api.tenant import (
 from gpustack.schemas.workers import Worker
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
+from gpustack.config.config import get_global_config
+from gpustack.utils.locks import get_lock_path
 from gpustack.schemas.model_files import (
     ModelFile,
     ModelFileCreate,
@@ -275,6 +277,11 @@ async def reset_model_file(session: SessionDep, ctx: TenantContextDep, id: int):
     )
 
     try:
+        cfg = get_global_config()
+        lock_path = get_lock_path(cfg.cache_dir, model_file)
+        if Path(lock_path).exists():
+            Path(lock_path).unlink()
+
         model_file.state = ModelFileStateEnum.DOWNLOADING
         model_file.download_progress = 0
         model_file.state_message = ""


### PR DESCRIPTION
A failed/aborted download leaves a `.lock` file under `cache_dir` next to the target file. The downloader takes that lock before it starts writing and never reaches the release path when the process dies (worker crash, container OOM, network drop). Subsequent reset attempts then re-enter the DOWNLOADING state but block forever on the orphaned lock.

`reset_model_file` is the documented escape hatch — resetting state back to DOWNLOADING to retry the download — so it's the right place to also drop the orphaned lock file. Use the existing `get_lock_path` helper from `utils.locks` to resolve the path consistently with the download path.