### PR TITLE
fix(config): route get_image_name through plugin version override

### DIFF
--- a/gpustack/cmd/version.py
+++ b/gpustack/cmd/version.py
@@ -1,8 +1,7 @@
 import argparse
 import logging
 
-from gpustack import __version__, __git_commit__
-from gpustack.extension import Plugin, iter_plugin_classes
+from gpustack.extension import resolve_version_info
 
 logger = logging.getLogger(__name__)
 
@@ -22,26 +21,8 @@ def setup_version_cmd(subparsers: argparse._SubParsersAction):
     parser.set_defaults(func=run)
 
 
-def _resolve_version_info() -> tuple[str, str]:
-    """Let plugins override the reported version. First non-None wins; on
-    any failure, fall back to core's baked-in values."""
-    for name, plugin_class in iter_plugin_classes():
-        if not (isinstance(plugin_class, type) and issubclass(plugin_class, Plugin)):
-            continue
-        try:
-            info = plugin_class.get_version_info()
-        except Exception:
-            logger.debug(
-                "Failed to read version info from plugin '%s'", name, exc_info=True
-            )
-            continue
-        if info is not None:
-            return info
-    return __version__, __git_commit__
-
-
 def run(args):
-    version, git_commit = _resolve_version_info()
+    version, git_commit = resolve_version_info()
     if args.short:
         print(version)
     else:

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -41,7 +41,7 @@ from gpustack.schemas.config import (
     PredefinedConfigNoDefaults,
     GatewayModeEnum,
 )
-from gpustack import __version__, __operator_version__
+from gpustack import __operator_version__
 from gpustack.config.registration import (
     read_registration_token,
     read_worker_token,
@@ -946,7 +946,10 @@ def get_image_name(
 ) -> str:
     if image_name_override:
         return image_name_override
-    version = __version__
+    # Lazy import: gpustack.extension imports from this module at top level.
+    from gpustack.extension import resolve_version_info
+
+    version, _ = resolve_version_info()
     if version.removeprefix("v") == "0.0.0":
         version = "dev"
     prefix = f"{registry}/" if registry else ""

--- a/gpustack/extension.py
+++ b/gpustack/extension.py
@@ -25,6 +25,35 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def resolve_version_info() -> Tuple[str, str]:
+    """Let plugins override the reported version. First non-None wins; on
+    any failure, fall back to core's baked-in values.
+
+    Used wherever core needs the *user-facing* version — ``gpustack version``,
+    the ``/version`` endpoint's response, OpenAPI ``info.version``, and the
+    worker image tag returned by the cluster registration-token endpoint.
+    Anything that surfaces an image reference or a build identifier to
+    operators should go through this helper so a downstream repackage can
+    present a consistent build string instead of the wheel's baked-in
+    ``__version__``.
+    """
+    from gpustack import __version__, __git_commit__
+
+    for name, plugin_class in iter_plugin_classes():
+        if not (isinstance(plugin_class, type) and issubclass(plugin_class, Plugin)):
+            continue
+        try:
+            info = plugin_class.get_version_info()
+        except Exception:
+            logger.debug(
+                "Failed to read version info from plugin '%s'", name, exc_info=True
+            )
+            continue
+        if info is not None:
+            return info
+    return __version__, __git_commit__
+
+
 def iter_plugin_classes() -> Generator[Tuple[str, type], None, None]:
     """Iterate over registered plugin classes via the ``gpustack.plugins``
     entry-point group.


### PR DESCRIPTION
The cluster registration-token endpoint computes the worker image via get_image_name, which read gpustack.__version__ directly and so leaked the wheel version into downstream repackages. A plugin already has Plugin.get_version_info() (consumed by gpustack version, /version, OpenAPI info.version), but get_image_name bypassed it — a repackaged distribution saw the "Add worker" Run Command pointing at the underlying wheel tag instead of its own build tag.

Hoist cmd/version.py's _resolve_version_info into a public helper on extension.py and have get_image_name use it. The helper goes through a lazy import inside get_image_name to avoid the circular dependency with gpustack.extension (which imports Config at module level).