### PR TITLE
fix: serialize creator_id as snake_case like owner_principal_id

### DIFF
--- a/gpustack/schemas/common.py
+++ b/gpustack/schemas/common.py
@@ -199,6 +199,7 @@ def pydantic_column_type(
 
 _IGNORE_CAMEL_CASE_FIELDS = {
     "owner_principal_id",
+    "creator_id",
     "created_at",
     "updated_at",
     "deleted_at",


### PR DESCRIPTION
creator_id was missing from _IGNORE_CAMEL_CASE_FIELDS, so Public models carrying the camelCase alias generator emitted it as creatorId. The UI reads creator_id and silently fell back to owner-based attribution: regular users looked fine (their owner IS the creator) while admin-created rows rendered '-' (owner is the platform principal). Exempt it like the other top-level attribution ids; nothing consumes the camel form.