### PR TITLE
fix: skip idle_in_transaction_session_timeout on openGauss

### DIFF
--- a/gpustack/server/init_db.py
+++ b/gpustack/server/init_db.py
@@ -13,6 +13,7 @@ from sqlalchemy import DDL, event, text
 
 from gpustack import envs
 from gpustack.server import db
+from gpustack.utils.db import is_opengauss
 from gpustack.schemas.api_keys import ApiKey
 from gpustack.schemas.inference_backend import InferenceBackend
 from gpustack.schemas.model_usage import ModelUsage
@@ -73,6 +74,11 @@ async def init_db(db_url: str):
 async def init_db_engine(db_url: str):
     connect_args = {}
     if db_url.startswith("postgresql://"):
+        # Probe once to see whether we're talking to openGauss — it presents
+        # as PostgreSQL but rejects PG's millisecond-scale value for
+        # ``idle_in_transaction_session_timeout``. Skip the setting on openGauss.
+        opengauss = await is_opengauss(db_url)
+
         db_url = re.sub(r'^postgresql://', 'postgresql+asyncpg://', db_url)
         parsed = urlparse(db_url)
         # rewrite the parameters to use asyncpg with custom database schema
@@ -83,14 +89,15 @@ async def init_db_engine(db_url: str):
             option = qoptions[0]
             if option.startswith('-csearch_path='):
                 schema_name = option[len('-csearch_path=') :]
-        server_settings = {
-            'idle_in_transaction_session_timeout': str(
-                envs.DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_SECONDS * 1000
-            ),
-        }
+        server_settings = {}
         if schema_name:
             server_settings['search_path'] = schema_name
-        connect_args['server_settings'] = server_settings
+        if not opengauss and envs.DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_SECONDS > 0:
+            server_settings['idle_in_transaction_session_timeout'] = str(
+                envs.DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_SECONDS * 1000
+            )
+        if server_settings:
+            connect_args['server_settings'] = server_settings
         new_parsed = parsed._replace(query={})
         db_url = urlunparse(new_parsed)
 

--- a/gpustack/utils/db.py
+++ b/gpustack/utils/db.py
@@ -1,10 +1,32 @@
 """Database-related utilities shared across GPUStack components."""
 
 import re
+from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 
+import asyncpg
 from sqlalchemy.dialects.postgresql import base as pg_base
 
 _pg_version_patched = False
+
+
+async def is_opengauss(db_url: str) -> bool:
+    """Return True when the PostgreSQL-shaped URL points at openGauss.
+
+    Opens a one-off asyncpg connection and inspects ``SELECT version()`` —
+    openGauss reports itself with ``openGauss`` in the version string
+    rather than ``PostgreSQL``. Only the ``options`` query parameter is
+    stripped from the DSN (asyncpg does not accept libpq's ``-c...``
+    syntax); other params such as ``sslmode`` are preserved.
+    """
+    parsed = urlparse(db_url)
+    filtered = [(k, v) for k, v in parse_qsl(parsed.query) if k != 'options']
+    dsn = urlunparse(parsed._replace(query=urlencode(filtered)))
+    conn = await asyncpg.connect(dsn=dsn)
+    try:
+        version_str = await conn.fetchval("SELECT version()")
+    finally:
+        await conn.close()
+    return 'openGauss' in (version_str or '')
 
 
 def patch_pg_version_info() -> None:


### PR DESCRIPTION
openGauss presents as PostgreSQL but interprets the GUC in seconds (capped at 86400), so asyncpg's handshake rejected the PG-style millisecond value (28800000) and the server failed to start.

Probe once via asyncpg at engine init and omit the setting when the target is openGauss.