### PR TITLE
fix: stamp tenant scope on auto-created model_files / workers / benchmarks

### DIFF
--- a/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
+++ b/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
@@ -875,6 +875,120 @@ def upgrade() -> None:
                 sa.Column('cluster_id', sa.Integer(), nullable=True)
             )
 
+    # Backfill the cluster-derived tenant columns just added above. The
+    # ADD COLUMN step leaves every legacy row with NULL ``cluster_id`` /
+    # ``owner_principal_id``, which makes them invisible to non-bypass
+    # principals (cluster_access filter requires one to match). Derive
+    # the scope from the row's worker → cluster, same way the runtime
+    # paths (``routes/model_files.create_model_file`` /
+    # ``controllers._get_worker_tenant_scopes``) stamp new rows.
+    #
+    # Order matters: workers.owner_principal_id is sourced from
+    # clusters.owner_principal_id (already backfilled in section 10),
+    # and model_files / benchmarks read back through workers — so
+    # workers first, dependents second.
+    if dialect == 'mysql':
+        op.execute(
+            sa.text(
+                """
+                UPDATE workers w
+                JOIN clusters c ON c.id = w.cluster_id
+                SET w.owner_principal_id = c.owner_principal_id
+                WHERE w.owner_principal_id IS NULL
+                """
+            )
+        )
+        op.execute(
+            sa.text(
+                """
+                UPDATE model_files mf
+                JOIN workers w ON w.id = mf.worker_id
+                SET mf.cluster_id = w.cluster_id,
+                    mf.owner_principal_id = w.owner_principal_id
+                WHERE mf.worker_id IS NOT NULL
+                  AND (mf.cluster_id IS NULL OR mf.owner_principal_id IS NULL)
+                """
+            )
+        )
+        op.execute(
+            sa.text(
+                """
+                UPDATE benchmarks b
+                JOIN workers w ON w.id = b.worker_id
+                SET b.cluster_id = w.cluster_id,
+                    b.owner_principal_id = w.owner_principal_id
+                WHERE b.worker_id IS NOT NULL
+                  AND (b.cluster_id IS NULL OR b.owner_principal_id IS NULL)
+                """
+            )
+        )
+    else:
+        op.execute(
+            sa.text(
+                """
+                UPDATE workers
+                SET owner_principal_id = (
+                    SELECT clusters.owner_principal_id
+                    FROM clusters
+                    WHERE clusters.id = workers.cluster_id
+                )
+                WHERE owner_principal_id IS NULL
+                  AND EXISTS (
+                    SELECT 1 FROM clusters
+                    WHERE clusters.id = workers.cluster_id
+                  )
+                """
+            )
+        )
+        op.execute(
+            sa.text(
+                """
+                UPDATE model_files
+                SET cluster_id = (
+                    SELECT workers.cluster_id
+                    FROM workers
+                    WHERE workers.id = model_files.worker_id
+                ),
+                owner_principal_id = (
+                    SELECT workers.owner_principal_id
+                    FROM workers
+                    WHERE workers.id = model_files.worker_id
+                )
+                WHERE model_files.worker_id IS NOT NULL
+                  AND (model_files.cluster_id IS NULL
+                       OR model_files.owner_principal_id IS NULL)
+                  AND EXISTS (
+                    SELECT 1 FROM workers
+                    WHERE workers.id = model_files.worker_id
+                  )
+                """
+            )
+        )
+        op.execute(
+            sa.text(
+                """
+                UPDATE benchmarks
+                SET cluster_id = (
+                    SELECT workers.cluster_id
+                    FROM workers
+                    WHERE workers.id = benchmarks.worker_id
+                ),
+                owner_principal_id = (
+                    SELECT workers.owner_principal_id
+                    FROM workers
+                    WHERE workers.id = benchmarks.worker_id
+                )
+                WHERE benchmarks.worker_id IS NOT NULL
+                  AND (benchmarks.cluster_id IS NULL
+                       OR benchmarks.owner_principal_id IS NULL)
+                  AND EXISTS (
+                    SELECT 1 FROM workers
+                    WHERE workers.id = benchmarks.worker_id
+                  )
+                """
+            )
+        )
+
     # ------------------------------------------------------------------
     # 12. Inference backends Hybrid.
     # ------------------------------------------------------------------

--- a/gpustack/routes/benchmarks.py
+++ b/gpustack/routes/benchmarks.py
@@ -18,7 +18,6 @@ from gpustack.api.tenant import (
     assert_cluster_resource_visible,
     cluster_resource_visibility_conditions,
 )
-from gpustack.schemas.clusters import Cluster
 from gpustack.schemas.models import (
     Model,
     ModelInstance,
@@ -293,11 +292,11 @@ async def validate_and_mutate_benchmark_in(
         snapshot.gpus
     )
     mutated.worker_id = instance.worker_id
-    # Derive tenant scope from the benchmark's cluster.
-    if mutated.cluster_id is not None:
-        cluster = await Cluster.one_by_id(session, mutated.cluster_id)
-        if cluster is not None:
-            mutated.owner_principal_id = cluster.owner_principal_id
+    # Server-derive tenant scope from the target instance so client-supplied
+    # cluster_id can't smuggle a benchmark into another tenant, and so the
+    # row is visible to the owning Org via cluster_resource_visibility.
+    mutated.cluster_id = instance.cluster_id
+    mutated.owner_principal_id = instance.owner_principal_id
     return mutated
 
 

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -5,7 +5,7 @@ import asyncio
 import yaml
 from importlib.resources import files
 from functools import partial
-from typing import Any, Dict, List, Tuple, Optional, Set
+from typing import Any, Dict, Iterable, List, Tuple, Optional, Set
 from pydantic import BaseModel
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -564,6 +564,7 @@ async def get_or_create_lora_model_files_for_instance(
         return []
     worker_ids = _get_worker_ids_for_file_download(instance)
     base_desc = model_base_descriptor(model)
+    worker_scopes = await _get_worker_tenant_scopes(session, worker_ids)
     out: List[ModelFile] = []
     seen_ids: Set[int] = set()
 
@@ -595,6 +596,9 @@ async def get_or_create_lora_model_files_for_instance(
                     out.append(hit)
                     seen_ids.add(hit.id)
             else:
+                cluster_id, owner_principal_id = worker_scopes.get(
+                    worker_id, (None, None)
+                )
                 nf = ModelFile(
                     source=lora_src.source,
                     huggingface_repo_id=lora_src.huggingface_repo_id,
@@ -607,6 +611,8 @@ async def get_or_create_lora_model_files_for_instance(
                     state=ModelFileStateEnum.DOWNLOADING,
                     worker_id=worker_id,
                     source_index=lora_src.model_source_index,
+                    cluster_id=cluster_id,
+                    owner_principal_id=owner_principal_id,
                 )
                 created = await ModelFile.create(session, nf, auto_commit=False)
                 mf = created or nf
@@ -715,8 +721,10 @@ async def get_or_create_model_files_for_instance(
     model_source = instance
     if is_draft_model:
         model_source = instance.draft_model_source
+    worker_scopes = await _get_worker_tenant_scopes(session, missing_worker_ids)
     # Create model files for the missing worker IDs.
     for worker_id in missing_worker_ids:
+        cluster_id, owner_principal_id = worker_scopes.get(worker_id, (None, None))
         model_file = ModelFile(
             source=model_source.source,
             huggingface_repo_id=model_source.huggingface_repo_id,
@@ -727,6 +735,8 @@ async def get_or_create_model_files_for_instance(
             state=ModelFileStateEnum.DOWNLOADING,
             worker_id=worker_id,
             source_index=model_source.model_source_index,
+            cluster_id=cluster_id,
+            owner_principal_id=owner_principal_id,
         )
         await ModelFile.create(session, model_file, auto_commit=False)
         logger.info(
@@ -2177,6 +2187,30 @@ def _get_worker_ids_for_file_download(
     return worker_ids
 
 
+async def _get_worker_tenant_scopes(
+    session: AsyncSession, worker_ids: Iterable[int]
+) -> Dict[int, Tuple[Optional[int], Optional[int]]]:
+    """Resolve ``(cluster_id, owner_principal_id)`` for each worker so newly
+    created ModelFiles inherit the same tenant scope as their host worker —
+    matching the route-side derivation in ``routes/model_files.create_model_file``.
+    Without this, ModelFiles created by the controller come back with NULL
+    tenant columns and are invisible to org principals."""
+    scopes: Dict[int, Tuple[Optional[int], Optional[int]]] = {}
+    unique_worker_ids = {wid for wid in worker_ids if wid is not None}
+    if not unique_worker_ids:
+        return scopes
+    workers = await Worker.all_by_fields(
+        session,
+        extra_conditions=[Worker.id.in_(unique_worker_ids)],
+    )
+    for worker in workers:
+        scopes[worker.id] = (
+            worker.cluster_id,
+            getattr(worker, "owner_principal_id", None),
+        )
+    return scopes
+
+
 async def new_workers_from_pool(
     session: AsyncSession, pool: WorkerPool
 ) -> List[Worker]:
@@ -2212,6 +2246,10 @@ async def new_workers_from_pool(
             cluster=pool.cluster,
             worker_pool=pool,
             provider=pool.cluster.provider,
+            # Denormalize from cluster so cluster_resource_visibility_conditions
+            # can match without joining clusters. Mirrors the worker registration
+            # path in routes/workers.update_worker_data.
+            owner_principal_id=pool.cluster.owner_principal_id,
             name=f"pool-{pool.id}-"
             + ''.join(random.choices(string.ascii_lowercase + string.digits, k=8)),
             labels={


### PR DESCRIPTION

ModelFile rows created by the instance controllers, Worker rows provisioned from a worker pool, and Benchmark rows created via the API all left cluster_id / owner_principal_id NULL, which made them invisible to non-platform principals through
cluster_resource_visibility_conditions. Derive the scope server-side at create time (worker -> cluster for files / benchmarks, pool.cluster for workers), matching the existing patterns in
routes/model_files.create_model_file and routes/workers.update_worker_data.

Also backfill the legacy rows on the multi-tenancy foundation migration so installs upgraded before this fix become visible to their owning Org.