### PR TITLE
fix: surface friendly duplicate-name errors on resource create

### DIFF
--- a/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
+++ b/gpustack/migrations/versions/2026_04_28_1200-7c5e3f9a2d18_multi_tenancy_foundation.py
@@ -783,16 +783,18 @@ def upgrade() -> None:
     # ------------------------------------------------------------------
     # 11. Cluster-derived denormalized owner_principal_id columns.
     # ------------------------------------------------------------------
-    # Workers, model_files, benchmarks, model_providers, model_usages
-    # all need an owner pointer for per-row filtering. Nullable
-    # (NULL = on a global cluster, admin-managed); ON DELETE SET NULL
-    # keeps rows alive when the owner principal is deleted (principal
-    # delete cascades clusters, which cascade their workers anyway).
+    # Workers, model_files, benchmarks, model_usages all need an owner
+    # pointer for per-row filtering. Nullable (NULL = on a global
+    # cluster, admin-managed); ON DELETE SET NULL keeps rows alive
+    # when the owner principal is deleted (principal delete cascades
+    # clusters, which cascade their workers anyway).
+    #
+    # ``model_providers`` was originally in this group but later moved
+    # to the always-owned tier — see step 11b below.
     for tbl in (
         'workers',
         'model_files',
         'benchmarks',
-        'model_providers',
         'model_usages',
     ):
         if not column_exists(tbl, 'owner_principal_id'):
@@ -988,6 +990,112 @@ def upgrade() -> None:
                 """
             )
         )
+
+    # ------------------------------------------------------------------
+    # 11b. ``model_providers``: always-owned (no Global notion).
+    # ------------------------------------------------------------------
+    # Only ``gpu_instance_templates`` and ``inference_backends`` carry a
+    # NULL-owner Global notion. Providers always belong to an Org —
+    # admin in "All" mode creates them under the platform Org. Mirrors
+    # the ``models`` block in step 9: add nullable so the DDL accepts
+    # pre-existing rows, backfill to the platform Org, then lock to
+    # NOT NULL with a CASCADE FK.
+    if table_exists('model_providers') and not column_exists(
+        'model_providers', 'owner_principal_id'
+    ):
+        with op.batch_alter_table('model_providers', schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column('owner_principal_id', sa.Integer(), nullable=True)
+            )
+
+        op.execute(
+            sa.text(
+                "UPDATE model_providers SET owner_principal_id = :pid "
+                "WHERE owner_principal_id IS NULL"
+            ).bindparams(pid=platform_id)
+        )
+
+        with op.batch_alter_table('model_providers', schema=None) as batch_op:
+            batch_op.alter_column(
+                'owner_principal_id',
+                existing_type=sa.Integer(),
+                nullable=False,
+            )
+            batch_op.create_foreign_key(
+                'fk_model_providers_owner_principal_id_principals',
+                'principals',
+                ['owner_principal_id'],
+                ['id'],
+                ondelete='CASCADE',
+            )
+
+    # ------------------------------------------------------------------
+    # 11c. Convert global UNIQUE on ``name`` to per-owner composite for
+    # ``models`` and ``model_providers``.
+    # ------------------------------------------------------------------
+    # Both tables used to enforce ``name`` as globally unique. With
+    # multi-tenancy each row carries an ``owner_principal_id``, so two
+    # Orgs can independently define a "qwen3-0.6b" model / "openai"
+    # provider. Drop the legacy global UNIQUE and replace it with a
+    # composite UNIQUE on ``(owner_principal_id, name)``.
+    #
+    # The drop dance mirrors step 12 (inference_backends): MySQL /
+    # OceanBase reflect unique-only indexes via information_schema;
+    # Postgres / openGauss go through ``pg_constraint`` + a fallback
+    # ``DROP INDEX`` for the index Alembic emitted on column-level
+    # ``unique=True``. We avoid ``batch_alter_table`` for the drops so
+    # an idempotent re-run doesn't trip on an already-removed
+    # constraint.
+    for tbl, idx_name, uq_name in (
+        ('models', 'ix_models_name', 'uix_models_name_per_owner'),
+        (
+            'model_providers',
+            'ix_model_providers_name',
+            'uix_model_providers_name_per_owner',
+        ),
+    ):
+        if not table_exists(tbl):
+            continue
+        if dialect == 'postgresql':
+            for name_row in bind.execute(
+                sa.text(
+                    "SELECT c.conname FROM pg_constraint c "
+                    "JOIN pg_class t ON t.oid = c.conrelid "
+                    "WHERE t.relname = :tbl "
+                    "AND c.contype = 'u' "
+                    "AND array_length(c.conkey, 1) = 1 "
+                    "AND (SELECT a.attname FROM pg_attribute a "
+                    "     WHERE a.attrelid = c.conrelid "
+                    "     AND a.attnum = c.conkey[1]) = 'name'"
+                ).bindparams(tbl=tbl)
+            ):
+                op.execute(
+                    f'ALTER TABLE {tbl} '
+                    f'DROP CONSTRAINT IF EXISTS "{name_row[0]}"'
+                )
+            op.execute(f'DROP INDEX IF EXISTS {idx_name}')
+        else:
+            unique_idx_names = [
+                row[0]
+                for row in bind.execute(
+                    sa.text(
+                        "SELECT DISTINCT INDEX_NAME FROM "
+                        "information_schema.STATISTICS "
+                        "WHERE TABLE_SCHEMA = DATABASE() "
+                        "AND TABLE_NAME = :tbl "
+                        "AND COLUMN_NAME = 'name' "
+                        "AND NON_UNIQUE = 0 "
+                        "AND INDEX_NAME <> 'PRIMARY'"
+                    ).bindparams(tbl=tbl)
+                )
+            ]
+            for name in unique_idx_names:
+                op.execute(f"ALTER TABLE {tbl} DROP INDEX `{name}`")
+
+        with op.batch_alter_table(tbl, schema=None) as batch_op:
+            batch_op.create_unique_constraint(
+                uq_name, ['owner_principal_id', 'name']
+            )
 
     # ------------------------------------------------------------------
     # 12. Inference backends Hybrid.

--- a/gpustack/routes/api_keys.py
+++ b/gpustack/routes/api_keys.py
@@ -174,7 +174,9 @@ async def create_api_key(
     }
     existing = await ApiKey.one_by_fields(session, fields)
     if existing:
-        raise AlreadyExistsException(message=f"Api key {key_in.name} already exists")
+        raise AlreadyExistsException(
+            message=f"API key with name '{key_in.name}' already exists."
+        )
 
     if key_in.custom is None:
         access_key, secret_key = secrets.token_hex(8), secrets.token_hex(16)

--- a/gpustack/routes/benchmarks.py
+++ b/gpustack/routes/benchmarks.py
@@ -310,8 +310,7 @@ async def create_benchmark(
     existing = await Benchmark.one_by_field(session, "name", benchmark_in.name)
     if existing:
         raise AlreadyExistsException(
-            message=f"Benchmark '{benchmark_in.name}' already exists. "
-            "Please choose a different name or check the existing benchmark."
+            message=f"Benchmark with name '{benchmark_in.name}' already exists."
         )
 
     mutated = await validate_and_mutate_benchmark_in(session, benchmark_in)

--- a/gpustack/routes/cloud_credentials.py
+++ b/gpustack/routes/cloud_credentials.py
@@ -101,7 +101,7 @@ async def create(
     )
     if existing:
         raise AlreadyExistsException(
-            message=f"cloud credential {input.name} already exists"
+            message=f"Cloud credential with name '{input.name}' already exists."
         )
 
     try:

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -370,7 +370,9 @@ async def create_cluster(
         },
     )
     if existing:
-        raise AlreadyExistsException(message=f"cluster {input.name} already exists")
+        raise AlreadyExistsException(
+            message=f"Cluster with name '{input.name}' already exists."
+        )
 
     create_update_check(input.provider, input)
     if input.provider == ClusterProvider.Kubernetes:

--- a/gpustack/routes/gpu_instance_persistent_volume_types.py
+++ b/gpustack/routes/gpu_instance_persistent_volume_types.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from starlette.responses import StreamingResponse
 
 from gpustack.api.exceptions import (
+    AlreadyExistsException,
     ConflictException,
     InternalServerErrorException,
     NotFoundException,
@@ -134,6 +135,18 @@ async def create_gpu_instance_persistent_volume_type(
     )
 
     _validate_create_obj(create_obj)
+
+    existed = await GPUInstancePersistentVolumeType.exist_by_fields(
+        session=session,
+        fields={
+            "owner_principal_id": create_obj.owner_principal_id,
+            "name": create_obj.name,
+        },
+    )
+    if existed:
+        raise AlreadyExistsException(
+            message=(f"Storage type with name '{create_obj.name}' already exists."),
+        )
 
     async with handle_error(
         message="Failed to create GPU instance persistent volume type",

--- a/gpustack/routes/gpu_instance_persistent_volumes.py
+++ b/gpustack/routes/gpu_instance_persistent_volumes.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
 from gpustack.api.exceptions import (
+    AlreadyExistsException,
     InternalServerErrorException,
     InvalidException,
     NotFoundException,
@@ -106,6 +107,18 @@ async def create_gpu_instance_persistent_volume(
     )
 
     persistent_volume_type_id = await _validate_create_obj(session, ctx, create_obj)
+
+    existed = await GPUInstancePersistentVolume.exist_by_fields(
+        session=session,
+        fields={
+            "owner_principal_id": create_obj.owner_principal_id,
+            "name": create_obj.name,
+        },
+    )
+    if existed:
+        raise AlreadyExistsException(
+            message=(f"Storage with name '{create_obj.name}' already exists."),
+        )
 
     source = _build_create_source(create_obj, ctx.user.id, persistent_volume_type_id)
     async with handle_error(

--- a/gpustack/routes/gpu_instance_ssh_public_keys.py
+++ b/gpustack/routes/gpu_instance_ssh_public_keys.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends
 from starlette.responses import StreamingResponse
 
 from gpustack.api.exceptions import (
+    AlreadyExistsException,
     InternalServerErrorException,
     NotFoundException,
 )
@@ -102,6 +103,18 @@ async def create_gpu_instance_ssh_public_key(
     )
 
     _validate_create_obj(create_obj)
+
+    existed = await GPUInstanceSSHPublicKey.exist_by_fields(
+        session=session,
+        fields={
+            "owner_principal_id": create_obj.owner_principal_id,
+            "name": create_obj.name,
+        },
+    )
+    if existed:
+        raise AlreadyExistsException(
+            message=(f"SSH public key with name '{create_obj.name}' already exists."),
+        )
 
     async with handle_error(
         message="Failed to create GPU instance SSH public key",

--- a/gpustack/routes/gpu_instance_templates.py
+++ b/gpustack/routes/gpu_instance_templates.py
@@ -136,7 +136,10 @@ async def create_gpu_instance_template(
     )
     if existed:
         raise AlreadyExistsException(
-            message="GPU instance template already exists",
+            message=(
+                f"GPU instance template with name '{create_obj.name}' "
+                "already exists."
+            ),
         )
 
     async with handle_error(

--- a/gpustack/routes/gpu_instances.py
+++ b/gpustack/routes/gpu_instances.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends
 from starlette.responses import StreamingResponse
 
 from gpustack.api.exceptions import (
+    AlreadyExistsException,
     InternalServerErrorException,
     InvalidException,
     NotFoundException,
@@ -106,6 +107,18 @@ async def create_gpu_instance(
     )
 
     persistent_volume_id = await _validate_create_obj(session, ctx, create_obj)
+
+    existed = await GPUInstance.exist_by_fields(
+        session=session,
+        fields={
+            "owner_principal_id": create_obj.owner_principal_id,
+            "name": create_obj.name,
+        },
+    )
+    if existed:
+        raise AlreadyExistsException(
+            message=(f"GPU instance with name '{create_obj.name}' already exists."),
+        )
 
     source = _build_create_source(create_obj, ctx.user.id, persistent_volume_id)
     async with handle_error(

--- a/gpustack/routes/inference_backend.py
+++ b/gpustack/routes/inference_backend.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from starlette.responses import StreamingResponse
 
 from gpustack.api.exceptions import (
+    AlreadyExistsException,
     InternalServerErrorException,
     NotFoundException,
     BadRequestException,
@@ -1057,8 +1058,8 @@ async def create_inference_backend(
         },
     )
     if existing:
-        raise BadRequestException(
-            message=f"Inference backend with name '{backend_in.backend_name}' already exists",
+        raise AlreadyExistsException(
+            message=f"Inference backend with name '{backend_in.backend_name}' already exists.",
         )
 
     # Validate version names for custom backends before creating
@@ -1338,8 +1339,8 @@ async def create_inference_backend_from_yaml(  # noqa: C901
             },
         )
         if existing:
-            raise BadRequestException(
-                message=f"Inference backend with name '{req_yaml_data['backend_name']}' already exists",
+            raise AlreadyExistsException(
+                message=f"Inference backend with name '{req_yaml_data['backend_name']}' already exists.",
             )
 
         allowed_keys = [

--- a/gpustack/routes/model_provider.py
+++ b/gpustack/routes/model_provider.py
@@ -34,6 +34,7 @@ from gpustack.api.tenant import (
     assert_resource_visible,
     tenant_list_conditions,
 )
+from gpustack.schemas.principals import platform_principal_id
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 from openai.types import Model as OAIModel
@@ -142,18 +143,25 @@ def parse_api_tokens(
 async def create_model_provider(
     session: SessionDep, ctx: TenantContextDep, input: ModelProviderCreate
 ):
-    # Provider names are unique per Org (admin's Global providers
-    # — owner_principal_id=NULL — form their own namespace).
+    # Every provider belongs to one Org. Admin in "All" mode (no
+    # current principal) falls back to the platform Org so the row has
+    # a concrete owner — provider does not carry a NULL-owner Global
+    # notion (unlike Instance Template / Inference Backend).
+    target_org_id = ctx.current_principal_id or platform_principal_id()
+
+    # Provider names are unique within their owning Org.
     existing = await ModelProvider.one_by_fields(
         session,
         {
             'deleted_at': None,
             "name": input.name,
-            "owner_principal_id": ctx.current_principal_id,
+            "owner_principal_id": target_org_id,
         },
     )
     if existing:
-        raise AlreadyExistsException(message=f"provider {input.name} already exists")
+        raise AlreadyExistsException(
+            message=f"Model provider with name '{input.name}' already exists."
+        )
     validate_provider(input)
     input_dict = input.model_dump(exclude={"api_tokens", "clone_from_id"})
     existing_tokens = []
@@ -170,9 +178,7 @@ async def create_model_provider(
     input_dict["api_tokens"] = parse_api_tokens(
         existing_tokens=existing_tokens, api_tokens=input.api_tokens
     )
-    # Tenant scope: bind to caller's current Org. Platform admin in
-    # "All" mode (no current_principal_id) creates global (NULL).
-    input_dict["owner_principal_id"] = ctx.current_principal_id
+    input_dict["owner_principal_id"] = target_org_id
     try:
         created = await ModelProvider.create(session=session, source=input_dict)
         return ModelProvider._convert_to_public_class(created)
@@ -224,6 +230,23 @@ async def update_model_provider(
         not_found_message=f"provider {id} not found",
     )
     validate_provider(input)
+    # Rename check: if the caller is changing ``name``, make sure the
+    # new name doesn't collide with another provider under the same
+    # owner. The composite UNIQUE on the table would catch this at
+    # commit time, but we surface a friendly 409 first.
+    if input.name != provider.name:
+        clash = await ModelProvider.one_by_fields(
+            session,
+            {
+                'deleted_at': None,
+                "name": input.name,
+                "owner_principal_id": provider.owner_principal_id,
+            },
+        )
+        if clash and clash.id != provider.id:
+            raise AlreadyExistsException(
+                message=f"Model provider with name '{input.name}' already exists."
+            )
     deleted_models = deleted_model_names(provider.models or [], input.models or [])
     try:
         input_dict = input.model_dump(exclude={"api_tokens"})

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -486,7 +486,7 @@ async def create_model_route(
     )
     if existing:
         raise AlreadyExistsException(
-            f"ModelRoute with name '{input.name}' already exists."
+            message=f"Model route with name '{input.name}' already exists."
         )
     source = input.model_dump(exclude={"targets"})
     targets = input.targets or []
@@ -580,7 +580,7 @@ async def update_model_route(
     )
     if duplicated_name and duplicated_name.id != id:
         raise AlreadyExistsException(
-            f"ModelRoute with name '{input.name}' already exists."
+            message=f"Model route with name '{input.name}' already exists."
         )
     existing_name = existing.name
     input_name = input.name

--- a/gpustack/routes/models.py
+++ b/gpustack/routes/models.py
@@ -527,17 +527,29 @@ async def validate_distributed_vllm_limit_per_worker(
 async def create_model(
     session: SessionDep, ctx: TenantContextDep, model_in: ModelCreate
 ):
+    # Resolve the owning Org first — admin in "All" mode (no current
+    # principal) inherits the chosen cluster's Org, or falls back to
+    # the platform Org. The same value drives both the uniqueness
+    # pre-check below and the row we stamp on insert; resolving it up
+    # front keeps them in sync so the pre-check actually catches a
+    # collision in the Org the model will land in.
+    target_org_id = ctx.current_principal_id
+    if target_org_id is None and model_in.cluster_id is not None:
+        cluster = await Cluster.one_by_id(session, model_in.cluster_id)
+        if cluster is not None:
+            target_org_id = cluster.owner_principal_id
+    if target_org_id is None:
+        target_org_id = platform_principal_id()
+
     # Model & ModelRoute names are unique within their Org. Two Orgs
     # can each have a "llama3" without colliding.
-    org_scope = ctx.current_principal_id
     existing = await Model.one_by_fields(
         session,
-        {"name": model_in.name, "owner_principal_id": org_scope},
+        {"name": model_in.name, "owner_principal_id": target_org_id},
     )
     if existing:
         raise AlreadyExistsException(
-            message=f"Model '{model_in.name}' already exists. "
-            "Please choose a different name or check the existing model."
+            message=f"Model with name '{model_in.name}' already exists."
         )
     should_create_route = (
         model_in.enable_model_route is not None and model_in.enable_model_route
@@ -545,12 +557,11 @@ async def create_model(
     if should_create_route:
         existing_route = await ModelRoute.one_by_fields(
             session,
-            {"name": model_in.name, "owner_principal_id": org_scope},
+            {"name": model_in.name, "owner_principal_id": target_org_id},
         )
         if existing_route:
             raise AlreadyExistsException(
-                message=f"Model route '{model_in.name}' already exists. "
-                "Please choose a different name or check the existing model route."
+                message=f"Model route with name '{model_in.name}' already exists."
             )
     await validate_model_in(session, model_in)
     model_in_dict = model_in.model_dump(exclude={"enable_model_route"})
@@ -558,19 +569,9 @@ async def create_model(
     # Stamp tenant scope. ModelBase has owner_principal_id defaulted to
     # PLATFORM_PRINCIPAL_ID, so `model_dump()` always emits the key —
     # `setdefault` would silently leave it at 1 even when the caller is
-    # acting under a different Org. Override directly:
-    #   - Caller has a current Org context → that Org wins
-    #   - Caller is admin in "All" mode → fall back to the chosen
-    #     cluster's owner Org so the model lives where it actually runs
-    #     (otherwise it'd land in Platform/Default and the cluster's Org
-    #     couldn't see / manage it)
-    target_org_id = ctx.current_principal_id
-    if target_org_id is None and model_in.cluster_id is not None:
-        cluster = await Cluster.one_by_id(session, model_in.cluster_id)
-        if cluster is not None:
-            target_org_id = cluster.owner_principal_id
-    if target_org_id is not None:
-        model_in_dict["owner_principal_id"] = target_org_id
+    # acting under a different Org. Override directly with the value we
+    # resolved above.
+    model_in_dict["owner_principal_id"] = target_org_id
 
     # Multi-tenant default: a non-platform Org's new model (and the
     # route(s) it spawns) is scoped to that Org via ALLOWED_PRINCIPALS

--- a/gpustack/routes/organizations.py
+++ b/gpustack/routes/organizations.py
@@ -107,7 +107,7 @@ async def create_organization(session: SessionDep, org_in: OrganizationCreate):
     ).first()
     if existing:
         raise AlreadyExistsException(
-            message=f"Organization with name '{org_in.name}' already exists"
+            message=f"Organization with name '{org_in.name}' already exists."
         )
 
     try:

--- a/gpustack/routes/user_groups.py
+++ b/gpustack/routes/user_groups.py
@@ -172,7 +172,9 @@ async def create_group(session: SessionDep, body: UserGroupCreate):
         },
     )
     if existing:
-        raise AlreadyExistsException(message=f"Group '{body.name}' already exists")
+        raise AlreadyExistsException(
+            message=f"Group with name '{body.name}' already exists."
+        )
 
     try:
         group = Principal(
@@ -212,7 +214,9 @@ async def update_group(session: SessionDep, group_id: int, body: UserGroupUpdate
             },
         )
         if clash and clash.id != group.id:
-            raise AlreadyExistsException(message=f"Group '{body.name}' already exists")
+            raise AlreadyExistsException(
+                message=f"Group with name '{body.name}' already exists."
+            )
 
     try:
         await group.update(session, body.model_dump(exclude_unset=True))

--- a/gpustack/routes/users.py
+++ b/gpustack/routes/users.py
@@ -157,7 +157,9 @@ async def create_user(session: SessionDep, user_in: UserCreate):
         )
     ).first()
     if existing:
-        raise AlreadyExistsException(message=f"User {user_in.username} already exists")
+        raise AlreadyExistsException(
+            message=f"User with name '{user_in.username}' already exists."
+        )
 
     try:
         to_create = User(

--- a/gpustack/routes/workers.py
+++ b/gpustack/routes/workers.py
@@ -340,7 +340,10 @@ def get_existing_worker(
         if existing_worker is not None:
             if existing_worker.cluster_id != cluster_id:
                 raise AlreadyExistsException(
-                    message=f"worker with name {worker_in.name} already exists in another cluster"
+                    message=(
+                        f"Worker with name '{worker_in.name}' already exists "
+                        "in another cluster."
+                    )
                 )
             return existing_worker
 
@@ -360,7 +363,9 @@ def check_worker_name_conflict(
         iter(filter_workers_by_fields(workers, name_conflict_fields)), None
     )
     if name_conflict_worker is not None:
-        raise AlreadyExistsException(message=f"worker with name {name} already exists")
+        raise AlreadyExistsException(
+            message=f"Worker with name '{name}' already exists."
+        )
 
 
 def find_available_worker_name(

--- a/gpustack/schemas/model_provider.py
+++ b/gpustack/schemas/model_provider.py
@@ -20,6 +20,7 @@ from pydantic import (
     model_validator,
     Field as PydanticField,
 )
+from sqlalchemy import UniqueConstraint
 from sqlmodel import (
     Field,
     Column,
@@ -496,7 +497,7 @@ class MaskedAPIToken(BaseModel):
 
 
 class ModelProviderBase(SQLModel):
-    name: str = Field(index=True, nullable=False, unique=True)
+    name: str = Field(index=True, nullable=False)
     description: Optional[str] = Field(default=None, nullable=True)
     timeout: int = Field(default=120, nullable=False)
     config: ProviderConfigType = Field(
@@ -550,12 +551,22 @@ class ModelProviderCreate(ModelProviderUpdate):
 
 class ModelProvider(ModelProviderBase, BaseModelMixin, table=True):
     __tablename__ = "model_providers"
+    __table_args__ = (
+        # Provider names are unique within their owning Org — two Orgs
+        # can each have an "openai" provider without colliding.
+        UniqueConstraint(
+            'owner_principal_id', 'name', name='uix_model_providers_name_per_owner'
+        ),
+    )
     id: Optional[int] = Field(default=None, primary_key=True)
-    # Tenant scope. NULL = global (admin-managed). Org-owned
-    # providers carry the owning Org id.
+    # Every provider belongs to one Org. The route layer fills this
+    # with ctx.current_principal_id, falling back to platform_principal_id
+    # for admin in "All" mode (Global providers are not a thing — only
+    # instance templates and inference backends carry a NULL-owner
+    # Global notion).
     owner_principal_id: Optional[int] = Field(
         default=None,
-        sa_column=Column(Integer, ForeignKey("principals.id"), nullable=True),
+        sa_column=Column(Integer, ForeignKey("principals.id"), nullable=False),
     )
     api_tokens: List[str] = Field(
         sa_column=Column(JSON, nullable=False),

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -5,7 +5,7 @@ import hashlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
 from pydantic import BaseModel, ConfigDict, field_serializer, model_validator
-from sqlalchemy import JSON, Column, ForeignKey, Integer
+from sqlalchemy import JSON, Column, ForeignKey, Integer, UniqueConstraint
 from sqlalchemy.orm import selectinload
 from sqlmodel import Field, Relationship, SQLModel, Text, select
 
@@ -216,7 +216,7 @@ class SpeculativeConfig(BaseModel):
 
 
 class ModelSpecBase(SQLModel, ModelSource):
-    name: str = Field(index=True, unique=True)
+    name: str = Field(index=True)
     description: Optional[str] = Field(
         sa_type=Text,
         nullable=True,
@@ -292,6 +292,13 @@ class ModelBase(ModelSpecBase):
 
 class Model(ModelBase, BaseModelMixin, table=True):
     __tablename__ = 'models'
+    __table_args__ = (
+        # Model names are unique within their owning Org — two Orgs
+        # can each have a "qwen3-0.6b" without colliding.
+        UniqueConstraint(
+            'owner_principal_id', 'name', name='uix_models_name_per_owner'
+        ),
+    )
     id: Optional[int] = Field(default=None, primary_key=True)
 
     instances: list["ModelInstance"] = Relationship(


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5446

Several create handlers (SSH public key, persistent volume / type, GPU instance) only relied on a DB UNIQUE constraint to catch same-name collisions, so callers saw a raw asyncpg / asyncmy IntegrityError traceback in the UI. Model and ModelProvider had a per-org pre-check but the underlying constraint was globally unique, so cross-org collisions still leaked the raw error.

Add an explicit pre-check on every affected handler that raises AlreadyExistsException with the unified wording "{Resource} with name '<X>' already exists.", and convert the global UNIQUE on models.name / model_providers.name to a per-owner composite so two Orgs can independently use the same model / provider name.