### PR TITLE
docs: format and copyedit pass on usage and API key pages

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -101,15 +101,19 @@ The **Applies to** column indicates where the environment variable should be set
 | `GPUSTACK_USAGE_EVENTS_ARCHIVE_CRON`               | Cron expression (UTC) for the resource-events archiver's recurring sweep. The archiver also runs once on server startup regardless of this schedule.                                                                                               | `30 3 * * *` | Server     |
 | `GPUSTACK_USAGE_EVENTS_ARCHIVE_BATCH_SIZE`         | Per-batch row count for resource-events archival moves.                                                                                                                                                                                            | `5000`       | Server     |
 
-> **Note — `GPUSTACK_USAGE_ROLLUP_TIMEZONE` scope & DST.** This one timezone
-> governs every usage view: the daily `model_usages` token rollup, the
-> GPU/storage time buckets, and the displayed Last Active and resource-event
-> times. For a zone that observes **DST**
-> this has two consequences worth knowing: (a) near a DST transition an event's
-> displayed clock time can fall on a different calendar day than the bucket it is
-> counted in; and (b) re-running the same historical query after a DST switch can
-> re-bucket older rows by an hour, so the result drifts over time. Non-DST zones
-> (UTC, `Asia/Shanghai`, …) are exact and unaffected.
+!!! note "`GPUSTACK_USAGE_ROLLUP_TIMEZONE` scope & DST"
+
+    This one timezone governs every usage view: the daily `model_usages` token
+    rollup, the GPU/storage time buckets, and the displayed Last Active and
+    resource-event times. For a zone that observes **DST** this has two
+    consequences worth knowing:
+
+    - Near a DST transition an event's displayed clock time can fall on a
+      different calendar day than the bucket it is counted in.
+    - Re-running the same historical query after a DST switch can re-bucket
+      older rows by an hour, so the result drifts over time.
+
+    Non-DST zones (UTC, `Asia/Shanghai`, …) are exact and unaffected.
 
 ### Cluster Configuration
 

--- a/docs/user-guide/api-key-management.md
+++ b/docs/user-guide/api-key-management.md
@@ -8,11 +8,14 @@ GPUStack supports authentication using API keys. Each GPUStack user can generate
 2. Click the `Add API Key` button.
 3. Fill in the `Name`, `Description`, and select the `Expiration` of the API key.
 4. Select the `Type` of the API key:
+
    - **Auto-generated**: GPUStack generates the API key for you.
    - **Custom**: Provide your own key value in the `Key` field. This field is required when choosing **Custom**.
+
 5. In the `Access Permissions` section, select the permissions for the API key:
+
    - **Platform Management**: Grants access to platform management endpoints (users, models, workers, etc.).
-   - **Model Access**: Grants access to inference APIs. When selected, choose either **All models** or **Allowed models**, and if choosing **Allowed models**, select which models this API key can access from the list.
+   - **Model Access**: Grants access to inference APIs. When selected, choose either `All models` or `Allowed models`, and if choosing `Allowed models`, select which models this API key can access from the list.
 
    If no permission is selected, the API key has no access permissions.
 6. Click the `Save` button.
@@ -29,8 +32,10 @@ GPUStack supports authentication using API keys. Each GPUStack user can generate
 3. Click the `Edit` button in the `Operations` column.
 4. Update the `Description` if needed.
 5. In the `Access Permissions` section, adjust the selected permissions:
+
    - **Platform Management**: Grants access to platform management endpoints (users, models, workers, etc.).
-   - **Model Access**: Grants access to inference APIs. When selected, choose either **All models** or **Allowed models**, and if choosing **Allowed models**, select which models this API key can access from the list.
+   - **Model Access**: Grants access to inference APIs. When selected, choose either `All models` or `Allowed models`, and if choosing `Allowed models`, select which models this API key can access from the list.
+
 6. Click the `Save` button.
 
 !!! note

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -8,7 +8,7 @@ attribute consumption to users, and reason about cost.
 
 1. Navigate to the `Usage` page from the left navigation (the bar-chart icon).
 2. Select a tab — `Summary`, `Tokens`, `GPU Instances`, `Storage`, or `Resource Events`.
-3. Set the **date range** (and any other filters) to scope the report.
+3. Set the `date range` (and any other filters) to scope the report.
 
 The tabs are:
 
@@ -28,7 +28,7 @@ The tabs are:
 
 ## Visibility
 
-GPUStack has two roles — `Admin` and `User` (see [User Management](user-management.md)):
+GPUStack has two roles — **Admin** and **User** (see [User Management](user-management.md)):
 
 - **Admin** — can view usage across all users, and narrow the view with the **Filter by user**
   control.
@@ -44,31 +44,31 @@ Every tab (except Resource Events, which has its own filters) shares the same co
 - **Refresh** — re-fetch with the current filters.
 - **Metric** — which value the trend chart and KPI sort use (e.g. GPU Hours vs Instance Hours).
 - **Group by** — split the trend chart into one series per group (e.g. per instance type).
-- **Granularity** — the trend bucket: **Hour / Day / Week / Month** for GPU Instances and
-  Storage, **Day / Week / Month** for Tokens (token usage is a daily rollup, so it has no
-  hourly granularity).
-- **Export** (download icon, Tokens / GPU Instances / Storage) — opens a preview of the
-  current filtered breakdown and lets you download it.
+- **Granularity** — the trend bucket. GPU Instances and Storage support
+  **Hour / Day / Week / Month**; Tokens supports **Day / Week / Month** only (token usage is a
+  daily rollup, so it has no hourly bucket).
+- **Export** (download icon, available on Tokens / GPU Instances / Storage) — opens a preview
+  of the current filtered breakdown and lets you download it.
 
 ## Metric definitions
 
 | Metric                                                        | Meaning                                                                                                             |
 | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Input Tokens**                                              | Prompt tokens. **Input Tokens Cached** is the subset served from the prompt cache.                                  |
+| **Input Tokens**                                              | Prompt tokens. **Input Cached Tokens** is the subset served from the prompt cache.                                  |
 | **Output Tokens**                                             | Completion tokens generated.                                                                                        |
 | **Total Tokens**                                              | Input + Output.                                                                                                     |
 | **Instance Hours**                                            | Wall-clock instance runtime: Σ(uptime) regardless of how many cards the instance holds.                             |
 | **GPU Hours**                                                 | Accelerator runtime: Σ(uptime × GPU card count). A 2-GPU instance run for 1 hour = 2 GPU Hours but 1 Instance Hour. |
 | **GB-Days**                                                   | Provisioned storage over time: capacity (GB) × days held.                                                           |
 | **GB-Hours**                                                  | Same as GB-Days, expressed per hour.                                                                                |
-| **Active Instances** / **Active Storages** / **Active Users** | Resources that are still live (not deleted) within the window — Active Instances / Active Storages / Active Users.  |
+| **Active Instances** / **Active Storages** / **Active Users** | Resources that are still live (not **Deleted**) within the window.                                                  |
 | **Last Active**                                               | The most recent bucket in which the resource accrued usage.                                                         |
 
 !!! note
 
     Deleted resources keep their historical usage — a deleted model, instance, or storage
     still appears in the tables (flagged **Deleted**) and contributes to the totals, but it is
-    no longer counted as "Active".
+    no longer counted as **Active**.
 
 ## Summary
 
@@ -87,7 +87,7 @@ Token consumption from LLM inference. KPIs across the top: **Input / Output / To
 
 The bottom section groups the detail table three ways:
 
-- **Models** — per model: Input / Input Cached / Output / Total Tokens, API Requests, Last Active.
+- **Models** — per model: Input Tokens / Input Cached Tokens / Output Tokens / Total Tokens, API Requests, Last Active.
 - **Users** — per user (admins only).
 - **API Keys** — per API key.
 


### PR DESCRIPTION
- environment-variables: convert DST note from blockquote to admonition; split the two DST consequences into a bullet list.
- api-key-management: insert blank lines so sub-bullets under ordered list items render as nested lists under sane_lists; switch inline `All models` / `Allowed models` to backticks to match surrounding UI references.
- usage: align UI-label styling with project conventions (procedural navigation in backticks, descriptive/KPI terms in bold); remove redundant trailing repetition in the Active Resources metric row; complete column names in the Models breakdown; clarify the Granularity and Export descriptions.