### PR TITLE
chore: demote missing-scope inference backend log to debug

### DIFF
--- a/gpustack/worker/inference_backend_manager.py
+++ b/gpustack/worker/inference_backend_manager.py
@@ -109,7 +109,7 @@ class InferenceBackendManager:
                 else:
                     with _cache_lock:
                         self._missing_scopes.add(scope_key)
-                    logger.warning(
+                    logger.debug(
                         f"No backend row for owner {owner_principal_id} of "
                         f"backend {backend_name} after cache refresh; using "
                         f"the Platform configuration only. If this owner is "


### PR DESCRIPTION
The no-override fallback path is the common steady state for owners that legitimately have no Org-scoped backend row, so warning-level noise on every model start was misleading.