### PR TITLE
fix(scheduler): use backend_name (runtime selection) in CUSTOM backend check

### DIFF
--- a/gpustack/policies/worker_filters/backend_framework_filter.py
+++ b/gpustack/policies/worker_filters/backend_framework_filter.py
@@ -159,7 +159,7 @@ class BackendFrameworkFilter(WorkerFilter):
             )
             return workers, []
 
-        if self.model.backend == BackendEnum.CUSTOM:
+        if self.backend_name == BackendEnum.CUSTOM:
             return workers, []
 
         async with async_session() as session:


### PR DESCRIPTION
Hi, 

`BackendFrameworkFilter.filter` short-circuits when the model is on the CUSTOM backend. The check reads `self.model.backend` — the value persisted in the DB row — but elsewhere in the same class the runtime backend is read from `self.backend_name`, which reflects the actual selection used for this scheduling pass (e.g. when `self.model.backend` is unset and the backend has been resolved from the inference backend config).

When `self.model.backend` is empty but `self.backend_name == CUSTOM`, the filter currently falls through to the framework-compatibility lookup and filters out workers that would actually be valid CUSTOM-backend hosts.

Swap the read to `self.backend_name` so the short-circuit triggers in the case it was intended to handle.