### PR TITLE
feat(usage): enhance resource usage

### DIFF
--- a/gpustack/migrations/versions/2026_05_29_1000-b2c3d4e5f6a7_metered_usage.py
+++ b/gpustack/migrations/versions/2026_05_29_1000-b2c3d4e5f6a7_metered_usage.py
@@ -94,6 +94,12 @@ def _create_metered_usage_indexes(table_name: str) -> None:
                     table_name, ['resource_type', 'meter_key', 'bucket_start'], unique=False)
     op.create_index(f'ix_{table_name}_sku_bucket',
                     table_name, ['sku', 'bucket_start'], unique=False)
+    # Serves the breakdown's representative-row lookup
+    # (MAX(id) WHERE meter_key=? AND sku IN (...) GROUP BY sku): leading
+    # meter_key+sku seeks the group, trailing id makes the per-group MAX(id)
+    # an index-only rightmost read.
+    op.create_index(f'ix_{table_name}_meter_sku_id',
+                    table_name, ['meter_key', 'sku', 'id'], unique=False)
     op.create_index(f'ix_{table_name}_creator_id_bucket',
                     table_name, ['creator_id', 'bucket_start'], unique=False)
 
@@ -203,6 +209,7 @@ def downgrade() -> None:
 
     for t in ('metered_usage_archive', 'metered_usage'):
         op.drop_index(f'ix_{t}_creator_id_bucket', table_name=t)
+        op.drop_index(f'ix_{t}_meter_sku_id', table_name=t)
         op.drop_index(f'ix_{t}_sku_bucket', table_name=t)
         op.drop_index(f'ix_{t}_resource_type_meter_bucket', table_name=t)
         op.drop_index(f'ix_{t}_consumer_principal_id_bucket', table_name=t)

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -330,6 +330,7 @@ async def _attach_dimensions(session, gb: str, items: List[dict]) -> None:
                 "vram_mib": d.get("vram_mib"),
                 "gpu_count": d.get("gpu_count"),
                 "ephemeral_mib": d.get("ephemeral_mib"),
+                "local_storage_mib": d.get("local_storage_mib"),
             }
     elif gb == "volume":
         # Per-volume storage type + provisioned capacity (constant per volume),

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -12,9 +12,10 @@ The token tabs keep using ``gpustack/routes/usage.py`` (``model_usages``)
 unchanged; this module only serves the time-based resources.
 """
 
+import json
 from datetime import date, datetime, timedelta
 from math import ceil
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
@@ -238,10 +239,12 @@ async def _enrich_items(session, gb: str, items: List[dict]) -> None:
       the GPU Instances list instead of the raw flavor slug. Dimensions are
       flavor-constant per sku, so one representative row per sku is enough.
     """
+    if not items:
+        return
     if gb in ("user", "instance", "volume"):
         ids = [i["id"] for i in items if i.get("id") is not None]
-        existing: set = set()
-        names: dict = {}
+        existing: set[int] = set()
+        names: dict[int, str] = {}
         if ids:
             if gb == "user":
                 principals = (
@@ -293,7 +296,12 @@ async def _dims_by_representative(session, *, group_col, keys, extra_filter):
 
 
 async def _attach_dimensions(session, gb: str, items: List[dict]) -> None:
-    """Attach the ``dimensions`` the UI needs per grouping (in place)."""
+    """Attach the ``dimensions`` the UI needs per grouping (in place).
+
+    Only the ``instance_type`` / ``instance`` / ``volume`` groupings carry
+    dimensions; for any other grouping (e.g. ``user`` / ``date``) this is a
+    no-op.
+    """
     if gb == "instance_type":
         # Flavor-constant specs per sku → pretty product name + per-card specs.
         dims = await _dims_by_representative(
@@ -636,6 +644,12 @@ def _phase_message_of(spec_snapshot) -> Optional[str]:
     """``status.phaseMessage`` from the event's spec snapshot — the detail behind
     a failure phase (the UI shows it as the event's error message). Reads both
     the snake / camel key since serialization differs by path."""
+    if isinstance(spec_snapshot, str):
+        # Some drivers / replay paths hand back the JSON column as a raw string.
+        try:
+            spec_snapshot = json.loads(spec_snapshot)
+        except (ValueError, TypeError):
+            return None
     if not isinstance(spec_snapshot, dict):
         return None
     status = spec_snapshot.get("status")
@@ -777,7 +791,10 @@ async def resource_meta(
     # Distinct resources of one type — id + latest snapshot name. metered_usage
     # snapshots the name, so deleted resources still resolve a label; flag the
     # ones no longer live (not in the source table) so the filter can tag them.
-    async def _resources(resource_type: str, model) -> List[Dict[str, Any]]:
+    async def _resources(
+        resource_type: str,
+        model: Type[Union[GPUInstance, GPUInstancePersistentVolume]],
+    ) -> List[Dict[str, Any]]:
         stmt = _scoped(
             select(
                 MeteredUsage.resource_id,
@@ -791,7 +808,7 @@ async def resource_meta(
         )
         rows = (await session.exec(stmt)).all()
         rids = [r.resource_id for r in rows]
-        live: set = set()
+        live: set[int] = set()
         if rids:
             live = set(
                 (await session.exec(select(model.id).where(model.id.in_(rids)))).all()

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -291,6 +291,33 @@ async def _enrich_items(session, gb: str, items: List[dict]) -> None:
                 "vram_mib": d.get("vram_mib"),
             }
 
+    if gb == "volume":
+        # Per-volume storage type + provisioned capacity (constant per volume),
+        # for the Storage tab's Type / Capacity columns.
+        ids = [i.get("id") for i in items if i.get("id") is not None]
+        dims_by_id: dict = {}
+        if ids:
+            rep_ids = (
+                select(func.max(MeteredUsage.id))
+                .where(MeteredUsage.meter_key == METER_STORAGE_CAPACITY)
+                .where(MeteredUsage.resource_id.in_(ids))
+                .group_by(MeteredUsage.resource_id)
+            )
+            rows = (
+                await session.exec(
+                    select(MeteredUsage.resource_id, MeteredUsage.dimensions).where(
+                        MeteredUsage.id.in_(rep_ids)
+                    )
+                )
+            ).all()
+            dims_by_id = {r[0]: (r[1] or {}) for r in rows}
+        for i in items:
+            d = dims_by_id.get(i.get("id")) or {}
+            i["dimensions"] = {
+                "storage_type": d.get("storage_type"),
+                "capacity_mib": d.get("capacity_mib"),
+            }
+
 
 async def _run_breakdown(
     session,

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -227,6 +227,71 @@ def _apply_scope(
     return statement
 
 
+async def _enrich_items(session, gb: str, items: List[dict]) -> None:
+    """Post-query enrichment of breakdown rows (mutates ``items`` in place).
+
+    * entity groupings (user / instance / volume): resolve display names
+      (``metered_usage`` doesn't snapshot them) and flag rows whose entity was
+      since deleted — the same "(Deleted)" treatment the token breakdown gives.
+    * instance-type / per-instance groupings: attach the flavor's display fields
+      (pretty product name + per-card cpu/mem/vram) so the UI renders them like
+      the GPU Instances list instead of the raw flavor slug. Dimensions are
+      flavor-constant per sku, so one representative row per sku is enough.
+    """
+    if gb in ("user", "instance", "volume"):
+        ids = [i["id"] for i in items if i.get("id") is not None]
+        existing: set = set()
+        names: dict = {}
+        if ids:
+            if gb == "user":
+                principals = (
+                    await session.exec(select(Principal).where(Principal.id.in_(ids)))
+                ).all()
+                names = {p.id: (p.display_name or p.name) for p in principals}
+                existing = set(names)
+            else:
+                model = GPUInstance if gb == "instance" else GPUInstancePersistentVolume
+                existing = set(
+                    (
+                        await session.exec(select(model.id).where(model.id.in_(ids)))
+                    ).all()
+                )
+        for i in items:
+            rid = i.get("id")
+            if rid is None:
+                continue
+            if gb == "user" and names.get(rid):
+                i["key"] = names[rid]
+            i["deleted"] = rid not in existing
+
+    if gb in ("instance_type", "instance"):
+        skus = [i.get("sku") for i in items if i.get("sku")]
+        dims_by_sku: dict = {}
+        if skus:
+            rep_ids = (
+                select(func.max(MeteredUsage.id))
+                .where(_UPTIME)
+                .where(MeteredUsage.sku.in_(skus))
+                .group_by(MeteredUsage.sku)
+            )
+            rows = (
+                await session.exec(
+                    select(MeteredUsage.sku, MeteredUsage.dimensions).where(
+                        MeteredUsage.id.in_(rep_ids)
+                    )
+                )
+            ).all()
+            dims_by_sku = {r[0]: (r[1] or {}) for r in rows}
+        for i in items:
+            d = dims_by_sku.get(i.get("sku")) or {}
+            i["dimensions"] = {
+                "product": d.get("product"),
+                "unit_cpu_milli": d.get("unit_cpu_milli"),
+                "unit_memory_mib": d.get("unit_memory_mib"),
+                "vram_mib": d.get("vram_mib"),
+            }
+
+
 async def _run_breakdown(
     session,
     *,
@@ -350,46 +415,7 @@ async def _run_breakdown(
         item["metrics"]["last_active"] = getattr(row, "last_active", None)
         items.append(item)
 
-    # For entity groupings, resolve display names (metered_usage doesn't
-    # snapshot them) and flag rows whose entity has since been deleted — same
-    # "(Deleted)" treatment the token breakdown gives stale identities.
-    gb = request.group_by
-    if gb in ("user", "instance", "volume"):
-        ids = [i["id"] for i in items if i.get("id") is not None]
-        existing: set = set()
-        names: dict = {}
-        if ids:
-            if gb == "user":
-                principals = (
-                    await session.exec(select(Principal).where(Principal.id.in_(ids)))
-                ).all()
-                names = {p.id: (p.display_name or p.name) for p in principals}
-                existing = set(names)
-            elif gb == "instance":
-                existing = set(
-                    (
-                        await session.exec(
-                            select(GPUInstance.id).where(GPUInstance.id.in_(ids))
-                        )
-                    ).all()
-                )
-            else:  # volume
-                existing = set(
-                    (
-                        await session.exec(
-                            select(GPUInstancePersistentVolume.id).where(
-                                GPUInstancePersistentVolume.id.in_(ids)
-                            )
-                        )
-                    ).all()
-                )
-        for i in items:
-            rid = i.get("id")
-            if rid is None:
-                continue
-            if gb == "user" and names.get(rid):
-                i["key"] = names[rid]
-            i["deleted"] = rid not in existing
+    await _enrich_items(session, request.group_by, items)
 
     return {
         "summary": metrics_of(summary_row) if summary_row is not None else {},
@@ -664,14 +690,22 @@ async def resource_meta(
             await session.exec(select(Principal).where(Principal.id.in_(ids)))
         ).all()
         name_by_id = {p.id: (p.display_name or p.name) for p in principals}
+        # A creator id that no longer resolves to a principal was deleted —
+        # flag it so the filter shows a "(Deleted)" tag (same as the Tokens tab).
         creators = [
-            {"id": cid, "label": name_by_id.get(cid) or f"User {cid}"} for cid in ids
+            {
+                "id": cid,
+                "label": name_by_id.get(cid) or f"User {cid}",
+                "deleted": cid not in name_by_id,
+            }
+            for cid in ids
         ]
         creators.sort(key=lambda c: (c["label"] or "").lower())
 
     # Distinct resources of one type — id + latest snapshot name. metered_usage
-    # snapshots the name, so deleted resources still resolve a label.
-    async def _resources(resource_type: str) -> List[Dict[str, Any]]:
+    # snapshots the name, so deleted resources still resolve a label; flag the
+    # ones no longer live (not in the source table) so the filter can tag them.
+    async def _resources(resource_type: str, model) -> List[Dict[str, Any]]:
         stmt = _scoped(
             select(
                 MeteredUsage.resource_id,
@@ -684,13 +718,26 @@ async def resource_meta(
             MeteredUsage.consumer_principal_id,
         )
         rows = (await session.exec(stmt)).all()
+        rids = [r.resource_id for r in rows]
+        live: set = set()
+        if rids:
+            live = set(
+                (await session.exec(select(model.id).where(model.id.in_(rids)))).all()
+            )
         out = [
-            {"id": r.resource_id, "label": r.name or f"#{r.resource_id}"} for r in rows
+            {
+                "id": r.resource_id,
+                "label": r.name or f"#{r.resource_id}",
+                "deleted": r.resource_id not in live,
+            }
+            for r in rows
         ]
         out.sort(key=lambda x: (x["label"] or "").lower())
         return out
 
-    instances = await _resources(RESOURCE_TYPE_GPU_INSTANCE)
-    volumes = await _resources(RESOURCE_TYPE_PERSISTENT_VOLUME)
+    instances = await _resources(RESOURCE_TYPE_GPU_INSTANCE, GPUInstance)
+    volumes = await _resources(
+        RESOURCE_TYPE_PERSISTENT_VOLUME, GPUInstancePersistentVolume
+    )
 
     return {"creators": creators, "instances": instances, "volumes": volumes}

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -264,55 +264,84 @@ async def _enrich_items(session, gb: str, items: List[dict]) -> None:
                 i["key"] = names[rid]
             i["deleted"] = rid not in existing
 
-    if gb in ("instance_type", "instance"):
-        skus = [i.get("sku") for i in items if i.get("sku")]
-        dims_by_sku: dict = {}
-        if skus:
-            rep_ids = (
-                select(func.max(MeteredUsage.id))
-                .where(_UPTIME)
-                .where(MeteredUsage.sku.in_(skus))
-                .group_by(MeteredUsage.sku)
+    await _attach_dimensions(session, gb, items)
+
+
+async def _dims_by_representative(session, *, group_col, keys, extra_filter):
+    """``{group value: dimensions}`` from the latest row per group.
+
+    Picks MAX(id) per ``group_col`` among rows matching ``extra_filter`` (e.g.
+    uptime / storage-capacity meter) and returns that representative row's
+    ``dimensions`` blob — dimensions are constant per group so any row will do.
+    """
+    if not keys:
+        return {}
+    rep_ids = (
+        select(func.max(MeteredUsage.id))
+        .where(extra_filter)
+        .where(group_col.in_(keys))
+        .group_by(group_col)
+    )
+    rows = (
+        await session.exec(
+            select(group_col, MeteredUsage.dimensions).where(
+                MeteredUsage.id.in_(rep_ids)
             )
-            rows = (
-                await session.exec(
-                    select(MeteredUsage.sku, MeteredUsage.dimensions).where(
-                        MeteredUsage.id.in_(rep_ids)
-                    )
-                )
-            ).all()
-            dims_by_sku = {r[0]: (r[1] or {}) for r in rows}
+        )
+    ).all()
+    return {r[0]: (r[1] or {}) for r in rows}
+
+
+async def _attach_dimensions(session, gb: str, items: List[dict]) -> None:
+    """Attach the ``dimensions`` the UI needs per grouping (in place)."""
+    if gb == "instance_type":
+        # Flavor-constant specs per sku → pretty product name + per-card specs.
+        dims = await _dims_by_representative(
+            session,
+            group_col=MeteredUsage.sku,
+            keys=[i.get("sku") for i in items if i.get("sku")],
+            extra_filter=_UPTIME,
+        )
         for i in items:
-            d = dims_by_sku.get(i.get("sku")) or {}
+            d = dims.get(i.get("sku")) or {}
             i["dimensions"] = {
                 "product": d.get("product"),
                 "unit_cpu_milli": d.get("unit_cpu_milli"),
                 "unit_memory_mib": d.get("unit_memory_mib"),
                 "vram_mib": d.get("vram_mib"),
             }
-
-    if gb == "volume":
+    elif gb == "instance":
+        # Per-instance dims: gpu_count varies per instance (unlike the flavor),
+        # so the Instances table renders "<product> x <count>" plus the spec
+        # popover like the GPU Instances list. Keyed by resource_id since the
+        # sku is count-independent.
+        dims = await _dims_by_representative(
+            session,
+            group_col=MeteredUsage.resource_id,
+            keys=[i.get("id") for i in items if i.get("id") is not None],
+            extra_filter=_UPTIME,
+        )
+        for i in items:
+            d = dims.get(i.get("id")) or {}
+            i["dimensions"] = {
+                "product": d.get("product"),
+                "unit_cpu_milli": d.get("unit_cpu_milli"),
+                "unit_memory_mib": d.get("unit_memory_mib"),
+                "vram_mib": d.get("vram_mib"),
+                "gpu_count": d.get("gpu_count"),
+                "ephemeral_mib": d.get("ephemeral_mib"),
+            }
+    elif gb == "volume":
         # Per-volume storage type + provisioned capacity (constant per volume),
         # for the Storage tab's Type / Capacity columns.
-        ids = [i.get("id") for i in items if i.get("id") is not None]
-        dims_by_id: dict = {}
-        if ids:
-            rep_ids = (
-                select(func.max(MeteredUsage.id))
-                .where(MeteredUsage.meter_key == METER_STORAGE_CAPACITY)
-                .where(MeteredUsage.resource_id.in_(ids))
-                .group_by(MeteredUsage.resource_id)
-            )
-            rows = (
-                await session.exec(
-                    select(MeteredUsage.resource_id, MeteredUsage.dimensions).where(
-                        MeteredUsage.id.in_(rep_ids)
-                    )
-                )
-            ).all()
-            dims_by_id = {r[0]: (r[1] or {}) for r in rows}
+        dims = await _dims_by_representative(
+            session,
+            group_col=MeteredUsage.resource_id,
+            keys=[i.get("id") for i in items if i.get("id") is not None],
+            extra_filter=MeteredUsage.meter_key == METER_STORAGE_CAPACITY,
+        )
         for i in items:
-            d = dims_by_id.get(i.get("id")) or {}
+            d = dims.get(i.get("id")) or {}
             i["dimensions"] = {
                 "storage_type": d.get("storage_type"),
                 "capacity_mib": d.get("capacity_mib"),

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -573,6 +573,18 @@ async def usage_summary(
     }
 
 
+def _phase_message_of(spec_snapshot) -> Optional[str]:
+    """``status.phaseMessage`` from the event's spec snapshot — the detail behind
+    a failure phase (the UI shows it as the event's error message). Reads both
+    the snake / camel key since serialization differs by path."""
+    if not isinstance(spec_snapshot, dict):
+        return None
+    status = spec_snapshot.get("status")
+    if not isinstance(status, dict):
+        return None
+    return status.get("phase_message") or status.get("phaseMessage")
+
+
 @router.get("/resource-events")
 async def resource_events(
     session: SessionDep,
@@ -633,6 +645,7 @@ async def resource_events(
                 "event_type": r.event_type,
                 "event_message": r.event_message,
                 "phase": r.phase,
+                "phase_message": _phase_message_of(r.spec_snapshot),
                 "creator_id": r.creator_id,
                 "creator_name": r.creator_name,
             }

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -314,7 +314,8 @@ async def _attach_dimensions(session, gb: str, items: List[dict]) -> None:
         # Per-instance dims: gpu_count varies per instance (unlike the flavor),
         # so the Instances table renders "<product> x <count>" plus the spec
         # popover like the GPU Instances list. Keyed by resource_id since the
-        # sku is count-independent.
+        # sku is count-independent. ``persistent_mib`` was snapshotted at
+        # metering time, so it survives the PV being deleted later.
         dims = await _dims_by_representative(
             session,
             group_col=MeteredUsage.resource_id,
@@ -331,6 +332,7 @@ async def _attach_dimensions(session, gb: str, items: List[dict]) -> None:
                 "gpu_count": d.get("gpu_count"),
                 "ephemeral_mib": d.get("ephemeral_mib"),
                 "local_storage_mib": d.get("local_storage_mib"),
+                "persistent_mib": d.get("persistent_mib"),
             }
     elif gb == "volume":
         # Per-volume storage type + provisioned capacity (constant per volume),

--- a/gpustack/server/resource_usage_collector.py
+++ b/gpustack/server/resource_usage_collector.py
@@ -54,7 +54,6 @@ from gpustack.utils.resource_usage import (
     parse_accelerator_count,
     parse_gpu_descriptor,
     parse_gpu_type,
-    parse_gpu_vram_mib,
     parse_quantity_to_mib,
     parse_quantity_to_millicores,
 )
@@ -159,11 +158,12 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
     local_storage_mib = parse_quantity_to_mib(
         resources.get("local_storage") or resources.get("localStorage")
     )
-    # Per-card VRAM lives in the device descriptor blob, not the instance spec.
-    vram_mib = parse_gpu_vram_mib(snap.get("description"))
-    # Pretty product name + per-card cpu/mem for the "Instance Type" display
+    # Pretty product name + per-card cpu/mem/vram for the "Instance Type" display
     # (so Usage matches the GPU Instances list instead of the raw flavor slug).
+    # Per-card VRAM rides in the same descriptor blob, so read it from there
+    # rather than parsing spec.memory a second time.
     descriptor = parse_gpu_descriptor(snap.get("description"))
+    vram_mib = descriptor.get("vram_mib", 0)
 
     dimensions = {
         "gpu_type": gpu_type,
@@ -215,8 +215,11 @@ async def _resolve_persistent_mib(session, window: "_OpenWindow") -> None:
     exist — and snapshotting it onto the metered rows means the Usage breakdown
     keeps showing the size even after the PV is later deleted (unlike resolving
     lazily at read time). PV names are unique per principal, so match on owner.
+
+    ``persistent_name`` is consumed (popped) here — it's only an internal lookup
+    key, so it shouldn't bloat every persisted metered row.
     """
-    name = window.dimensions.get("persistent_name")
+    name = window.dimensions.pop("persistent_name", None)
     if not name or window.owner_principal_id is None:
         return
     pv = (

--- a/gpustack/server/resource_usage_collector.py
+++ b/gpustack/server/resource_usage_collector.py
@@ -30,6 +30,9 @@ from sqlalchemy import func
 from sqlmodel import select
 
 from gpustack import envs
+from gpustack.schemas.gpu_instance_persistent_volumes import (
+    GPUInstancePersistentVolume,
+)
 from gpustack.schemas.metered_usage import (
     METER_INSTANCE_UPTIME,
     UNIT_SECONDS,
@@ -141,6 +144,7 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
     resources = spec.get("resources") or {}
     volume = spec.get("volume") or {}
     ephemeral = volume.get("ephemeral") or {}
+    persistent = volume.get("persistent") or {}
 
     # model_dump may serialize the field by name (``type_``) or alias
     # (``type``) depending on by_alias — read both for robustness.
@@ -170,6 +174,11 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
         "ephemeral_mib": ephemeral_mib,
         "local_storage_mib": local_storage_mib,
     }
+    # Persistent data disk is a reference to a separate PV resource (only its
+    # name is in the instance spec) — store the name so the breakdown can
+    # resolve its provisioned capacity for the Disk → Persistent row.
+    if persistent.get("name"):
+        dimensions["persistent_name"] = persistent["name"]
     if descriptor.get("product"):
         dimensions["product"] = descriptor["product"]
     if descriptor.get("unit_cpu_milli"):
@@ -195,6 +204,37 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
         gpu_count=gpu_count,
         dimensions=dimensions,
     )
+
+
+async def _resolve_persistent_mib(session, window: "_OpenWindow") -> None:
+    """Resolve the referenced persistent volume's capacity into the window's
+    dimensions (``persistent_mib``), once, at metering time.
+
+    The instance spec only references the PV by name; its size lives on the
+    separate PV resource. Resolving it here — while the PV is guaranteed to
+    exist — and snapshotting it onto the metered rows means the Usage breakdown
+    keeps showing the size even after the PV is later deleted (unlike resolving
+    lazily at read time). PV names are unique per principal, so match on owner.
+    """
+    name = window.dimensions.get("persistent_name")
+    if not name or window.owner_principal_id is None:
+        return
+    pv = (
+        await session.exec(
+            select(GPUInstancePersistentVolume).where(
+                GPUInstancePersistentVolume.owner_principal_id
+                == window.owner_principal_id,
+                GPUInstancePersistentVolume.name == name,
+            )
+        )
+    ).first()
+    spec = getattr(pv, "spec", None) if pv else None
+    cap = getattr(spec, "capacity", None)
+    if cap is None and isinstance(spec, dict):
+        cap = spec.get("capacity")
+    mib = parse_quantity_to_mib(cap) if cap else 0
+    if mib:
+        window.dimensions["persistent_mib"] = mib
 
 
 class ResourceUsageCollector:
@@ -258,6 +298,7 @@ class ResourceUsageCollector:
                     if e.event_type == EVENT_TYPE_PHASE_TO_METERED:
                         window = _open_window_from_event(e)
                         if window is not None:
+                            await _resolve_persistent_mib(session, window)
                             self._open[rid] = window
                 if self._open:
                     await self._seed_settled_through(session)
@@ -326,6 +367,11 @@ class ResourceUsageCollector:
             if evt.event_type == EVENT_TYPE_PHASE_TO_METERED:
                 window = _open_window_from_event(evt)
                 if window is not None:
+                    # Snapshot the persistent-volume size while the PV still
+                    # exists (only for instances that reference one).
+                    if window.dimensions.get("persistent_name"):
+                        async with async_session() as session:
+                            await _resolve_persistent_mib(session, window)
                     # Replace any stale window (missed close during a crash);
                     # the per-row settled_until absorbs the older time safely.
                     self._open[window.resource_id] = window

--- a/gpustack/server/resource_usage_collector.py
+++ b/gpustack/server/resource_usage_collector.py
@@ -49,6 +49,7 @@ from gpustack.utils.resource_usage import (
     instance_sku,
     iter_utc_hour_segments,
     parse_accelerator_count,
+    parse_gpu_descriptor,
     parse_gpu_type,
     parse_gpu_vram_mib,
     parse_quantity_to_mib,
@@ -150,6 +151,24 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
     ephemeral_mib = parse_quantity_to_mib(ephemeral.get("capacity"))
     # Per-card VRAM lives in the device descriptor blob, not the instance spec.
     vram_mib = parse_gpu_vram_mib(snap.get("description"))
+    # Pretty product name + per-card cpu/mem for the "Instance Type" display
+    # (so Usage matches the GPU Instances list instead of the raw flavor slug).
+    descriptor = parse_gpu_descriptor(snap.get("description"))
+
+    dimensions = {
+        "gpu_type": gpu_type,
+        "gpu_count": gpu_count,
+        "vram_mib": vram_mib,
+        "cpu_milli": cpu_milli,
+        "memory_mib": mem_mib,
+        "ephemeral_mib": ephemeral_mib,
+    }
+    if descriptor.get("product"):
+        dimensions["product"] = descriptor["product"]
+    if descriptor.get("unit_cpu_milli"):
+        dimensions["unit_cpu_milli"] = descriptor["unit_cpu_milli"]
+    if descriptor.get("unit_memory_mib"):
+        dimensions["unit_memory_mib"] = descriptor["unit_memory_mib"]
 
     return _OpenWindow(
         resource_id=evt.resource_id,
@@ -167,14 +186,7 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
         window_start=_naive_utc(evt.occurred_at),
         sku=instance_sku(gpu_type, gpu_count, cpu_milli, mem_mib),
         gpu_count=gpu_count,
-        dimensions={
-            "gpu_type": gpu_type,
-            "gpu_count": gpu_count,
-            "vram_mib": vram_mib,
-            "cpu_milli": cpu_milli,
-            "memory_mib": mem_mib,
-            "ephemeral_mib": ephemeral_mib,
-        },
+        dimensions=dimensions,
     )
 
 

--- a/gpustack/server/resource_usage_collector.py
+++ b/gpustack/server/resource_usage_collector.py
@@ -149,6 +149,12 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
     cpu_milli = parse_quantity_to_millicores(resources.get("cpu"))
     mem_mib = parse_quantity_to_mib(resources.get("ram"))
     ephemeral_mib = parse_quantity_to_mib(ephemeral.get("capacity"))
+    # System (OS) disk — the GPU Instances list shows it under Disk → System.
+    # The snapshot is model_dump(mode="json") (by field name), so read the
+    # snake_case field; fall back to the camelCase alias for robustness.
+    local_storage_mib = parse_quantity_to_mib(
+        resources.get("local_storage") or resources.get("localStorage")
+    )
     # Per-card VRAM lives in the device descriptor blob, not the instance spec.
     vram_mib = parse_gpu_vram_mib(snap.get("description"))
     # Pretty product name + per-card cpu/mem for the "Instance Type" display
@@ -162,6 +168,7 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
         "cpu_milli": cpu_milli,
         "memory_mib": mem_mib,
         "ephemeral_mib": ephemeral_mib,
+        "local_storage_mib": local_storage_mib,
     }
     if descriptor.get("product"):
         dimensions["product"] = descriptor["product"]

--- a/gpustack/utils/resource_usage.py
+++ b/gpustack/utils/resource_usage.py
@@ -106,6 +106,51 @@ def parse_gpu_vram_mib(description: Any) -> int:
     return parse_quantity_to_mib(spec.get("memory"))
 
 
+def parse_gpu_descriptor(description: Any) -> dict:
+    """Display-flavor fields parsed from a GPUInstance ``description`` blob:
+    ``{"spec": {"product": "NVIDIA-GeForce-RTX-5090-D", "memory": "32607Mi",
+    "unitResourcesParsed": {"cpu": {"cores": 18}, "ram": {"value": 54,
+    "unit": "Gi"}}}}``.
+
+    Returns whichever of ``product`` / ``vram_mib`` / ``unit_cpu_milli`` /
+    ``unit_memory_mib`` could be parsed (per-card specs) — used to enrich
+    ``metered_usage.dimensions`` so the Usage "Instance Type" view can render the
+    pretty product name + per-card specs, matching the GPU Instances list.
+    Missing / unparseable keys are omitted (CPU instances → ``{}``).
+    """
+    data = description
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (ValueError, TypeError):
+            return {}
+    if not isinstance(data, dict):
+        return {}
+    spec = data.get("spec")
+    if not isinstance(spec, dict):
+        return {}
+    out: dict = {}
+    if spec.get("product"):
+        out["product"] = spec["product"]
+    vram = parse_quantity_to_mib(spec.get("memory"))
+    if vram:
+        out["vram_mib"] = vram
+    unit = spec.get("unitResourcesParsed")
+    if isinstance(unit, dict):
+        cpu = unit.get("cpu")
+        if isinstance(cpu, dict) and cpu.get("cores"):
+            try:
+                out["unit_cpu_milli"] = int(float(cpu["cores"]) * 1000)
+            except (ValueError, TypeError):
+                pass
+        ram = unit.get("ram")
+        if isinstance(ram, dict) and ram.get("value") is not None:
+            mib = parse_quantity_to_mib(f"{ram.get('value')}{ram.get('unit', '')}")
+            if mib:
+                out["unit_memory_mib"] = mib
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Kubernetes quantity parser
 # ---------------------------------------------------------------------------

--- a/gpustack/utils/resource_usage.py
+++ b/gpustack/utils/resource_usage.py
@@ -171,9 +171,10 @@ def _parse_unit_resources(spec: dict) -> tuple:
         if isinstance(ram, dict):
             amount = ram["num"] if ram.get("num") is not None else ram.get("value")
             if amount is not None:
-                mem_mib = (
-                    parse_quantity_to_mib(f"{amount}{ram.get('unit', '')}") or None
-                )
+                # ``or ""`` (not a get-default) so an explicit ``unit: None``
+                # doesn't stringify into "<amount>None" and fail to parse.
+                unit = ram.get("unit") or ""
+                mem_mib = parse_quantity_to_mib(f"{amount}{unit}") or None
     return cpu_milli, mem_mib
 
 

--- a/gpustack/utils/resource_usage.py
+++ b/gpustack/utils/resource_usage.py
@@ -135,20 +135,46 @@ def parse_gpu_descriptor(description: Any) -> dict:
     vram = parse_quantity_to_mib(spec.get("memory"))
     if vram:
         out["vram_mib"] = vram
-    unit = spec.get("unitResourcesParsed")
-    if isinstance(unit, dict):
-        cpu = unit.get("cpu")
+    cpu_milli, mem_mib = _parse_unit_resources(spec)
+    if cpu_milli:
+        out["unit_cpu_milli"] = cpu_milli
+    if mem_mib:
+        out["unit_memory_mib"] = mem_mib
+    return out
+
+
+def _parse_unit_resources(spec: dict) -> tuple:
+    """Per-card ``(cpu_milli, mem_mib)`` from a descriptor spec.
+
+    Prefers the raw ``unitResources`` quantity strings (e.g. ``"8000m"`` /
+    ``"24576Mi"``) — unambiguous k8s quantities. Falls back to
+    ``unitResourcesParsed``, whose ram ``value``/``unit`` can be inconsistent
+    (observed ``{"value": 24, "unit": "Mi", "num": 24576}`` for a 24Gi card),
+    so its ``num`` (the real amount in ``unit``) is trusted over ``value``.
+    """
+    raw = spec.get("unitResources")
+    parsed = spec.get("unitResourcesParsed")
+    cpu_milli = None
+    mem_mib = None
+    if isinstance(raw, dict):
+        cpu_milli = parse_quantity_to_millicores(raw.get("cpu")) or None
+        mem_mib = parse_quantity_to_mib(raw.get("ram")) or None
+    if cpu_milli is None and isinstance(parsed, dict):
+        cpu = parsed.get("cpu")
         if isinstance(cpu, dict) and cpu.get("cores"):
             try:
-                out["unit_cpu_milli"] = int(float(cpu["cores"]) * 1000)
+                cpu_milli = int(float(cpu["cores"]) * 1000)
             except (ValueError, TypeError):
-                pass
-        ram = unit.get("ram")
-        if isinstance(ram, dict) and ram.get("value") is not None:
-            mib = parse_quantity_to_mib(f"{ram.get('value')}{ram.get('unit', '')}")
-            if mib:
-                out["unit_memory_mib"] = mib
-    return out
+                cpu_milli = None
+    if mem_mib is None and isinstance(parsed, dict):
+        ram = parsed.get("ram")
+        if isinstance(ram, dict):
+            amount = ram["num"] if ram.get("num") is not None else ram.get("value")
+            if amount is not None:
+                mem_mib = (
+                    parse_quantity_to_mib(f"{amount}{ram.get('unit', '')}") or None
+                )
+    return cpu_milli, mem_mib
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routes/test_resource_usage_api.py
+++ b/tests/routes/test_resource_usage_api.py
@@ -11,6 +11,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from gpustack.routes.resource_usage import (
     ResourceBreakdownRequest,
+    _phase_message_of,
     _run_breakdown,
     usage_summary,
 )
@@ -411,3 +412,16 @@ async def test_summary_unions_tokens_and_metered(session):
     assert out["storage_gb_days"] == pytest.approx(
         204800 * 25200 / 1024 / 86400, abs=0.01
     )
+
+
+def test_phase_message_of():
+    # camelCase (model_dump by alias) and snake_case (by field name) both read
+    assert _phase_message_of({"status": {"phaseMessage": "boom"}}) == "boom"
+    assert _phase_message_of({"status": {"phase_message": "kaboom"}}) == "kaboom"
+    # raw JSON string (some drivers / replay paths) is parsed defensively
+    assert _phase_message_of('{"status": {"phaseMessage": "oops"}}') == "oops"
+    # missing / malformed → None (no crash)
+    assert _phase_message_of({"status": {}}) is None
+    assert _phase_message_of({"status": "not-a-dict"}) is None
+    assert _phase_message_of(None) is None
+    assert _phase_message_of("not json") is None

--- a/tests/utils/test_resource_usage.py
+++ b/tests/utils/test_resource_usage.py
@@ -175,6 +175,22 @@ def test_parse_gpu_descriptor():
     assert out["unit_memory_mib"] == 54 * 1024
     assert out["vram_mib"] == 32607  # per-card VRAM from spec.memory
 
+    # Raw ``unitResources`` strings are preferred (unambiguous k8s quantities).
+    raw = parse_gpu_descriptor(
+        '{"spec":{"unitResources":{"cpu":"8000m","ram":"24576Mi"}}}'
+    )
+    assert raw["unit_cpu_milli"] == 8000
+    assert raw["unit_memory_mib"] == 24576
+
+    # Inconsistent ``unitResourcesParsed.ram`` (value/unit disagree with num,
+    # e.g. value=24 + unit="Mi" for a 24Gi card) — trust ``num`` over ``value``.
+    inconsistent = parse_gpu_descriptor(
+        '{"spec":{"unitResourcesParsed":'
+        '{"cpu":{"cores":8},"ram":{"value":24,"unit":"Mi","num":24576}}}}'
+    )
+    assert inconsistent["unit_cpu_milli"] == 8000
+    assert inconsistent["unit_memory_mib"] == 24576
+
     # accepts an already-parsed dict too
     assert parse_gpu_descriptor({"spec": {"product": "X"}}) == {"product": "X"}
     # missing / unparseable → empty (e.g. CPU instances with no descriptor)

--- a/tests/utils/test_resource_usage.py
+++ b/tests/utils/test_resource_usage.py
@@ -9,6 +9,7 @@ from gpustack.utils.resource_usage import (
     iter_utc_day_segments,
     iter_utc_hour_segments,
     parse_accelerator_count,
+    parse_gpu_descriptor,
     parse_gpu_type,
     parse_gpu_vram_mib,
     parse_quantity_to_mib,
@@ -159,3 +160,24 @@ def test_local_resource_type_constants_match_schema():
 
     assert _RESOURCE_TYPE_GPU_INSTANCE == RESOURCE_TYPE_GPU_INSTANCE
     assert _RESOURCE_TYPE_CPU_INSTANCE == RESOURCE_TYPE_CPU_INSTANCE
+
+
+def test_parse_gpu_descriptor():
+    desc = (
+        '{"name":"gpustack-nvidia-geforce-rtx-5090-d-18c-54gi",'
+        '"spec":{"product":"NVIDIA-GeForce-RTX-5090-D","memory":"32607Mi",'
+        '"unitResourcesParsed":{"cpu":{"cores":18},'
+        '"ram":{"value":54,"unit":"Gi"}}}}'
+    )
+    out = parse_gpu_descriptor(desc)
+    assert out["product"] == "NVIDIA-GeForce-RTX-5090-D"
+    assert out["unit_cpu_milli"] == 18000
+    assert out["unit_memory_mib"] == 54 * 1024
+    assert out["vram_mib"] == 32607  # per-card VRAM from spec.memory
+
+    # accepts an already-parsed dict too
+    assert parse_gpu_descriptor({"spec": {"product": "X"}}) == {"product": "X"}
+    # missing / unparseable → empty (e.g. CPU instances with no descriptor)
+    assert parse_gpu_descriptor(None) == {}
+    assert parse_gpu_descriptor("not json") == {}
+    assert parse_gpu_descriptor({}) == {}


### PR DESCRIPTION
- parse the GPUInstance descriptor (product, unitResources, memory) and store product + per-card unit_cpu_milli/unit_memory_mib in metered_usage.dimensions (vram_mib already captured).
- surface those flavor fields per instance-type / per-instance breakdown row (one representative row per sku, since dimensions are flavor-constant).
- flag deleted entities in the resource-meta filter lists (instances / volumes / creators no longer live) so the UI can tag them "(Deleted)" like the Tokens tab. Extracts post-query enrichment into _enrich_items.
- Add storage info to metered usage dimensions