### PR TITLE
docs: update navigation paths for new menu structure

### DIFF
--- a/docs/integrations/integrate-with-cherrystudio.md
+++ b/docs/integrations/integrate-with-cherrystudio.md
@@ -19,7 +19,7 @@ CherryStudio integrates with GPUStack to leverage locally hosted LLMs, embedding
 
 ## Create an API Key
 
-1. Hover over the user avatar and navigate to the `API Keys` page, then click on `New API Key`.
+1. Navigate to the `Access Control` > `API Keys` page, then click on `New API Key`.
 
 2. Fill in the name, then click `Save`.
 

--- a/docs/integrations/integrate-with-claude-code.md
+++ b/docs/integrations/integrate-with-claude-code.md
@@ -26,7 +26,7 @@ Claude Code is an agentic coding tool from Anthropic. Since model deployments on
 
 ## Create an API Key
 
-1. Hover over the user avatar and navigate to the **API Keys** page, then click **Add API Key**.
+1. Navigate to the **Access Control** > **API Keys** page, then click **Add API Key**.
 
 2. Enter a name, then click **Save**.
 

--- a/docs/integrations/integrate-with-dify.md
+++ b/docs/integrations/integrate-with-dify.md
@@ -19,7 +19,7 @@ Dify can integrate with GPUStack to leverage locally deployed LLMs, embeddings, 
 
 ## Create an API Key
 
-1. Hover over the user avatar and navigate to the `API Keys` page, then click on `New API Key`.
+1. Navigate to the `Access Control` > `API Keys` page, then click on `New API Key`.
 
 2. Fill in the name, then click `Save`.
 

--- a/docs/integrations/integrate-with-ragflow.md
+++ b/docs/integrations/integrate-with-ragflow.md
@@ -19,7 +19,7 @@ RAGFlow can integrate with GPUStack to leverage locally deployed LLMs, embedding
 
 ## Create an API Key
 
-1. Hover over the user avatar and navigate to the `API Keys` page, then click on `New API Key`.
+1. Navigate to the `Access Control` > `API Keys` page, then click on `New API Key`.
 
 2. Fill in the name, then click `Save`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -102,7 +102,7 @@ sudo docker run -d --name gpustack-worker \
 
 ## Use the model via API
 
-1. Hover over the user avatar and navigate to the `API Keys` page, then click the `New API Key` button.
+1. Navigate to the `Access Control` > `API Keys` page, then click the `New API Key` button.
 
 2. Fill in the `Name` and click the `Save` button.
 

--- a/docs/tutorials/inference-with-tool-calling.md
+++ b/docs/tutorials/inference-with-tool-calling.md
@@ -56,7 +56,7 @@ After deployment, you can monitor the model's status on the `Deployments` page.
 
 We will use the GPUStack API to interact with the model. To do this, you need to generate an API key:
 
-1. Hover over the user avatar and navigate to the `API Keys` page.
+1. Navigate to the `Access Control` > `API Keys` page.
 2. Click the `New API Key` button.
 3. Enter a name for the API key and click the `Save` button.
 4. Copy the generated API key for later use.

--- a/docs/user-guide/api-key-management.md
+++ b/docs/user-guide/api-key-management.md
@@ -4,7 +4,7 @@ GPUStack supports authentication using API keys. Each GPUStack user can generate
 
 ## Create API Key
 
-1. Hover over the user avatar and navigate to the `API Keys` page.
+1. Navigate to the `Access Control` > `API Keys` page.
 2. Click the `Add API Key` button.
 3. Fill in the `Name`, `Description`, and select the `Expiration` of the API key.
 4. Select the `Type` of the API key:
@@ -24,7 +24,7 @@ GPUStack supports authentication using API keys. Each GPUStack user can generate
 
 ## Edit Access Permissions
 
-1. Hover over the user avatar and navigate to the `API Keys` page.
+1. Navigate to the `Access Control` > `API Keys` page.
 2. Find the API key you want to edit.
 3. Click the `Edit` button in the `Operations` column.
 4. Update the `Description` if needed.
@@ -39,7 +39,7 @@ GPUStack supports authentication using API keys. Each GPUStack user can generate
 
 ## Delete API Key
 
-1. Hover over the user avatar and navigate to the `API Keys` page.
+1. Navigate to the `Access Control` > `API Keys` page.
 2. Find the API key you want to delete.
 3. Click the `Delete` button in the `Operations` column.
 4. Confirm the deletion.

--- a/docs/user-guide/inference-backend-management.md
+++ b/docs/user-guide/inference-backend-management.md
@@ -115,7 +115,7 @@ vllm serve Qwen/Qwen3.5-0.8B --tensor-parallel-size=2 --max-model-len=8192 --lor
 
 There are two ways to add a custom inference backend:
 
-- Through the UI form: Navigate to the **Resources > Inference Backends** page and click the **Add Custom Inference Backend** button.
+- Through the UI form: Navigate to the **Model Service > Inference Backends** page and click the **Add Custom Inference Backend** button.
 - Through YAML configuration: Import a YAML file containing the backend configuration.
 
 ### Enable Community Inference Backend

--- a/docs/using-models/using-embedding-models.md
+++ b/docs/using-models/using-embedding-models.md
@@ -29,7 +29,7 @@ After deployment, you can monitor the model deployment's status on the `Deployme
 
 We will use the GPUStack API to generate text embeddings, and an API key is required:
 
-1. Hover over the user avatar and navigate to the `API Keys` page.
+1. Navigate to the `Access Control` > `API Keys` page.
 2. Click the `New API Key` button.
 3. Enter a name for the API key and click the `Save` button.
 4. Copy the generated API key. You can only view the API key once, so make sure to save it securely.

--- a/docs/using-models/using-reranker-models.md
+++ b/docs/using-models/using-reranker-models.md
@@ -29,7 +29,7 @@ After deployment, you can monitor the model deployment's status on the `Deployme
 
 We will use the GPUStack API to interact with the model. To do this, you need to generate an API key:
 
-1. Hover over the user avatar and navigate to the `API Keys` page.
+1. Navigate to the `Access Control` > `API Keys` page.
 2. Click the `New API Key` button.
 3. Enter a name for the API key and click the `Save` button.
 4. Copy the generated API key. You can only view the API key once, so make sure to save it securely.


### PR DESCRIPTION
API Keys moved from the user avatar dropdown to the Access Control group, and Inference Backends moved from Resources to Model Service.