### PR TITLE
feat(users): support declaring source on user create API

### DIFF
--- a/gpustack/routes/user_groups.py
+++ b/gpustack/routes/user_groups.py
@@ -181,6 +181,7 @@ async def create_group(session: SessionDep, body: UserGroupCreate):
             kind=PrincipalType.GROUP,
             name=body.name,
             description=body.description,
+            source=body.source,
         )
         created = await Principal.create(session, group)
     except Exception as e:

--- a/gpustack/routes/users.py
+++ b/gpustack/routes/users.py
@@ -11,6 +11,7 @@ from gpustack.api.exceptions import (
     AlreadyExistsException,
     ForbiddenException,
     InternalServerErrorException,
+    InvalidException,
     NotFoundException,
     ConflictException,
 )
@@ -25,6 +26,7 @@ from gpustack.schemas.principals import (
 from gpustack.server.db import async_session
 from gpustack.server.deps import CurrentUserDep, SessionDep, TenantContextDep
 from gpustack.schemas.users import (
+    AuthProviderEnum,
     User,
     UserActivationUpdate,
     UserCreate,
@@ -162,12 +164,30 @@ async def create_user(session: SessionDep, user_in: UserCreate):
             message=f"User with name '{user_in.username}' already exists."
         )
 
+    # A local password on a non-Local user is a /login bypass around
+    # the IdP — ``authenticate_user`` only checks the password hash.
+    source = user_in.source if user_in.source is not None else AuthProviderEnum.Local
+    if source == AuthProviderEnum.Local and not user_in.password:
+        raise InvalidException(message="Password is required for Local users.")
+    if source != AuthProviderEnum.Local and user_in.password:
+        raise InvalidException(
+            message=f"Password must not be set for {source.value} users."
+        )
+    if source != AuthProviderEnum.Local and user_in.require_password_change:
+        raise InvalidException(
+            message=(
+                f"require_password_change is not applicable to "
+                f"{source.value} users."
+            )
+        )
+
     try:
         to_create = User(
             name=user_in.username,
             display_name=user_in.full_name,
             is_admin=user_in.is_admin,
             is_active=user_in.is_active,
+            source=source,
         )
         # Admin additionally joins the platform Org as OWNER; regular
         # users do NOT auto-join — admin can add them later if shared
@@ -214,6 +234,19 @@ async def update_user(session: SessionDep, id: int, user_in: UserUpdate):
         and await is_only_admin_user(session, user)
     ):
         raise ConflictException(message="Cannot deactivate the only admin user")
+
+    # See the guard in :func:`create_user` — same /login bypass.
+    if user.source != AuthProviderEnum.Local and user_in.password:
+        raise InvalidException(
+            message=f"Password must not be set for {user.source.value} users."
+        )
+    if user.source != AuthProviderEnum.Local and user_in.require_password_change:
+        raise InvalidException(
+            message=(
+                f"require_password_change is not applicable to "
+                f"{user.source.value} users."
+            )
+        )
 
     try:
         # ``exclude_none=True`` so omitting an optional field (e.g.
@@ -322,6 +355,12 @@ async def get_user_me(session: SessionDep, user: CurrentUserDep):
 async def update_user_me(
     session: SessionDep, user: CurrentUserDep, user_in: UserSelfUpdate
 ):
+    # See the guard in :func:`create_user` — same /login bypass.
+    if user.source != AuthProviderEnum.Local and user_in.password:
+        raise InvalidException(
+            message=f"Password must not be set for {user.source.value} users."
+        )
+
     try:
         update_data = user_in.model_dump(exclude_none=True)
         if "full_name" in update_data:

--- a/gpustack/schemas/user_groups.py
+++ b/gpustack/schemas/user_groups.py
@@ -27,7 +27,10 @@ class UserGroupUpdate(SQLModel):
 
 
 class UserGroupCreate(UserGroupUpdate):
-    pass
+    # Immutable after create (absent from ``UserGroupUpdate``). Used
+    # by ``sync_user_group_memberships`` to refuse cross-source name
+    # adoption.
+    source: AuthProviderEnum = AuthProviderEnum.Local
 
 
 class UserGroupListParams(ListParams):

--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -116,15 +116,20 @@ class UserBase(SQLModel):
     avatar_url: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)
     )
-    source: Optional[str] = Field(default=AuthProviderEnum.Local)
+    source: Optional[AuthProviderEnum] = Field(default=AuthProviderEnum.Local)
     require_password_change: bool = Field(default=False)
 
 
 class UserCreate(UserBase):
-    password: str
+    # Optional because non-Local sources authenticate via the IdP and
+    # carry no password row. The Local-source requires-password rule
+    # lives in the route handler so it can reference ``source``.
+    password: Optional[str] = None
 
     @field_validator('password')
     def validate_password(cls, value):
+        if value is None:
+            return value
         return _validate_password(value)
 
 

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -239,31 +239,22 @@ async def _insert_group_or_refetch(
     name: str,
     provider: AuthProviderEnum,
     now: datetime,
-) -> Principal:
+) -> Optional[Principal]:
     """Insert a new GROUP-principal, or re-fetch if a concurrent
     transaction beat us to it.
 
-    Wraps the insert in a SAVEPOINT (``session.begin_nested``) so the
-    surrounding sync transaction survives an ``IntegrityError`` from
-    the ``uix_principals_group_name`` partial unique index when two
-    concurrent first-time logins push the same group name — we just
-    re-read the row the winner inserted. On MySQL the partial unique
-    index isn't supported; the migration falls back to a plain index
-    and the SAVEPOINT acts purely as defensive scaffolding (the race
-    window is wider but real conflicts still resolve via the
-    re-fetch).
+    SAVEPOINT-wraps the insert so an IntegrityError from
+    ``uix_principals_group_name`` (PG partial unique; MySQL falls
+    back to a plain index) doesn't roll back the caller's
+    transaction — we re-read the winning row instead.
+
+    Returns ``None`` when the winning row's source disagrees with
+    ``provider`` (cross-source adoption is refused). Raises only if
+    IntegrityError fired but no row is visible on re-read.
     """
     grp = Principal(
         kind=PrincipalType.GROUP,
-        # IdP-supplied group name; unique within the GROUP partition
-        # (``uix_principals_group_name`` on PG, app-layer pre-check on
-        # MySQL). A non-GROUP principal with the same ``name`` lives
-        # in a separate partition and does not conflict.
         name=name,
-        # Tag the Group with the provider that brought it into
-        # existence. UI uses this to badge IdP-managed rows; sync
-        # doesn't condition on it (matching is by name regardless of
-        # source).
         source=provider,
         created_at=now,
         updated_at=now,
@@ -284,9 +275,16 @@ async def _insert_group_or_refetch(
             )
         ).first()
         if existing is None:
-            # IntegrityError but no row visible — surface it; the
-            # caller's transaction will roll back.
             raise
+        if existing.source != provider:
+            logger.warning(
+                "Group '%s' exists with source '%s'; refusing to adopt "
+                "for provider '%s' sync.",
+                name,
+                existing.source,
+                provider,
+            )
+            return None
         return existing
 
 
@@ -339,10 +337,8 @@ async def sync_user_group_memberships(
         seen.add(name)
         wanted_names.append(name)
 
-    # Resolve to Group-principal ids, auto-creating any we haven't
-    # seen before. Existing rows match by name regardless of their
-    # ``source`` — an admin-created "engineering" Group is reused
-    # when the IdP later pushes "engineering" too.
+    # Cross-source name matches are refused, not adopted — the IdP
+    # claim is skipped so the user's other groups still sync.
     desired_group_ids: Set[int] = set()
     if wanted_names:
         existing = (
@@ -359,21 +355,25 @@ async def sync_user_group_memberships(
         now = datetime.now(timezone.utc).replace(tzinfo=None)
         for name in wanted_names:
             grp = existing_by_name.get(name)
+            if grp is not None and grp.source != provider:
+                logger.warning(
+                    "Skipping group sync for '%s': exists with source "
+                    "'%s' but provider is '%s'.",
+                    name,
+                    grp.source,
+                    provider,
+                )
+                continue
             if grp is None:
-                # Race-tolerant create: a concurrent first-time login
-                # of another user can be inserting the same group name.
-                # On PG the ``uix_principals_group_name`` partial
-                # unique index aborts the loser with IntegrityError;
-                # on MySQL there's no partial unique so the window is
-                # wider but the SAVEPOINT-wrapped insert still lets us
-                # re-read the winner's row.
                 grp = await _insert_group_or_refetch(session, name, provider, now)
+                if grp is None:
+                    continue
             desired_group_ids.add(grp.id)
 
-    # Existing memberships for this user with source matching the
-    # provider — these are the rows the sync owns. We pull both
-    # active and soft-deleted so a re-add can revive the same row
-    # (keeps the audit timeline on a single id).
+    # Memberships this sync owns: this user's rows with matching
+    # provider on both the membership and the parent group. The
+    # group-source filter keeps legacy mis-attached rows out of the
+    # diff so first sync after upgrade doesn't silently delete them.
     user_pm_stmt = (
         select(PrincipalMembership)
         .join(Principal, Principal.id == PrincipalMembership.parent_principal_id)
@@ -381,6 +381,7 @@ async def sync_user_group_memberships(
             PrincipalMembership.member_principal_id == user_principal_id,
             PrincipalMembership.source == provider,
             Principal.kind == PrincipalType.GROUP,
+            Principal.source == provider,
         )
     )
     owned_rows: List[PrincipalMembership] = list(

--- a/tests/api/test_group_sync.py
+++ b/tests/api/test_group_sync.py
@@ -68,12 +68,19 @@ def test_coerce_non_string_scalar_is_empty():
 # ---- sync_user_group_memberships -------------------------------------------
 
 
-def _principal(id: int, name: str) -> Principal:
-    """Make a Group-principal Mock that quacks like a real row."""
+def _principal(
+    id: int,
+    name: str,
+    source: AuthProviderEnum = AuthProviderEnum.OIDC,
+) -> Principal:
+    """Group-principal Mock. ``source`` defaults to OIDC to match the
+    typical ``provider=OIDC`` test setup; pass explicitly to exercise
+    the cross-source skip path."""
     p = MagicMock(spec=Principal)
     p.id = id
     p.kind = PrincipalType.GROUP
     p.name = name
+    p.source = source
     p.deleted_at = None
     return p
 

--- a/tests/api/test_users_route.py
+++ b/tests/api/test_users_route.py
@@ -1,0 +1,189 @@
+"""Unit tests for :mod:`gpustack.routes.users` covering the
+``source`` × ``password`` validation matrix on create and update
+paths. Mock-based per :mod:`tests.api.test_p2_routes`.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from gpustack.api.exceptions import InvalidException
+from gpustack.routes import users as users_route
+from gpustack.schemas.users import AuthProviderEnum, UserCreate
+
+
+def _session_no_existing():
+    """Session whose dup-username lookup returns ``None``."""
+    session = MagicMock()
+    result = MagicMock()
+    result.first = MagicMock(return_value=None)
+    session.exec = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.add = MagicMock()
+    return session
+
+
+def _patch_creation_path(monkeypatch, *, is_admin=False):
+    """Stub the persistence side of ``create_user``. Returns the
+    ``set_password`` mock for invocation assertions."""
+    created = MagicMock()
+    created.id = 42
+    created.is_admin = is_admin
+    monkeypatch.setattr(users_route.User, "create", AsyncMock(return_value=created))
+    set_password_mock = AsyncMock()
+    monkeypatch.setattr(users_route, "set_password", set_password_mock)
+    monkeypatch.setattr(
+        users_route, "_to_user_public", AsyncMock(return_value=MagicMock())
+    )
+    return set_password_mock
+
+
+@pytest.mark.asyncio
+async def test_create_user_local_with_password_succeeds(monkeypatch):
+    set_password_mock = _patch_creation_path(monkeypatch)
+    session = _session_no_existing()
+    body = UserCreate(
+        username="alice",
+        password="StrongPassw0rd!",
+        source=AuthProviderEnum.Local,
+    )
+    await users_route.create_user(session=session, user_in=body)
+    set_password_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_user_local_without_password_rejected():
+    session = _session_no_existing()
+    body = UserCreate(username="alice", source=AuthProviderEnum.Local)
+    with pytest.raises(InvalidException):
+        await users_route.create_user(session=session, user_in=body)
+
+
+@pytest.mark.asyncio
+async def test_create_user_oidc_with_password_rejected():
+    session = _session_no_existing()
+    body = UserCreate(
+        username="alice",
+        password="StrongPassw0rd!",
+        source=AuthProviderEnum.OIDC,
+    )
+    with pytest.raises(InvalidException):
+        await users_route.create_user(session=session, user_in=body)
+
+
+@pytest.mark.asyncio
+async def test_create_user_oidc_without_password_succeeds(monkeypatch):
+    set_password_mock = _patch_creation_path(monkeypatch)
+    session = _session_no_existing()
+    body = UserCreate(username="alice", source=AuthProviderEnum.OIDC)
+    await users_route.create_user(session=session, user_in=body)
+    set_password_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_user_oidc_require_password_change_rejected():
+    session = _session_no_existing()
+    body = UserCreate(
+        username="alice",
+        source=AuthProviderEnum.OIDC,
+        require_password_change=True,
+    )
+    with pytest.raises(InvalidException):
+        await users_route.create_user(session=session, user_in=body)
+
+
+def test_create_user_invalid_source_rejected_at_schema():
+    # Pydantic enum validation catches this before the route runs,
+    # so FastAPI emits 422 instead of 500 from the catch-all.
+    with pytest.raises(ValidationError):
+        UserCreate(
+            username="alice",
+            password="StrongPassw0rd!",
+            source="Google",
+        )
+
+
+# ---- update_user / update_user_me password-bypass guards -------------------
+
+
+def _existing_user(source: AuthProviderEnum, *, user_id: int = 42):
+    u = MagicMock()
+    u.id = user_id
+    u.is_active = True
+    u.is_admin = False
+    u.source = source
+    return u
+
+
+@pytest.mark.asyncio
+async def test_update_user_rejects_password_for_oidc_user(monkeypatch):
+    session = MagicMock()
+    user = _existing_user(AuthProviderEnum.OIDC)
+    monkeypatch.setattr(users_route.User, "one_by_id", AsyncMock(return_value=user))
+    body = users_route.UserUpdate(username="alice", password="StrongPassw0rd!")
+    with pytest.raises(InvalidException):
+        await users_route.update_user(session=session, id=42, user_in=body)
+
+
+@pytest.mark.asyncio
+async def test_update_user_rejects_require_password_change_for_oidc_user(monkeypatch):
+    session = MagicMock()
+    user = _existing_user(AuthProviderEnum.OIDC)
+    monkeypatch.setattr(users_route.User, "one_by_id", AsyncMock(return_value=user))
+    body = users_route.UserUpdate(username="alice", require_password_change=True)
+    with pytest.raises(InvalidException):
+        await users_route.update_user(session=session, id=42, user_in=body)
+
+
+@pytest.mark.asyncio
+async def test_update_user_allows_password_for_local_user(monkeypatch):
+    session = MagicMock()
+    user = _existing_user(AuthProviderEnum.Local)
+    monkeypatch.setattr(users_route.User, "one_by_id", AsyncMock(return_value=user))
+
+    service_instance = MagicMock()
+    service_instance.update = AsyncMock()
+    monkeypatch.setattr(
+        users_route, "UserService", MagicMock(return_value=service_instance)
+    )
+    set_password_mock = AsyncMock()
+    monkeypatch.setattr(users_route, "set_password", set_password_mock)
+    monkeypatch.setattr(
+        users_route, "_to_user_public", AsyncMock(return_value=MagicMock())
+    )
+
+    body = users_route.UserUpdate(username="alice", password="StrongPassw0rd!")
+    await users_route.update_user(session=session, id=42, user_in=body)
+    set_password_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_user_me_rejects_password_for_oidc_user():
+    session = MagicMock()
+    user = _existing_user(AuthProviderEnum.OIDC)
+    body = users_route.UserSelfUpdate(password="StrongPassw0rd!")
+    with pytest.raises(InvalidException):
+        await users_route.update_user_me(session=session, user=user, user_in=body)
+
+
+@pytest.mark.asyncio
+async def test_update_user_me_allows_password_for_local_user(monkeypatch):
+    session = MagicMock()
+    user = _existing_user(AuthProviderEnum.Local)
+
+    service_instance = MagicMock()
+    service_instance.update = AsyncMock()
+    monkeypatch.setattr(
+        users_route, "UserService", MagicMock(return_value=service_instance)
+    )
+    set_password_mock = AsyncMock()
+    monkeypatch.setattr(users_route, "set_password", set_password_mock)
+    monkeypatch.setattr(
+        users_route, "_to_user_public", AsyncMock(return_value=MagicMock())
+    )
+
+    body = users_route.UserSelfUpdate(password="StrongPassw0rd!")
+    await users_route.update_user_me(session=session, user=user, user_in=body)
+    set_password_mock.assert_awaited_once()


### PR DESCRIPTION
Lets third-party integrations pre-provision OIDC/SAML users via the user create API.