### PR TITLE
refactor: compute Allocated server-side from current ModelInstance bindings

### DIFF
--- a/gpustack/client/generated_benchmark_client.py
+++ b/gpustack/client/generated_benchmark_client.py
@@ -48,32 +48,33 @@ class BenchmarkClient:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
         return BenchmarksPublic.model_validate(response.json())
 
-    def _list_from_cache(self, params: Dict[str, Any] = None) -> BenchmarksPublic:
+    def _list_from_cache(
+        self, params: Dict[str, Any] = None
+    ) -> Optional[BenchmarksPublic]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -193,68 +194,102 @@ class BenchmarkClient:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"benchmarks cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(f"benchmarks cache watch started")
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"benchmarks cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"benchmarks cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on benchmarks {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on benchmarks {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> BenchmarkPublic:
         """
@@ -268,27 +303,21 @@ class BenchmarkClient:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for benchmark {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = BenchmarkPublic.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return BenchmarkPublic.model_validate(response.json())
 
     def create(self, model_create: BenchmarkCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/client/generated_inference_backend_client.py
+++ b/gpustack/client/generated_inference_backend_client.py
@@ -48,18 +48,12 @@ class InferenceBackendClient:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
@@ -67,15 +61,20 @@ class InferenceBackendClient:
 
     def _list_from_cache(
         self, params: Dict[str, Any] = None
-    ) -> InferenceBackendsPublic:
+    ) -> Optional[InferenceBackendsPublic]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -197,68 +196,102 @@ class InferenceBackendClient:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"inference-backends cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(f"inference-backends cache watch started")
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"inference-backends cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"inference-backends cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on inference-backends {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on inference-backends {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> InferenceBackendPublic:
         """
@@ -272,27 +305,21 @@ class InferenceBackendClient:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for inferencebackend {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = InferenceBackendPublic.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return InferenceBackendPublic.model_validate(response.json())
 
     def create(self, model_create: InferenceBackendCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/client/generated_model_client.py
+++ b/gpustack/client/generated_model_client.py
@@ -48,32 +48,31 @@ class ModelClient:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
         return ModelsPublic.model_validate(response.json())
 
-    def _list_from_cache(self, params: Dict[str, Any] = None) -> ModelsPublic:
+    def _list_from_cache(self, params: Dict[str, Any] = None) -> Optional[ModelsPublic]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -193,68 +192,102 @@ class ModelClient:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"models cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(f"models cache watch started")
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"models cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"models cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on models {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on models {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> ModelPublic:
         """
@@ -268,27 +301,21 @@ class ModelClient:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for model {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = ModelPublic.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return ModelPublic.model_validate(response.json())
 
     def create(self, model_create: ModelCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/client/generated_model_file_client.py
+++ b/gpustack/client/generated_model_file_client.py
@@ -48,32 +48,33 @@ class ModelFileClient:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
         return ModelFilesPublic.model_validate(response.json())
 
-    def _list_from_cache(self, params: Dict[str, Any] = None) -> ModelFilesPublic:
+    def _list_from_cache(
+        self, params: Dict[str, Any] = None
+    ) -> Optional[ModelFilesPublic]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -193,68 +194,102 @@ class ModelFileClient:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"model-files cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(f"model-files cache watch started")
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"model-files cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"model-files cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on model-files {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on model-files {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> ModelFilePublic:
         """
@@ -268,27 +303,21 @@ class ModelFileClient:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for modelfile {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = ModelFilePublic.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return ModelFilePublic.model_validate(response.json())
 
     def create(self, model_create: ModelFileCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/client/generated_model_instance_client.py
+++ b/gpustack/client/generated_model_instance_client.py
@@ -48,32 +48,33 @@ class ModelInstanceClient:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
         return ModelInstancesPublic.model_validate(response.json())
 
-    def _list_from_cache(self, params: Dict[str, Any] = None) -> ModelInstancesPublic:
+    def _list_from_cache(
+        self, params: Dict[str, Any] = None
+    ) -> Optional[ModelInstancesPublic]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -193,68 +194,102 @@ class ModelInstanceClient:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"model-instances cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(f"model-instances cache watch started")
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"model-instances cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"model-instances cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on model-instances {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on model-instances {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> ModelInstancePublic:
         """
@@ -268,27 +303,21 @@ class ModelInstanceClient:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for modelinstance {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = ModelInstancePublic.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return ModelInstancePublic.model_validate(response.json())
 
     def create(self, model_create: ModelInstanceCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/client/generated_model_route_target_client.py
+++ b/gpustack/client/generated_model_route_target_client.py
@@ -48,18 +48,12 @@ class ModelRouteTargetClient:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
@@ -67,15 +61,20 @@ class ModelRouteTargetClient:
 
     def _list_from_cache(
         self, params: Dict[str, Any] = None
-    ) -> ModelRouteTargetsPublic:
+    ) -> Optional[ModelRouteTargetsPublic]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -197,68 +196,102 @@ class ModelRouteTargetClient:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"model-route-targets cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(f"model-route-targets cache watch started")
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"model-route-targets cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"model-route-targets cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on model-route-targets {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on model-route-targets {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> ModelRouteTargetPublic:
         """
@@ -272,27 +305,21 @@ class ModelRouteTargetClient:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for modelroutetarget {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = ModelRouteTargetPublic.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return ModelRouteTargetPublic.model_validate(response.json())
 
     def create(self, model_create: ModelRouteTargetCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/client/generated_user_client.py
+++ b/gpustack/client/generated_user_client.py
@@ -48,32 +48,31 @@ class UserClient:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
         return UsersPublic.model_validate(response.json())
 
-    def _list_from_cache(self, params: Dict[str, Any] = None) -> UsersPublic:
+    def _list_from_cache(self, params: Dict[str, Any] = None) -> Optional[UsersPublic]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -193,68 +192,102 @@ class UserClient:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"users cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(f"users cache watch started")
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"users cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"users cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on users {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on users {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> UserPublic:
         """
@@ -268,27 +301,21 @@ class UserClient:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for user {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = UserPublic.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return UserPublic.model_validate(response.json())
 
     def create(self, model_create: UserCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/client/generated_worker_client.py
+++ b/gpustack/client/generated_worker_client.py
@@ -48,32 +48,33 @@ class WorkerClient:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
         return WorkersPublic.model_validate(response.json())
 
-    def _list_from_cache(self, params: Dict[str, Any] = None) -> WorkersPublic:
+    def _list_from_cache(
+        self, params: Dict[str, Any] = None
+    ) -> Optional[WorkersPublic]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -193,68 +194,102 @@ class WorkerClient:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"workers cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(f"workers cache watch started")
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"workers cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"workers cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on workers {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on workers {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> WorkerPublic:
         """
@@ -268,27 +303,21 @@ class WorkerClient:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for worker {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = WorkerPublic.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return WorkerPublic.model_validate(response.json())
 
     def create(self, model_create: WorkerCreate):
         response = self._client.get_httpx_client().post(

--- a/gpustack/codegen/templates/client.py.jinja
+++ b/gpustack/codegen/templates/client.py.jinja
@@ -48,32 +48,33 @@ class {{ class_name }}Client:
         pagination_params = {"page", "perPage"} if params else set()
         has_pagination = any(k in pagination_params for k in (params or {}))
 
-        should_use_cache = (
-            use_cache
-            and self._enable_cache
-            and self._watch_started
-            and not has_pagination  # Don't use cache if pagination params exist
-        )
+        if use_cache and self._enable_cache and not has_pagination:
+            cached = self._list_from_cache(params)
+            if cached is not None:
+                return cached
 
-        # If cache should be used, try to read from cache
-        if should_use_cache:
-            return self._list_from_cache(params)
-
-        # Otherwise, make API call
+        # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)
         raise_if_response_error(response)
 
         return {{ class_name | to_plural }}Public.model_validate(response.json())
 
-    def _list_from_cache(self, params: Dict[str, Any] = None) -> {{ class_name | to_plural }}Public:
+    def _list_from_cache(
+        self, params: Dict[str, Any] = None
+    ) -> Optional[{{ class_name | to_plural }}Public]:
         """
-        List resources from cache instead of making an API call.
+        Snapshot the cache atomically with the _watch_started check.
 
-        Note: Cache is automatically populated when awatch() is called.
-        The first call to awatch() will set _watch_started=True and enable caching.
+        Returns None if the watch cache is not currently authoritative —
+        caller should fall back to a direct API call.
         """
-        # Get all cached items
+        # Atomically check _watch_started and snapshot the items so that
+        # awatch's teardown (which flips _watch_started=False and clears
+        # the cache under the same lock) can never leave us reading an
+        # empty cache while still believing it's authoritative.
         with self._cache_lock:
+            if not self._watch_started:
+                return None
             all_items = list(self._cache.values())
 
         # Apply filters if params provided
@@ -193,68 +194,104 @@ class {{ class_name }}Client:
         if stop_condition is None:
             stop_condition = lambda event: False
 
-        # Mark watch as started when awatch is called
-        # This enables list()/get() to use cache automatically
-        if self._enable_cache and not self._watch_started:
-            self._watch_started = True
-            logger.debug(f"{{ class_name | to_dash_plural }} cache watch started")
+        try:
+            async with self._client.get_async_httpx_client().stream(
+                "GET",
+                self._url,
+                params=params,
+                timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
+            ) as response:
+                await async_raise_if_response_error(response)
 
-        async with self._client.get_async_httpx_client().stream(
-            "GET",
-            self._url,
-            params=params,
-            timeout=httpx.Timeout(connect=10, read=None, write=10, pool=10),
-        ) as response:
-            await async_raise_if_response_error(response)
-            lines = response.aiter_lines()
-            while True:
-                try:
-                    line = await asyncio.wait_for(lines.__anext__(), timeout=45)
-                    if line:
-                        event_data = json.loads(line)
-                        event = Event(**event_data)
+                # Connection is up. The server's replay_existing=True snapshot
+                # that follows is authoritative, so drop any stale entries
+                # from a prior session — items deleted while we were
+                # disconnected won't get a DELETED event (already gone from
+                # DB) and would otherwise persist in the cache forever.
+                # Flip _watch_started here (not before connect) so that a
+                # failed connect doesn't leave list()/get() reading an empty
+                # cache while believing it's authoritative.
+                first_start = False
+                if self._enable_cache:
+                    with self._cache_lock:
+                        self._cache.clear()
+                        self._initial_sync_logged = False
+                        first_start = not self._watch_started
+                        self._watch_started = True
+                    if first_start:
+                        logger.debug(
+                            f"{{ class_name | to_dash_plural }} cache watch started"
+                        )
 
-                        # Update cache if enabled
-                        if self._enable_cache:
-                            await self._update_cache_from_event(event)
+                lines = response.aiter_lines()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(lines.__anext__(), timeout=45)
+                        if line:
+                            event_data = json.loads(line)
+                            event = Event(**event_data)
 
-                            # Log cache size after initial events (approximately)
+                            # Update cache if enabled
+                            if self._enable_cache:
+                                await self._update_cache_from_event(event)
+
+                                # Log cache size after initial events (approximately)
+                                if (
+                                    not self._initial_sync_logged
+                                    and event.type == EventType.CREATED
+                                ):
+                                    # Check if we have accumulated enough items (heuristic)
+                                    with self._cache_lock:
+                                        cache_size = len(self._cache)
+                                    if cache_size > 0:
+                                        # Set a flag to avoid repeated logging
+                                        self._initial_sync_logged = True
+                                        logger.debug(
+                                            f"{{ class_name | to_dash_plural }} cache populated with {cache_size} items"
+                                        )
+
+                            # Skip the callback if the event is still ID-only after
+                            # cache update (e.g. DELETED for an item this client
+                            # never saw). Subscribers like ServeManager call
+                            # model_validate(event.data) and would otherwise fail;
+                            # also they can't act without the full object.
                             if (
-                                not self._initial_sync_logged
-                                and event.type == EventType.CREATED
+                                isinstance(event.data, dict)
+                                and event.id is not None
+                                and set(event.data.keys()) == {"id"}
                             ):
-                                # Check if we have accumulated enough items (heuristic)
-                                with self._cache_lock:
-                                    cache_size = len(self._cache)
-                                if cache_size > 0:
-                                    # Set a flag to avoid repeated logging
-                                    self._initial_sync_logged = True
-                                    logger.debug(
-                                        f"{{ class_name | to_dash_plural }} cache populated with {cache_size} items"
-                                    )
-
-                        # Skip the callback if the event is still ID-only after
-                        # cache update (e.g. DELETED for an item this client
-                        # never saw). Subscribers like ServeManager call
-                        # model_validate(event.data) and would otherwise fail;
-                        # also they can't act without the full object.
-                        if (
-                            isinstance(event.data, dict)
-                            and event.id is not None
-                            and set(event.data.keys()) == {"id"}
-                        ):
-                            logger.debug(
-                                f"Skipping callback for ID-only {event.type} event on {{ class_name | to_dash_plural }} {event.id}"
-                            )
-                        elif callback:
-                            if asyncio.iscoroutinefunction(callback):
-                                await callback(event)
-                            else:
-                                callback(event)
-                        if stop_condition(event):
-                            break
-                except asyncio.TimeoutError:
-                    raise Exception("watch timeout")
+                                logger.debug(
+                                    f"Skipping callback for ID-only {event.type} event on {{ class_name | to_dash_plural }} {event.id}"
+                                )
+                            elif callback:
+                                if asyncio.iscoroutinefunction(callback):
+                                    await callback(event)
+                                else:
+                                    callback(event)
+                            if stop_condition(event):
+                                break
+                    except StopAsyncIteration:
+                        # Surface as an exception (not a clean return) so the
+                        # caller's reconnect loop hits its `except` branch and
+                        # respects its backoff — otherwise a server that keeps
+                        # closing the stream would trigger a tight reconnect loop.
+                        raise ConnectionError("Watch stream closed by server")
+                    except asyncio.TimeoutError:
+                        # Re-raise as asyncio.TimeoutError (not the built-in
+                        # TimeoutError) — on Python 3.10 they are distinct
+                        # classes and callers may catch the asyncio variant.
+                        raise asyncio.TimeoutError("watch timeout")
+        finally:
+            # When awatch is no longer running the cache is not authoritative
+            # — flip _watch_started=False so list()/get() fall back to direct
+            # API calls until the next successful (re)connect. Done under
+            # the lock together with the clear so concurrent readers can't
+            # observe (_watch_started=True, cache=empty).
+            if self._enable_cache:
+                with self._cache_lock:
+                    if self._watch_started:
+                        self._watch_started = False
+                        self._cache.clear()
 
     def get(self, id: int, use_cache: bool = True) -> {{ class_name }}Public:
         """
@@ -268,27 +305,21 @@ class {{ class_name }}Client:
         Returns:
             Resource object
         """
-        # Use cache if enabled, watch is running, and use_cache is True
-        should_use_cache = use_cache and self._enable_cache and self._watch_started
-
-        # Try to get from cache first if it should be used
-        if should_use_cache:
+        # Atomically check _watch_started and read from the cache so awatch's
+        # teardown can't slip between the two and leave us returning a miss.
+        if use_cache and self._enable_cache:
             with self._cache_lock:
-                if id in self._cache:
+                if self._watch_started and id in self._cache:
                     logger.trace(f"Cache hit for {{ class_name | lower }} {id}")
                     return self._cache[id]
 
-        # Fall back to API call
+        # Fall back to API call. Do NOT write the result into the cache:
+        # the awatch stream is the single source of truth, and a concurrent
+        # DELETED/UPDATED event arriving during this API call could be
+        # overwritten by a stale result here.
         response = self._client.get_httpx_client().get(f"{self._url}/{id}")
         raise_if_response_error(response)
-        result = {{ class_name }}Public.model_validate(response.json())
-
-        # Update cache if enabled
-        if self._enable_cache:
-            with self._cache_lock:
-                self._cache[id] = result
-
-        return result
+        return {{ class_name }}Public.model_validate(response.json())
 
     def create(self, model_create: {{ class_name }}Create):
         response = self._client.get_httpx_client().post(

--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -4,7 +4,17 @@ import importlib
 import json
 import logging
 import math
-from typing import Any, AsyncGenerator, Callable, Iterable, List, Optional, Union, Tuple
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Union,
+    Tuple,
+)
 
 import anyio
 from fastapi.encoders import jsonable_encoder
@@ -831,6 +841,7 @@ class ActiveRecordMixin:
         fuzzy_fields: Optional[dict] = None,
         filter_func: Optional[Callable[[Any], bool]] = None,
         options: Optional[List] = None,
+        event_transform: Optional[Callable[[Event], Awaitable[None]]] = None,
     ) -> AsyncGenerator[str, None]:
         """Stream events matching the given criteria as JSON strings.
 
@@ -839,6 +850,12 @@ class ActiveRecordMixin:
             fuzzy_fields: Fuzzy match filters
             filter_func: Optional filter function to apply to event data
             options: SQLAlchemy options for eager loading relationships (e.g., selectinload)
+            event_transform: Optional async hook called with the public Event
+                right before serialization. May mutate ``event.data`` in
+                place to inject fields derived from outside the raw
+                subscribe payload — used e.g. by /v2/workers to inject
+                allocated computed from current ModelInstance bindings so
+                the watch stream matches the REST response.
         """
         try:
             async for event in cls.subscribe(source="streaming", options=options):
@@ -861,6 +878,14 @@ class ActiveRecordMixin:
                     changed_fields=event.changed_fields,
                     id=event.id,
                 )
+                if event_transform is not None:
+                    try:
+                        await event_transform(public_event)
+                    except Exception as e:
+                        logger.error(
+                            f"event_transform failed for {cls.__name__} "
+                            f"event {event.id}: {e}"
+                        )
                 formatted = cls._format_event(public_event)
                 if formatted is not None:
                     yield formatted

--- a/gpustack/policies/utils.py
+++ b/gpustack/policies/utils.py
@@ -42,7 +42,53 @@ class WorkerGPUInfo(BaseModel):
     allocatable_vram: int  # in bytes
 
 
-def get_worker_allocatable_resource(  # noqa: C901
+def compute_worker_allocated(
+    all_model_instances: List[ModelInstance],
+    worker_id: int,
+    gpu_type: Optional[str] = None,
+) -> Allocated:
+    """Aggregate (ram, {gpu_index: vram}) for ``worker_id`` from current
+    ModelInstance assignments — main worker + distributed subordinates.
+
+    The single source of truth for "what's scheduled on this worker", used
+    by the scheduler (via :func:`get_worker_allocatable_resource`), the
+    workers REST API, and the worker-side collector. Mirrors the K8s
+    scheduler pattern of deriving Allocated from current workload→node
+    bindings rather than from anything the node self-reports.
+
+    For the main worker, both ram and per-GPU vram are counted. For
+    distributed subordinate workers, only vram is counted — the rpc-server
+    side doesn't consume the model's RAM.
+    """
+    allocated = Allocated(ram=0, vram={})
+
+    def add_vram(claim):
+        for gpu_index, vram in (claim.vram or {}).items():
+            allocated.vram[gpu_index] = allocated.vram.get(gpu_index, 0) + vram
+
+    for mi in all_model_instances:
+        if mi.worker_id == worker_id and (
+            gpu_type is None or mi.gpu_type is None or mi.gpu_type == gpu_type
+        ):
+            claim = mi.computed_resource_claim
+            if claim is not None:
+                allocated.ram += claim.ram or 0
+                if mi.gpu_indexes:
+                    add_vram(claim)
+
+        if mi.distributed_servers and mi.distributed_servers.subordinate_workers:
+            for sw in mi.distributed_servers.subordinate_workers:
+                if sw.worker_id != worker_id:
+                    continue
+                if sw.computed_resource_claim and (
+                    gpu_type is None or mi.gpu_type == gpu_type
+                ):
+                    add_vram(sw.computed_resource_claim)
+
+    return allocated
+
+
+def get_worker_allocatable_resource(
     all_model_instances: List[ModelInstance],
     worker: Worker,
     gpu_type: Optional[str] = None,
@@ -51,43 +97,9 @@ def get_worker_allocatable_resource(  # noqa: C901
     Get the worker with the latest allocatable resources, if gpu_type is provided, only consider the GPUs of that type.
     """
 
-    def update_allocated_vram(allocated, resource_claim):
-        for gpu_index, vram in resource_claim.vram.items():
-            allocated.vram[gpu_index] = allocated.vram.get(gpu_index, 0) + vram
-
     is_unified_memory = worker.status.memory.is_unified_memory
     model_instances = get_worker_model_instances(all_model_instances, worker)
-    allocated = Allocated(ram=0, vram={})
-
-    for model_instance in model_instances:
-        # Handle resource allocation for main worker
-        if model_instance.worker_id == worker.id and (
-            gpu_type is None
-            or model_instance.gpu_type is None
-            or model_instance.gpu_type == gpu_type
-        ):
-            allocated.ram += model_instance.computed_resource_claim.ram or 0
-            if model_instance.gpu_indexes:
-                update_allocated_vram(allocated, model_instance.computed_resource_claim)
-
-        # Handle resource allocation for subordinate workers
-        if (
-            model_instance.distributed_servers
-            and model_instance.distributed_servers.subordinate_workers
-        ):
-            for (
-                subordinate_worker
-            ) in model_instance.distributed_servers.subordinate_workers:
-                if subordinate_worker.worker_id != worker.id:
-                    continue
-
-                if subordinate_worker.computed_resource_claim and (
-                    gpu_type is None or model_instance.gpu_type == gpu_type
-                ):
-                    # rpc server only consider the vram
-                    update_allocated_vram(
-                        allocated, subordinate_worker.computed_resource_claim
-                    )
+    allocated = compute_worker_allocated(model_instances, worker.id, gpu_type)
 
     allocatable = Allocatable(ram=0, vram={})
     if worker.status.gpu_devices:

--- a/gpustack/routes/workers.py
+++ b/gpustack/routes/workers.py
@@ -4,7 +4,7 @@ import base64
 import uuid
 import logging
 import asyncio
-from typing import Optional, List, Dict, Any, Set
+from typing import Optional, List, Dict, Any, Set, Tuple
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
@@ -49,6 +49,8 @@ from gpustack.schemas.workers import (
     WorkerStatusStored,
     WorkerStateEnum,
 )
+from gpustack.server.bus import Event, EventType
+from gpustack.server.worker_allocated_cache import get_worker_allocated
 from gpustack.schemas.clusters import Cluster, Credential, ClusterStateEnum
 from gpustack.schemas.principals import Principal, PrincipalType
 from gpustack.schemas.api_keys import ApiKey
@@ -71,12 +73,80 @@ logger = logging.getLogger(__name__)
 create_worker_semaphore = asyncio.Semaphore(10)
 
 
-def to_worker_public(input: Worker, me: bool) -> WorkerPublic:
+def to_worker_public(
+    input: Worker,
+    me: bool,
+    allocated: Tuple[int, Dict[int, int]] = (0, {}),
+) -> WorkerPublic:
     data = input.model_dump()
     if me:
         data['me'] = me
 
+    _inject_allocated_into_status(data.get('status'), allocated)
+
     return WorkerPublic.model_validate(data)
+
+
+def _inject_allocated_into_status(
+    status: Optional[dict],
+    allocated: Tuple[int, Dict[int, int]],
+):
+    """Override status.memory.allocated and gpu_devices[*].memory.allocated
+    with values aggregated server-side from current ModelInstance assignments.
+
+    The worker's self-reported values are ignored: they can lag arbitrarily
+    when the worker is offline or its cache is stale. Following the K8s
+    Node.Allocated pattern, the orchestrator's view of "what's scheduled
+    here" is what the UI shows.
+    """
+    if status is None:
+        return
+    ram, vram = allocated
+    memory = status.get('memory')
+    if memory is not None:
+        memory['allocated'] = ram
+    for device in status.get('gpu_devices') or []:
+        device_memory = device.get('memory')
+        if device_memory is None:
+            continue
+        idx = device.get('index')
+        device_memory['allocated'] = vram.get(idx, 0) if idx is not None else 0
+
+
+async def _lookup_allocated(worker_id: int) -> Tuple[int, Dict[int, int]]:
+    """Cache-backed (ram, vram) lookup for a worker. Per-worker cache key
+    invalidated by ModelInstanceService on writes that touch this worker
+    (see server.worker_allocated_cache)."""
+    allocated = await get_worker_allocated(worker_id)
+    return (allocated.ram, allocated.vram)
+
+
+async def _inject_allocated_into_event(event: Event):
+    """Mutate a Worker watch event so its WorkerPublic carries the same
+    server-computed allocated as the REST response. The persisted
+    worker.status.*.allocated is None (workers don't report it anymore),
+    so without this the UI would receive the watch event and flash to 0
+    right after the REST fetch showed the correct value.
+    """
+    # DELETED events arrive with data={"id": N} (ID-only) — nothing to mutate.
+    if event.type == EventType.DELETED:
+        return
+    worker = event.data
+    if (
+        not isinstance(worker, WorkerPublic)
+        or worker.id is None
+        or worker.status is None
+    ):
+        return
+
+    ram, vram = await _lookup_allocated(worker.id)
+    if worker.status.memory is not None:
+        worker.status.memory.allocated = ram
+    for device in worker.status.gpu_devices or []:
+        if device.memory is None:
+            continue
+        idx = device.index
+        device.memory.allocated = vram.get(idx, 0) if idx is not None else 0
 
 
 def _make_worker_visibility_filter(ctx):
@@ -147,7 +217,10 @@ async def get_workers(
     if params.watch:
         return StreamingResponse(
             Worker.streaming(
-                fields=fields, fuzzy_fields=fuzzy_fields, filter_func=visible
+                fields=fields,
+                fuzzy_fields=fuzzy_fields,
+                filter_func=visible,
+                event_transform=_inject_allocated_into_event,
             ),
             media_type="text/event-stream",
         )
@@ -166,10 +239,13 @@ async def get_workers(
             per_page=params.perPage,
             order_by=_normalize_worker_order_by(params.order_by),
         )
-        if not user.worker:
-            return worker_list
+        me_id = user.worker.id if user.worker else None
         public_list = [
-            to_worker_public(worker, user.worker.id == worker.id)
+            to_worker_public(
+                worker,
+                me_id == worker.id,
+                await _lookup_allocated(worker.id),
+            )
             for worker in worker_list.items
         ]
         return WorkersPublic(items=public_list, pagination=worker_list.pagination)
@@ -184,9 +260,8 @@ async def get_worker(
 ):
     worker = await Worker.one_by_id(session, id)
     assert_cluster_resource_visible(ctx, worker, not_found_message="worker not found")
-    if user.worker is not None and user.worker.id == worker.id:
-        return to_worker_public(worker, True)
-    return worker
+    me = user.worker is not None and user.worker.id == worker.id
+    return to_worker_public(worker, me, await _lookup_allocated(worker.id))
 
 
 @router.get("/{id}/dashboard")

--- a/gpustack/schemas/workers.py
+++ b/gpustack/schemas/workers.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from enum import Enum
 from typing import ClassVar, Dict, Optional, Any, TYPE_CHECKING
+from typing_extensions import Annotated, deprecated
 from pydantic import ConfigDict, BaseModel, field_validator
 from urllib.parse import urlparse
 from sqlmodel import (
@@ -46,7 +47,19 @@ class UtilizationInfo(BaseModel):
 class MemoryInfo(UtilizationInfo):
     is_unified_memory: bool = Field(default=False)
     used: Optional[int] = Field(default=None)
-    allocated: Optional[int] = Field(default=None)
+    # Not written by workers anymore — they neither know nor need to track
+    # what's scheduled on them. Persisted DB values stay None going forward.
+    # On the /v2/workers response this is populated server-side from current
+    # ModelInstance bindings; see policies.utils.compute_worker_allocated.
+    allocated: Annotated[
+        Optional[int],
+        deprecated(
+            "Allocated is computed server-side on each /v2/workers query "
+            "from the current set of ModelInstance bindings; this field "
+            "on the worker-reported status is no longer populated and "
+            "should not be read directly."
+        ),
+    ] = Field(default=None)
 
 
 class CPUInfo(UtilizationInfo):

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -39,6 +39,7 @@ from gpustack.server.cache import (
     delete_cache_by_key,
     locked_cached,
 )
+from gpustack.server.worker_allocated_cache import invalidate_workers_allocated
 from gpustack.utils.usage_snapshots import propagate_user_rename
 
 
@@ -869,6 +870,7 @@ class ModelInstanceService:
     async def create(self, model_instance):
         result = await ModelInstance.create(self.session, model_instance)
         await delete_cache_by_key(self.get_running_instances, model_instance.model_id)
+        await invalidate_workers_allocated([model_instance])
         return result
 
     async def update(
@@ -877,12 +879,14 @@ class ModelInstanceService:
         result = await model_instance.update(self.session, source)
         await delete_cache_by_key(self.get_running_instances, model_instance.model_id)
         await delete_cache_by_key(self.get_by_id, model_instance.id)
+        await invalidate_workers_allocated([model_instance])
         return result
 
     async def delete(self, model_instance: ModelInstance):
         result = await model_instance.delete(self.session)
         await delete_cache_by_key(self.get_running_instances, model_instance.model_id)
         await delete_cache_by_key(self.get_by_id, model_instance.id)
+        await invalidate_workers_allocated([model_instance])
         return result
 
     async def batch_delete(self, model_instances: List[ModelInstance]):
@@ -899,6 +903,7 @@ class ModelInstanceService:
 
             for id in ids:
                 await delete_cache_by_key(self.get_running_instances, id)
+            await invalidate_workers_allocated(model_instances)
 
             return names
         except Exception as e:
@@ -922,6 +927,7 @@ class ModelInstanceService:
 
             for id in ids:
                 await delete_cache_by_key(self.get_running_instances, id)
+            await invalidate_workers_allocated(model_instances)
 
             return names
         except Exception as e:

--- a/gpustack/server/worker_allocated_cache.py
+++ b/gpustack/server/worker_allocated_cache.py
@@ -1,0 +1,99 @@
+"""Server-side per-worker cache of ``Allocated`` aggregated from current
+ModelInstance bindings.
+
+Cached at one key per worker (``WorkerAllocated.worker.{id}``) so that a
+single ModelInstance write only invalidates the workers actually bound to
+that instance — heartbeats from unrelated workers still hit cache without
+triggering recompute.
+
+Invalidation point is ModelInstanceService's mutation methods — every
+create / update / delete (and their batch variants) calls
+``invalidate_workers_allocated`` with the affected worker_ids after
+commit, so worker.status.allocated stays in sync with the ModelInstance
+table.
+
+UPDATE caveat: when an UPDATE reassigns an instance to a different
+worker (rare; rescheduling), only the NEW worker's cache is dropped
+here — the previous worker's cache stays until the next read after TTL
+expires, or until the next mutation that touches it. The bounded
+staleness is acceptable for the rescheduling case; chasing strict
+correctness would require capturing the pre-update state via SQLAlchemy
+history hooks.
+
+Mirrors the K8s scheduler NodeInfo cache: derive Allocated from current
+workload→node bindings; recompute is driven by workload mutations, not
+by node heartbeats.
+"""
+
+import logging
+from typing import Iterable, Set
+
+from sqlmodel import select, or_
+
+from gpustack.policies.base import Allocated
+from gpustack.schemas.models import ModelInstance
+from gpustack.server.cache import delete_cache_by_key, locked_cached
+from gpustack.server.db import async_session
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_key_for(worker_id: int) -> str:
+    return f"WorkerAllocated.worker.{worker_id}"
+
+
+def _key_builder(_f, *args, **kwargs):
+    worker_id = kwargs.get("worker_id")
+    if worker_id is None and args:
+        worker_id = args[0]
+    return _cache_key_for(worker_id)
+
+
+@locked_cached(key=_key_builder)
+async def get_worker_allocated(worker_id: int) -> Allocated:
+    """Return the cached ``Allocated`` for a single worker. On miss,
+    aggregates current ModelInstance bindings for this worker (main +
+    distributed subordinate)."""
+    # Lazy import to avoid a module-load cycle with policies.utils, which
+    # imports server.services (and services imports this module).
+    from gpustack.policies.utils import compute_worker_allocated
+
+    async with async_session() as session:
+        # main: cheap indexed filter.
+        # distributed subordinates live inside the distributed_servers JSON
+        # column which can't be filtered portably across PG/MySQL/
+        # OceanBase/openGauss for a specific worker_id, so fall back to
+        # fetching all distributed instances and letting the helper pick
+        # out the relevant ones in Python.
+        rows = (
+            await session.exec(
+                select(ModelInstance).where(
+                    or_(
+                        ModelInstance.worker_id == worker_id,
+                        ModelInstance.distributed_servers.is_not(None),
+                    )
+                )
+            )
+        ).all()
+    return compute_worker_allocated(rows, worker_id)
+
+
+async def invalidate_workers_allocated(instances: Iterable[ModelInstance]) -> None:
+    """Drop cached Allocated for every worker bound to any of the given
+    instances — main worker plus distributed subordinates.
+
+    Accepts an iterable so single-instance writes pass ``[instance]`` and
+    batch writes pass the batch directly; deduplication across the union
+    keeps the actual ``delete_cache_by_key`` calls minimal.
+    """
+    worker_ids: Set[int] = set()
+    for inst in instances:
+        if inst.worker_id is not None:
+            worker_ids.add(inst.worker_id)
+        dservers = inst.distributed_servers
+        if dservers and dservers.subordinate_workers:
+            for sw in dservers.subordinate_workers:
+                if sw.worker_id is not None:
+                    worker_ids.add(sw.worker_id)
+    for wid in worker_ids:
+        await delete_cache_by_key(_key=_cache_key_for(wid))

--- a/gpustack/worker/collector.py
+++ b/gpustack/worker/collector.py
@@ -1,14 +1,12 @@
 import socket
 import logging
-from typing import Optional, Callable
+from typing import Callable
 from gpustack.config.config import Config
 from gpustack.client.generated_clientset import ClientSet
 from gpustack.detectors.base import GPUDetectExepction
 from gpustack.detectors.custom.custom import Custom
 from gpustack.detectors.detector_factory import DetectorFactory
 from gpustack.envs import WORKER_STATUS_COLLECTION_LOG_SLOW_SECONDS
-from gpustack.policies.base import Allocated
-from gpustack.schemas.models import ComputedResourceClaim
 from gpustack.schemas.workers import (
     MountPoint,
     WorkerStatusPublic,
@@ -101,7 +99,6 @@ class WorkerStatusCollector:
                 logger.error(f"Failed to detect GPU devices: {e}")
         self._inject_unified_memory(status)
         self._inject_computed_filesystem_usage(status)
-        self._inject_allocated_resource(clientset, status)
 
         # If disable_worker_metrics is set, set metrics_port to -1
         metrics_port = self._cfg.worker_metrics_port
@@ -157,64 +154,3 @@ class WorkerStatusCollector:
             status.filesystem.append(computed)
         except Exception as e:
             logger.error(f"Failed to inject filesystem usage: {e}")
-
-    def _inject_allocated_resource(  # noqa: C901
-        self, clientset: ClientSet, status: WorkerStatus
-    ):
-        if clientset is None:
-            return
-        worker_id = self._worker_id_getter()
-        allocated = Allocated(ram=0, vram={})
-        try:
-            # TODO avoid listing model_instances with clientset.
-            # The calculation might not be needed here.
-            model_instances = clientset.model_instances.list()
-            for model_instance in model_instances.items:
-                if (
-                    model_instance.distributed_servers
-                    and model_instance.distributed_servers.subordinate_workers
-                ):
-                    for (
-                        subworker
-                    ) in model_instance.distributed_servers.subordinate_workers:
-                        if subworker.worker_id != worker_id:
-                            continue
-
-                        aggregate_computed_resource_claim_allocated(
-                            allocated, subworker.computed_resource_claim
-                        )
-
-                if model_instance.worker_id != worker_id:
-                    continue
-
-                aggregate_computed_resource_claim_allocated(
-                    allocated, model_instance.computed_resource_claim
-                )
-
-            # inject allocated resources
-            if status.memory is not None:
-                status.memory.allocated = allocated.ram
-            if status.gpu_devices is not None:
-                for i, device in enumerate(status.gpu_devices):
-                    if device.index in allocated.vram:
-                        status.gpu_devices[i].memory.allocated = allocated.vram[
-                            device.index
-                        ]
-                    else:
-                        status.gpu_devices[i].memory.allocated = 0
-        except Exception as e:
-            logger.error(f"Failed to inject allocated resources: {e}")
-
-
-def aggregate_computed_resource_claim_allocated(
-    allocated: Allocated, computed_resource_claim: Optional[ComputedResourceClaim]
-):
-    """Aggregate allocated resources from a ComputedResourceClaim into Allocated."""
-    if computed_resource_claim is None:
-        return
-
-    if computed_resource_claim.ram:
-        allocated.ram += computed_resource_claim.ram
-
-    for gpu_index, vram in (computed_resource_claim.vram or {}).items():
-        allocated.vram[gpu_index] = (allocated.vram.get(gpu_index) or 0) + vram

--- a/gpustack/worker/exporter.py
+++ b/gpustack/worker/exporter.py
@@ -13,6 +13,7 @@ from prometheus_client.core import (
 from gpustack.client.generated_clientset import ClientSet
 from gpustack.config.config import Config
 from gpustack.logging import setup_logging
+from gpustack.policies.utils import compute_worker_allocated
 from gpustack.utils.name import metric_name
 from gpustack.worker.collector import WorkerStatusCollector
 import uvicorn
@@ -237,6 +238,23 @@ class MetricExporter(Collector):
                 )
 
         # gpu
+        # Compute per-GPU allocated locally for the gram_allocated metric.
+        # The collector no longer writes allocated into status — the
+        # authoritative view is the server-side aggregation in /v2/workers
+        # (compute_worker_allocated against the ModelInstance table). We
+        # recompute here purely to keep the Prometheus metric working,
+        # using the same helper to guarantee identical math.
+        allocated_vram: dict[int, int] = {}
+        try:
+            clientset = self._clientset_getter()
+            if clientset is not None:
+                model_instances = clientset.model_instances.list()
+                allocated_vram = compute_worker_allocated(
+                    model_instances.items, self._worker_id_getter()
+                ).vram
+        except Exception as e:
+            logger.error(f"Failed to compute allocated GPU memory for metrics: {e}")
+
         if status.gpu_devices is not None:
             for i, d in enumerate(status.gpu_devices):
                 gpu_chip_index = "0"  # TODO(michelia): Placeholder, replace with actual chip index if available
@@ -268,7 +286,11 @@ class MetricExporter(Collector):
 
                 if d.memory is not None:
                     _add_metric(gram_total, gpu_label_values, d.memory.total)
-                    _add_metric(gram_allocated, gpu_label_values, d.memory.allocated)
+                    _add_metric(
+                        gram_allocated,
+                        gpu_label_values,
+                        allocated_vram.get(d.index) if d.index is not None else None,
+                    )
                     _add_metric(gram_used, gpu_label_values, d.memory.used)
 
                     if (

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -254,20 +254,23 @@ class ServeManager:
             if mi.get_deployment_metadata(self._worker_id) is not None
         }
 
-        model_instances_page = self._clientset.model_instances.list(use_cache=False)
-        page_items = model_instances_page.items or []
-
-        # An empty response is more likely a transient list failure than a
-        # genuine "server has no instances" — skip the reap pass to avoid
-        # tearing down live workloads on a single bad page.
-        if not page_items:
-            return
+        # page=-1 returns all rows — needed because the default perPage=100
+        # would have the reap below missing workloads on page 2+.
+        response = self._clientset.model_instances.list(
+            params={"page": -1},
+            use_cache=False,
+        )
+        all_items = response.items or []
 
         # Reap entries the server no longer reports — watch streams can drop
-        # DELETED events on disconnect.
+        # DELETED events on disconnect, and when the user stops every model
+        # the server legitimately reports zero instances. list() raises on
+        # API failure rather than returning empty, so an empty result is
+        # authoritative — local_assigned_ids - ∅ = local_assigned_ids and
+        # everything still tracked locally is correctly reaped.
         authoritative_ids: Set[int] = {
             mi.id
-            for mi in page_items
+            for mi in all_items
             if mi.get_deployment_metadata(self._worker_id) is not None
         }
         for stale_id in local_assigned_ids - authoritative_ids:
@@ -283,8 +286,13 @@ class ServeManager:
             except Exception as e:
                 logger.warning(f"Failed to reap stale model instance {stale.name}: {e}")
 
+        if not all_items:
+            # Nothing left to sync; reap pass above already handled stale
+            # local state.
+            return
+
         model_instances: List[ModelInstance] = []
-        for model_instance in page_items:
+        for model_instance in all_items:
             # if the model instance is assigned to this worker, it must be scheduled.
             # But we don't need to sync the scheduled model when it is not initialized yet.
             if (


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5513

1. `fix(client)`: reset watch cache on awatch (re)connect

`ModelInstanceClient.awatch` (and sibling generated clients) lost DELETED
events for items removed during a disconnect: the server's
`replay_existing=True` snapshot on reconnect only sends CREATED for
currently-present rows, so DELETED events for gone-during-gap items were
lost forever. Worker-side fallout:
- collector summed phantom `computed_resource_claim.vram` into
  `status.gpu_devices[i].memory.allocated`
- `runtime_metrics_aggregator` kept scraping the (now closed) metrics port

Reset cache on every awatch (re)connect, with all cache + `_watch_started`
access serialized through `_cache_lock` so `list()` / `get()` can never
observe `(_watch_started=True, cache=empty)`. Also surface a proper
`ConnectionError` on stream EOF and `asyncio.TimeoutError` on read
timeout so the caller's reconnect loop respects its backoff.

2. `fix(serve_manager)`: reap stale local instances when server returns 0

`sync_model_instances_state` had a `if not page_items: return` early-out
that predated the reap pass. When reap was layered on top later, the
early-out silently skipped it in the legitimate "server has zero
instances now" case (e.g. user stopped every model). Result: orphan
inference process kept holding GPU memory, the scheduler couldn't see
the stuck capacity.

Move the early-out below the reap so `local_assigned_ids - ∅` correctly
reaps everything local when the server is genuinely empty.

3. `refactor(workers)`: compute Allocated server-side from ModelInstance bindings

Even with the worker-side bugs fixed, the design was fragile by
construction: workers self-reported allocated; server stored and
surfaced the report. Whenever a worker was offline or its watch cache
lagged, the UI saw stale data.

Switch to the K8s Node.Allocated pattern — derive Allocated server-side
from current `ModelInstance` rows on every read, behind a per-worker
cache invalidated by `ModelInstanceService` writes. A model deleted on
the server is immediately reflected as 0 allocation in the UI,
regardless of worker state.
