### PR TITLE
fix(db): parse openGauss-lite version strings

### DIFF
--- a/gpustack/utils/db.py
+++ b/gpustack/utils/db.py
@@ -11,8 +11,10 @@ def patch_pg_version_info() -> None:
     """Teach SQLAlchemy's PGDialect to parse openGauss version strings.
 
     openGauss presents itself with the PostgreSQL dialect but reports
-    ``(openGauss X.Y.Z build ...)`` instead of ``PostgreSQL X.Y.Z``,
-    which SQLAlchemy's default regex rejects with ``AssertionError``.
+    ``(openGauss X.Y.Z build ...)`` — or a variant such as
+    ``(openGauss-lite X.Y.Z-RC3 build ...)`` — instead of
+    ``PostgreSQL X.Y.Z``, which SQLAlchemy's default regex rejects
+    with ``AssertionError``.
     We delegate to the original parser first so future upstream fixes
     are preserved, and only fall back to an openGauss regex on failure.
 
@@ -30,7 +32,7 @@ def patch_pg_version_info() -> None:
             return orig_get_server_version_info(self, connection)
         except AssertionError:
             v = connection.exec_driver_sql("select pg_catalog.version()").scalar()
-            m = re.search(r"openGauss (\d+)\.(\d+)(?:\.(\d+))?", v or "")
+            m = re.search(r"openGauss\S* (\d+)\.(\d+)(?:\.(\d+))?", v or "")
             if not m:
                 raise
             return tuple(int(x) if x is not None else 0 for x in m.group(1, 2, 3))

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects.postgresql import base as pg_base
+
+from gpustack.utils.db import patch_pg_version_info
+
+
+def _version_info(version_string: str):
+    patch_pg_version_info()
+    connection = MagicMock()
+    connection.exec_driver_sql.return_value.scalar.return_value = version_string
+    dialect = pg_base.PGDialect.__new__(pg_base.PGDialect)
+    return dialect._get_server_version_info(connection)
+
+
+@pytest.mark.parametrize(
+    "version_string, expected",
+    [
+        (
+            "(openGauss 5.0.0 build 8e338bd1) compiled at 2023-03-29, 64-bit",
+            (5, 0, 0),
+        ),
+        (
+            "(openGauss-lite 7.0.0-RC3 build ) compiled at 2026-04-21 "
+            "15:29:26 commit 0 last mr  release on aarch64-unknown-linux-gnu, "
+            "compiled by g++ (GCC) 10.3.1, 64-bit",
+            (7, 0, 0),
+        ),
+        ("(openGauss 5.0 build) 64-bit", (5, 0, 0)),
+        (
+            "PostgreSQL 14.5 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit",
+            (14, 5),
+        ),
+    ],
+)
+def test_pg_version_info(version_string, expected):
+    assert _version_info(version_string) == expected
+
+
+def test_pg_version_info_unparseable_raises():
+    with pytest.raises(AssertionError):
+        _version_info("TotallyUnknownDB 1.2.3")


### PR DESCRIPTION
openGauss-lite reports its version as '(openGauss-lite X.Y.Z-RCn build ...)', which the openGauss fallback regex rejected because it required a space right after 'openGauss', so server version detection still failed with AssertionError. Allow any suffix after 'openGauss' while keeping the patch component optional.

address #5041