### PR TITLE
fix: derive container namespace from gpustack image, not operator image

### DIFF
--- a/gpustack/k8s/manifest_template.py
+++ b/gpustack/k8s/manifest_template.py
@@ -13,7 +13,7 @@ from gpustack_runtime.detector import ManufacturerEnum
 
 
 _DEFAULT_OPERATOR_IMAGE = f"gpustack/gpustack-operator:{__operator_version__}"
-_DEFAULT_OPERATOR_NAMESPACE = "gpustack"
+_DEFAULT_CONTAINER_NAMESPACE = "gpustack"
 _DEFAULT_CLUSTER_NAMESPACE = "gpustack-system"
 
 
@@ -145,24 +145,35 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
 
     @computed_field
     @property
-    def operator_container_namespace(self) -> Optional[str]:
+    def container_namespace(self) -> Optional[str]:
         """
-        Namespace segment inferred from the resolved operator image — used by
+        Namespace segment inferred from the resolved gpustack image — used by
         the operator runtime (``GPUSTACK_CONTAINER_NAMESPACE``) to compose
-        sibling image references. Strip the cluster registry prefix first so
-        the leading segment isn't mistaken for a namespace, then take
-        everything up to the final ``/``. Suppressed when the namespace is
-        the built-in ``gpustack`` default since the operator already knows
-        that one.
+        sibling image references. The operator image may live elsewhere, so the
+        namespace must come from the gpustack image (``self.image``) instead.
+
+        Strip the registry prefix first so the leading segment isn't mistaken
+        for a namespace, then take everything up to the final ``/`` (the
+        trailing ``<name>:<tag>`` segment is discarded). The registry can be
+        either the configured ``system_default_container_registry`` or one
+        embedded directly in the reference (e.g. via an ``image_name_override``
+        like ``quay.io/gpustack/gpustack:dev``); the latter is detected with
+        the same heuristic as ``apply_registry_override_to_image`` — the first
+        path segment is a registry when it contains ``.`` or ``:`` or equals
+        ``localhost``. Suppressed when the namespace is the built-in
+        ``gpustack`` default since the operator already knows that one.
         """
-        image = self.operator_image
+        image = self.image
         registry = (self.system_default_container_registry or "").strip().rstrip("/")
         if registry and image.startswith(registry + "/"):
             image = image[len(registry) + 1 :]
+        first, sep, rest = image.partition("/")
+        if sep and ("." in first or ":" in first or first == "localhost"):
+            image = rest
         if "/" not in image:
             return None
         namespace = image.rsplit("/", 1)[0]
-        if namespace == _DEFAULT_OPERATOR_NAMESPACE:
+        if namespace == _DEFAULT_CONTAINER_NAMESPACE:
             return None
         return namespace
 

--- a/gpustack/k8s/operator.jinja
+++ b/gpustack/k8s/operator.jinja
@@ -193,9 +193,9 @@ data:
                 - name: GPUSTACK_CONTAINER_REGISTRY
                   value: {{ config.system_default_container_registry }}
                 {%- endif %}
-                {%- if config.operator_container_namespace %}
+                {%- if config.container_namespace %}
                 - name: GPUSTACK_CONTAINER_NAMESPACE
-                  value: {{ config.operator_container_namespace }}
+                  value: {{ config.container_namespace }}
                 {%- endif %}
                 {%- if config.image_pull_secrets %}
                 - name: GPUSTACK_IMAGE_PULL_SECRETS

--- a/tests/k8s/test_template_render.py
+++ b/tests/k8s/test_template_render.py
@@ -417,3 +417,69 @@ def test_multi_vendor_volume_mounts_applied_only_to_owning_vendor():
         "gpustack-ascend-driver",
         "gpustack-ascend-toolkit",
     }
+
+
+# ---------------------------------------------------------------------------
+# GPUSTACK_CONTAINER_NAMESPACE — derived from the gpustack image, not the
+# operator image (the operator image may live in a different namespace).
+# ---------------------------------------------------------------------------
+
+
+def _config_with_image(image, **kwargs):
+    registration = ClusterRegistrationTokenPublic(
+        token="t",
+        server_url="http://server",
+        image=image,
+        env={"GPUSTACK_TOKEN": "t"},
+        args=[],
+    )
+    return TemplateConfig(
+        registration=registration,
+        cluster_owner_principal_identifier="alice",
+        **kwargs,
+    )
+
+
+def test_container_namespace_default_gpustack_is_suppressed():
+    # gpustack/gpustack:test → namespace "gpustack" is the built-in default,
+    # so the operator already knows it and the env var is omitted.
+    cfg = _config_with_image("gpustack/gpustack:test")
+    assert cfg.container_namespace is None
+
+
+def test_container_namespace_from_custom_gpustack_image():
+    cfg = _config_with_image("myorg/gpustack:test")
+    assert cfg.container_namespace == "myorg"
+
+
+def test_container_namespace_strips_registry_and_keeps_deep_namespace():
+    cfg = _config_with_image(
+        "reg.io/myorg/sub/gpustack:v1",
+        system_default_container_registry="reg.io",
+    )
+    assert cfg.container_namespace == "myorg/sub"
+
+
+def test_container_namespace_ignores_operator_image_namespace():
+    # The operator image lives in a different namespace than the gpustack
+    # image; the env var must follow the gpustack image so the operator
+    # composes sibling references against the right namespace.
+    cfg = _config_with_image(
+        "myorg/gpustack:test",
+        k8s_options=K8sOptions(operatorImage="otherns/gpustack-operator:test"),
+    )
+    assert cfg.container_namespace == "myorg"
+
+
+def test_container_namespace_strips_embedded_registry_from_image_override():
+    # image_name_override may carry a full reference with an embedded registry
+    # and no system_default_container_registry set. The registry (first segment
+    # with a ".") must not leak into the namespace; quay.io/gpustack/gpustack
+    # resolves to the default "gpustack" namespace → suppressed.
+    cfg = _config_with_image("quay.io/gpustack/gpustack:dev")
+    assert cfg.container_namespace is None
+
+
+def test_container_namespace_strips_embedded_registry_with_port():
+    cfg = _config_with_image("myreg:5000/org/gpustack:dev")
+    assert cfg.container_namespace == "org"


### PR DESCRIPTION
Strip embedded registry too so image_name_override like quay.io/gpustack/gpustack:dev parses correctly. Rename operator_container_namespace to container_namespace.

Refer to issue:
- #5456 