### PR TITLE
fix: hydrate require_password_change on user API responses

### DIFF
--- a/gpustack/routes/users.py
+++ b/gpustack/routes/users.py
@@ -33,10 +33,33 @@ from gpustack.schemas.users import (
     UsersPublic,
     UserSelfUpdate,
 )
-from gpustack.server.passwords import set_password
+from gpustack.server.passwords import (
+    is_password_change_required,
+    password_change_required_map,
+    set_password,
+)
 from gpustack.server.services import UserService
 
 router = APIRouter()
+
+
+async def _to_user_public(session, user: User) -> UserPublic:
+    # ``require_password_change`` lives on the ``user_passwords`` row,
+    # not on the Principal — hydrate it here so the wire response
+    # reflects the actual force-change state.
+    result = UserPublic.model_validate(user)
+    result.require_password_change = await is_password_change_required(session, user.id)
+    return result
+
+
+async def _to_users_public(session, page) -> UsersPublic:
+    flag_map = await password_change_required_map(session, [u.id for u in page.items])
+    items = []
+    for u in page.items:
+        item = UserPublic.model_validate(u)
+        item.require_password_change = flag_map.get(u.id, False)
+        items.append(item)
+    return UsersPublic(items=items, pagination=page.pagination)
 
 
 class UserMembership(BaseModel):
@@ -62,7 +85,7 @@ async def get_users(
         )
 
     async with async_session() as session:
-        return await User.paginated_by_query(
+        page = await User.paginated_by_query(
             session=session,
             fuzzy_fields=fuzzy_fields,
             page=params.page,
@@ -73,6 +96,7 @@ async def get_users(
             },
             order_by=params.order_by,
         )
+        return await _to_users_public(session, page)
 
 
 @router.get("/{id}", response_model=UserPublic)
@@ -80,7 +104,7 @@ async def get_user(session: SessionDep, id: int):
     user = await User.one_by_id(session, id)
     if not user:
         raise NotFoundException(message="User not found")
-    return user
+    return await _to_user_public(session, user)
 
 
 @router.get("/{id}/memberships", response_model=List[UserMembership])
@@ -172,7 +196,7 @@ async def create_user(session: SessionDep, user_in: UserCreate):
     except Exception as e:
         raise InternalServerErrorException(message=f"Failed to create user: {e}")
 
-    return user
+    return await _to_user_public(session, user)
 
 
 @router.put("/{id}", response_model=UserPublic)
@@ -216,7 +240,7 @@ async def update_user(session: SessionDep, id: int, user_in: UserUpdate):
     except Exception as e:
         raise InternalServerErrorException(message=f"Failed to update user: {e}")
 
-    return user
+    return await _to_user_public(session, user)
 
 
 @router.patch("/{id}/activation", response_model=UserPublic)
@@ -233,7 +257,7 @@ async def update_user_activation(
 
     changed = user.is_active != activation_data.is_active
     if not changed:
-        return user
+        return await _to_user_public(session, user)
 
     if (
         user.is_active
@@ -251,7 +275,7 @@ async def update_user_activation(
             message=f"Failed to update user activation: {e}"
         )
 
-    return user
+    return await _to_user_public(session, user)
 
 
 @router.delete("/{id}")
@@ -287,8 +311,8 @@ me_router = APIRouter()
 
 
 @me_router.get("/me", response_model=UserPublic)
-async def get_user_me(user: CurrentUserDep):
-    return user
+async def get_user_me(session: SessionDep, user: CurrentUserDep):
+    return await _to_user_public(session, user)
 
 
 @me_router.put("/me", response_model=UserPublic)
@@ -306,7 +330,7 @@ async def update_user_me(
     except Exception as e:
         raise InternalServerErrorException(message=f"Failed to update user: {e}")
 
-    return user
+    return await _to_user_public(session, user)
 
 
 # User-search endpoint accessible to org owners (any) and platform
@@ -328,7 +352,7 @@ async def list_user_directory(
     if search:
         fuzzy_fields = {"name": search, "display_name": search}
     async with async_session() as session:
-        return await User.paginated_by_query(
+        result = await User.paginated_by_query(
             session=session,
             fuzzy_fields=fuzzy_fields,
             page=page,
@@ -338,3 +362,4 @@ async def list_user_directory(
                 "deleted_at": None,
             },
         )
+        return await _to_users_public(session, result)

--- a/gpustack/server/passwords.py
+++ b/gpustack/server/passwords.py
@@ -11,8 +11,9 @@ the storage contract.
 """
 
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Dict, Iterable, Optional
 
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from gpustack.schemas.user_passwords import (
@@ -119,6 +120,29 @@ async def is_password_change_required(session: AsyncSession, principal_id: int) 
     """
     row = await _get(session, principal_id)
     return bool(row and row.require_password_change)
+
+
+async def password_change_required_map(
+    session: AsyncSession,
+    principal_ids: Iterable[int],
+) -> Dict[int, bool]:
+    """Batch variant of :func:`is_password_change_required` for list
+    endpoints — one query for the whole page instead of N. Missing ids
+    (no password row, e.g. SSO / system accounts) are absent from the
+    returned dict; callers should treat absence as ``False``.
+    """
+    ids = [pid for pid in principal_ids if pid is not None]
+    if not ids:
+        return {}
+    rows = (
+        await session.exec(
+            select(UserPassword).where(
+                UserPassword.owner_principal_id.in_(ids),
+                UserPassword.deleted_at.is_(None),
+            )
+        )
+    ).all()
+    return {row.owner_principal_id: bool(row.require_password_change) for row in rows}
 
 
 async def clear_require_password_change(


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5462

The flag lives on the user_passwords row, not on the Principal, so UserPublic responses fell back to the default False — first-login admins saw require_password_change: false on /v2/users/me.

Add a batched user_passwords lookup and hydrate the flag on every endpoint that returns UserPublic / UsersPublic.