### PR TITLE
fix: principal prefix in my-models

### DIFF
--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -29,6 +29,7 @@ from gpustack.schemas.model_routes import (
     ModelUserAccessExtended,
     MyModel,
     TargetStateEnum,
+    effective_route_name,
 )
 from gpustack.schemas.links import ModelRoutePrincipalLink
 from gpustack.schemas.principals import platform_principal_id
@@ -341,7 +342,7 @@ async def _get_model_routes(
             conditions = build_category_conditions(session, target_class, categories)
             extra_conditions.append(or_(*conditions))
 
-        return await target_class.paginated_by_query(
+        result = await target_class.paginated_by_query(
             session=session,
             fields=fields,
             fuzzy_fields=fuzzy_fields,
@@ -349,6 +350,57 @@ async def _get_model_routes(
             per_page=params.perPage,
             order_by=params.order_by,
             extra_conditions=extra_conditions,
+        )
+        await _apply_effective_name_to_my_models(session, target_class, result.items)
+        return result
+
+
+async def _apply_effective_name_to_my_models(
+    session: AsyncSession, target_class, items: List[MyModel]
+) -> None:
+    """Overwrite ``item.name`` with the OpenAI-style effective name —
+    bare for the platform Org, ``<owner-name>/<name>`` otherwise — so
+    the My Models consumption surface (card, Open-in-Playground) uses
+    the same id ``/v1/models`` reports. Cross-Org grants surface under
+    their owning Org's prefix instead of the caller's current Org,
+    which is the gap a frontend cache lookup can't close (the granting
+    Org isn't in the caller's member list).
+
+    Search/filter remain against the raw ``name`` column on the DB
+    side. Writes go through ``__dict__`` rather than the attribute
+    setter so SQLAlchemy's instrumentation doesn't mark the instance
+    dirty — otherwise a later autoflush (or any caller that adds a
+    commit downstream) would attempt to ``UPDATE`` the
+    ``non_admin_user_models`` view and error. Pydantic's
+    ``from_attributes`` reads via ``getattr``, which still resolves
+    through ``__dict__``, so the response picks up the rewritten value.
+
+    Accepts ``target_class`` so callers can invoke unconditionally —
+    the helper short-circuits for ``ModelRoute``. Keeps the surrounding
+    ``_get_model_routes`` / ``_get_model_route`` branches flat (their
+    cyclomatic complexity is already at the limit).
+    """
+    if target_class is not MyModel:
+        return
+    if not items:
+        return
+    owner_ids = {
+        item.owner_principal_id for item in items if item.owner_principal_id is not None
+    }
+    if not owner_ids:
+        return
+    stmt = select(Principal.id, Principal.name).where(
+        col(Principal.id).in_(owner_ids),
+        Principal.kind == PrincipalType.ORG,
+    )
+    owner_names: Dict[int, Optional[str]] = dict((await session.exec(stmt)).all())
+    platform_id = platform_principal_id()
+    for item in items:
+        owner_id = item.owner_principal_id
+        item.__dict__['name'] = effective_route_name(
+            route_name=item.name,
+            owner_name=owner_names.get(owner_id) if owner_id is not None else None,
+            is_platform_org=owner_id == platform_id,
         )
 
 
@@ -453,6 +505,7 @@ async def _get_model_route(
                 existing,
                 not_found_message=f"ModelAccess with id '{id}' not found.",
             )
+    await _apply_effective_name_to_my_models(session, target_class, [existing])
     return existing
 
 

--- a/tests/routes/test_model_routes.py
+++ b/tests/routes/test_model_routes.py
@@ -86,6 +86,60 @@ async def test_get_model_routes_filters_categories_on_target_class(monkeypatch):
     assert captured["extra_conditions"]
 
 
+@pytest.mark.asyncio
+async def test_apply_effective_name_to_my_models_prefixes_by_owner(monkeypatch):
+    """Items get rewritten in place: platform Org's route stays bare,
+    non-platform Orgs prefix with the owner's ``name``. This is what
+    lets the My Models page render and Open-in-Playground submit the
+    OpenAI-style id even for cross-Org grants (granting Org isn't in
+    the caller's client-side cache, but the server has it)."""
+    monkeypatch.setattr(model_routes, "platform_principal_id", lambda: 1)
+
+    items = [
+        SimpleNamespace(name="qwen3-0.6b", owner_principal_id=1),
+        SimpleNamespace(name="qwen3-0.6b", owner_principal_id=2),
+        SimpleNamespace(name="bge-m3", owner_principal_id=3),
+    ]
+
+    session = SimpleNamespace()
+    exec_result = MagicMock()
+    exec_result.all.return_value = [(2, "alpha"), (3, "beta")]
+    session.exec = AsyncMock(return_value=exec_result)
+
+    await model_routes._apply_effective_name_to_my_models(session, MyModel, items)
+
+    assert items[0].name == "qwen3-0.6b"  # platform Org → no prefix
+    assert items[1].name == "alpha/qwen3-0.6b"
+    assert items[2].name == "beta/bge-m3"
+
+
+@pytest.mark.asyncio
+async def test_apply_effective_name_to_my_models_skips_model_route():
+    """``ModelRoute`` callers (the management surface) reuse the same
+    code path but must skip the rewrite — Routes always belong to the
+    caller's own Org, the frontend already has it cached, and the page
+    expects raw ``name``."""
+    session = SimpleNamespace(exec=AsyncMock())
+    item = SimpleNamespace(name="qwen3-0.6b", owner_principal_id=2)
+
+    await model_routes._apply_effective_name_to_my_models(session, ModelRoute, [item])
+
+    session.exec.assert_not_called()
+    assert item.name == "qwen3-0.6b"
+
+
+@pytest.mark.asyncio
+async def test_apply_effective_name_to_my_models_empty_is_noop():
+    """Empty input must short-circuit before any session query — the
+    helper runs on every MyModel list (including 0-result pages) and a
+    spurious round-trip per page would be a regression."""
+    session = SimpleNamespace(exec=AsyncMock())
+
+    await model_routes._apply_effective_name_to_my_models(session, MyModel, [])
+
+    session.exec.assert_not_called()
+
+
 def test_assert_target_tenant_aligned_same_org():
     # Same Org is always allowed.
     model_routes._assert_target_tenant_aligned(


### PR DESCRIPTION
Rewrite ``MyModel`` rows' ``name`` to the OpenAI-style id at serialization time (bare for the platform Org, ``<owner-name>/<name>`` otherwise) on the consumption path (``GET /v2/my-models`` list + detail).

Cross-Org grants surfaced under the caller's current Org's prefix on the frontend — the granting Org isn't in the caller's client-side cache, so the lookup fell through to ``getCurrentOrg()`` and produced ``<callerOrg>/<name>`` instead of ``<ownerOrg>/<name>``. The server has both ids in hand; doing it here closes that gap.

Search/filter remain against the raw ``name`` column on the DB side; the rewrite is at serialization only (no commit, and ``MyModel`` is a SQL VIEW anyway). The Routes management surface (``/model-routes``) keeps its previous shape — it's always scoped to the caller's own Org, so the frontend cache lookup there is already correct.