### PR TITLE
fix: ensure resolved_path is backfilled when promoting to STARTING

### DIFF
--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -1909,13 +1909,38 @@ def _refresh_instance_download_progress(
     return False
 
 
+def _first_resolved_path(
+    files: Optional[List[ModelFile]], *, exclude_lora: bool = False
+) -> Optional[str]:
+    """Return the first resolved path among `files`, skipping LoRA files when
+    `exclude_lora` is set. None if no file carries a resolved path."""
+    for file in files or []:
+        if exclude_lora and file.is_lora:
+            continue
+        if file.resolved_paths:
+            return file.resolved_paths[0]
+    return None
+
+
 async def _promote_to_starting_if_complete(
     session: AsyncSession, instance: ModelInstance
 ) -> bool:
-    """When all files are ready, attach the LoRA
-    mount list and move to STARTING. Returns True if promoted."""
-    if not await model_instance_download_completed(session, instance):
+    """When all files are ready, attach the LoRA mount list, backfill the
+    resolved paths, and move to STARTING. Returns True if promoted."""
+    loaded = await ModelInstance.one_by_id_with_model_files(session, instance.id)
+    if not _download_completed(loaded):
         return False
+    # Promotion is the single choke point into STARTING, so backfill the paths
+    # here: the subordinate path never sets them and concurrent events may carry
+    # a None snapshot, which crashes the worker on Path(None).
+    if not instance.resolved_path:
+        instance.resolved_path = _first_resolved_path(
+            loaded.model_files, exclude_lora=True
+        )
+    if instance.draft_model_source and not instance.draft_model_resolved_path:
+        instance.draft_model_resolved_path = _first_resolved_path(
+            loaded.draft_model_files
+        )
     mounted, lora_skipped = await _build_mounted_loras_payload(session, instance)
     if mounted is not None:
         instance.mounted_loras = mounted
@@ -2164,29 +2189,28 @@ async def _build_mounted_loras_payload(
     return out, skipped
 
 
-async def model_instance_download_completed(
-    session: AsyncSession, instance: ModelInstance
-) -> bool:
-    inst = await ModelInstance.one_by_id_with_model_files(session, instance.id)
-    if inst is None:
+def _download_completed(instance: Optional[ModelInstance]) -> bool:
+    """True when every ModelFile (primary, LoRA, draft) is READY. Pure check over
+    an already-loaded instance — the caller owns the single eager load."""
+    if instance is None:
         return False
 
-    if not inst.model_files and not inst.draft_model_source:
+    if not instance.model_files and not instance.draft_model_source:
         return False
 
-    for f in inst.model_files or []:
-        if f.state != ModelFileStateEnum.READY:
+    for model_file in instance.model_files or []:
+        if model_file.state != ModelFileStateEnum.READY:
             return False
 
-    if inst.draft_model_source:
-        draft_files = inst.draft_model_files or []
+    if instance.draft_model_source:
+        draft_files = instance.draft_model_files or []
         if not draft_files:
             return False
-        for f in draft_files:
-            if f.state != ModelFileStateEnum.READY:
+        for draft_file in draft_files:
+            if draft_file.state != ModelFileStateEnum.READY:
                 return False
 
-    # Subordinate files are in inst.model_files (checked above) — the single
+    # Subordinate files are in instance.model_files (checked above) — the single
     # source of truth. The old subordinate_workers progress check raced with the
     # distributed sync path and could stick at DOWNLOADING after all hit 100%.
     return True

--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -226,7 +226,12 @@ class InferenceServer(ABC):
         if event.data["state"] == ModelInstanceStateEnum.ERROR:
             raise ModelInstanceStateError()
         elif event.data["state"] == ModelInstanceStateEnum.STARTING:
-            self._model_path = str(Path(event.data["resolved_path"]).absolute())
+            resolved_path = event.data["resolved_path"]
+            if not resolved_path:
+                raise ValueError(
+                    "Model instance reached STARTING without a resolved model path"
+                )
+            self._model_path = str(Path(resolved_path).absolute())
             if event.data["draft_model_resolved_path"]:
                 self._draft_model_path = str(
                     Path(event.data["draft_model_resolved_path"]).absolute()

--- a/tests/server/test_model_file_state_sync.py
+++ b/tests/server/test_model_file_state_sync.py
@@ -76,7 +76,7 @@ def _distributed_instance(sub_download_progress: float) -> ModelInstance:
 @contextlib.contextmanager
 def _patched(instance: ModelInstance):
     """Patch every DB touchpoint so the sync runs in-memory, while letting
-    model_instance_download_completed execute for real against instance.model_files."""
+    _download_completed execute for real against instance.model_files."""
     service = MagicMock()
     service.return_value.update = AsyncMock()
     patches = [
@@ -128,3 +128,21 @@ async def test_subordinate_ready_promotes_when_progress_already_100():
         await sync_distributed_model_file_state(MagicMock(), sub_file, instance)
 
     assert instance.state == ModelInstanceStateEnum.STARTING
+
+
+@pytest.mark.asyncio
+async def test_promotion_backfills_resolved_path_from_ready_primary_file():
+    """Reaching STARTING must always carry a resolved_path, otherwise the worker
+    crashes with Path(None) ("expected str, bytes or os.PathLike object, not
+    NoneType"). The subordinate READY path promotes without setting resolved_path,
+    and a concurrent main-worker event may promote off a snapshot where it is
+    still None. Promotion must backfill it from the READY primary ModelFile."""
+    instance = _distributed_instance(sub_download_progress=100)
+    instance.resolved_path = None
+    sub_file = instance.model_files[1]  # subordinate file, never owns resolved_path
+
+    with _patched(instance):
+        await sync_distributed_model_file_state(MagicMock(), sub_file, instance)
+
+    assert instance.state == ModelInstanceStateEnum.STARTING
+    assert instance.resolved_path == "/cache/main"


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5492
In commit [269e3aea](https://github.com/gpustack/gpustack/commit/269e3aea0eecc865e3db5cf2febdc74763cf88bc), the race condition still exists, which could result in resolve_paths being empty and causing a null‑value exception at runtime.