### PR TITLE
fix: support name filter on model instances list

### DIFF
--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -101,8 +101,11 @@ async def get_model_instances(
     worker_id: Optional[int] = None,
     cluster_id: Optional[int] = None,
     state: Optional[str] = None,
+    search: Optional[str] = None,
 ):
     fields = {}
+    search = search.strip() if search else None
+    fuzzy_fields = {"name": search} if search else {}
     if id:
         fields["id"] = id
 
@@ -135,7 +138,11 @@ async def get_model_instances(
             else None
         )
         return StreamingResponse(
-            ModelInstance.streaming(fields=fields, filter_func=filter_func),
+            ModelInstance.streaming(
+                fields=fields,
+                fuzzy_fields=fuzzy_fields,
+                filter_func=filter_func,
+            ),
             media_type="text/event-stream",
         )
 
@@ -144,6 +151,7 @@ async def get_model_instances(
         return await ModelInstance.paginated_by_query(
             session=session,
             fields=fields,
+            fuzzy_fields=fuzzy_fields,
             extra_conditions=extra_conditions,
             page=params.page,
             per_page=params.perPage,


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5702#issuecomment-4807989515

The frontend sends a 'search' query param on GET /model-instances for the 'Filter by name' input, but the handler never declared it, so FastAPI dropped it and the list came back unfiltered. Wire 'search' through as a fuzzy filter on the name column for both the paginated and streaming paths, matching the workers endpoint.