### PR TITLE
fix(catalog): restrict MiniCPM-V-4.6 and ERNIE-Image to NVIDIA GPUs

### DIFF
--- a/gpustack/assets/model-catalog-modelscope.yaml
+++ b/gpustack/assets/model-catalog-modelscope.yaml
@@ -2513,6 +2513,8 @@ model_sets:
   release_date: "2026-04-07"
   specs:
     - mode: standard
+      gpu_filters:
+        vendor: nvidia
       quantization: BF16
       source: model_scope
       model_scope_model_id: PaddlePaddle/ERNIE-Image
@@ -2820,6 +2822,8 @@ model_sets:
   release_date: "2026-05-11"
   specs:
     - mode: standard
+      gpu_filters:
+        vendor: nvidia
       quantization: BF16
       source: model_scope
       model_scope_model_id: OpenBMB/MiniCPM-V-4.6
@@ -2828,15 +2832,6 @@ model_sets:
         - --context-length=32768
         - --dtype=bfloat16
         - --sampling-defaults=openai
-        - --trust-remote-code
-    - mode: standard
-      gpu_filters:
-        vendor: ascend
-      quantization: BF16
-      source: model_scope
-      model_scope_model_id: OpenBMB/MiniCPM-V-4.6
-      backend: vLLM
-      backend_parameters:
         - --trust-remote-code
 # Audio models
 - name: CosyVoice2-0.5B

--- a/gpustack/assets/model-catalog.yaml
+++ b/gpustack/assets/model-catalog.yaml
@@ -2674,6 +2674,8 @@ model_sets:
   release_date: "2026-04-07"
   specs:
     - mode: standard
+      gpu_filters:
+        vendor: nvidia
       quantization: BF16
       source: huggingface
       huggingface_repo_id: baidu/ERNIE-Image
@@ -2999,6 +3001,8 @@ model_sets:
   release_date: "2026-05-11"
   specs:
     - mode: standard
+      gpu_filters:
+        vendor: nvidia
       quantization: BF16
       source: huggingface
       huggingface_repo_id: openbmb/MiniCPM-V-4.6
@@ -3007,15 +3011,6 @@ model_sets:
         - --context-length=32768
         - --dtype=bfloat16
         - --sampling-defaults=openai
-        - --trust-remote-code
-    - mode: standard
-      gpu_filters:
-        vendor: ascend
-      quantization: BF16
-      source: huggingface
-      huggingface_repo_id: openbmb/MiniCPM-V-4.6
-      backend: vLLM
-      backend_parameters:
         - --trust-remote-code
 # Audio models
 - name: CosyVoice2-0.5B


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5549
https://github.com/gpustack/gpustack/issues/5550

Both models fail to run on Ascend with either SGLang or vLLM, so add nvidia vendor filters and drop the unreachable Ascend-only vLLM spec of MiniCPM-V-4.6.