### PR TITLE
fix: pin fastapi below 0.137.0 to avoid empty path error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{name = "GPUStack Authors", email = "contact@gpustack.ai"}]
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "fastapi>=0.115.0",
+    "fastapi>=0.115.0,<0.137.0",
     "sqlmodel>=0.0.18",
     "pydantic>=2.11.5",
     "pydantic-settings>=2.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1507,7 +1507,7 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "dataclasses-json", specifier = ">=0.6.7" },
-    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastapi", specifier = ">=0.115.0,<0.137.0" },
     { name = "fastapi-cdn-host", specifier = ">=0.8.0" },
     { name = "gpustack-higress-plugins", specifier = "==0.2.3.post4" },
     { name = "gpustack-runner", specifier = "==0.1.26.post5" },


### PR DESCRIPTION
FastAPI 0.137.0 refactored include_router to preserve original APIRoute instances instead of flattening prefix into path on inclusion. This makes the "Prefix and path cannot be both empty" check fire against routes declared with @router.get("") even when included under a non-empty prefix, breaking the docker build with FastAPIError on get_api_keys.