### PR TITLE
fix: scope ext-auth to gpustack hostname on shared gateway

### DIFF
--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -27,7 +27,6 @@ from gpustack.gateway.client import (
     McpBridgeSpec,
     McpBridgeRegistry,
     WasmPluginSpec,
-    WasmPluginMatchRule,
 )
 from gpustack.gateway.labels_annotations import managed_labels, match_labels
 from gpustack.gateway.utils import (
@@ -43,6 +42,7 @@ from gpustack.gateway.utils import (
     router_header_key,
     gpustack_original_path_header,
     gpustack_fallback_path_header,
+    model_route_ingress_prefix,
 )
 from gpustack.gateway.plugins import (
     get_plugin_url_with_name_and_version,
@@ -295,13 +295,9 @@ def ext_auth_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
     resource_name = "gpustack-llm-ext-auth"
     registry = get_gpustack_higress_registry(cfg=cfg)
 
-    # this is to auth requests except for gpustack
+    # auth every path on the matched route
     default_match_rule = get_match_rules(
         match_type="blacklist",
-        paths=[("/", "prefix")],
-    )
-    gpustack_match_rule = get_match_rules(
-        match_type="whitelist",
         paths=[("/", "prefix")],
     )
 
@@ -336,16 +332,37 @@ def ext_auth_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         "endpoint_mode": "forward_auth",
         "timeout": envs.HIGRESS_EXT_AUTH_TIMEOUT_MS,
     }
+    # Scope ext-auth to gpustack's own inference routes by route-name prefix,
+    # so unrelated traffic on a shared Higress gateway is never authenticated.
+    #
+    # gpustack model-route ingresses are named ``ai-route-route-<id>.internal``
+    # (and ``ai-route-route-<id>.fallback.internal`` for fallbacks), both of
+    # which share the ``ai-route-route-`` prefix. Other routes -- the gpustack
+    # control-plane mirror ingress, and any other tenant sharing the gateway --
+    # do not match this prefix, so the ext-auth matcher returns nil for them and
+    # the request passes through unauthenticated. This replaces the previous
+    # "global blacklist + ingress whitelist" shape and needs no hostname.
+    #
+    # Higress route names carry a ``<namespace>/`` prefix when the gpustack
+    # ingresses live in a different namespace than the gateway; mirror the
+    # ``service_namespace_prefix`` convention used elsewhere so the match still
+    # works cross-namespace (otherwise the prefix would not match and inference
+    # APIs would be left unauthenticated under FAIL_OPEN).
     namespace = cfg.get_namespace()
-    if namespace == cfg.gateway_namespace:
-        namespace = ""
-    # the ingress in plugin matchRules should not contains namespace prefix
-    # if it is in the same namespace with the gateway.
-    ingress_name = f"{namespace}/{envs.GATEWAY_MIRROR_INGRESS_NAME}".lstrip("/")
+    service_namespace_prefix = (
+        f"{namespace}/" if namespace and namespace != cfg.gateway_namespace else ""
+    )
+    route_prefix = f"{service_namespace_prefix}{model_route_ingress_prefix}"
+
     expected_spec = WasmPluginSpec(
         defaultConfig={
-            "http_service": http_service,
-            **default_match_rule,
+            "_rules_": [
+                {
+                    "_match_route_prefix_": [route_prefix],
+                    "http_service": http_service,
+                    **default_match_rule,
+                }
+            ],
         },
         defaultConfigDisable=False,
         failStrategy="FAIL_OPEN",
@@ -354,16 +371,6 @@ def ext_auth_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         url=get_plugin_url_with_name_and_version(
             name="ext-auth", version="2.0.0", cfg=cfg
         ),
-        matchRules=[
-            WasmPluginMatchRule(
-                config={
-                    "http_service": http_service,
-                    **gpustack_match_rule,
-                },
-                configDisable=False,
-                ingress=[ingress_name],
-            )
-        ],
     )
     return resource_name, expected_spec
 

--- a/tests/gateway/test_gateway_plugins.py
+++ b/tests/gateway/test_gateway_plugins.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from gpustack.gateway.plugins import (
     HigressPlugin,
     get_plugin_url_prefix,
@@ -7,6 +7,7 @@ from gpustack.gateway.plugins import (
     supported_plugins,
     http_path_prefix,
 )
+from gpustack.gateway import ext_auth_plugin
 
 
 def make_cfg(plugin_server_url: str):
@@ -106,3 +107,46 @@ class TestSupportedPlugins:
             "gpustack-set-header-pre-route",
         ]:
             assert expected in names, f"{expected} not found in supported_plugins"
+
+
+class TestExtAuthPlugin:
+    def _build(self, namespace, gateway_namespace):
+        registry = MagicMock()
+        registry.get_service_name.return_value = "gpustack.static"
+        registry.port = 80
+        cfg = MagicMock()
+        cfg.get_derived_gateway_token.return_value = "token"
+        cfg.get_namespace.return_value = namespace
+        cfg.gateway_namespace = gateway_namespace
+        with (
+            patch(
+                "gpustack.gateway.get_gpustack_higress_registry", return_value=registry
+            ),
+            patch(
+                "gpustack.gateway.get_plugin_url_with_name_and_version",
+                return_value="http://127.0.0.1/wasm/ext-auth/2.0.0/plugin.wasm",
+            ),
+        ):
+            return ext_auth_plugin(cfg=cfg)
+
+    def _rule(self, spec):
+        rules = spec.defaultConfig["_rules_"]
+        assert len(rules) == 1
+        return rules[0]
+
+    def test_scopes_to_model_route_prefix(self):
+        _, spec = self._build(namespace="default", gateway_namespace="higress-system")
+        # auth is applied via defaultConfig _rules_ matched by route prefix,
+        # not a global catch-all, and there are no separate matchRules.
+        assert spec.defaultConfigDisable is False
+        assert not spec.matchRules
+        rule = self._rule(spec)
+        assert rule["_match_route_prefix_"] == ["default/ai-route-route-"]
+        assert rule["match_type"] == "blacklist"
+
+    def test_no_namespace_prefix_when_same_namespace(self):
+        _, spec = self._build(
+            namespace="higress-system", gateway_namespace="higress-system"
+        )
+        rule = self._rule(spec)
+        assert rule["_match_route_prefix_"] == ["ai-route-route-"]


### PR DESCRIPTION
Scope the ext-auth WasmPlugin to gpustack's own inference routes by route-name prefix, so unrelated traffic on a shared Higress gateway is no longer authenticated against gpustack.

Previously ext-auth was installed with a global `defaultConfig` (a `blacklist` on `/`) plus an `ingress` whitelist for the mirror ingress. On a shared gateway, every other route/hostname fell through to the global blacklist and was forced through `/token-auth`.

### What changed

- ext-auth now authenticates only via `defaultConfig._rules_` matched by `_match_route_prefix_` against gpustack's model-route ingress prefix (`ai-route-route-`, which also covers the `*.fallback.internal` variants). It runs in the `AUTHN` phase where the route is already resolved, so route-name matching is available.
- Routes that don't match the prefix — the gpustack control-plane mirror ingress and any other tenant sharing the gateway — get a nil matcher and pass through. This needs no hostname/domain configuration, is unaffected by direct gateway-IP access, and removes the need for the separate ingress whitelist rule.
- The prefix is namespaced via the `service_namespace_prefix` convention (`<namespace>/ai-route-route-` when gpustack runs in a different namespace than the gateway; `ai-route-route-` when they share one), so the match still works cross-namespace instead of silently leaving inference APIs unauthenticated under `FAIL_OPEN`.

### Notes

- Legacy `ai-route-model-*` ingresses (the older prefix, already cleaned up with `reason="legacy"`) are no longer authenticated under route-prefix scoping. Acceptable since they are being removed, called out here for in-place upgrades.
- A manual workaround for existing releases is documented in the issue.

### Tests

`TestExtAuthPlugin` covers the route-prefix scoping with and without the namespace prefix.

Refer to issue:
- #5744
