### PR TITLE
fix: repair ray address already in use after vllm v0.18.0

### DIFF
--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -479,7 +479,11 @@ class VLLMServer(InferenceServer):
             if shape in ("dp_only", "nested"):
                 env["VLLM_DP_MASTER_PORT"] = str(self._model_instance.ports[-1])
         else:
-            env["VLLM_PORT"] = str(self._model_instance.ports[-1])
+            # vLLM >= 0.18 (RayExecutorV2) reuses VLLM_PORT for the TCPStore
+            # master, which then collides with the EngineCore handshake socket
+            # (EADDRINUSE). Keep the pin only for older RayDistributedExecutor.
+            if compare_versions(self._model.backend_version, "0.18.0") < 0:
+                env["VLLM_PORT"] = str(self._model_instance.ports[-1])
             env["RAY_LOG_TO_STDERR"] = env.pop("RAY_LOG_TO_STDERR", "0")
             env["RAY_BACKEND_LOG_LEVEL"] = env.pop("RAY_BACKEND_LOG_LEVEL", "warning")
 


### PR DESCRIPTION
Starting from version 0.18.0, vLLM has removed its dependency on Ray and implemented a new RayExecutorV2. The port‑validation logic in this version has changed, resulting in an "address already in use" error on every startup. To resolve this, we need to either:
1. Unpin the VLLM_PORT environment variable, allowing vLLM to handle Ray's port‑occupancy detection itself.
2. Use VLLM_USE_RAY_V2_EXECUTOR_BACKEND=0 to force the use of the legacy executor. But once it is deprecated, we will still need to make changes again.