### PR TITLE
fix(my-models): unify owner-prefix naming for admin and non-admin

### DIFF
--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -263,6 +263,7 @@ async def _get_model_routes(
     target_class: Union[ModelRoute, MyModel] = ModelRoute,
     ctx: Optional[TenantContext] = None,
     include_grants: bool = False,
+    include_owner_prefix: bool = False,
 ):
     fuzzy_fields = {}
     if search:
@@ -351,12 +352,16 @@ async def _get_model_routes(
             order_by=params.order_by,
             extra_conditions=extra_conditions,
         )
-        await _apply_effective_name_to_my_models(session, target_class, result.items)
+        await _apply_effective_name_to_my_models(
+            session, result.items, enabled=include_owner_prefix
+        )
         return result
 
 
 async def _apply_effective_name_to_my_models(
-    session: AsyncSession, target_class, items: List[MyModel]
+    session: AsyncSession,
+    items: List[Union[ModelRoute, MyModel]],
+    enabled: bool,
 ) -> None:
     """Overwrite ``item.name`` with the OpenAI-style effective name —
     bare for the platform Org, ``<owner-name>/<name>`` otherwise — so
@@ -375,12 +380,19 @@ async def _apply_effective_name_to_my_models(
     ``from_attributes`` reads via ``getattr``, which still resolves
     through ``__dict__``, so the response picks up the rewritten value.
 
-    Accepts ``target_class`` so callers can invoke unconditionally —
-    the helper short-circuits for ``ModelRoute``. Keeps the surrounding
-    ``_get_model_routes`` / ``_get_model_route`` branches flat (their
-    cyclomatic complexity is already at the limit).
+    Gated per-endpoint via ``include_owner_prefix``, NOT per
+    ``target_class``: ``get_my_models`` serves both the non-admin
+    ``MyModel`` view and the admin ``ModelRoute`` table from one route,
+    so keying the rewrite off the class diverged the two responses
+    (admin saw raw names, non-admin saw prefixed) and broke frontend
+    consumers that expect one ``name`` format. The endpoint now passes
+    ``include_owner_prefix=True`` for both, while other listing
+    surfaces leave it off and keep the raw ``name``. The ``enabled``
+    short-circuit lives here rather than at the call site so
+    ``_get_model_routes`` stays flat (its cyclomatic complexity is
+    already at the limit).
     """
-    if target_class is not MyModel:
+    if not enabled:
         return
     if not items:
         return
@@ -465,6 +477,7 @@ async def _get_model_route(
     owner_principal_id: Optional[int] = None,
     ctx: Optional[TenantContext] = None,
     include_grants: bool = False,
+    include_owner_prefix: bool = False,
 ):
     fields = {"id": id}
     if user_id is not None:
@@ -505,7 +518,9 @@ async def _get_model_route(
                 existing,
                 not_found_message=f"ModelAccess with id '{id}' not found.",
             )
-    await _apply_effective_name_to_my_models(session, target_class, [existing])
+    await _apply_effective_name_to_my_models(
+        session, [existing], enabled=include_owner_prefix
+    )
     return existing
 
 
@@ -1464,6 +1479,7 @@ async def get_my_models(
         user_id=user_id,
         ctx=ctx,
         include_grants=user.is_admin,
+        include_owner_prefix=True,
     )
 
 
@@ -1487,4 +1503,5 @@ async def get_my_model(
         target_class=target_class,
         ctx=ctx,
         include_grants=user.is_admin,
+        include_owner_prefix=True,
     )

--- a/tests/routes/test_model_routes.py
+++ b/tests/routes/test_model_routes.py
@@ -109,7 +109,7 @@ async def test_apply_effective_name_to_my_models_prefixes_by_owner(monkeypatch):
     exec_result.all.return_value = [(2, "alpha"), (3, "beta")]
     session.exec = AsyncMock(return_value=exec_result)
 
-    await model_routes._apply_effective_name_to_my_models(session, MyModel, items)
+    await model_routes._apply_effective_name_to_my_models(session, items, enabled=True)
 
     assert items[0].name == "qwen3-0.6b"  # platform Org → no prefix
     assert items[1].name == "alpha/qwen3-0.6b"
@@ -117,18 +117,39 @@ async def test_apply_effective_name_to_my_models_prefixes_by_owner(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_apply_effective_name_to_my_models_skips_model_route():
-    """``ModelRoute`` callers (the management surface) reuse the same
-    code path but must skip the rewrite — Routes always belong to the
-    caller's own Org, the frontend already has it cached, and the page
-    expects raw ``name``."""
+async def test_apply_effective_name_to_my_models_skips_when_disabled():
+    """The rewrite is gated by ``enabled``, not the item's class —
+    callers that don't opt in (the management list/get surfaces) leave
+    ``name`` raw and avoid the owner-name lookup round-trip entirely."""
     session = SimpleNamespace(exec=AsyncMock())
     item = SimpleNamespace(name="qwen3-0.6b", owner_principal_id=2)
 
-    await model_routes._apply_effective_name_to_my_models(session, ModelRoute, [item])
+    await model_routes._apply_effective_name_to_my_models(
+        session, [item], enabled=False
+    )
 
     session.exec.assert_not_called()
     assert item.name == "qwen3-0.6b"
+
+
+@pytest.mark.asyncio
+async def test_apply_effective_name_to_my_models_prefixes_admin_model_routes(
+    monkeypatch,
+):
+    """When enabled, ``ModelRoute`` rows (the admin ``get_my_models``
+    path) get prefixed just like the non-admin ``MyModel`` view, so a
+    single endpoint returns one consistent ``name`` format for both."""
+    monkeypatch.setattr(model_routes, "platform_principal_id", lambda: 1)
+
+    item = ModelRoute(name="qwen3-0.6b", owner_principal_id=2)
+    session = SimpleNamespace()
+    exec_result = MagicMock()
+    exec_result.all.return_value = [(2, "alpha")]
+    session.exec = AsyncMock(return_value=exec_result)
+
+    await model_routes._apply_effective_name_to_my_models(session, [item], enabled=True)
+
+    assert item.name == "alpha/qwen3-0.6b"
 
 
 def test_model_route_create_rejects_slashed_name():
@@ -165,7 +186,7 @@ async def test_apply_effective_name_to_my_models_empty_is_noop():
     spurious round-trip per page would be a regression."""
     session = SimpleNamespace(exec=AsyncMock())
 
-    await model_routes._apply_effective_name_to_my_models(session, MyModel, [])
+    await model_routes._apply_effective_name_to_my_models(session, [], enabled=True)
 
     session.exec.assert_not_called()
 


### PR DESCRIPTION
Gate the effective-name rewrite per-endpoint via include_owner_prefix instead of target_class, so get_my_models returns one consistent name format for both the admin ModelRoute and non-admin MyModel paths.