### PR TITLE
feat: enhance log persistence by reconnecting on stream EOF

### DIFF
--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import deque
 import contextlib
 from datetime import datetime, timezone
 import multiprocessing
@@ -838,10 +839,12 @@ class ServeManager:
         stop_event: threading.Event,
         token: Optional[str] = None,
     ):
-        """Persist container logs to local file.
+        """Persist container logs to local file (runs in a separate thread).
 
-        This is a blocking operation that runs in a separate thread.
-        Retries indefinitely until container is created.
+        Reconnects on stream EOF while the workload is still alive, resuming by
+        skipping already-written history (matched by an anchor window of the
+        last lines written). Exits once the workload has terminated or is
+        deleted.
 
         Args:
             workload_name: Name of the container workload
@@ -851,6 +854,10 @@ class ServeManager:
                 If None, logs from the default (index=0) container are fetched.
         """
         retry_count = 0
+        first_connect = True
+        # Anchor: a window of the last lines written. Matching a run of lines
+        # (not one) avoids false-matching a repeated line during replay.
+        anchor_window = deque(maxlen=5)
 
         while not stop_event.is_set():
             try:
@@ -862,18 +869,56 @@ class ServeManager:
                 )
 
                 if hasattr(log_stream, '__iter__'):
-                    with open(log_path, 'w', buffering=1, encoding='utf-8') as f:
+                    # On reconnect the runtime replays history from the start;
+                    # skip it until the anchor window matches.
+                    anchor = list(anchor_window)
+                    skip_until_anchor = not first_connect and bool(anchor)
+                    replayed = deque(maxlen=len(anchor)) if anchor else None
+                    received_lines = False
+                    with open(
+                        log_path,
+                        'w' if first_connect else 'a',
+                        buffering=1,
+                        encoding='utf-8',
+                    ) as f:
+                        first_connect = False
                         for line in log_stream:
+                            received_lines = True
                             if stop_event.is_set():
                                 break
 
                             if isinstance(line, bytes):
-                                f.write(line.decode('utf-8', errors='replace'))
+                                line = line.decode('utf-8', errors='replace')
                             else:
-                                f.write(str(line))
-                            f.flush()
+                                line = str(line)
 
-                break
+                            if skip_until_anchor:
+                                replayed.append(line)
+                                if list(replayed) == anchor:
+                                    skip_until_anchor = False
+                                continue
+
+                            f.write(line)
+                            f.flush()
+                            anchor_window.append(line)
+                    retry_count = 0
+
+                    # Anchor never matched -> rotated out; restart fresh. An
+                    # empty reconnect must NOT reset, or the next round reopens
+                    # in 'w' and truncates the saved log.
+                    if skip_until_anchor and received_lines:
+                        first_connect = True
+                        anchor_window.clear()
+
+                if stop_event.is_set() or not self._container_still_running(
+                    workload_name
+                ):
+                    break
+                logger.debug(
+                    f"Log stream for {workload_name} ended while workload still "
+                    f"running; reconnecting"
+                )
+                stop_event.wait(timeout=1)
 
             except Exception as e:
                 if stop_event.is_set():
@@ -886,6 +931,19 @@ class ServeManager:
                 stop_event.wait(timeout=2)
 
         logger.debug(f"Log persistence thread for {workload_name} exiting")
+
+    def _container_still_running(self, workload_name: str) -> bool:
+        """Whether the workload is still alive (a dead stream should reconnect
+        rather than exit)."""
+        try:
+            workload = get_workload(workload_name)
+        except Exception:
+            return True  # transient query failure: reconnect, don't drop logs
+        return bool(workload) and workload.state in (
+            WorkloadStatusStateEnum.PENDING,
+            WorkloadStatusStateEnum.INITIALIZING,
+            WorkloadStatusStateEnum.RUNNING,
+        )
 
     def _discover_sidecar_logs(
         self,

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -13,7 +13,16 @@ from gpustack.schemas.models import (
 )
 from gpustack.server.bus import Event, EventType
 from gpustack.worker.serve_manager import ServeManager
+from gpustack_runtime.deployer import WorkloadStatusStateEnum
 from tests.utils.model import new_model, new_model_instance
+
+
+def _fake_stop_event():
+    """A never-set stop event whose wait() returns instantly, so the log
+    persistence loop is driven purely by the get_workload state sequence."""
+    stop_event = MagicMock()
+    stop_event.is_set.return_value = False
+    return stop_event
 
 
 def _build_serve_manager(worker_id: int = 1):
@@ -236,3 +245,162 @@ def test_reap_stale_instance_purges_logs(tmp_path: Path):
         manager.sync_model_instances_state()
 
     assert not log.exists()
+
+
+def test_persist_container_logs_reconnects_and_dedupes(tmp_path: Path):
+    """On stream EOF while the workload is still running, reconnect and resume
+    by skipping already-written history (anchor), appending only new lines."""
+    manager, _clients = _build_serve_manager()
+    log_path = str(tmp_path / "1.container.0.log")
+
+    # First stream: initial history. Reconnect: full history replay + new line.
+    streams = [iter(["a\n", "b\n"]), iter(["a\n", "b\n", "c\n"])]
+    tails = []
+
+    def fake_logs_workload(**kwargs):
+        tails.append(kwargs["tail"])
+        return streams.pop(0)
+
+    # First EOF -> still RUNNING (reconnect); second EOF -> FAILED (exit).
+    states = [
+        SimpleNamespace(state=WorkloadStatusStateEnum.RUNNING),
+        SimpleNamespace(state=WorkloadStatusStateEnum.FAILED),
+    ]
+
+    with (
+        patch(
+            "gpustack.worker.serve_manager.logs_workload",
+            side_effect=fake_logs_workload,
+        ),
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            side_effect=lambda name: states.pop(0),
+        ),
+    ):
+        manager._persist_container_logs("wl", log_path, _fake_stop_event())
+
+    assert tails == [-1, -1]
+    assert Path(log_path).read_text(encoding="utf-8") == "a\nb\nc\n"
+
+
+def test_persist_container_logs_exits_when_workload_gone(tmp_path: Path):
+    """EOF while the workload no longer exists -> exit immediately, no reconnect."""
+    manager, _clients = _build_serve_manager()
+    log_path = str(tmp_path / "1.container.0.log")
+    tails = []
+
+    def fake_logs_workload(**kwargs):
+        tails.append(kwargs["tail"])
+        return iter(["a\n"])
+
+    with (
+        patch(
+            "gpustack.worker.serve_manager.logs_workload",
+            side_effect=fake_logs_workload,
+        ),
+        patch("gpustack.worker.serve_manager.get_workload", return_value=None),
+    ):
+        manager._persist_container_logs("wl", log_path, _fake_stop_event())
+
+    assert tails == [-1]  # only one connection, no reconnect
+    assert Path(log_path).read_text(encoding="utf-8") == "a\n"
+
+
+def test_persist_container_logs_resets_when_anchor_rotated(tmp_path: Path):
+    """If the anchor line was rotated out of the reconnect logs, restart from
+    scratch (full rewrite) instead of skipping new lines forever."""
+    manager, _clients = _build_serve_manager()
+    log_path = str(tmp_path / "1.container.0.log")
+
+    streams = [
+        iter(["a\n", "b\n"]),  # round1: write a,b (anchor=b)
+        iter(["x\n", "c\n"]),  # round2: anchor 'b' rotated out -> skip all, reset
+        iter(["x\n", "c\n", "d\n"]),  # round3: fresh rewrite recovers
+    ]
+    states = [
+        SimpleNamespace(state=WorkloadStatusStateEnum.RUNNING),
+        SimpleNamespace(state=WorkloadStatusStateEnum.RUNNING),
+        SimpleNamespace(state=WorkloadStatusStateEnum.FAILED),
+    ]
+
+    with (
+        patch(
+            "gpustack.worker.serve_manager.logs_workload",
+            side_effect=lambda **kwargs: streams.pop(0),
+        ),
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            side_effect=lambda name: states.pop(0),
+        ),
+    ):
+        manager._persist_container_logs("wl", log_path, _fake_stop_event())
+
+    assert Path(log_path).read_text(encoding="utf-8") == "x\nc\nd\n"
+
+
+def test_persist_container_logs_empty_reconnect_keeps_history(tmp_path: Path):
+    """An empty reconnect (0 lines) must not reset first_connect; otherwise the
+    next reconnect reopens in 'w' and truncates already-persisted logs."""
+    manager, _clients = _build_serve_manager()
+    log_path = str(tmp_path / "1.container.0.log")
+
+    streams = [
+        iter(["a\n", "b\n"]),  # round1: write a,b
+        iter([]),  # round2: empty reconnect (0 lines) -> must NOT reset
+        iter(["b\n"]),  # round3: suffix replay; a,b already persisted survive
+    ]
+    states = [
+        SimpleNamespace(state=WorkloadStatusStateEnum.RUNNING),
+        SimpleNamespace(state=WorkloadStatusStateEnum.RUNNING),
+        SimpleNamespace(state=WorkloadStatusStateEnum.FAILED),
+    ]
+
+    with (
+        patch(
+            "gpustack.worker.serve_manager.logs_workload",
+            side_effect=lambda **kwargs: streams.pop(0),
+        ),
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            side_effect=lambda name: states.pop(0),
+        ),
+    ):
+        manager._persist_container_logs("wl", log_path, _fake_stop_event())
+
+    # Had the empty round2 reset first_connect, round3 would reopen in 'w' and
+    # truncate 'a'; a,b surviving proves it did not.
+    assert Path(log_path).read_text(encoding="utf-8") == "a\nb\n"
+
+
+def test_persist_container_logs_window_anchor_ignores_repeated_line(
+    tmp_path: Path,
+):
+    """The multi-line anchor window only matches the true tail: a single-line
+    anchor would false-match an earlier identical line and duplicate history."""
+    manager, _clients = _build_serve_manager()
+    log_path = str(tmp_path / "1.container.0.log")
+
+    streams = [
+        iter(["A\n", "B\n", "A\n", "B\n"]),  # round1: last line B repeats earlier
+        iter(["A\n", "B\n", "A\n", "B\n", "C\n"]),  # round2: full replay + new C
+    ]
+    states = [
+        SimpleNamespace(state=WorkloadStatusStateEnum.RUNNING),
+        SimpleNamespace(state=WorkloadStatusStateEnum.FAILED),
+    ]
+
+    with (
+        patch(
+            "gpustack.worker.serve_manager.logs_workload",
+            side_effect=lambda **kwargs: streams.pop(0),
+        ),
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            side_effect=lambda name: states.pop(0),
+        ),
+    ):
+        manager._persist_container_logs("wl", log_path, _fake_stop_event())
+
+    # Window [A,B,A,B] matches only at the end; single-line 'B' would match
+    # index 1 and duplicate A,B.
+    assert Path(log_path).read_text(encoding="utf-8") == "A\nB\nA\nB\nC\n"


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5740

The worker tails pod logs over a long-lived HTTP stream (worker → kube-apiserver → kubelet/containerd → container). containerd caps a follow log stream at ~4h regardless of activity (see kubernetes/kubernetes#104580)
this is unrelated to --streaming-connection-idle-timeout (which doesn't apply under containerd), and the stream ends with a clean EOF, not an error.

On stream EOF, decide via get_workload state instead of unconditionally exiting:                                                                                                                                                 
- Workload still alive → reconnect and resume.                                                                                                                                                                                   
- Terminated / deleted → exit the thread (logs really are done).                                                                                                                                                                 
                                                                                                                                                                                                                               
On reconnect the runtime replays history from the start, so we re-fetch with tail=-1 and skip the replayed lines up to a content anchor (the last line already written), appending only new lines — no duplication, no loss, no  
file rewrite, no UI jump. If the anchor was rotated out of the retained logs, restart fresh so the stream still recovers.