### PR TITLE
fix(usage): align resource buckets and timestamps to the rollup timezone

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,7 +84,7 @@ The **Applies to** column indicates where the environment variable should be set
 
 | Variable                                           | Description                                                                                                                                                                                                                                        | Default      | Applies to |
 | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ---------- |
-| `GPUSTACK_USAGE_ROLLUP_TIMEZONE`                   | IANA timezone (e.g. `Asia/Shanghai`) for bucketing the daily `model_usages` rollup. Empty ⇒ use OS local timezone (`TZ` / `/etc/localtime`).                                                                                                       | (empty)      | Server     |
+| `GPUSTACK_USAGE_ROLLUP_TIMEZONE`                   | IANA timezone (e.g. `Asia/Shanghai`) for bucketing all usage views and rendering Last Active / event times (see note below). Empty ⇒ use OS local timezone (`TZ` / `/etc/localtime`).                                                              | (empty)      | Server     |
 | `GPUSTACK_USAGE_ESTIMATED_BYTES_PER_INPUT_TOKEN`   | Bytes-per-token divisor used to estimate prompt tokens when a gateway report arrives with `completed=false` and `input_token` is blank. Defaults target English-leaning GPT-style tokenizers; lower it (e.g. `2`) for CJK-heavy workloads.         | `4`          | Server     |
 | `GPUSTACK_USAGE_ESTIMATED_TOKENS_PER_OUTPUT_CHUNK` | Tokens-per-chunk multiplier used to estimate completion tokens for incomplete streams when `output_token` is blank.                                                                                                                                | `1`          | Server     |
 | `GPUSTACK_USAGE_DETAILS_RETENTION_MONTHS`          | Retention window for `model_usage_details` (the per-request audit table). Rows older than this (anchored on `COALESCE(completed_at, created_at)`) are moved to `model_usage_details_archive` by the leader-only archiver.                          | `13`         | Server     |
@@ -100,6 +100,16 @@ The **Applies to** column indicates where the environment variable should be set
 | `GPUSTACK_USAGE_EVENTS_RETENTION_MONTHS`           | Retention window for `resource_events` (the resource lifecycle / audit log). Rows older than this are moved to `resource_events_archive` by the leader-only archiver.                                                                              | `13`         | Server     |
 | `GPUSTACK_USAGE_EVENTS_ARCHIVE_CRON`               | Cron expression (UTC) for the resource-events archiver's recurring sweep. The archiver also runs once on server startup regardless of this schedule.                                                                                               | `30 3 * * *` | Server     |
 | `GPUSTACK_USAGE_EVENTS_ARCHIVE_BATCH_SIZE`         | Per-batch row count for resource-events archival moves.                                                                                                                                                                                            | `5000`       | Server     |
+
+> **Note — `GPUSTACK_USAGE_ROLLUP_TIMEZONE` scope & DST.** This one timezone
+> governs every usage view: the daily `model_usages` token rollup, the
+> GPU/storage time buckets, and the displayed Last Active and resource-event
+> times. For a zone that observes **DST**
+> this has two consequences worth knowing: (a) near a DST transition an event's
+> displayed clock time can fall on a different calendar day than the bucket it is
+> counted in; and (b) re-running the same historical query after a DST switch can
+> re-bucket older rows by an hour, so the result drifts over time. Non-DST zones
+> (UTC, `Asia/Shanghai`, …) are exact and unaffected.
 
 ### Cluster Configuration
 

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
-from sqlalchemy import Date, and_, case, cast, desc, func, or_
+from sqlalchemy import and_, case, desc, func, literal_column, or_
 from sqlmodel import select
 
 from gpustack.api.exceptions import InvalidException
@@ -48,6 +48,12 @@ from gpustack.schemas.usage import (
 )
 from gpustack.schemas.resource_events import ResourceEvent
 from gpustack.server.deps import CurrentUserDep, SessionDep, TenantContextDep
+from gpustack.utils.rollup_tz import (
+    resolve_rollup_tz,
+    rollup_fixed_tz,
+    rollup_offset_minutes,
+    to_rollup_aware,
+)
 
 router = APIRouter()
 
@@ -170,21 +176,48 @@ def _group_columns(
     raise InvalidException(message=f"Unsupported group_by: {group_by}")
 
 
+def _rollup_shift(col, dialect: str, offset_min: int):
+    """Add the rollup-tz UTC offset (minutes) to a UTC timestamp column so SQL
+    date bucketing groups by the rollup-tz calendar. A plain interval add →
+    portable across PostgreSQL / MySQL with no tz tables (fixed offset, so
+    DST-naive)."""
+    if offset_min == 0:
+        return col
+    if dialect == "postgresql":
+        return col + literal_column(f"interval '{offset_min} minutes'")
+    if dialect == "mysql":
+        return func.date_add(col, literal_column(f"interval {offset_min} minute"))
+    # Fallback for the in-memory sqlite test engine / any other backend.
+    sign = "+" if offset_min >= 0 else "-"
+    return func.datetime(col, f"{sign}{abs(offset_min)} minutes")
+
+
 def _bucket_expr(session, granularity: str):
     """Time-bucket expression over ``bucket_start`` for the requested
-    granularity. Rows are stored at hourly granularity; coarser buckets are
-    derived via date_trunc (PostgreSQL) / date functions (MySQL)."""
-    col = MeteredUsage.bucket_start
-    if granularity == USAGE_GRANULARITY_HOUR:
-        return col  # already hour-truncated by the collector
+    granularity. Rows are stored at hourly UTC granularity; we shift to the
+    rollup timezone (so buckets follow the operator's calendar, consistent with
+    the token rollup) then truncate via date_trunc (PostgreSQL) / date functions
+    (MySQL).
+
+    For a half-hour-offset rollup tz (e.g. ``+05:30``) the hour labels land on
+    the UTC ``:30`` boundary, so one stored UTC hour straddles two displayed
+    hours. Harmless for aggregation (totals are unchanged) — only the hour-axis
+    labels look offset by 30 minutes."""
     dialect = session.get_bind().dialect.name
+    col = _rollup_shift(MeteredUsage.bucket_start, dialect, rollup_offset_minutes())
+    if granularity == USAGE_GRANULARITY_HOUR:
+        if dialect == "postgresql":
+            return func.date_trunc("hour", col)
+        if dialect == "mysql":
+            return func.date_format(col, "%Y-%m-%d %H:00:00")
+        return func.strftime("%Y-%m-%d %H:00:00", col)  # sqlite test engine
     if dialect == "postgresql":
         unit = {
             USAGE_GRANULARITY_WEEK: "week",
             USAGE_GRANULARITY_MONTH: "month",
         }.get(granularity, "day")
         return func.date_trunc(unit, col)
-    # MySQL
+    # MySQL (and the sqlite test engine)
     if granularity == USAGE_GRANULARITY_MONTH:
         return func.date_format(col, "%Y-%m-01")
     if granularity == USAGE_GRANULARITY_WEEK:
@@ -193,11 +226,56 @@ def _bucket_expr(session, granularity: str):
     return func.date(col)  # day
 
 
+def _localize_bucket(value: Any, granularity: str, fixed_tz=None) -> Any:
+    """Label an hour bucket with the rollup offset so it serializes
+    self-describing (e.g. ``2026-06-10T14:00:00+08:00``).
+
+    ``_bucket_expr`` already shifted ``bucket_start`` into the rollup wall clock;
+    this just attaches the matching fixed offset. The SQL value is a naive
+    datetime (PostgreSQL ``date_trunc``) or an ``"YYYY-MM-DD HH:00:00"`` string
+    (MySQL ``date_format``). Day/week/month buckets are calendar dates with no
+    time-of-day, so they carry no offset and pass through unchanged.
+
+    Pass ``fixed_tz`` to reuse one resolved per request (avoids re-reading the
+    env for every row); defaults to resolving it."""
+    if granularity != USAGE_GRANULARITY_HOUR or value is None:
+        return value
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value)
+    if isinstance(value, datetime) and value.tzinfo is None:
+        return value.replace(tzinfo=fixed_tz or rollup_fixed_tz())
+    return value
+
+
+def _rollup_day_window(
+    start_date: Optional[date], end_date: Optional[date]
+) -> Tuple[Optional[datetime], Optional[datetime]]:
+    """Map an inclusive rollup-tz day range to a half-open UTC ``[start, end)``
+    datetime window. Both ends are shifted back by the rollup offset, so a stored
+    UTC timestamp compares against the rollup calendar day the UI selected — the
+    same shift ``_bucket_expr`` applies to the displayed buckets. Half-open +
+    naive datetimes keep the bucket_start / occurred_at index usable (no
+    per-row ``cast(..., Date)``). A ``None`` bound yields ``None`` (skip it)."""
+    offset = timedelta(minutes=rollup_offset_minutes())
+    start_dt = (
+        datetime(start_date.year, start_date.month, start_date.day) - offset
+        if start_date is not None
+        else None
+    )
+    end_dt = (
+        datetime(end_date.year, end_date.month, end_date.day)
+        + timedelta(days=1)
+        - offset
+        if end_date is not None
+        else None
+    )
+    return start_dt, end_dt
+
+
 def _bucket_in_range(statement, start_date: date, end_date: date):
-    """Filter ``bucket_start`` (datetime) to the inclusive [start_date, end_date]
-    day range, as half-open datetime bounds so the index is usable."""
-    start_dt = datetime(start_date.year, start_date.month, start_date.day)
-    end_dt = datetime(end_date.year, end_date.month, end_date.day) + timedelta(days=1)
+    """Filter ``MeteredUsage.bucket_start`` to the inclusive rollup-tz day range
+    [start_date, end_date] (see :func:`_rollup_day_window`)."""
+    start_dt, end_dt = _rollup_day_window(start_date, end_date)
     return statement.where(MeteredUsage.bucket_start >= start_dt).where(
         MeteredUsage.bucket_start < end_dt
     )
@@ -479,19 +557,30 @@ async def _run_breakdown(
         out["active_users"] = int(getattr(row, "active_users", 0) or 0)
         return out
 
+    # Resolve the rollup tz once per request (not per row): the DST-correct tz
+    # for instants, plus the fixed-offset tz that labels the SQL-shifted buckets.
+    aware_tz = resolve_rollup_tz()
+    fixed_tz = rollup_fixed_tz()
     items = []
     for row in rows:
         item = {"metrics": metrics_of(row)}
         # Carry whichever grouping columns this query selected — a compound
         # (date + dimension) trend row has both ``group_date`` and ``group_key``.
         if hasattr(row, "group_date"):
-            item["date"] = getattr(row, "group_date", None)
+            item["date"] = _localize_bucket(
+                getattr(row, "group_date", None), request.granularity, fixed_tz
+            )
         if hasattr(row, "group_key"):
             item["key"] = getattr(row, "group_key", None)
         if hasattr(row, "group_id"):
             item["id"] = getattr(row, "group_id", None)
         item["sku"] = getattr(row, "sku", None)
-        item["metrics"]["last_active"] = getattr(row, "last_active", None)
+        # max(bucket_start) is a UTC instant → show it in the rollup tz, aware
+        # (carries an offset) so the API is self-describing and the UI renders
+        # the rollup wall clock via parseZone without re-converting.
+        item["metrics"]["last_active"] = to_rollup_aware(
+            getattr(row, "last_active", None), aware_tz
+        )
         items.append(item)
 
     # Per-row display dims matter only for single-dimension table groupings; a
@@ -719,10 +808,16 @@ async def resource_events(
         # func.lower(...) LIKE keeps it portable across PostgreSQL and MySQL.
         needle = f"%{resource_name.strip().lower()}%"
         stmt = stmt.where(func.lower(ResourceEvent.resource_name).like(needle))
-    if start_date is not None:
-        stmt = stmt.where(cast(ResourceEvent.occurred_at, Date) >= start_date)
-    if end_date is not None:
-        stmt = stmt.where(cast(ResourceEvent.occurred_at, Date) <= end_date)
+    # Filter by the rollup-tz calendar day, matching how occurred_at is
+    # displayed (and the breakdown buckets) — NOT the raw UTC day. Otherwise an
+    # event at 2026-05-26 20:00 UTC, shown as 2026-05-27 04:00+08:00, would be
+    # missed by a 2026-05-27 filter and wrongly returned by a 2026-05-26 one
+    # (the #5523 cross-boundary bug). Half-open UTC window, no per-row cast.
+    ev_start, ev_end = _rollup_day_window(start_date, end_date)
+    if ev_start is not None:
+        stmt = stmt.where(ResourceEvent.occurred_at >= ev_start)
+    if ev_end is not None:
+        stmt = stmt.where(ResourceEvent.occurred_at < ev_end)
 
     count_stmt = select(func.count()).select_from(stmt.subquery())
     total = (await session.exec(count_stmt)).first() or 0
@@ -735,6 +830,7 @@ async def resource_events(
         )
     ).all()
 
+    aware_tz = resolve_rollup_tz()  # resolved once, not per row
     return {
         "pagination": Pagination(
             page=page,
@@ -745,7 +841,10 @@ async def resource_events(
         "items": [
             {
                 "id": r.id,
-                "occurred_at": r.occurred_at,
+                # Show the event instant in the rollup tz, aware (carries an
+                # offset) so the API is self-describing and the UI renders the
+                # rollup wall clock via parseZone without re-converting.
+                "occurred_at": to_rollup_aware(r.occurred_at, aware_tz),
                 "resource_type": r.resource_type,
                 "resource_id": r.resource_id,
                 "resource_name": r.resource_name,

--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -3,7 +3,6 @@ import logging
 import time
 from datetime import date, datetime, timezone, tzinfo
 from typing import Dict, List, Optional, Set, Tuple
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pydantic import BaseModel
 from sqlmodel import or_
@@ -19,6 +18,7 @@ from gpustack.schemas.model_usage_details import ModelUsageDetails
 from gpustack.schemas.models import Model, is_embedding_model, is_reranker_model
 from gpustack.schemas.principals import Principal
 from gpustack.server.db import async_session
+from gpustack.utils.rollup_tz import resolve_rollup_tz
 from gpustack.utils.usage_snapshots import build_model_usage_snapshot
 
 logger = logging.getLogger(__name__)
@@ -35,8 +35,8 @@ FLUSH_INTERVAL_SECONDS = 10
 # ``operation`` and ``date`` are part of the key so per-operation rollups
 # stay separate and a stream that crosses midnight lands in the period
 # it ends in (anchored on completed_at). ``date`` is computed in the
-# configured rollup timezone (see ``_resolve_rollup_tz``), not UTC, so
-# midnight here means local-calendar midnight.
+# configured rollup timezone (see ``_ROLLUP_TZ``), not UTC, so midnight here
+# means local-calendar midnight.
 gateway_metrics_buffer: Dict[str, "ModelUsageMetrics"] = {}
 # Raw per-report metrics retained for ``model_usage_details`` audit rows.
 # Unlike ``gateway_metrics_buffer``, entries are not aggregated.
@@ -107,31 +107,11 @@ def _unixmilli_to_naive_utc(ms: Optional[int]) -> Optional[datetime]:
     return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc).replace(tzinfo=None)
 
 
-def _resolve_rollup_tz() -> tzinfo:
-    """Resolve the timezone used to bucket the daily ``model_usages.date`` rollup.
-
-    Priority:
-      1. ``GPUSTACK_USAGE_ROLLUP_TIMEZONE`` env (IANA name, e.g. ``Asia/Shanghai``).
-      2. Operating system local timezone (``TZ`` env / ``/etc/localtime``).
-    Falls back to UTC if the OS lookup somehow yields no tzinfo.
-    """
-    tz_name = envs.USAGE_ROLLUP_TIMEZONE
-    if tz_name:
-        try:
-            return ZoneInfo(tz_name)
-        except (ZoneInfoNotFoundError, ValueError):
-            # ``ValueError`` covers malformed keys (absolute paths, ``..``
-            # segments) that ``ZoneInfo`` rejects before lookup.
-            logger.warning(
-                "Invalid GPUSTACK_USAGE_ROLLUP_TIMEZONE=%r, falling back to OS local tz",
-                tz_name,
-            )
-    return datetime.now(timezone.utc).astimezone().tzinfo or timezone.utc
-
-
-# Resolved once at import time. Tests can monkeypatch this attribute to pin
-# a deterministic timezone independent of the host's ``TZ``.
-_ROLLUP_TZ: tzinfo = _resolve_rollup_tz()
+# Shared with the metered_usage read API so the daily token rollup and the
+# GPU/storage views share one timezone (see ``gpustack.utils.rollup_tz``).
+# Resolved once at import time; tests monkeypatch this attribute to pin a
+# deterministic timezone independent of the host's ``TZ``.
+_ROLLUP_TZ: tzinfo = resolve_rollup_tz()
 
 
 def _resolve_metric_datetime(

--- a/gpustack/utils/rollup_tz.py
+++ b/gpustack/utils/rollup_tz.py
@@ -1,0 +1,82 @@
+"""Shared timezone for the usage views.
+
+``model_usages`` is bucketed into daily rows in this timezone at ingest
+(see ``metrics_collector``); the ``metered_usage`` read API reuses it so the
+GPU-instance / storage breakdowns, Last Active and resource-event times all
+line up in one operator-chosen calendar instead of a mix of UTC and local.
+
+Resolution (``resolve_rollup_tz``):
+  1. ``GPUSTACK_USAGE_ROLLUP_TIMEZONE`` (IANA name, e.g. ``Asia/Shanghai``)
+  2. the OS local timezone (``TZ`` / ``/etc/localtime``)
+  3. UTC as a last resort.
+
+Read at call time (not cached) so it stays test-overridable.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone, tzinfo
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from gpustack import envs
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_rollup_tz() -> tzinfo:
+    tz_name = envs.USAGE_ROLLUP_TIMEZONE
+    if tz_name:
+        try:
+            return ZoneInfo(tz_name)
+        except (ZoneInfoNotFoundError, ValueError):
+            logger.warning(
+                "Invalid GPUSTACK_USAGE_ROLLUP_TIMEZONE=%r, falling back to OS "
+                "local tz",
+                tz_name,
+            )
+    return datetime.now(timezone.utc).astimezone().tzinfo or timezone.utc
+
+
+def rollup_offset_minutes(now: Optional[datetime] = None) -> int:
+    """The rollup timezone's current UTC offset in whole minutes (e.g. 480 for
+    +08:00, -300 for -05:00).
+
+    Used to shift UTC ``bucket_start`` into the rollup timezone for SQL date
+    bucketing with a plain interval add — portable across PostgreSQL / MySQL /
+    SQLite with no per-dialect timezone tables. It's a *fixed* offset, so it's
+    DST-naive (exact for non-DST zones like UTC / Asia/Shanghai; off by up to an
+    hour near a DST transition otherwise). Point-in-time conversions
+    (``to_rollup_aware``) use the real tz instead and stay DST-correct.
+    """
+    ref = now or datetime.now(timezone.utc)
+    offset = ref.astimezone(resolve_rollup_tz()).utcoffset()
+    return int(offset.total_seconds() // 60) if offset else 0
+
+
+def rollup_fixed_tz(now: Optional[datetime] = None) -> timezone:
+    """A fixed-offset ``timezone`` matching :func:`rollup_offset_minutes`.
+
+    Used to *label* the SQL-bucketed timestamps (which were shifted by that same
+    fixed offset) with an explicit offset so they serialize self-describing
+    (e.g. ``+08:00``) — without a second, possibly DST-divergent, conversion.
+    """
+    return timezone(timedelta(minutes=rollup_offset_minutes(now)))
+
+
+def to_rollup_aware(
+    value: Optional[datetime], tz: Optional[tzinfo] = None
+) -> Optional[datetime]:
+    """Convert a (UTC) instant to an *aware* datetime in the rollup timezone —
+    DST-correct. Keeps tzinfo so it serializes with an explicit offset (e.g.
+    ``+08:00``): the API is self-describing and the UI renders the rollup-tz
+    wall clock via ``dayjs.parseZone`` without re-converting to the browser's
+    timezone. ``None`` passes through.
+
+    Pass ``tz`` to reuse a timezone resolved once per request (avoids re-reading
+    the env / re-parsing ``ZoneInfo`` for every row); defaults to resolving it.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(tz or resolve_rollup_tz())

--- a/tests/routes/test_resource_usage_api.py
+++ b/tests/routes/test_resource_usage_api.py
@@ -1,7 +1,7 @@
 """Integration tests for the metered_usage read API SQL — exercises the real
 aggregation (case/coalesce/group-by) against an in-memory sqlite engine."""
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -521,3 +521,223 @@ async def test_breakdown_date_sub_group_splits_series(session):
     by_sku = {i["key"]: i["metrics"]["gpu_hours"] for i in out["items"]}
     assert by_sku["h100x2"] == pytest.approx(49795 * 2 / 3600, abs=0.01)
     assert by_sku["a100x1"] == pytest.approx(3600 / 3600, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_buckets_and_last_active_use_rollup_tz(session, monkeypatch):
+    # Pin the rollup tz to +08:00 (no DST). A 20:00 UTC bucket is 04:00 the
+    # NEXT day there → it must bucket on 05-27, and Last Active reads 05-27.
+    from gpustack import envs
+    from sqlalchemy import and_
+
+    monkeypatch.setattr(envs, "USAGE_ROLLUP_TIMEZONE", "Asia/Shanghai")
+
+    session.add(
+        _mu(
+            meter_key=METER_INSTANCE_UPTIME,
+            resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+            resource_id=901,
+            resource_name="tz-gpu",
+            sku="tz-sku",
+            sku_count=1,
+            quantity=3600,
+            unit="seconds",
+            bucket_start=datetime(2026, 5, 26, 20, 0, 0),
+        )
+    )
+    await session.commit()
+
+    req = ResourceBreakdownRequest(
+        scope="all",
+        start_date=date(2026, 5, 26),
+        end_date=date(2026, 5, 27),
+        group_by=["date", "instance_type"],
+    )
+    out = await _run_breakdown(
+        session,
+        user=USER,
+        ctx=CTX,
+        request=req,
+        base_filter=and_(
+            MeteredUsage.meter_key == METER_INSTANCE_UPTIME,
+            MeteredUsage.resource_type == RESOURCE_TYPE_GPU_INSTANCE,
+        ),
+        metric_keys=["gpu_hours"],
+    )
+    tz_rows = [i for i in out["items"] if i.get("key") == "tz-sku"]
+    assert tz_rows, "tz-sku row missing"
+    # Bucketed on the rollup-tz day (05-27), not UTC's 05-26.
+    assert str(tz_rows[0]["date"]).startswith("2026-05-27")
+    # Last Active is the same instant rendered in the rollup tz (04:00 on 05-27),
+    # and aware (carries the +08:00 offset) so the API is self-describing.
+    last_active = tz_rows[0]["metrics"]["last_active"]
+    assert last_active.utcoffset() == timedelta(hours=8)
+    assert str(last_active).startswith("2026-05-27 04:00:00+08:00")
+
+    # Hour granularity → the bucket itself is an aware, offset-carrying instant.
+    hour_req = ResourceBreakdownRequest(
+        scope="all",
+        start_date=date(2026, 5, 26),
+        end_date=date(2026, 5, 27),
+        group_by=["date"],
+        granularity="hour",
+    )
+    hour_out = await _run_breakdown(
+        session,
+        user=USER,
+        ctx=CTX,
+        request=hour_req,
+        base_filter=and_(
+            MeteredUsage.meter_key == METER_INSTANCE_UPTIME,
+            MeteredUsage.resource_type == RESOURCE_TYPE_GPU_INSTANCE,
+        ),
+        metric_keys=["gpu_hours"],
+    )
+    hour_dates = {str(i["date"]) for i in hour_out["items"]}
+    assert "2026-05-27 04:00:00+08:00" in hour_dates
+
+
+@pytest.mark.asyncio
+async def test_resource_events_filter_uses_rollup_tz_day(session, monkeypatch):
+    # #5523 regression: an event at 2026-05-26 20:00 UTC is 2026-05-27 04:00 in
+    # +08:00, so it must match a 05-27 filter and NOT a 05-26 one — matching how
+    # occurred_at is displayed (the bug was filtering on the raw UTC day).
+    from gpustack import envs
+    from gpustack.routes.resource_usage import resource_events
+    from gpustack.schemas.resource_events import EVENT_TYPE_CREATED, ResourceEvent
+
+    monkeypatch.setattr(envs, "USAGE_ROLLUP_TIMEZONE", "Asia/Shanghai")
+    session.add(
+        ResourceEvent(
+            occurred_at=datetime(2026, 5, 26, 20, 0, 0),
+            resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+            resource_id=801,
+            resource_name="tz-evt",
+            event_type=EVENT_TYPE_CREATED,
+            creator_id=7,
+        )
+    )
+    await session.commit()
+
+    def names(out):
+        return {e["resource_name"] for e in out["items"]}
+
+    # The rollup-tz day (05-27) finds it, displayed at 04:00+08:00.
+    out = await resource_events(
+        session,
+        USER,
+        CTX,
+        scope="all",
+        start_date=date(2026, 5, 27),
+        end_date=date(2026, 5, 27),
+        resource_name="tz-evt",
+    )
+    assert names(out) == {"tz-evt"}
+    occurred = out["items"][0]["occurred_at"]
+    assert occurred.utcoffset() == timedelta(hours=8)
+    assert str(occurred).startswith("2026-05-27 04:00:00+08:00")
+
+    # The raw UTC day (05-26) must NOT return it anymore.
+    out = await resource_events(
+        session,
+        USER,
+        CTX,
+        scope="all",
+        start_date=date(2026, 5, 26),
+        end_date=date(2026, 5, 26),
+        resource_name="tz-evt",
+    )
+    assert names(out) == set()
+
+
+@pytest.mark.asyncio
+async def test_buckets_use_negative_offset_rollup_tz(session, monkeypatch):
+    # Negative-offset zone (America/Bogota, UTC-05:00, no DST). A 02:00 UTC
+    # bucket is 21:00 the PREVIOUS day there → it must bucket on 05-25 and Last
+    # Active carries the -05:00 offset.
+    from gpustack import envs
+    from sqlalchemy import and_
+
+    monkeypatch.setattr(envs, "USAGE_ROLLUP_TIMEZONE", "America/Bogota")
+    session.add(
+        _mu(
+            meter_key=METER_INSTANCE_UPTIME,
+            resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+            resource_id=902,
+            resource_name="neg-gpu",
+            sku="neg-sku",
+            sku_count=1,
+            quantity=3600,
+            unit="seconds",
+            bucket_start=datetime(2026, 5, 26, 2, 0, 0),
+        )
+    )
+    await session.commit()
+
+    req = ResourceBreakdownRequest(
+        scope="all",
+        start_date=date(2026, 5, 25),
+        end_date=date(2026, 5, 26),
+        group_by=["date", "instance_type"],
+    )
+    out = await _run_breakdown(
+        session,
+        user=USER,
+        ctx=CTX,
+        request=req,
+        base_filter=and_(
+            MeteredUsage.meter_key == METER_INSTANCE_UPTIME,
+            MeteredUsage.resource_type == RESOURCE_TYPE_GPU_INSTANCE,
+        ),
+        metric_keys=["gpu_hours"],
+    )
+    rows = [i for i in out["items"] if i.get("key") == "neg-sku"]
+    assert rows, "neg-sku row missing"
+    assert str(rows[0]["date"]).startswith("2026-05-25")
+    last_active = rows[0]["metrics"]["last_active"]
+    assert last_active.utcoffset() == timedelta(hours=-5)
+    assert str(last_active).startswith("2026-05-25 21:00:00-05:00")
+
+
+@pytest.mark.asyncio
+async def test_breakdown_range_boundary_includes_shifted_edge(session, monkeypatch):
+    # The row sits at exactly start_day − offset: 2026-05-26 16:00 UTC is
+    # 2026-05-27 00:00 in +08:00, the first instant of the selected start day.
+    # The half-open shifted window must include it (off-by-one guard).
+    from gpustack import envs
+    from sqlalchemy import and_
+
+    monkeypatch.setattr(envs, "USAGE_ROLLUP_TIMEZONE", "Asia/Shanghai")
+    session.add(
+        _mu(
+            meter_key=METER_INSTANCE_UPTIME,
+            resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+            resource_id=903,
+            resource_name="edge-gpu",
+            sku="edge-sku",
+            sku_count=1,
+            quantity=3600,
+            unit="seconds",
+            bucket_start=datetime(2026, 5, 26, 16, 0, 0),
+        )
+    )
+    await session.commit()
+
+    req = ResourceBreakdownRequest(
+        scope="all",
+        start_date=date(2026, 5, 27),  # selecting only 05-27 (rollup tz)
+        end_date=date(2026, 5, 27),
+        group_by=["instance_type"],
+    )
+    out = await _run_breakdown(
+        session,
+        user=USER,
+        ctx=CTX,
+        request=req,
+        base_filter=and_(
+            MeteredUsage.meter_key == METER_INSTANCE_UPTIME,
+            MeteredUsage.resource_type == RESOURCE_TYPE_GPU_INSTANCE,
+        ),
+        metric_keys=["gpu_hours"],
+    )
+    assert "edge-sku" in {i.get("key") for i in out["items"]}


### PR DESCRIPTION
Resource breakdowns and the events log previously bucketed/serialized in UTC while the token tabs bucket by the rollup-tz calendar day, so the same calendar boundary disagreed across tabs (issue #5523).

Extract the rollup-tz resolution into a shared util and reuse it here:
- _bucket_expr shifts bucket_start by the rollup-tz UTC offset (fixed offset, DST-naive) before SQL date_trunc/date_format, so day/week/month buckets follow the rollup calendar. Portable across PostgreSQL / MySQL / SQLite with no tz-table dependency.
- last_active and event occurred_at are converted with a DST-correct astimezone() and serialized naive, so the frontend renders the rollup-tz wall clock verbatim.

Stored data stays UTC; only read/display is converted.