### PR TITLE
docs: copyediting pass

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -136,7 +136,7 @@ If the model is stored on a specific worker, you can use the worker selector to 
 
 Another option is to mount a shared storage across multiple nodes.
 
-And the model files must be mounted into the container, and the host directory and the container mount path must be identical.
+The model files must also be mounted into the container, and the host directory and the container mount path must be identical.
 
 When deploying Safetensors models from Local Path, the path **must point to the absolute path of the model directory which contain `*.safetensors`, `config.json`, and other files**.
 
@@ -146,7 +146,7 @@ When deploying GGUF models from Local Path, the path **must point to the absolut
 
 ### What should I do if the model is stuck in `Pending` state?
 
-`Pending` means that there are currently no workers meeting the model’s requirements, move the mouse over the `Pending` status to view the reason.
+`Pending` means that no workers currently meet the model's requirements. Hover over the `Pending` status to view the reason.
 
 First, check the `Workers` section to ensure that the worker status is Ready.
 
@@ -180,7 +180,7 @@ Try restarting the GPUStack container where the model is scheduled. If the issue
 
 ### What should I do if the model is stuck in `Error` state?
 
-Move the mouse over the `Error` status to view the reason. If there is a `View More` button, click it to check the error messages in the model logs and analyze the cause of the error.
+Hover over the `Error` status to view the reason. If there is a `View More` button, click it to check the error messages in the model logs and analyze the cause of the error.
 
 ### Why does the model fail to start when using a custom backend version based on the official vLLM image with `PYPI_PACKAGES_INSTALL`?
 

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -23,7 +23,7 @@ In addition:
 
 - The GPUStack server is deployed as a `StatefulSet` and currently does **not** support more than one replica.
 - By default, the bundled embedded `PostgreSQL` database is used. It is recommended to specify an external database via `server.externalDatabaseURL` for production.
-- Higress plugins are served by a dedicated `gpustack/higress-plugins` Deployment installed alongside GPUStack. When the Higress gateway restarts, it downloads the plugins from this service; if the service is unavailable, the gateway's startup is blocked until the plugins become accessible.
+- Higress plugins are served by a dedicated `gpustack/higress-plugins` Deployment installed alongside GPUStack. The Higress gateway downloads plugins from this service on restart; if the service is unavailable, gateway startup is blocked until the plugins become accessible.
 - The bundled `higress-core` sub-chart deploys Higress as the cluster's ingress controller. If another ingress controller is already running, set `higress-core.enabled=false` and point `gateway.ingressClassname` at an existing Higress instance.
 
 ## Install k3s (optional)

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -36,7 +36,7 @@ Check the GPUStack container logs:
 sudo docker logs -f gpustack
 ```
 
-If everything is normal, open `http://your_host_ip` in a browser to access the GPUStack UI.
+Once the server is up, open `http://your_host_ip` in a browser to access the GPUStack UI.
 
 Log in with username `admin` and the default password. Retrieve the initial password with:
 
@@ -143,7 +143,7 @@ Start the GPUStack server:
 sudo docker compose -f docker-compose.server.yaml up -d
 ```
 
-If everything is normal, open `http://your_host_ip` in a browser to access the GPUStack UI.
+Once the server is up, open `http://your_host_ip` in a browser to access the GPUStack UI.
 
 Log in with username `admin` and the default password. Retrieve the initial password with:
 

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -8,7 +8,7 @@ GPUStack supports most modern Linux distributions on **AMD64** and **ARM64** arc
 
 !!! note
 
-    - GPUStack is not supported for direct installation via PyPi. For best compatibility, use the provided Docker images.
+    - Installing GPUStack directly via PyPI is not supported. For best compatibility, use the provided Docker images.
     - The Network Time Protocol (NTP) package must be installed to ensure consistent state synchronization between nodes.
 
 ## Database Requirements

--- a/docs/integrations/integrate-with-cherrystudio.md
+++ b/docs/integrations/integrate-with-cherrystudio.md
@@ -1,6 +1,6 @@
-# Integrate with CherryStudio
+# Integrate with Cherry Studio
 
-CherryStudio integrates with GPUStack to leverage locally hosted LLMs, embeddings and reranking capabilities.
+Cherry Studio integrates with GPUStack to leverage locally hosted LLMs, embeddings, and reranking capabilities.
 
 ## Deploying Models
 
@@ -25,15 +25,15 @@ CherryStudio integrates with GPUStack to leverage locally hosted LLMs, embedding
 
 3. Copy the API key and save it for later use.
 
-## Integrating GPUStack into CherryStudio
+## Integrating GPUStack into Cherry Studio
 
-1. Open CherryStudio, go to `Settings` → `Model Provider`, find GPUStack, enable it, and configure it as shown:
+1. Open Cherry Studio, go to `Settings` → `Model Provider`, find GPUStack, enable it, and configure it as shown:
 
     - `API Key`: Input the API key you copied from previous steps.
 
     - `API Host`: `Access URL` in the `API Access Info` panel.
 
-   ![CherryStudio GPUStack setup](../assets/integrations/integration-cherrystudio-01.png)
+   ![Cherry Studio GPUStack setup](../assets/integrations/integration-cherrystudio-01.png)
 
 2. In the GPUStack provider configuration, click "Manage" and enable the models you need:
 
@@ -45,7 +45,7 @@ CherryStudio integrates with GPUStack to leverage locally hosted LLMs, embedding
 
    ![Test API](../assets/integrations/integration-cherrystudio-04.png)
 
-After configuration, return to the CherryStudio home page and start using your models.
+After configuration, return to the Cherry Studio home page and start using your models.
 
 ## Using LLMs
 

--- a/docs/integrations/integrate-with-claude-code.md
+++ b/docs/integrations/integrate-with-claude-code.md
@@ -67,7 +67,7 @@ Install [CC-Switch](https://github.com/farion1231/cc-switch) following its docum
 
 2. Verify that the configuration is correct by using the `/status` command.
 
-3. Ask Claude to create a Flappy Bird game:
+3. Try a sample task, for example, ask Claude Code to create a Flappy Bird game:
 
    ```
    Write a Flappy Bird game.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -66,7 +66,7 @@ done
 
 ### Migrate Server Using Docker
 
-Since v2.0.0, you no longer need to specify the GPU computing platform or version (such as `-cpu`, `-cuda12.8`, or `-rocm`) for the server or worker images. Simply use the latest image: gpustack/gpustack:latest.
+Since v2.0.0, you no longer need to specify the GPU computing platform or version (such as `-cpu`, `-cuda12.8`, or `-rocm`) for the server or worker images. Use the unified image instead: `gpustack/gpustack:latest`.
 
 #### Embedded Database Migration (SQLite → PostgreSQL)
 
@@ -88,7 +88,7 @@ sudo docker run -d --name gpustack \
 
 If you are getting the error from docker `docker: Error response from daemon: unknown or invalid runtime name: nvidia`, please check [Accelerator Runtime Requirements](./installation/requirements.md#accelerator-runtime-requirements) first and following the document [Other GPU Architectures](#other-gpu-architectures) to change the `--runtime nvidia` argument with your runtime.
 
-Also customizing the `--data-dir`, `GPUSTACK_DATA_DIR` is also supported in database migration by following command changes:
+Customizing the data directory via `--data-dir` or `GPUSTACK_DATA_DIR` is also supported during database migration. Adjust the command as follows:
 
 ```diff
 ...

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-This guide will walk you through running GPUStack on your own self-hosted GPU servers. To use [cloud GPUs](./tutorials/adding-gpucluster-using-digitalocean.md), or integrating with an [existing Kubernetes cluster](./tutorials/adding-gpucluster-using-kubernetes.md), see the relevant tutorials.
+This guide walks you through running GPUStack on self-hosted GPU servers. To use [cloud GPUs](./tutorials/adding-gpucluster-using-digitalocean.md) or to integrate with an [existing Kubernetes cluster](./tutorials/adding-gpucluster-using-kubernetes.md), see the relevant tutorials.
 
 !!! info "Prerequisites"
 

--- a/docs/tutorials/running-deepseek-r1-671b-with-distributed-ascend-mindie.md
+++ b/docs/tutorials/running-deepseek-r1-671b-with-distributed-ascend-mindie.md
@@ -26,7 +26,7 @@ Before you begin, make sure the following requirements are met:
 !!! note
 
     - In this tutorial, we assume a setup of 4 nodes, each equipped with 8 910B3 NPUs and connected via 200G Huawei Cache Conherence Network (HCCN).
-    - Altas NPUs do not support the FP8 precision originally used by DeepSeek R1. Hence, we use the BF16 version from [Unsloth](https://huggingface.co/unsloth/DeepSeek-R1-BF16).
+    - Atlas NPUs do not support the FP8 precision originally used by DeepSeek R1. Hence, we use the BF16 version from [Unsloth](https://huggingface.co/unsloth/DeepSeek-R1-BF16).
 
 ## Step 1: Install GPUStack Server
 
@@ -87,7 +87,7 @@ sudo docker run -d --name gpustack \
 
     - Replace the placeholder paths, IP address/hostname, and cluster token accordingly.
     - Replace `/path/to/your/model` with the actual path on your system where the DeepSeek R1 model files are stored.
-    - Ensure the `hccn_tool` tool is installed and configured correctly on your system. This is required for discvoring the HCCN network communication.
+    - Ensure `hccn_tool` is installed and configured correctly on your system. This is required for discovering the HCCN network communication.
 
 After all workers are added, return to the GPUStack UI.
 

--- a/docs/user-guide/cluster-management.md
+++ b/docs/user-guide/cluster-management.md
@@ -43,7 +43,7 @@ The kubernetes can be registered after the cluster is created.
 1. Go to `Clusters` page.
 2. Find the cluster which you want to register the Kubernetes cluster.
 3. Click the ellipsis button in the operations column, then select `Register Cluster`.
-4. Select the options to register cluster. Following the same steps as abovve, from `Select the GPU vendor` to `Run command`.
+4. Select the options to register the cluster. Follow the same steps as above, from `Select the GPU vendor` to `Run command`.
 
 #### Kubernetes Cluster Options
 
@@ -74,7 +74,7 @@ The `Advanced` settings expose the following Kubernetes deployment options:
 3. Adding one or more `Worker Pools`. For each pool, `Name`, `Instance Type`, `OS Image`, `Replicas`, `Batch Size`, `Labels` and `Volumes` can be specified.
 4. Click `Save` after the worker pools are configured.
 
-The worker poll can be added after the cluster is created.
+Additional worker pools can be added after the cluster is created.
 
 1. Go to `Clusters` page.
 2. Find the `DigitalOcean` cluster which you want to add worker pool.

--- a/docs/user-guide/model-provider-management.md
+++ b/docs/user-guide/model-provider-management.md
@@ -44,7 +44,7 @@ The currently supported providers are:
 1. Go to `Providers` Page.
 2. Click the `Add Provider`.
 3. Fill the required options like `Name`, `Type`, `API Key`.
-4. Click `Add Model` to configure at lease one model for this provider.
+4. Click `Add Model` to configure at least one model for this provider.
 5. Click the `Save` button.
 
 ## Add Route for Provider

--- a/docs/user-guide/model-route-management.md
+++ b/docs/user-guide/model-route-management.md
@@ -7,7 +7,7 @@ GPUStack provides model route management capabilities. Through model routes, you
 1. Go to `Routes` page.
 2. Click `Add Route`.
 3. Fill the route `Name` as the serving model name.
-4. Select at lease one `Route Targets`.
+4. Select one or more `Route Targets`.
 5. Click the `Save` button.
 
 ## Manage Route Targets

--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -126,7 +126,7 @@ _(where `custom_metrics_config.json` is your new config file)_
 **Get default config:**
 
 ```bash
-curl -X POST http://<gpustack_server_host>:<gpustack_server_port>/v2/metrics/default-config
+curl http://<gpustack_server_host>:<gpustack_server_port>/v2/metrics/default-config
 ```
 
 > **Note**: The configuration should be provided in valid JSON format.

--- a/docs/user-guide/playground/rerank.md
+++ b/docs/user-guide/playground/rerank.md
@@ -6,7 +6,7 @@ The Rerank Playground allows you to test reranker models that reorder multiple t
 
 Add multiple text entries to the document for reranking.
 
-## Bach Input Text
+## Batch Input Text
 
 Enable `Batch Input Mode` to split multi-line text into separate entries based on line breaks. This is useful for processing multiple text snippets efficiently.
 

--- a/docs/user-guide/sso.md
+++ b/docs/user-guide/sso.md
@@ -4,7 +4,7 @@ GPUStack supports Single Sign-On (SSO) authentication methods such as OIDC and S
 
 ## OIDC
 
-Any authentication provider that supports OIDC can be configured. The `email`, `name` and `picture` claims are used if available. The allowed redirect URI should include `<server-url>/auth/oidc/callback`.
+Any authentication provider that supports OIDC can be configured. The `email`, `name`, and `picture` claims are used if available. The allowed redirect URI should include `<server-url>/auth/oidc/callback`.
 
 If your OIDC provider uses a certificate issued by a private or corporate CA, see [Additional Trusted CAs](../installation/installation.md#additional-trusted-cas) for how to mount CA certificates into the GPUStack container.
 

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -107,8 +107,8 @@ The detail table groups by:
 
 !!! note
 
-    CPU instances have no accelerator, so they contribute to **Instance Hours** but 0 to
-    **GPU Hours**.
+    CPU instances have no accelerator, so they contribute to **Instance Hours** but
+    not to **GPU Hours**.
 
 ## Storage
 

--- a/docs/using-models/using-large-language-models.md
+++ b/docs/using-models/using-large-language-models.md
@@ -14,7 +14,7 @@ Before you begin, ensure that you have the following:
 
 ## Step 1: Deploy Large Language Models
 
-### Deoloy from Catalog
+### Deploy from Catalog
 
 Large language models in the catalog are marked with the `LLM` category. When you select a large language model from the catalog, the default configurations should work as long as you have enough GPU resources and the backend is compatible with your setup (e.g., vLLM backend requires an amd64 Linux worker).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,7 +153,7 @@ nav:
       - Migration: migration.md
       - User Guide:
           - Playground:
-              - Playgound: user-guide/playground/index.md
+              - Overview: user-guide/playground/index.md
               - Chat: user-guide/playground/chat.md
               - Image: user-guide/playground/image.md
               - Audio: user-guide/playground/audio.md


### PR DESCRIPTION
Fix typos (abovve, at lease, Bach, Deoloy, Altas, discvoring, PyPi, Playgound), correct an incorrect HTTP verb in the metrics example (default-config is GET, not POST), standardize Cherry Studio branding, and tighten various awkward sentences across the docs.