### PR TITLE
fix: scope route name validator to write path

### DIFF
--- a/gpustack/schemas/model_routes.py
+++ b/gpustack/schemas/model_routes.py
@@ -317,6 +317,18 @@ class ModelRouteUpdateBase(SQLModel):
                 raise ValueError(f"Invalid category: {category}")
         return v
 
+
+class ModelRouteUpdate(ModelRouteUpdateBase):
+    targets: Optional[List[ModelRouteTargetUpdateItem]] = Field(
+        default=None, nullable=True
+    )
+
+    # Name validation lives on the write path only. Read-side classes
+    # (``ModelRouteBase`` and descendants — ``ModelRoute``, ``MyModel``,
+    # ``ModelRoutePublic``) skip it so the server-side enrichment in
+    # ``_apply_effective_name_to_my_models`` can surface
+    # ``<owner-name>/<name>`` without tripping the no-slash rule that
+    # only ever applied to user-supplied input.
     @model_validator(mode="after")
     def validate_name(self):
         name = self.name
@@ -328,12 +340,6 @@ class ModelRouteUpdateBase(SQLModel):
                 "underscores, or dots, and not end with hyphen or underscore"
             )
         return self
-
-
-class ModelRouteUpdate(ModelRouteUpdateBase):
-    targets: Optional[List[ModelRouteTargetUpdateItem]] = Field(
-        default=None, nullable=True
-    )
 
 
 class ModelRouteCreate(ModelRouteUpdate):

--- a/tests/routes/test_model_routes.py
+++ b/tests/routes/test_model_routes.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -14,7 +15,9 @@ from gpustack.schemas.common import Pagination
 from gpustack.schemas.model_routes import (
     AccessPolicyEnum,
     ModelRoute,
+    ModelRouteCreate,
     ModelRouteListParams,
+    ModelRoutePublic,
     ModelRoutesPublic,
     MyModel,
 )
@@ -126,6 +129,33 @@ async def test_apply_effective_name_to_my_models_skips_model_route():
 
     session.exec.assert_not_called()
     assert item.name == "qwen3-0.6b"
+
+
+def test_model_route_create_rejects_slashed_name():
+    """The no-slash rule must still gate user input on the write path —
+    otherwise a hand-typed ``foo/bar`` would collide with the
+    ``<owner>/<name>`` shape the read path synthesizes."""
+    with pytest.raises(ValueError, match="must start with a letter"):
+        ModelRouteCreate(name="org1/qwen3-0.6b", targets=[])
+
+
+def test_model_route_public_accepts_enriched_slashed_name():
+    """Regression: the My Models response serializes through
+    ``ModelRoutePublic``; once ``_apply_effective_name_to_my_models``
+    rewrites ``name`` to ``<owner>/<name>``, response validation must
+    accept it (the prior inherited validator rejected it with
+    ``Unexpected error occurred: 1 validation error``)."""
+    now = datetime(2026, 6, 7, tzinfo=timezone.utc)
+    public = ModelRoutePublic.model_validate(
+        {
+            "id": 1,
+            "name": "org1/qwen3-0.6b",
+            "owner_principal_id": 6,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+    assert public.name == "org1/qwen3-0.6b"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The enrichment in c1b2fbbe rewrites ``MyModel.name`` to ``<owner-org>/<name>`` at serialization time, but ``validate_name`` lived on ``ModelRouteUpdateBase`` and was inherited by ``ModelRoutePublic`` — so FastAPI's response-side ``model_validate`` re-ran the no-slash regex on the enriched value and 500'd the ``GET /v2/my-models`` call for any non-platform Org member.

Move the validator down to ``ModelRouteUpdate``. It still gates ``ModelRouteUpdate`` / ``ModelRouteCreate`` (the only paths that take user-supplied names) and no longer fires on ``ModelRouteBase`` or its read-side descendants (``ModelRoute``, ``MyModel``, ``ModelRoutePublic``), which only hold values validated at write time plus the server-synthesized prefixed form.

The existing helper tests passed because they used ``SimpleNamespace`` and bypassed Pydantic; add two pins that drive the actual schema boundary — write rejects ``org1/qwen3-0.6b``, ``ModelRoutePublic`` accepts it.