### PR TITLE
fix(chart): make ytt comments valid in operator bootstrap

### DIFF
--- a/charts/gpustack-chart/templates/operator-bootstrap.yaml
+++ b/charts/gpustack-chart/templates/operator-bootstrap.yaml
@@ -143,7 +143,7 @@ data:
                 - gpustack-operator
                 - worker
                 - -v=2
-                # ytt if/end: only wraps the immediately following node
+                #! ytt if/end: only wraps the immediately following node
                 #@ if/end data.values.certmanagerEnabled:
                 - --cert-dir=/var/run/gpustack/certs
               resources:
@@ -217,7 +217,7 @@ data:
               volumeMounts:
                 - name: gpustack-data-dir
                   mountPath: /var/lib/gpustack
-                # ytt if/end: only wraps the immediately following node
+                #! ytt if/end: only wraps the immediately following node
                 #@ if/end data.values.certmanagerEnabled:
                 - name: gpustack-cert-dir
                   mountPath: /var/run/gpustack/certs
@@ -226,7 +226,7 @@ data:
               hostPath:
                 path: {{ .Values.worker.dataDir | quote }}
                 type: DirectoryOrCreate
-            # ytt if/end: only wraps the immediately following node
+            #! ytt if/end: only wraps the immediately following node
             #@ if/end data.values.certmanagerEnabled:
             - name: gpustack-cert-dir
               secret:


### PR DESCRIPTION
## Summary

- Fix the embedded ytt comments in the Helm operator bootstrap template so `ytt` does not parse them as invalid ytt syntax.
- Keep the existing conditional cert-manager nodes unchanged; only convert explanatory comments from `# ...` to ytt comments `#! ...`.

## Changes

- Updated three `# ytt if/end...` explanatory comments in `charts/gpustack-chart/templates/operator-bootstrap.yaml` to `#! ytt if/end...`.

## Real behavior proof

Behavior or issue addressed: Installing the GPUStack Helm chart with `worker.enabled=true` could make the operator worker bootstrap job fail before applying objects because ytt parsed a plain `# ytt if/end...` explanatory comment as invalid ytt syntax.
Real environment tested: Repository `gpustack/gpustack`, branch `fix/operator-ytt-empty-table`, commit pending at test time, using Helm v3.20.2 and ytt v0.52.1 from a git worktree on latest `origin/main` commit `227028ef`.
Exact steps or command run after this patch:
```shell
helm dependency build /tmp/gpustack-5698-validate-chart
helm lint /tmp/gpustack-5698-validate-chart --set worker.enabled=true --set image.tag=v2.2.0 --set operator.image.tag=v0.3.0
helm template gpustack /tmp/gpustack-5698-validate-chart --namespace gpustack-system --set global.hub=quay.io --set worker.enabled=true --set image.tag=v2.2.0 --set operator.image.tag=v0.3.0
ytt --file /tmp/gpustack-5698-proof/after/ytt --data-value-yaml certmanagerEnabled=false
ytt --file /tmp/gpustack-5698-proof/after/ytt --data-value-yaml certmanagerEnabled=true
```
Evidence after fix: Terminal output from the verification:
```text
## V1 git diff --check
## helm lint
==> Linting /tmp/gpustack-5698-validate-chart

1 chart(s) linted, 0 chart(s) failed
## helm template
rendered 2193 lines
## ytt certmanager false
rendered 144 lines
## ytt certmanager true
rendered 179 lines
```
Observed result after fix: The rendered ConfigMap's embedded ytt template now compiles successfully for both cert-manager disabled and enabled paths; before the patch, the same ytt command failed with `Failed to parse line 115: '# ytt if/end: only wraps the immediately following node'`.
What was not tested: I did not deploy to a live Kubernetes v1.35 cluster; validation was limited to Helm rendering and ytt compilation of the operator bootstrap manifests.

## Test Plan

- `git diff --check`
- `helm lint /tmp/gpustack-5698-validate-chart --set worker.enabled=true --set image.tag=v2.2.0 --set operator.image.tag=v0.3.0`
- `helm template gpustack /tmp/gpustack-5698-validate-chart --namespace gpustack-system --set global.hub=quay.io --set worker.enabled=true --set image.tag=v2.2.0 --set operator.image.tag=v0.3.0`
- `ytt --file /tmp/gpustack-5698-proof/after/ytt --data-value-yaml certmanagerEnabled=false`
- `ytt --file /tmp/gpustack-5698-proof/after/ytt --data-value-yaml certmanagerEnabled=true`

Fixes #5698
