### PR TITLE
[v2.3.0]feat: add endpoint to download model instance logs files

### DIFF
--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -1,9 +1,16 @@
 import asyncio
+import io
 import json
+import zipfile
 from typing import List, Optional, Tuple
 import aiohttp
 from fastapi import APIRouter, Request, status, HTTPException
-from fastapi.responses import PlainTextResponse, StreamingResponse, RedirectResponse
+from fastapi.responses import (
+    PlainTextResponse,
+    StreamingResponse,
+    RedirectResponse,
+    Response,
+)
 from urllib.parse import urlencode
 
 from gpustack.api.responses import StreamingResponseWithStatusCode
@@ -228,12 +235,16 @@ async def fetch_worker(session, worker_id):
 async def get_serving_logs(  # noqa: C901
     request: Request,
     session: SessionDep,
+    ctx: TenantContextDep,
     id: int,
     log_options: LogOptionsDep,
     worker_id: Optional[int] = None,
     container_name: Optional[str] = None,
 ):
     model_instance = await fetch_model_instance(session, id)
+    assert_resource_visible(
+        ctx, model_instance, not_found_message="Model instance not found"
+    )
 
     # Reverse-map: convert UI display name back to internal container name.
     if container_name:
@@ -318,6 +329,258 @@ async def get_serving_logs(  # noqa: C901
         )
 
 
+@router.get("/{id}/logs/download")
+async def download_serving_logs(
+    request: Request,
+    session: SessionDep,
+    ctx: TenantContextDep,
+    id: int,
+):
+    """Download a model instance's complete current logs as a file.
+
+    Collects every worker (main + subordinates) and every container per worker
+    (the default main workload plus Ray-style sidecars). A single log stream
+    downloads as a plain-text .log; multiple streams as a flat zip with one file
+    per worker/container. Always the full current logs (no tail/follow/previous).
+    """
+    model_instance = await fetch_model_instance(session, id)
+    assert_resource_visible(
+        ctx, model_instance, not_found_message="Model instance not found"
+    )
+    targets = await resolve_instance_log_worker_targets(session, model_instance)
+
+    # Discover every (worker, container) log stream once (one options call/worker).
+    streams = await _plan_log_streams(request, model_instance, targets)
+
+    # A single reachable stream is proxied straight through, without buffering a
+    # whole (possibly huge) log on the server.
+    if len(streams) == 1 and streams[0]["worker"] is not None:
+        only = streams[0]
+        return _stream_single_worker_log(
+            request, model_instance, only["worker"], only["container_internal"]
+        )
+
+    entries = await _fetch_log_streams(request, model_instance, streams)
+    # Zip compression is CPU-bound and synchronous; run it off the event loop.
+    return await asyncio.to_thread(_package_downloaded_logs, model_instance, entries)
+
+
+def _stream_single_worker_log(
+    request: Request,
+    model_instance: ModelInstance,
+    worker: Worker,
+    container_internal: str,
+) -> StreamingResponse:
+    """Stream one worker/container's logs straight through, without buffering."""
+    params = _build_serve_log_params(model_instance, container_name=container_internal)
+    timeout = aiohttp.ClientTimeout(total=envs.PROXY_TIMEOUT, sock_connect=5)
+
+    async def stream():
+        try:
+            async for chunk, _, _ in stream_to_worker(
+                worker=worker,
+                method="GET",
+                path=f"serveLogs/{model_instance.id}",
+                proxy_client=request.app.state.http_client,
+                no_proxy_client=request.app.state.http_client_no_proxy,
+                params=params,
+                timeout=timeout,
+                raw=True,
+            ):
+                yield chunk if isinstance(chunk, bytes) else chunk.encode()
+        except Exception as e:
+            yield f"\nFailed to fetch logs: {e}\n".encode()
+
+    filename = _sanitize_filename(f"{model_instance.name or model_instance.id}.log")
+    return StreamingResponse(
+        stream(),
+        media_type="text/plain; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+def _sanitize_filename(name: str) -> str:
+    """Make a name safe as a download / zip entry name and HTTP header value.
+
+    Strips path separators, double quotes, and control characters, which would
+    otherwise break the Content-Disposition header or enable header injection.
+    """
+    cleaned = name.replace("/", "_").replace("\\", "_").replace('"', "_")
+    return "".join(ch for ch in cleaned if ch.isprintable())
+
+
+def _build_serve_log_params(
+    model_instance: ModelInstance, container_name: Optional[str] = None
+) -> dict:
+    """Fixed proxy params for a full, non-follow log download of one container."""
+    params = {
+        "tail": -1,
+        "follow": False,
+        "model_instance_name": model_instance.name,
+        "previous": False,
+    }
+    if container_name:
+        params["container_name"] = container_name
+    if (
+        model_instance.state != ModelInstanceStateEnum.RUNNING
+        and model_instance.model_files
+        and model_instance.model_files[0].state != ModelFileStateEnum.READY
+    ):
+        params["model_file_id"] = model_instance.model_files[0].id
+    return params
+
+
+async def _discover_worker_containers(
+    request: Request, worker: Worker, model_instance_id: int
+) -> List[str]:
+    """Internal container names for the current restart of one worker.
+
+    Falls back to ["default"] (the main workload logs) when discovery fails or a
+    worker has no container files, so every worker contributes at least its log.
+    """
+    try:
+        payload = await fetch_serve_log_options_from_worker(
+            request, worker, model_instance_id
+        )
+    except Exception:
+        return ["default"]
+    current = next((entry for entry in payload.restarts if not entry.previous), None)
+    containers = current.containers if current else []
+    return list(containers) or ["default"]
+
+
+async def _fetch_worker_container_log(
+    request: Request,
+    model_instance: ModelInstance,
+    worker: Worker,
+    container_internal: str,
+) -> bytes:
+    """Fetch one worker/container's complete logs, capturing errors as content."""
+    timeout = aiohttp.ClientTimeout(total=envs.PROXY_TIMEOUT, sock_connect=5)
+    try:
+        resp, body = await request_to_worker(
+            worker=worker,
+            method="GET",
+            path=f"serveLogs/{model_instance.id}",
+            proxy_client=request.app.state.http_client,
+            no_proxy_client=request.app.state.http_client_no_proxy,
+            params=_build_serve_log_params(
+                model_instance, container_name=container_internal
+            ),
+            timeout=timeout,
+            raise_on_error=False,
+        )
+    except Exception as e:
+        return f"Failed to fetch logs: {e}\n".encode()
+    if resp.status != 200:
+        return f"Failed to fetch logs: HTTP {resp.status}\n".encode()
+    return body or b""
+
+
+async def _plan_log_streams(
+    request: Request,
+    model_instance: ModelInstance,
+    targets: List[Tuple[int, str, Optional[Worker]]],
+) -> List[dict]:
+    """Discover every (worker, container) log stream, one options call per worker.
+
+    Returns flat stream descriptors {"worker_label", "worker", "container_internal",
+    "container_display"}. A worker missing from the DB still yields one placeholder
+    stream so its absence is reported instead of silently dropped.
+    """
+
+    async def per_worker(target: Tuple[int, str, Optional[Worker]]) -> List[dict]:
+        worker_id, worker_name, worker = target
+        label = worker_name or f"worker-{worker_id}"
+        if worker is None:
+            return [
+                {
+                    "worker_label": label,
+                    "worker": None,
+                    "container_internal": "default",
+                    "container_display": "default",
+                }
+            ]
+        is_main = worker_id == model_instance.worker_id
+        containers = await _discover_worker_containers(
+            request, worker, model_instance.id
+        )
+        return [
+            {
+                "worker_label": label,
+                "worker": worker,
+                "container_internal": container_internal,
+                "container_display": _map_container_display_name(
+                    container_internal, model_instance, is_main
+                ),
+            }
+            for container_internal in containers
+        ]
+
+    grouped = await asyncio.gather(*[per_worker(t) for t in targets])
+    return [stream for group in grouped for stream in group]
+
+
+async def _fetch_log_streams(
+    request: Request,
+    model_instance: ModelInstance,
+    streams: List[dict],
+) -> List[dict]:
+    """Fetch each planned stream's content in parallel into package entries."""
+
+    async def fetch(stream: dict) -> dict:
+        if stream["worker"] is None:
+            content = b"Worker not found in database\n"
+        else:
+            content = await _fetch_worker_container_log(
+                request, model_instance, stream["worker"], stream["container_internal"]
+            )
+        return {
+            "worker": stream["worker_label"],
+            "container": stream["container_display"],
+            "content": content,
+        }
+
+    return list(await asyncio.gather(*[fetch(stream) for stream in streams]))
+
+
+def _package_downloaded_logs(
+    model_instance: ModelInstance, entries: List[dict]
+) -> Response:
+    """A single stream downloads as a .log; multiple stream as a flat zip."""
+    if len(entries) == 1:
+        filename = _sanitize_filename(f"{model_instance.name or model_instance.id}.log")
+        return Response(
+            content=entries[0]["content"],
+            media_type="text/plain; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    buffer = io.BytesIO()
+    seen: set[str] = set()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for entry in entries:
+            name = _sanitize_filename(f"{entry['worker']}.{entry['container']}.log")
+            unique = name
+            index = 1
+            while unique in seen:
+                unique = _sanitize_filename(
+                    f"{entry['worker']}.{entry['container']}.{index}.log"
+                )
+                index += 1
+            seen.add(unique)
+            archive.writestr(unique, entry["content"])
+
+    zip_name = _sanitize_filename(
+        f"{model_instance.name or model_instance.id}.logs.zip"
+    )
+    return Response(
+        content=buffer.getvalue(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{zip_name}"'},
+    )
+
+
 async def resolve_instance_log_worker_targets(
     session, model_instance: ModelInstance
 ) -> List[Tuple[int, str, Optional[Worker]]]:
@@ -387,10 +650,14 @@ async def fetch_serve_log_options_from_worker(
 async def get_model_instance_log_options(
     request: Request,
     session: SessionDep,
+    ctx: TenantContextDep,
     id: int,
 ):
     """Return per-worker restart_count values that exist on disk for this model instance."""
     model_instance = await fetch_model_instance(session, id)
+    assert_resource_visible(
+        ctx, model_instance, not_found_message="Model instance not found"
+    )
     targets = await resolve_instance_log_worker_targets(session, model_instance)
 
     async def fetch_one(

--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -1,10 +1,14 @@
 import asyncio
 import json
-from typing import List, Optional, Tuple
+from typing import AsyncIterator, Dict, List, Optional, Tuple
 import aiohttp
 from fastapi import APIRouter, Request, status, HTTPException
-from fastapi.responses import PlainTextResponse, StreamingResponse, RedirectResponse
-from urllib.parse import urlencode
+from fastapi.responses import (
+    PlainTextResponse,
+    StreamingResponse,
+    RedirectResponse,
+)
+from urllib.parse import quote, urlencode
 
 from gpustack.api.responses import StreamingResponseWithStatusCode
 from gpustack import envs
@@ -43,6 +47,7 @@ from gpustack.schemas.models import (
 from gpustack.schemas.model_files import ModelFileStateEnum
 from gpustack.config.config import get_global_config
 from gpustack.utils.grafana import resolve_grafana_base_url
+from gpustack.utils.tabular_export import stream_zip
 
 router = APIRouter()
 
@@ -273,20 +278,13 @@ async def get_serving_logs(  # noqa: C901
 
         worker = await fetch_worker(session, target_worker_id)
 
-        params = {
-            "tail": log_options.tail,
-            "follow": log_options.follow,
-            "model_instance_name": model_instance.name,
-            "previous": log_options.previous,
-        }
-        if container_name:
-            params["container_name"] = container_name
-        if (
-            model_instance.state != ModelInstanceStateEnum.RUNNING
-            and model_instance.model_files
-            and model_instance.model_files[0].state != ModelFileStateEnum.READY
-        ):
-            params["model_file_id"] = model_instance.model_files[0].id
+        params = _build_serve_log_params(
+            model_instance,
+            tail=log_options.tail,
+            follow=log_options.follow,
+            previous=log_options.previous,
+            container_name=container_name,
+        )
 
     timeout = aiohttp.ClientTimeout(total=envs.PROXY_TIMEOUT, sock_connect=5)
 
@@ -327,6 +325,262 @@ async def get_serving_logs(  # noqa: C901
         return PlainTextResponse(
             content=body.decode() if body else "", status_code=resp.status
         )
+
+
+@router.get(
+    "/{id}/logs/download",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Plain text for one log stream, a zip archive for several.",
+            "content": {"text/plain": {}, "application/zip": {}},
+        }
+    },
+)
+async def download_serving_logs(
+    request: Request,
+    ctx: TenantContextDep,
+    id: int,
+):
+    """Download a model instance's complete current logs as a file.
+
+    Collects every worker (main + subordinates) and every container per worker
+    (the default main workload plus Ray-style sidecars). A single log stream
+    downloads as a plain-text .log; multiple streams as a flat zip with one file
+    per worker/container. Always the full current logs (no tail/follow/previous).
+    Both shapes stream, so neither a log nor the archive is ever buffered whole.
+    """
+    # Session released before streaming so a download doesn't hold a connection.
+    async with async_session() as session:
+        model_instance = await fetch_model_instance(session, ctx, id)
+        targets = await resolve_instance_log_worker_targets(session, model_instance)
+
+    # Discover every (worker, container) log stream once (one options call/worker).
+    streams = await _plan_log_streams(request, model_instance, targets)
+
+    # A dead end has to fail before streaming fixes the status. Only structural
+    # ones qualify: a failed discovery still falls back to the main workload.
+    if all(stream["worker"] is None for stream in streams):
+        detail = "; ".join(
+            f"{stream['worker_label']}: {stream['error']}" for stream in streams
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to fetch logs from all workers: {detail}",
+        )
+
+    if len(streams) == 1:
+        return _stream_single_worker_log(request, model_instance, streams[0])
+    return _stream_zipped_worker_logs(request, model_instance, streams)
+
+
+def _stream_single_worker_log(
+    request: Request,
+    model_instance: ModelInstance,
+    stream: dict,
+) -> StreamingResponse:
+    """Stream one worker/container's logs straight through, without buffering."""
+    filename = _sanitize_filename(f"{model_instance.name or model_instance.id}.log")
+    return StreamingResponse(
+        _worker_log_chunks(request, model_instance, stream),
+        media_type="text/plain; charset=utf-8",
+        headers=_attachment_headers(filename),
+    )
+
+
+def _stream_zipped_worker_logs(
+    request: Request,
+    model_instance: ModelInstance,
+    streams: List[dict],
+) -> StreamingResponse:
+    """Stream a flat zip with one member per log; peak memory is one chunk."""
+    zip_name = _sanitize_filename(
+        f"{model_instance.name or model_instance.id}.logs.zip"
+    )
+    return StreamingResponse(
+        stream_zip(_zip_members(request, model_instance, streams)),
+        media_type="application/zip",
+        headers=_attachment_headers(zip_name),
+    )
+
+
+async def _zip_members(
+    request: Request,
+    model_instance: ModelInstance,
+    streams: List[dict],
+) -> AsyncIterator[Tuple[str, AsyncIterator[bytes]]]:
+    """Name each stream, suffixing a repeated worker/container label."""
+    seen: set[str] = set()
+    for stream in streams:
+        label = f"{stream['worker_label']}.{stream['container_display']}"
+        name = _sanitize_filename(f"{label}.log")
+        index = 1
+        while name in seen:
+            name = _sanitize_filename(f"{label}.{index}.log")
+            index += 1
+        seen.add(name)
+        yield name, _worker_log_chunks(request, model_instance, stream)
+
+
+async def _worker_log_chunks(
+    request: Request,
+    model_instance: ModelInstance,
+    stream: dict,
+) -> AsyncIterator[bytes]:
+    """One stream's complete logs; its own failures become file content."""
+    worker = stream["worker"]
+    if worker is None:
+        yield f"Failed to fetch logs: {stream['error']}\n".encode()
+        return
+
+    # Discovery failed but the fallback still reads the main workload. Say so,
+    # or a sidecar log missing from the archive looks like it never existed.
+    if stream["error"]:
+        yield (
+            f"Note: container discovery failed ({stream['error']}); "
+            "this log covers the main workload only.\n"
+        ).encode()
+
+    params = _build_serve_log_params(
+        model_instance, container_name=stream["container_internal"]
+    )
+    timeout = aiohttp.ClientTimeout(total=envs.PROXY_TIMEOUT, sock_connect=5)
+    try:
+        async for chunk, _, status_code in stream_to_worker(
+            worker=worker,
+            method="GET",
+            path=f"serveLogs/{model_instance.id}",
+            proxy_client=request.app.state.http_client,
+            no_proxy_client=request.app.state.http_client_no_proxy,
+            params=params,
+            timeout=timeout,
+            raw=True,
+        ):
+            payload = chunk if isinstance(chunk, bytes) else chunk.encode()
+            # Label an error body so it can't be read as real log output.
+            if status_code >= 400:
+                yield f"Failed to fetch logs: HTTP {status_code}: ".encode() + payload
+                return
+            yield payload
+    except Exception as e:
+        yield f"\nFailed to fetch logs: {e}\n".encode()
+
+
+def _sanitize_filename(name: str) -> str:
+    """Make a name safe as a download filename / zip entry name.
+
+    Non-ASCII stays: zip entries are UTF-8, and the header percent-encodes it.
+    """
+    cleaned = name.replace("/", "_").replace("\\", "_").replace('"', "_")
+    cleaned = "".join(ch for ch in cleaned if ch.isprintable()).strip(". ")
+    return cleaned or "logs"
+
+
+def _attachment_headers(filename: str) -> Dict[str, str]:
+    """A Content-Disposition that survives a non-ASCII filename (RFC 6266).
+
+    Starlette encodes headers as latin-1, so a CJK name needs ``filename*``.
+    """
+    quoted = quote(filename, safe="")
+    if quoted == filename:
+        return {"Content-Disposition": f'attachment; filename="{filename}"'}
+    ascii_filename = "".join(
+        ch if ch.isascii() and ch.isprintable() else "_" for ch in filename
+    )
+    return {
+        "Content-Disposition": (
+            f'attachment; filename="{ascii_filename}"; filename*=UTF-8\'\'{quoted}'
+        )
+    }
+
+
+def _build_serve_log_params(
+    model_instance: ModelInstance,
+    tail: int = -1,
+    follow: bool = False,
+    previous: bool = False,
+    container_name: Optional[str] = None,
+) -> dict:
+    """Proxy params for one container's logs; defaults to a full, non-follow read."""
+    params = {
+        "tail": tail,
+        "follow": follow,
+        "model_instance_name": model_instance.name,
+        "previous": previous,
+    }
+    if container_name:
+        params["container_name"] = container_name
+    if (
+        model_instance.state != ModelInstanceStateEnum.RUNNING
+        and model_instance.model_files
+        and model_instance.model_files[0].state != ModelFileStateEnum.READY
+    ):
+        params["model_file_id"] = model_instance.model_files[0].id
+    return params
+
+
+async def _discover_worker_containers(
+    request: Request, worker: Worker, model_instance_id: int
+) -> Tuple[List[str], Optional[str]]:
+    """Internal container names for one worker, plus any discovery error.
+
+    A failed discovery still falls back to ["default"] (the main workload logs).
+    """
+    try:
+        payload = await fetch_serve_log_options_from_worker(
+            request, worker, model_instance_id
+        )
+    except Exception as e:
+        return ["default"], str(e)
+    current = next((entry for entry in payload.restarts if not entry.previous), None)
+    containers = current.containers if current else []
+    return list(containers) or ["default"], None
+
+
+async def _plan_log_streams(
+    request: Request,
+    model_instance: ModelInstance,
+    targets: List[Tuple[int, str, Optional[Worker]]],
+) -> List[dict]:
+    """Discover every (worker, container) log stream, one options call per worker.
+
+    Returns flat stream descriptors {"worker_label", "worker", "container_internal",
+    "container_display", "error"}. A worker missing from the DB still yields one
+    placeholder stream so its absence is reported instead of silently dropped.
+    """
+
+    async def per_worker(target: Tuple[int, str, Optional[Worker]]) -> List[dict]:
+        worker_id, worker_name, worker = target
+        label = worker_name or f"worker-{worker_id}"
+        if worker is None:
+            return [
+                {
+                    "worker_label": label,
+                    "worker": None,
+                    "container_internal": "default",
+                    "container_display": "default",
+                    "error": "Worker not found in database",
+                }
+            ]
+        is_main = worker_id == model_instance.worker_id
+        containers, error = await _discover_worker_containers(
+            request, worker, model_instance.id
+        )
+        return [
+            {
+                "worker_label": label,
+                "worker": worker,
+                "container_internal": container_internal,
+                "container_display": _map_container_display_name(
+                    container_internal, model_instance, is_main
+                ),
+                "error": error,
+            }
+            for container_internal in containers
+        ]
+
+    grouped = await asyncio.gather(*[per_worker(t) for t in targets])
+    return [stream for group in grouped for stream in group]
 
 
 async def resolve_instance_log_worker_targets(

--- a/tests/routes/test_model_instance_log_download.py
+++ b/tests/routes/test_model_instance_log_download.py
@@ -1,0 +1,206 @@
+"""Route tests for downloading a model instance's serving logs.
+
+The endpoint's shape follows how many (worker, container) log streams it finds,
+so these drive the route directly with the worker calls faked. The body is
+consumed inside the patch scope: it only talks to the workers once iterated.
+"""
+
+import contextlib
+import io
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from gpustack.routes.model_instances import download_serving_logs
+from gpustack.schemas.models import (
+    BackendEnum,
+    ModelInstanceLogRestartEntry,
+    ModelInstanceStateEnum,
+    ServeLogOptionsResponse,
+)
+
+MODULE = "gpustack.routes.model_instances"
+
+
+@contextlib.asynccontextmanager
+async def _fake_async_session():
+    yield MagicMock()
+
+
+def _instance(name="llama-abc"):
+    return SimpleNamespace(
+        id=7,
+        name=name,
+        worker_id=1,
+        state=ModelInstanceStateEnum.RUNNING,
+        model_files=[],
+        backend=BackendEnum.VLLM,
+        model=None,
+        distributed_servers=None,
+    )
+
+
+def _target(worker_id, name, present=True):
+    worker = SimpleNamespace(id=worker_id, name=name) if present else None
+    return (worker_id, name, worker)
+
+
+async def _download(instance, targets, *, options, logs):
+    """Run the endpoint and return (response, body).
+
+    ``options`` maps a worker name to its container list or to the exception its
+    discovery raises; ``logs`` maps (worker name, internal container name) to
+    (status, chunks) — the main workload's internal name is "default".
+    """
+
+    async def fake_options(_request, worker, _instance_id):
+        planned = options[worker.name]
+        if isinstance(planned, Exception):
+            raise planned
+        return ServeLogOptionsResponse(
+            restarts=[
+                ModelInstanceLogRestartEntry(previous=False, containers=planned),
+                ModelInstanceLogRestartEntry(previous=True, containers=["stale"]),
+            ]
+        )
+
+    fetched = []
+
+    async def fake_stream(**kwargs):
+        container = kwargs["params"].get("container_name")
+        fetched.append((kwargs["worker"].name, container))
+        status_code, chunks = logs[(kwargs["worker"].name, container)]
+        for chunk in chunks:
+            yield chunk, {}, status_code
+
+    with (
+        patch(f"{MODULE}.async_session", _fake_async_session),
+        patch(f"{MODULE}.fetch_model_instance", AsyncMock(return_value=instance)),
+        patch(
+            f"{MODULE}.resolve_instance_log_worker_targets",
+            AsyncMock(return_value=targets),
+        ),
+        patch(f"{MODULE}.fetch_serve_log_options_from_worker", fake_options),
+        patch(f"{MODULE}.stream_to_worker", fake_stream),
+    ):
+        response = await download_serving_logs(
+            request=MagicMock(), ctx=MagicMock(), id=7
+        )
+        # Nothing fetched yet: iterating the body is what pulls each log.
+        assert fetched == []
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode())
+    return response, b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_single_stream_downloads_plain_text_log():
+    response, body = await _download(
+        _instance(),
+        [_target(1, "worker-a")],
+        options={"worker-a": ["default"]},
+        logs={("worker-a", "default"): (200, [b"first chunk\n", b"second chunk\n"])},
+    )
+
+    assert response.media_type == "text/plain; charset=utf-8"
+    assert (
+        response.headers["content-disposition"]
+        == 'attachment; filename="llama-abc.log"'
+    )
+    assert body == b"first chunk\nsecond chunk\n"
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_instance_name_stays_header_encodable():
+    # Starlette encodes headers as latin-1, so a bare filename= would raise.
+    response, _ = await _download(
+        _instance(name="模型-abc"),
+        [_target(1, "worker-a")],
+        options={"worker-a": ["default"]},
+        logs={("worker-a", "default"): (200, [b"log\n"])},
+    )
+
+    disposition = response.headers["content-disposition"]
+    assert disposition == (
+        "attachment; filename=\"__-abc.log\"; filename*=UTF-8''%E6%A8%A1%E5%9E%8B-abc.log"
+    )
+    disposition.encode("latin-1")
+
+
+@pytest.mark.asyncio
+async def test_multiple_streams_download_as_a_zip_with_failures_captured():
+    instance = _instance()
+    targets = [
+        _target(1, "worker-a"),
+        _target(2, "worker-b"),
+        _target(3, "worker-c", present=False),
+    ]
+    response, body = await _download(
+        instance,
+        targets,
+        options={
+            # "default" displays as the backend name, so this label collides.
+            "worker-a": ["default", "vLLM"],
+            "worker-b": ValueError("HTTP 404: no log options"),
+        },
+        logs={
+            ("worker-a", "default"): (200, [b"main\n"]),
+            ("worker-a", "vLLM"): (200, [b"sidecar\n"]),
+            ("worker-b", "default"): (500, [b"boom"]),
+        },
+    )
+
+    assert response.media_type == "application/zip"
+    archive = zipfile.ZipFile(io.BytesIO(body))
+    assert archive.testzip() is None
+    assert archive.namelist() == [
+        "worker-a.vLLM.log",
+        "worker-a.vLLM.1.log",
+        "worker-b.ray-worker.log",
+        "worker-c.default.log",
+    ]
+    assert archive.read("worker-a.vLLM.log") == b"main\n"
+    assert archive.read("worker-a.vLLM.1.log") == b"sidecar\n"
+    # A failed discovery is noted, and an error body must not read as real log
+    # output.
+    worker_b_log = archive.read("worker-b.ray-worker.log")
+    assert worker_b_log.startswith(b"Note: container discovery failed (HTTP 404: ")
+    assert b"Failed to fetch logs: HTTP 500: boom" in worker_b_log
+    assert b"Worker not found in database" in archive.read("worker-c.default.log")
+
+
+@pytest.mark.asyncio
+async def test_discovery_failure_still_serves_the_main_workload():
+    # Discovery is only how containers are found: losing it falls back to the
+    # main workload, whose logs a single worker can still serve on its own.
+    response, body = await _download(
+        _instance(),
+        [_target(1, "worker-a")],
+        options={"worker-a": ValueError("HTTP 404: no log options")},
+        logs={("worker-a", "default"): (200, [b"real log\n"])},
+    )
+
+    assert response.media_type == "text/plain; charset=utf-8"
+    # Noted inline, so a sidecar log missing from the download can't pass for
+    # one that never existed.
+    assert body == (
+        b"Note: container discovery failed (HTTP 404: no log options); "
+        b"this log covers the main workload only.\n"
+        b"real log\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_proxyable_worker_fails_with_502():
+    # Not in the database, so nothing can be proxied and no fallback can help.
+    with pytest.raises(HTTPException) as raised:
+        await _download(
+            _instance(), [_target(1, "worker-a", present=False)], options={}, logs={}
+        )
+
+    assert raised.value.status_code == 502
+    assert "Failed to fetch logs from all workers" in raised.value.detail


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5662

Split the original download and log‑viewing APIs (get_serving_logs), with log downloading handled by a separate API.

The new API requires frontend integration, but it remains backward compatible with the old download method (though multi‑node packaged downloads are not supported).