### PR TITLE
docs: bump CUDA/ROCm requirements and fix Cherry Studio naming

### DIFF
--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -50,7 +50,7 @@ Ensure all required drivers and toolkits are installed before running GPUStack.
 
 #### Requirements
 
-- [NVIDIA GPU Driver](https://www.nvidia.com/en-us/drivers/) that supports NVIDIA CUDA 12.6 or higher.
+- [NVIDIA GPU Driver](https://www.nvidia.com/en-us/drivers/) that supports NVIDIA CUDA 12.8 or higher.
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit)
 
 Run the following commands to verify:
@@ -75,7 +75,7 @@ sudo docker info 2>/dev/null | grep -q "nvidia" \
 
 #### Requirements
 
-- [AMD GPU Driver](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/) that supports AMD ROCm 6.4 or higher.
+- [AMD GPU Driver](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/) that supports AMD ROCm 7.0 or higher.
 - [AMD Container Runtime](https://instinct.docs.amd.com/projects/container-toolkit/en/latest/container-runtime/overview.html)
 
 Run the following commands to verify:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,7 +204,7 @@ nav:
           - Integrate with Claude Code: integrations/integrate-with-claude-code.md
           - Integrate with Dify: integrations/integrate-with-dify.md
           - Integrate with RAGFlow: integrations/integrate-with-ragflow.md
-          - Integrate with CherryStudio: integrations/integrate-with-cherrystudio.md
+          - Integrate with Cherry Studio: integrations/integrate-with-cherrystudio.md
           - Integrate with OpenClaw: integrations/integrate-with-openclaw.md
           - Integrate with n8n: integrations/integrate-with-n8n.md
           - Integrate with MaxKB: integrations/integrate-with-maxkb.md


### PR DESCRIPTION
- Update minimum CUDA from 12.6 to 12.8, ROCm from 6.4 to 7.0.
- Rename "CherryStudio" to "Cherry Studio" in the Integrations nav to match the official brand and the page body.