### PR TITLE
fix: invalidate accessible-model cache on org membership change

### DIFF
--- a/gpustack/routes/organization_members.py
+++ b/gpustack/routes/organization_members.py
@@ -39,6 +39,7 @@ from gpustack.schemas.principals import (
     PrincipalType,
 )
 from gpustack.server.deps import SessionDep, TenantContextDep
+from gpustack.server.services import delete_accessible_model_cache
 
 router = APIRouter()
 
@@ -153,6 +154,38 @@ async def _has_other_owner(
         .limit(1)
     )
     return (await session.exec(stmt)).first() is not None
+
+
+async def _affected_user_ids(session, members: List[Principal]) -> set[int]:
+    """User ids whose ``get_user_accessible_model_names`` cache must be
+    invalidated when these Org memberships change.
+
+    USER members map to themselves. GROUP members fan out to every
+    active user currently in the group — removing a Group from an Org
+    revokes Org-mediated route access for each of those users via the
+    transitive branch of ``principal_users``. Soft-deleted users are
+    skipped: they can't authenticate, so no stale cache to clear.
+    """
+    user_ids: set[int] = set()
+    group_ids: set[int] = set()
+    for p in members:
+        if p.kind == PrincipalType.USER:
+            user_ids.add(p.id)
+        elif p.kind == PrincipalType.GROUP:
+            group_ids.add(p.id)
+    if group_ids:
+        stmt = (
+            select(PrincipalMembership.member_principal_id)
+            .join(Principal, Principal.id == PrincipalMembership.member_principal_id)
+            .where(
+                PrincipalMembership.parent_principal_id.in_(group_ids),
+                PrincipalMembership.deleted_at.is_(None),
+                Principal.kind == PrincipalType.USER,
+                Principal.deleted_at.is_(None),
+            )
+        )
+        user_ids.update((await session.exec(stmt)).all())
+    return user_ids
 
 
 async def _enrich_with_labels(
@@ -325,6 +358,11 @@ async def add_org_members(
         await session.rollback()
         raise InvalidException(message=f"Failed to add members: {e}")
 
+    # Bust each affected user's accessible-models cache so a session that
+    # queried before being added doesn't see a stale empty set.
+    affected = await _affected_user_ids(session, [p for p, _ in stored])
+    await delete_accessible_model_cache(*affected)
+
     return [_to_public(p, row.role, row.created_at, org.id) for p, row in stored]
 
 
@@ -398,8 +436,20 @@ async def remove_org_member(
                 message="Cannot remove the only owner of this organization"
             )
 
+    # Snapshot the affected users BEFORE the soft-delete: for a GROUP
+    # member, the per-user fan-out reads ``principal_memberships`` rows
+    # that are still active here, but the Org→Group row we're about to
+    # delete doesn't affect that lookup (we expand the Group's own
+    # members, not its Org bindings).
+    affected = await _affected_user_ids(session, [p])
+
     try:
         await membership.delete(session, soft=True)
     except Exception as e:
         await session.rollback()
         raise InvalidException(message=f"Failed to remove member: {e}")
+
+    # Existing sessions for these users would otherwise keep hitting the
+    # cached accessible-model set until TTL expiry and continue
+    # resolving the just-removed Org's routes.
+    await delete_accessible_model_cache(*affected)

--- a/gpustack/routes/token.py
+++ b/gpustack/routes/token.py
@@ -134,7 +134,7 @@ async def server_auth(
             api_key=api_key,
         ):
             raise ForbiddenException(
-                message=f"Api key not allowed to access model {model_name}"
+                message=f"Not allowed to access model {model_name}"
             )
     cache_token = jwt_manager.create_token(
         {"consumer": consumer, "token": registration_token, "model": model_name},

--- a/tests/api/test_p2_routes.py
+++ b/tests/api/test_p2_routes.py
@@ -300,6 +300,79 @@ async def test_has_other_owner_rejects_empty_group_owner():
     )
 
 
+@pytest.mark.asyncio
+async def test_remove_user_member_invalidates_access_cache(monkeypatch):
+    """Removing a USER from an Org must bust that user's
+    ``get_user_accessible_model_names`` cache; otherwise an existing
+    session keeps hitting the cached set (which still includes the Org's
+    routes) until TTL expiry.
+    """
+    org = _principal(id=10, display_name="Acme", name="acme")
+    member = _principal(
+        id=200, kind=PrincipalType.USER, display_name="user-2", name="user-2"
+    )
+    membership = MagicMock(spec=PrincipalMembership)
+    membership.parent_principal_id = 10
+    membership.member_principal_id = 200
+    membership.role = OrgRole.MEMBER
+    membership.deleted_at = None
+    membership.delete = AsyncMock()
+    _patch_org_and_member(monkeypatch, org, member)
+    monkeypatch.setattr(
+        organization_members,
+        "_find_membership",
+        AsyncMock(return_value=membership),
+    )
+    invalidated = AsyncMock()
+    monkeypatch.setattr(
+        organization_members, "delete_accessible_model_cache", invalidated
+    )
+    ctx = _ctx(is_admin=True)
+    await organization_members.remove_org_member(
+        session=MagicMock(), ctx=ctx, org_id=10, principal_id=200
+    )
+    membership.delete.assert_awaited_once()
+    invalidated.assert_awaited_once_with(200)
+
+
+@pytest.mark.asyncio
+async def test_remove_group_member_invalidates_each_user(monkeypatch):
+    """Removing a GROUP from an Org fans cache invalidation out to every
+    active user in the group — they lose Org-mediated access via the
+    transitive branch of ``principal_users`` and any cached
+    accessible-model set must be cleared per user.
+    """
+    org = _principal(id=10, display_name="Acme", name="acme")
+    group = _principal(
+        id=300, kind=PrincipalType.GROUP, display_name=None, name="gpu-admins"
+    )
+    membership = MagicMock(spec=PrincipalMembership)
+    membership.parent_principal_id = 10
+    membership.member_principal_id = 300
+    membership.role = OrgRole.MEMBER
+    membership.deleted_at = None
+    membership.delete = AsyncMock()
+    _patch_org_and_member(monkeypatch, org, group)
+    monkeypatch.setattr(
+        organization_members,
+        "_find_membership",
+        AsyncMock(return_value=membership),
+    )
+    # _affected_user_ids issues one session.exec() to expand the group into
+    # its active user-principal ids.
+    session = _session_returning([501, 502])
+    invalidated = AsyncMock()
+    monkeypatch.setattr(
+        organization_members, "delete_accessible_model_cache", invalidated
+    )
+    ctx = _ctx(is_admin=True)
+    await organization_members.remove_org_member(
+        session=session, ctx=ctx, org_id=10, principal_id=300
+    )
+    invalidated.assert_awaited_once()
+    assert set(invalidated.await_args.args) == {501, 502}
+
+
 # ---- cluster_access route --------------------------------------------------
 
 


### PR DESCRIPTION
UserService.get_user_accessible_model_names is cached per user_id, but remove_org_member / add_org_members only mutated principal_memberships and never busted the cache — so an existing session kept resolving the org's routes (or kept seeing the pre-add empty set) until TTL expiry.

Fan out the invalidation: USER members map to themselves, GROUP members expand to every active user in the group (the transitive branch of principal_users is what grants them org-mediated access). update_org_member is left alone — role isn't part of the access predicate.