### PR TITLE
fix: normalize cluster registration urls

### DIFF
--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -347,6 +347,11 @@ class Config(WorkerConfig, BaseSettings):
             if validators.url(self.server_url) is not True:
                 raise Exception("Invalid server URL.")
 
+        if self.server_external_url:
+            self.server_external_url = self.server_external_url.rstrip("/")
+            if validators.url(self.server_external_url) is not True:
+                raise Exception("Invalid server external URL.")
+
         if self.resources:
             self.get_gpu_devices()
             self.get_system_info()

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -83,13 +83,13 @@ router = APIRouter()
 def get_server_url(request: Request, cluster_override: Optional[str]) -> str:
     """Construct the server URL based on request headers or fallback to default."""
     if cluster_override:
-        return cluster_override.strip("/")
+        return cluster_override.rstrip("/")
     url = get_global_config().server_external_url
     if not url:
         url = f"{request.url.scheme}://{request.url.hostname}"
         if request.url.port:
             url += f":{request.url.port}"
-    return url.removesuffix("/")
+    return url.rstrip("/")
 
 
 def _is_cluster_visible(cluster: Cluster, ctx: TenantContext) -> bool:

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -491,6 +491,7 @@ class ClusterUpdate(SQLModel):
             parsed = urlparse(v)
             if not parsed.scheme or not parsed.netloc:
                 raise ValueError("Invalid server_url format")
+            return v.rstrip("/")
         return v
 
 

--- a/tests/routers/test_clusters.py
+++ b/tests/routers/test_clusters.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gpustack.config.config import Config
+from gpustack.routes.clusters import get_server_url
+from gpustack.schemas.clusters import ClusterUpdate
+
+
+def _request(url):
+    return SimpleNamespace(url=url)
+
+
+def _url(scheme="http", hostname="127.0.0.1", port=None):
+    return SimpleNamespace(scheme=scheme, hostname=hostname, port=port)
+
+
+def test_get_server_url_strips_trailing_slash_from_cluster_override():
+    server_url = get_server_url(
+        _request(_url()),
+        "http://example.com:30080/",
+    )
+
+    assert server_url == "http://example.com:30080"
+    assert f"{server_url}/v2/clusters/1/manifests" == (
+        "http://example.com:30080/v2/clusters/1/manifests"
+    )
+
+
+def test_get_server_url_strips_trailing_slash_from_external_url():
+    config = SimpleNamespace(server_external_url="http://example.com:30080/")
+
+    with patch("gpustack.routes.clusters.get_global_config", return_value=config):
+        server_url = get_server_url(_request(_url()), None)
+
+    assert server_url == "http://example.com:30080"
+    assert f"{server_url}/v2/clusters/1/manifests" == (
+        "http://example.com:30080/v2/clusters/1/manifests"
+    )
+
+
+def test_get_server_url_falls_back_to_request_origin():
+    server_url = get_server_url(
+        _request(_url(scheme="https", hostname="gpustack.example", port=8443)),
+        None,
+    )
+
+    assert server_url == "https://gpustack.example:8443"
+
+
+def test_cluster_update_normalizes_server_url():
+    cluster = ClusterUpdate(
+        name="k8s",
+        server_url="http://example.com:30080/",
+    )
+
+    assert cluster.server_url == "http://example.com:30080"
+
+
+def test_config_normalizes_server_external_url(monkeypatch, tmp_path):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    config = Config(
+        data_dir=str(tmp_path / "data"),
+        server_external_url="http://example.com:30080/",
+    )
+
+    assert config.server_external_url == "http://example.com:30080"


### PR DESCRIPTION
## Problem

Cluster registration URLs can keep a trailing slash when they come from `GPUSTACK_SERVER_EXTERNAL_URL` or a per-cluster `server_url`. The UI then appends `/v2/clusters/.../manifests`, which can produce a duplicate slash in the generated `curl | kubectl apply` command.

Fixes #5574.

## Solution

I normalized registration base URLs at the config/schema boundary and kept the route helper defensive by trimming trailing slashes before returning the registration payload URL. This keeps the stored and returned base URL canonical before manifest paths are appended.

## Testing

- `uv run pytest tests\routers\test_clusters.py -q`
- `uv run black --check gpustack\config\config.py gpustack\routes\clusters.py gpustack\schemas\clusters.py tests\routers\test_clusters.py`
- `uv run flake8 tests\routers\test_clusters.py`
- `git diff --check`