### PR TITLE
fix: reserve VLLM_PORT to avoid port conflicts during distributed initialization

### DIFF
--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -464,6 +464,7 @@ class VLLMServer(InferenceServer):
         # see https://docs.vllm.ai/en/stable/configuration/env_vars.html.
         env["VLLM_HOST_IP"] = self._worker.ip
 
+        ports = self._model_instance.ports or []
         executor_backend = resolve_executor_backend(
             self._model.backend_parameters, self._model.backend_version
         )
@@ -476,10 +477,16 @@ class VLLMServer(InferenceServer):
                 if deployment_metadata is not None
                 else None
             )
-            if shape in ("dp_only", "nested"):
-                env["VLLM_DP_MASTER_PORT"] = str(self._model_instance.ports[-1])
+            if shape in ("dp_only", "nested") and ports:
+                env["VLLM_DP_MASTER_PORT"] = str(ports[-1])
+            # Pin vLLM's internal init port to a reserved one so get_open_port()
+            # can't grab a kernel-stealable ephemeral port (#5657). Needs the
+            # runner patch that makes get_open_port() honor VLLM_PORT.
+            if len(ports) > 3:
+                env["VLLM_PORT"] = str(ports[3])
         else:
-            env["VLLM_PORT"] = str(self._model_instance.ports[-1])
+            if ports:
+                env["VLLM_PORT"] = str(ports[-1])
             env["RAY_LOG_TO_STDERR"] = env.pop("RAY_LOG_TO_STDERR", "0")
             env["RAY_BACKEND_LOG_LEVEL"] = env.pop("RAY_BACKEND_LOG_LEVEL", "warning")
 

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -1286,26 +1286,42 @@ class ServeManager:
             mi.ports = [mi.port]
             unavailable_ports.add(mi.port)
 
-            # Additional ports for distributed servers.
-            #
-            # ports[0]: HTTP API (always).
-            # Native (mp) path — both reserved unconditionally, dp_only uses
-            # ports[1], mp_only uses ports[2], nested uses both:
+            # Additional ports for distributed servers (mp path allocates all):
+            #   ports[0]: HTTP API (always)
             #   ports[1]: --data-parallel-rpc-port (DP coordinator ZMQ)
-            #   ports[2]: --master-port (PyTorch torch.distributed TCP store)
-            # Ray path: ports[1] = DP RPC when user-specified dp > 1.
-            # ports[-1]: subordinate workers' connecting port.
+            #   ports[2]: --master-port (PyTorch distributed TCP store)
+            #   ports[3]: env VLLM_PORT
+            #   ports[-1]: connecting port (= VLLM_DP_MASTER_PORT for dp_only/nested)
+            # Ray path: only ports[1] (DP RPC), when user dp > 1.
             if mi.distributed_servers and mi.distributed_servers.subordinate_workers:
+                # Allocate first so we can fence off the 10-port band vLLM reserves
+                # around VLLM_DP_MASTER_PORT (= connecting port), keeping the cross
+                # ports (incl. VLLM_PORT) outside it.
+                connecting_port = network.get_free_port(
+                    port_range=self._config.service_port_range,
+                    unavailable_ports=unavailable_ports,
+                    host=mi.worker_ip,
+                )
+                unavailable_ports.add(connecting_port)
+
+                cross_ports: List[int] = []
                 if backend == BackendEnum.VLLM:
                     executor_backend = resolve_executor_backend(
                         model.backend_parameters, model.backend_version
                     )
                     if executor_backend == "mp":
-                        # Pre-allocate both DP RPC and PyTorch master ports;
-                        # the two channels use different protocols (ZMQ vs
-                        # TCPStore) and can't share one port in the nested
-                        # shape, so reserving both keeps the layout stable.
-                        cross_port_count = 2
+                        # DP RPC + PyTorch master + VLLM_PORT. Clamp the band to
+                        # service_port_range; out-of-range ports would inflate
+                        # get_free_port's exhaustion count.
+                        _, end_port = network.parse_port_range(
+                            self._config.service_port_range
+                        )
+                        unavailable_ports |= set(
+                            range(
+                                connecting_port, min(connecting_port + 10, end_port + 1)
+                            )
+                        )
+                        cross_port_count = 3
                     else:
                         dps = find_int_parameter(
                             model.backend_parameters,
@@ -1318,17 +1334,11 @@ class ServeManager:
                             unavailable_ports=unavailable_ports,
                             host=mi.worker_ip,
                         )
-                        mi.ports.append(cross_port)
+                        cross_ports.append(cross_port)
                         unavailable_ports.add(cross_port)
 
-                # Connecting port for subordinate workers communication
-                connecting_port = network.get_free_port(
-                    port_range=self._config.service_port_range,
-                    unavailable_ports=unavailable_ports,
-                    host=mi.worker_ip,
-                )
+                mi.ports.extend(cross_ports)
                 mi.ports.append(connecting_port)
-                unavailable_ports.add(connecting_port)
 
             self._assigned_ports[mi.id] = set(mi.ports)
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5657

This issue needs to be repair together with https://github.com/gpustack/runner/pull/190
