### PR TITLE
feat(extension): let plugins override version reported by CLI

### DIFF
--- a/gpustack/cmd/version.py
+++ b/gpustack/cmd/version.py
@@ -1,5 +1,10 @@
 import argparse
+import logging
+
 from gpustack import __version__, __git_commit__
+from gpustack.extension import Plugin, iter_plugin_classes
+
+logger = logging.getLogger(__name__)
 
 
 def setup_version_cmd(subparsers: argparse._SubParsersAction):
@@ -17,8 +22,27 @@ def setup_version_cmd(subparsers: argparse._SubParsersAction):
     parser.set_defaults(func=run)
 
 
+def _resolve_version_info() -> tuple[str, str]:
+    """Let plugins override the reported version. First non-None wins; on
+    any failure, fall back to core's baked-in values."""
+    for name, plugin_class in iter_plugin_classes():
+        if not (isinstance(plugin_class, type) and issubclass(plugin_class, Plugin)):
+            continue
+        try:
+            info = plugin_class.get_version_info()
+        except Exception:
+            logger.debug(
+                "Failed to read version info from plugin '%s'", name, exc_info=True
+            )
+            continue
+        if info is not None:
+            return info
+    return __version__, __git_commit__
+
+
 def run(args):
+    version, git_commit = _resolve_version_info()
     if args.short:
-        print(__version__)
+        print(version)
     else:
-        print(f"{__version__} ({__git_commit__})")
+        print(f"{version} ({git_commit})")

--- a/gpustack/extension.py
+++ b/gpustack/extension.py
@@ -104,3 +104,15 @@ class Plugin:
         must be a classmethod and must not depend on instance state.
         """
         return []
+
+    @classmethod
+    def get_version_info(cls) -> Optional[Tuple[str, str]]:
+        """Override the version reported by ``gpustack version`` and the
+        ``/version`` endpoint.
+
+        Return ``(version, git_commit)`` to override the core values, or
+        ``None`` to defer to core. Called at CLI-parse time, so this must
+        be a classmethod and must not depend on instance state. If multiple
+        plugins return a value, the first non-None wins.
+        """
+        return None


### PR DESCRIPTION
Add a ``get_version_info()`` classmethod hook on ``Plugin`` and route ``gpustack version`` through it. Without this, the CLI keeps reporting core's baked-in version/commit even when an installed plugin overrides the ``/version`` HTTP endpoint — making the CLI output diverge from what the UI shows.