### PR TITLE
ci(pack): trigger on ui-built repository_dispatch

### DIFF
--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -13,6 +13,8 @@ defaults:
 
 on:
   workflow_dispatch: {}
+  repository_dispatch:
+    types: [ui-built]
   push:
     branches:
       - "main"


### PR DESCRIPTION
Listen for the ui-built event dispatched by gpustack-ui's CI so a UI merge triggers a backend repack that bundles the freshly published UI tarball.