### PR TITLE
Benchmark GGUF tokenizer compat

### DIFF
--- a/gpustack/routes/benchmarks.py
+++ b/gpustack/routes/benchmarks.py
@@ -288,6 +288,7 @@ async def validate_and_mutate_benchmark_in(
         )  # treat non-positive request_rate as unlimited
 
     snapshot = await get_benchmark_snapshot(session, instance, model)
+    _apply_gguf_tokenizer_source(snapshot, instance, model)
     mutated.snapshot = snapshot
     mutated.gpu_summary, mutated.gpu_vendor_summary = summary_gpu_snapshots(
         snapshot.gpus
@@ -299,6 +300,57 @@ async def validate_and_mutate_benchmark_in(
         if cluster is not None:
             mutated.owner_principal_id = cluster.owner_principal_id
     return mutated
+
+
+_GGUF_SUFFIXES = ("-gguf", "-GGUF")
+
+
+def _derive_tokenizer_source(model: Model) -> Optional[str]:
+    """Derive a HF-format tokenizer source from a GGUF model's source ID.
+
+    Strips a trailing `-GGUF` suffix from huggingface_repo_id or
+    model_scope_model_id, on the assumption that the sibling non-GGUF repo
+    holds an HF tokenizer compatible with the one embedded in the .gguf file.
+    Returns None when no candidate matches the naming convention.
+    """
+    candidates = [
+        getattr(model, "huggingface_repo_id", None),
+        getattr(model, "model_scope_model_id", None),
+    ]
+    for cand in candidates:
+        if not cand:
+            continue
+        for suffix in _GGUF_SUFFIXES:
+            if cand.endswith(suffix):
+                return cand[: -len(suffix)]
+    return None
+
+
+def _apply_gguf_tokenizer_source(snapshot, instance, model: Model) -> None:
+    """For llama.cpp instances, stamp the per-instance snapshot with a
+    tokenizer_source so the runner can pass a HF-compatible path to
+    `--processor` instead of the .gguf file.
+
+    Raises BadRequestException if the model's source ID doesn't follow the
+    `-GGUF` naming convention, since the benchmark cannot run without a
+    valid tokenizer.
+    """
+    if instance.backend != "llama.cpp":
+        return
+    tokenizer_source = _derive_tokenizer_source(model)
+    if not tokenizer_source:
+        raise BadRequestException(
+            message=(
+                f"Benchmarking GGUF model '{model.name}' requires a HF-format "
+                "tokenizer source (config.json + tokenizer.json). Could not "
+                "auto-derive one from the model's source identifier. Configure "
+                "the model with a `-GGUF` suffixed huggingface_repo_id or "
+                "model_scope_model_id so the sibling repo can be located."
+            )
+        )
+    instance_snap = snapshot.instances.get(instance.name)
+    if instance_snap is not None:
+        instance_snap.tokenizer_source = tokenizer_source
 
 
 @router.post("", response_model=BenchmarkPublic)

--- a/gpustack/schemas/benchmark.py
+++ b/gpustack/schemas/benchmark.py
@@ -72,6 +72,12 @@ class ModelInstanceSnapshot(ModelInstanceRuntimeInfo):
     name: str
     resolved_path: Optional[str] = None
 
+    # Optional override of the value passed to `benchmark-runner --processor`.
+    # Populated for GGUF models so the runner can load a HF-format tokenizer
+    # (config.json + tokenizer.json) from a sibling repo, since the .gguf file
+    # itself is not a valid HF AutoTokenizer source.
+    tokenizer_source: Optional[str] = None
+
     # resource info
     state: Optional[str] = None
     state_message: Optional[str] = None

--- a/gpustack/worker/benchmark/runner.py
+++ b/gpustack/worker/benchmark/runner.py
@@ -45,6 +45,7 @@ class BenchmarkRunner:
     _config: Config
     _benchmark: Benchmark
     _model_path: str
+    _processor_arg: str
     _model_endpoint: str
     _model_backend_parameters: Optional[List[str]]
     _api_url: str
@@ -102,6 +103,12 @@ class BenchmarkRunner:
 
             self._benchmark_dir = self._config.benchmark_dir
             self._model_path = instance_snapshot.resolved_path
+            # tokenizer_source overrides --processor for GGUF models so the
+            # benchmark runner can load a HF-format tokenizer instead of the
+            # raw .gguf file (which AutoTokenizer cannot decode).
+            self._processor_arg = (
+                instance_snapshot.tokenizer_source or instance_snapshot.resolved_path
+            )
             self._model_endpoint = f"http://{instance_snapshot.worker_ip}:{instance_snapshot.ports[0] if instance_snapshot.ports else ''}"
             self._model_backend_parameters = instance_snapshot.backend_parameters
 
@@ -231,7 +238,7 @@ class BenchmarkRunner:
             "--sample-requests",
             "0",
             "--processor",
-            self._model_path,
+            self._processor_arg,
             "--output-dir",
             f"{self._benchmark_dir}",
             "--outputs",


### PR DESCRIPTION
Hi,

When the model under benchmark is on the `llama.cpp` backend, the benchmark runner currently passes the resolved `.gguf` file path as `--processor`. Both `guidellm` and the ShareGPT prompt adapter try to load that path with HuggingFace's `AutoTokenizer.from_pretrained()`, which expects a directory of HF tokenizer JSON files — not a binary GGUF blob. The result is a UTF-8 decode error before any request is sent.

Fix by heuristically deriving a sibling HF/MS repo whose tokenizer matches the GGUF-embedded one. Quantizers conventionally publish a `-GGUF` suffixed repo whose parent (without the suffix) holds the full HF tokenizer (Qwen, Llama-3 quant repos, etc.). On benchmark creation:

  * If `instance.backend == "llama.cpp"`, strip the `-GGUF` suffix from `huggingface_repo_id` or `model_scope_model_id`. If neither has the suffix, reject the benchmark creation early with a clear error.
  * Store the derived repo id on the per-instance snapshot as `tokenizer_source`.
  * The runner picks `tokenizer_source` over `resolved_path` for the `--processor` flag.

For non-GGUF models the snapshot has `tokenizer_source = None` and the runner falls back to `resolved_path` exactly as before.