### PR TITLE
feat: record creator_id on templates, SSH keys and storage types

### DIFF
--- a/gpustack/migrations/versions/2026_05_28_0852-61929acb0676_gpu_instances.py
+++ b/gpustack/migrations/versions/2026_05_28_0852-61929acb0676_gpu_instances.py
@@ -30,8 +30,10 @@ def upgrade() -> None:
     sa.Column('display_name', sqlmodel.sql.sqltypes.AutoString(length=63), nullable=True),
     sa.Column('description', sqlmodel.sql.sqltypes.AutoString(length=1024), nullable=True),
     sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('creator_id', sa.Integer(), nullable=True),
     sa.Column('name', sqlmodel.sql.sqltypes.AutoString(length=63), nullable=False),
     sa.Column('spec', gpustack.schemas.common.JSON(), nullable=False),
+    sa.ForeignKeyConstraint(['creator_id'], ['principals.id'], ondelete='SET NULL'),
     sa.ForeignKeyConstraint(['owner_principal_id'], ['principals.id'], ondelete='CASCADE'),
     sa.PrimaryKeyConstraint('id'),
     sa.UniqueConstraint('owner_principal_id', 'name', name='uq_gpu_instance_persistent_volume_type_name_per_principal')
@@ -46,7 +48,9 @@ def upgrade() -> None:
     sa.Column('description', sqlmodel.sql.sqltypes.AutoString(length=1024), nullable=True),
     sa.Column('spec', gpustack.schemas.common.JSON(), nullable=False),
     sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('creator_id', sa.Integer(), nullable=True),
     sa.Column('name', sqlmodel.sql.sqltypes.AutoString(length=63), nullable=False),
+    sa.ForeignKeyConstraint(['creator_id'], ['principals.id'], ondelete='SET NULL'),
     sa.ForeignKeyConstraint(['owner_principal_id'], ['principals.id'], ondelete='CASCADE'),
     sa.PrimaryKeyConstraint('id'),
     sa.UniqueConstraint('owner_principal_id', 'name', name='uq_gpu_instance_ssh_public_key_name_per_principal')
@@ -62,7 +66,9 @@ def upgrade() -> None:
     sa.Column('manufacturer', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
     sa.Column('spec', gpustack.schemas.common.JSON(), nullable=False),
     sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('creator_id', sa.Integer(), nullable=True),
     sa.Column('name', sqlmodel.sql.sqltypes.AutoString(length=63), nullable=False),
+    sa.ForeignKeyConstraint(['creator_id'], ['principals.id'], ondelete='SET NULL'),
     sa.ForeignKeyConstraint(['owner_principal_id'], ['principals.id'], ondelete='CASCADE'),
     sa.PrimaryKeyConstraint('id'),
     sa.UniqueConstraint('owner_principal_id', 'name', name='uq_gpu_instance_template_name_per_principal')

--- a/gpustack/routes/gpu_instance_persistent_volume_types.py
+++ b/gpustack/routes/gpu_instance_persistent_volume_types.py
@@ -148,12 +148,14 @@ async def create_gpu_instance_persistent_volume_type(
             message=(f"Storage type with name '{create_obj.name}' already exists."),
         )
 
+    source: dict = create_obj.model_dump()
+    source["creator_id"] = ctx.user.id
     async with handle_error(
         message="Failed to create GPU instance persistent volume type",
     ):
         return await GPUInstancePersistentVolumeType.create(
             session=session,
-            source=create_obj,
+            source=source,
         )
 
 

--- a/gpustack/routes/gpu_instance_ssh_public_keys.py
+++ b/gpustack/routes/gpu_instance_ssh_public_keys.py
@@ -116,12 +116,14 @@ async def create_gpu_instance_ssh_public_key(
             message=(f"SSH public key with name '{create_obj.name}' already exists."),
         )
 
+    source: dict = create_obj.model_dump()
+    source["creator_id"] = ctx.user.id
     async with handle_error(
         message="Failed to create GPU instance SSH public key",
     ):
         return await GPUInstanceSSHPublicKey.create(
             session=session,
-            source=create_obj,
+            source=source,
         )
 
 

--- a/gpustack/routes/gpu_instance_templates.py
+++ b/gpustack/routes/gpu_instance_templates.py
@@ -142,12 +142,14 @@ async def create_gpu_instance_template(
             ),
         )
 
+    source: dict = create_obj.model_dump()
+    source["creator_id"] = ctx.user.id
     async with handle_error(
         message="Failed to create GPU instance template",
     ):
         return await GPUInstanceTemplate.create(
             session=session,
-            source=create_obj,
+            source=source,
         )
 
 

--- a/gpustack/schemas/gpu_instance_persistent_volume_types.py
+++ b/gpustack/schemas/gpu_instance_persistent_volume_types.py
@@ -250,6 +250,20 @@ class GPUInstancePersistentVolumeType(
     )
     id: Optional[int] = Field(default=None, primary_key=True)
 
+    # Record the creator of the GPU instance persistent volume type for
+    # auditing and ownership purposes.
+    creator_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("principals.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    """
+    Reference to the principal who created the GPU instance persistent volume type.
+    """
+
     name: str = Field(
         max_length=63,
     )
@@ -300,6 +314,11 @@ class GPUInstancePersistentVolumeTypePublic(
     """
 
     spec: GPUInstancePersistentVolumeTypeSpecPublic
+
+    creator_id: Optional[int] = None
+    """
+    Reference to the principal who created the GPU instance persistent volume type.
+    """
 
 
 class GPUInstancePersistentVolumeTypeListParams(ListParams):

--- a/gpustack/schemas/gpu_instance_ssh_public_keys.py
+++ b/gpustack/schemas/gpu_instance_ssh_public_keys.py
@@ -99,6 +99,20 @@ class GPUInstanceSSHPublicKey(GPUInstanceSSHPublicKeyBase, BaseModelMixin, table
     )
     id: Optional[int] = Field(default=None, primary_key=True)
 
+    # Record the creator of the GPU instance SSH public key for auditing
+    # and ownership purposes.
+    creator_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("principals.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    """
+    Reference to the principal who created the GPU instance SSH public key.
+    """
+
     name: str = Field(
         max_length=63,
     )
@@ -132,6 +146,11 @@ class GPUInstanceSSHPublicKeyPublic(GPUInstanceSSHPublicKeyCreate, PublicFields)
     """
     Represents the public view of a GPU instance SSH public key,
     containing only fields that are safe to expose to clients.
+    """
+
+    creator_id: Optional[int] = None
+    """
+    Reference to the principal who created the GPU instance SSH public key.
     """
 
     pass

--- a/gpustack/schemas/gpu_instance_templates.py
+++ b/gpustack/schemas/gpu_instance_templates.py
@@ -115,6 +115,20 @@ class GPUInstanceTemplate(GPUInstanceTemplateBase, BaseModelMixin, table=True):
     )
     id: Optional[int] = Field(default=None, primary_key=True)
 
+    # Record the creator of the GPU instance template for auditing and
+    # ownership purposes.
+    creator_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("principals.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    """
+    Reference to the principal who created the GPU instance template.
+    """
+
     name: str = Field(
         max_length=63,
     )
@@ -150,7 +164,10 @@ class GPUInstanceTemplatePublic(GPUInstanceTemplateCreate, PublicFields):
     containing only fields that are safe to expose to clients.
     """
 
-    pass
+    creator_id: Optional[int] = None
+    """
+    Reference to the principal who created the GPU instance template.
+    """
 
 
 class GPUInstanceTemplateListParams(ListParams):


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5572

GPU instances and persistent volumes have carried creator_id since their creation; templates, SSH public keys and persistent volume types only had the owning principal. The UI wants to show who created a row (Creator column).

Add the same nullable FK -> principals (SET NULL) column to the three remaining resources, stamp ctx.user.id on create, and expose it in the Public schemas. The columns are folded into the existing gpu_instances revision.