### PR TITLE
fix(schemas): expose owner_principal_id on Public schemas

### DIFF
--- a/gpustack/routes/api_keys.py
+++ b/gpustack/routes/api_keys.py
@@ -55,6 +55,7 @@ def _api_key_to_public(
         user_name=user_name or api_key.user_name,
         value=value,
         masked_value=get_masked_api_key_value(api_key.access_key, api_key.is_custom),
+        owner_principal_id=api_key.owner_principal_id,
         created_at=api_key.created_at,
         updated_at=api_key.updated_at,
         expires_at=api_key.expires_at,

--- a/gpustack/schemas/api_keys.py
+++ b/gpustack/schemas/api_keys.py
@@ -101,6 +101,14 @@ class ApiKeyPublic(ApiKeyBase):
     value: Optional[str] = None  # only available when creating
     masked_value: Optional[str] = None  # partial characters for identification
     is_custom: bool
+    # The owning Org. Server-set on create from the caller's tenant
+    # context (the DB column is NOT NULL — every key lives in exactly
+    # one Org), so it intentionally stays out of ApiKeyCreate / Update
+    # — but readers (list / get responses) need it to render which Org
+    # owns the key, hence the explicit declaration here. Typed as a
+    # plain `int` so the generated OpenAPI / TS clients treat it as
+    # required and non-nullable.
+    owner_principal_id: int
     created_at: datetime
     updated_at: datetime
     expires_at: Optional[datetime] = None

--- a/gpustack/schemas/benchmark.py
+++ b/gpustack/schemas/benchmark.py
@@ -320,6 +320,10 @@ class BenchmarkFullPublic(
     BenchmarkMetrics,
 ):
     id: int
+    # The owning Org. Server-derived from the cluster on create and
+    # therefore kept out of BenchmarkBase / Create — declared on the
+    # Public schemas so readers can render the owning Org.
+    owner_principal_id: Optional[int] = None
     created_at: datetime
     updated_at: datetime
 
@@ -336,6 +340,7 @@ class BenchmarkPublic(
     BenchmarkMetricsLite,
 ):
     id: int
+    owner_principal_id: Optional[int] = None
     created_at: datetime
     updated_at: datetime
 

--- a/gpustack/schemas/model_files.py
+++ b/gpustack/schemas/model_files.py
@@ -96,6 +96,12 @@ class ModelFilePublic(
     ModelFileBase,
 ):
     id: int
+    # The owning Org, denormalized from worker → cluster on create.
+    # Lives on the row but is intentionally absent from ModelFileBase
+    # (and therefore from Create / Update payloads) since clients
+    # must not smuggle their own tenant override. Surfaced here so
+    # list / get responses can render which Org owns the file.
+    owner_principal_id: Optional[int] = None
     created_at: datetime
     updated_at: datetime
 

--- a/gpustack/schemas/model_provider.py
+++ b/gpustack/schemas/model_provider.py
@@ -597,7 +597,14 @@ class ModelProvider(ModelProviderBase, BaseModelMixin, table=True):
 
 
 class ModelProviderPublic(ModelProviderUpdate, PublicFields):
-    pass
+    # The owning Org. Server-set on create from the caller's tenant
+    # context (the DB column is NOT NULL — providers have no "Global"
+    # notion, unlike instance templates / inference backends). Kept
+    # out of ModelProviderBase / Update so clients can't smuggle their
+    # own tenant override; surfaced here for list / get responses.
+    # Typed as a plain `int` so the generated OpenAPI / TS clients
+    # treat it as required and non-nullable.
+    owner_principal_id: int
 
 
 ModelProvidersPublic = PaginatedList[ModelProviderPublic]


### PR DESCRIPTION
For these four resources the field was declared only on the table=true class, so it never made it into <Resource>Public — list and get responses dropped it silently. Readers that need to render the owning Org (e.g. an admin viewing rows across tenants) saw the field as absent and fell back to a "Global" label for every row.

The field stays out of Base / Create / Update on purpose. Unlike Cluster / CloudCredential, these resources derive their org from a parent (worker → cluster for ModelFile, cluster for Benchmark, user for ApiKey, caller's tenant context for ModelProvider) and clients must not be able to smuggle a tenant override through the create payload. Declaring it directly on the Public schemas surfaces it for readers without opening a create-time hole.

Verified by importing each Public and checking model_fields contains "owner_principal_id"; tests/routers/test_benchmarks.py, tests/routers/test_model_provider.py, tests/utils/test_api_keys.py and tests/routes/test_api_keys.py all still pass.