### PR TITLE
fix: GPUs page showed 0 VRAM allocated after model deployment

### DIFF
--- a/gpustack/routes/gpu_devices.py
+++ b/gpustack/routes/gpu_devices.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 from gpustack.api.tenant import (
@@ -5,8 +7,13 @@ from gpustack.api.tenant import (
     assert_cluster_resource_visible,
     cluster_resource_visibility_conditions,
 )
+from gpustack.server.bus import Event, EventType
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
+from gpustack.server.worker_allocated_cache import (
+    get_worker_allocated,
+    vram_allocated_for_index,
+)
 from gpustack.schemas.gpu_devices import (
     GPUDevice,
     GPUDeviceListParams,
@@ -16,6 +23,38 @@ from gpustack.schemas.gpu_devices import (
 
 
 router = APIRouter()
+
+
+async def _lookup_vram_allocated(worker_id: int) -> Dict[int, int]:
+    """Cache-backed {gpu_index: vram} lookup for a worker (see
+    server.worker_allocated_cache)."""
+    allocated = await get_worker_allocated(worker_id)
+    return allocated.vram
+
+
+def to_gpu_device_public(device: GPUDevice, vram: Dict[int, int]) -> GPUDevicePublic:
+    """Override memory.allocated with the value aggregated server-side from
+    current ModelInstance assignments, mirroring /v2/workers — the
+    persisted view row carries only the worker-reported value, which is
+    deprecated and no longer populated."""
+    data = device.model_dump()
+    memory = data.get('memory')
+    if memory is not None:
+        memory['allocated'] = vram_allocated_for_index(vram, data.get('index'))
+    return GPUDevicePublic.model_validate(data)
+
+
+async def _inject_allocated_into_event(event: Event):
+    """Mutate a GPUDevice watch event so it carries the same
+    server-computed allocated as the REST response."""
+    # DELETED events arrive with data={"id": N} (ID-only) — nothing to mutate.
+    if event.type == EventType.DELETED:
+        return
+    device = event.data
+    if not isinstance(device, GPUDevicePublic) or device.memory is None:
+        return
+    vram = await _lookup_vram_allocated(device.worker_id)
+    device.memory.allocated = vram_allocated_for_index(vram, device.index)
 
 
 @router.get("", response_model=GPUDevicesPublic)
@@ -51,13 +90,16 @@ async def get_gpus(
     if params.watch:
         return StreamingResponse(
             GPUDevice.streaming(
-                fuzzy_fields=fuzzy_fields, fields=fields, filter_func=_gpu_visible
+                fuzzy_fields=fuzzy_fields,
+                fields=fields,
+                filter_func=_gpu_visible,
+                event_transform=_inject_allocated_into_event,
             ),
             media_type="text/event-stream",
         )
 
     async with async_session() as session:
-        return await GPUDevice.paginated_by_query(
+        paginated = await GPUDevice.paginated_by_query(
             session=session,
             fuzzy_fields=fuzzy_fields,
             page=params.page,
@@ -66,6 +108,15 @@ async def get_gpus(
             extra_conditions=extra_conditions,
             order_by=params.order_by,
         )
+        vram_by_worker = {
+            worker_id: await _lookup_vram_allocated(worker_id)
+            for worker_id in {device.worker_id for device in paginated.items}
+        }
+        items = [
+            to_gpu_device_public(device, vram_by_worker[device.worker_id])
+            for device in paginated.items
+        ]
+        return GPUDevicesPublic(items=items, pagination=paginated.pagination)
 
 
 @router.get("/{id}", response_model=GPUDevicePublic)
@@ -74,4 +125,4 @@ async def get_gpu(session: SessionDep, ctx: TenantContextDep, id: str):
     assert_cluster_resource_visible(
         ctx, model, not_found_message="GPU device not found"
     )
-    return model
+    return to_gpu_device_public(model, await _lookup_vram_allocated(model.worker_id))

--- a/gpustack/routes/workers.py
+++ b/gpustack/routes/workers.py
@@ -50,7 +50,10 @@ from gpustack.schemas.workers import (
     WorkerStateEnum,
 )
 from gpustack.server.bus import Event, EventType
-from gpustack.server.worker_allocated_cache import get_worker_allocated
+from gpustack.server.worker_allocated_cache import (
+    get_worker_allocated,
+    vram_allocated_for_index,
+)
 from gpustack.schemas.clusters import Cluster, Credential, ClusterStateEnum
 from gpustack.schemas.principals import Principal, PrincipalType
 from gpustack.schemas.api_keys import ApiKey
@@ -109,8 +112,7 @@ def _inject_allocated_into_status(
         device_memory = device.get('memory')
         if device_memory is None:
             continue
-        idx = device.get('index')
-        device_memory['allocated'] = vram.get(idx, 0) if idx is not None else 0
+        device_memory['allocated'] = vram_allocated_for_index(vram, device.get('index'))
 
 
 async def _lookup_allocated(worker_id: int) -> Tuple[int, Dict[int, int]]:
@@ -145,8 +147,7 @@ async def _inject_allocated_into_event(event: Event):
     for device in worker.status.gpu_devices or []:
         if device.memory is None:
             continue
-        idx = device.index
-        device.memory.allocated = vram.get(idx, 0) if idx is not None else 0
+        device.memory.allocated = vram_allocated_for_index(vram, device.index)
 
 
 def _make_worker_visibility_filter(ctx):

--- a/gpustack/schemas/gpu_devices.py
+++ b/gpustack/schemas/gpu_devices.py
@@ -1,5 +1,5 @@
 from typing import ClassVar, List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlmodel import SQLModel
 
 from gpustack.mixins import BaseModelMixin
@@ -41,7 +41,11 @@ class GPUDeviceListParams(ListParams):
 
 
 class GPUDevicePublic(GPUDeviceBase):
-    pass
+    # Unlike WorkerPublic (SQLModel-based, from_attributes=True), this class
+    # is plain pydantic — without from_attributes the streaming path's
+    # _convert_to_public_class(GPUDevice) raises ValidationError and kills
+    # the watch stream on the first replayed event.
+    model_config = ConfigDict(from_attributes=True)
 
 
 GPUDevicesPublic = PaginatedList[GPUDevicePublic]

--- a/gpustack/server/worker_allocated_cache.py
+++ b/gpustack/server/worker_allocated_cache.py
@@ -26,7 +26,7 @@ by node heartbeats.
 """
 
 import logging
-from typing import Iterable, Set
+from typing import Dict, Iterable, Optional, Set
 
 from sqlmodel import select, or_
 
@@ -36,6 +36,15 @@ from gpustack.server.cache import delete_cache_by_key, locked_cached
 from gpustack.server.db import async_session
 
 logger = logging.getLogger(__name__)
+
+
+def vram_allocated_for_index(vram: Dict[int, int], index: Optional[int]) -> int:
+    """Allocated VRAM for one GPU of a worker, given the worker's
+    {gpu_index: vram} aggregation. 0 when the device index is unknown or no
+    instance is assigned to it — shared fallback semantics for every place
+    that injects allocated into a device payload (/v2/workers and
+    /v1/gpu-devices, REST and watch)."""
+    return vram.get(index, 0) if index is not None else 0
 
 
 def _cache_key_for(worker_id: int) -> str:

--- a/tests/routers/test_gpu_devices.py
+++ b/tests/routers/test_gpu_devices.py
@@ -1,0 +1,120 @@
+import pytest
+from unittest.mock import patch
+
+from gpustack.policies.base import Allocated
+from gpustack.routes.gpu_devices import (
+    _inject_allocated_into_event,
+    to_gpu_device_public,
+)
+from gpustack.schemas.gpu_devices import GPUDevice, GPUDevicePublic
+from gpustack.server.bus import Event, EventType
+from gpustack.server.worker_allocated_cache import vram_allocated_for_index
+
+
+_DEFAULT_MEMORY = "default"
+
+
+def make_gpu_device(memory=_DEFAULT_MEMORY, index=0):
+    if memory is _DEFAULT_MEMORY:
+        memory = {"total": 100, "used": 10}
+    device = GPUDevice(
+        id="w1:cuda:0",
+        worker_id=1,
+        worker_name="w1",
+        worker_ip="10.0.0.1",
+        worker_ifname="eth0",
+        cluster_id=1,
+        index=index,
+        name="A100",
+    )
+    # Simulate a row loaded from gpu_devices_view: JSON columns arrive as
+    # raw dicts on table models (no validation on load).
+    object.__setattr__(device, "memory", memory)
+    return device
+
+
+@pytest.mark.parametrize(
+    "vram, index, expected",
+    [
+        ({0: 123, 1: 456}, 0, 123),
+        ({0: 123}, 1, 0),  # device has no instance assigned
+        ({0: 123}, None, 0),  # device index unknown
+        ({}, 0, 0),
+    ],
+)
+def test_vram_allocated_for_index(vram, index, expected):
+    assert vram_allocated_for_index(vram, index) == expected
+
+
+def test_to_gpu_device_public_injects_allocated():
+    public = to_gpu_device_public(make_gpu_device(), {0: 123})
+    assert isinstance(public, GPUDevicePublic)
+    assert public.memory.allocated == 123
+    assert public.memory.total == 100
+
+
+def test_to_gpu_device_public_no_assignment_defaults_zero():
+    public = to_gpu_device_public(make_gpu_device(), {1: 999})
+    assert public.memory.allocated == 0
+
+
+def test_to_gpu_device_public_index_none_defaults_zero():
+    public = to_gpu_device_public(make_gpu_device(index=None), {0: 123})
+    assert public.memory.allocated == 0
+
+
+def test_to_gpu_device_public_memory_none():
+    public = to_gpu_device_public(make_gpu_device(memory=None), {0: 123})
+    assert public.memory is None
+
+
+def test_convert_to_public_class():
+    """Covers the streaming conversion path: GPUDevicePublic needs
+    from_attributes to validate the GPUDevice table model, otherwise the
+    watch stream dies on the first replayed event."""
+    public = GPUDevice._convert_to_public_class(make_gpu_device())
+    assert isinstance(public, GPUDevicePublic)
+
+
+def _patched_allocated(vram):
+    async def fake_get_worker_allocated(worker_id):
+        return Allocated(ram=0, vram=vram)
+
+    return patch(
+        "gpustack.routes.gpu_devices.get_worker_allocated",
+        fake_get_worker_allocated,
+    )
+
+
+@pytest.mark.asyncio
+async def test_inject_allocated_into_event():
+    device = GPUDevice._convert_to_public_class(make_gpu_device())
+    event = Event(type=EventType.UPDATED, data=device, id=1)
+    with _patched_allocated({0: 777}):
+        await _inject_allocated_into_event(event)
+    assert event.data.memory.allocated == 777
+
+
+@pytest.mark.asyncio
+async def test_inject_allocated_into_event_skips_deleted():
+    event = Event(type=EventType.DELETED, data={"id": 1}, id=1)
+    with _patched_allocated({0: 777}):
+        await _inject_allocated_into_event(event)
+    assert event.data == {"id": 1}
+
+
+@pytest.mark.asyncio
+async def test_inject_allocated_into_event_skips_non_public_data():
+    event = Event(type=EventType.UPDATED, data={"id": 1}, id=1)
+    with _patched_allocated({0: 777}):
+        await _inject_allocated_into_event(event)
+    assert event.data == {"id": 1}
+
+
+@pytest.mark.asyncio
+async def test_inject_allocated_into_event_skips_memory_none():
+    device = GPUDevice._convert_to_public_class(make_gpu_device(memory=None))
+    event = Event(type=EventType.UPDATED, data=device, id=1)
+    with _patched_allocated({0: 777}):
+        await _inject_allocated_into_event(event)
+    assert event.data.memory is None


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5558

The /v1/gpu-devices API returned the worker-reported memory.allocated from gpu_devices_view, but workers no longer report this deprecated field. Inject the server-side allocated aggregated from current ModelInstance assignments into the REST list/get responses and the watch stream, the same way /v1/workers does.