### PR TITLE
fix: missing `model_usage_details.completed` column flooding logs

### DIFF
--- a/gpustack/migrations/versions/2026_06_24_1100-c4d7e8f9a0b1_v2_2_2_database_changes.py
+++ b/gpustack/migrations/versions/2026_06_24_1100-c4d7e8f9a0b1_v2_2_2_database_changes.py
@@ -1,6 +1,6 @@
-"""v2.2.1 database changes
+"""v2.2.2 database changes
 
-Bundles the pre-release schema tweaks for v2.2.1:
+Bundles the pre-release schema tweaks for v2.2.2:
 
 1. ``principals.source`` (and ``principal_memberships.source``) goes
    from the ``authproviderenum`` enum to ``VARCHAR(64)``, opening it

--- a/pack/Dockerfile
+++ b/pack/Dockerfile
@@ -341,13 +341,18 @@ RUN <<EOF
         && gosu postgres echo "host  all  root  ::1/128       trust" >> /etc/postgresql/main/pg_hba.conf \
         && gosu postgres echo "host  all  all   0.0.0.0/0     scram-sha-256" >> /etc/postgresql/main/pg_hba.conf
 
+    # Logging: emit one file per calendar day with a readable date name and
+    # disable size-based rotation so a busy day stays in a single file.
+    # Postgres' own rotation never deletes old logs (that is what let them
+    # grow to 18GB, issue #5774) — retention is enforced out-of-band by the
+    # supercronic cleanup job in /var/lib/istio/cron.txt.
     gosu postgres sed -i "s/^data_directory/#data_directory/" "$PGCONFIG_FILE" \
         && gosu postgres sed -i "s/^hba_file/#hba_file/" "$PGCONFIG_FILE" \
         && gosu postgres sed -i "s/^#log_destination/log_destination/" "$PGCONFIG_FILE" \
-        && gosu postgres sed -i "s/^#log_min_messages = warning/log_min_messages = info/" "$PGCONFIG_FILE" \
         && gosu postgres sed -i "s/^#logging_collector = off/logging_collector = on/" "$PGCONFIG_FILE" \
-        && gosu postgres sed -i "s/^#log_filename/log_filename/" "$PGCONFIG_FILE" \
-        && gosu postgres sed -i "s/^#log_rotation_size/log_rotation_size/" "$PGCONFIG_FILE"
+        && gosu postgres sed -i "s|^[# ]*log_filename.*|log_filename = 'postgresql-%Y-%m-%d.log'|" "$PGCONFIG_FILE" \
+        && gosu postgres sed -i "s|^[# ]*log_rotation_age.*|log_rotation_age = 1d|" "$PGCONFIG_FILE" \
+        && gosu postgres sed -i "s|^[# ]*log_rotation_size.*|log_rotation_size = 0|" "$PGCONFIG_FILE"
 
     # Cleanup
     rm -rf /var/tmp/* \

--- a/pack/rootfs/etc/s6-overlay/scripts/postgres-log-cleanup.sh
+++ b/pack/rootfs/etc/s6-overlay/scripts/postgres-log-cleanup.sh
@@ -1,0 +1,37 @@
+#!/command/with-contenv /bin/bash
+# shellcheck shell=bash
+# shellcheck disable=SC1091,SC1090
+# ================================
+# Embedded Postgres log cleanup (invoked by supercronic; see cron.txt)
+# ================================
+# Postgres' logging_collector rotates logs but never deletes them, so without
+# this the logs grow unbounded (issue #5774). Resolve LOG_DIR exactly the way
+# the postgres longrun service does — sourcing base.sh, the postgres .env, then
+# default-variables.sh — so a custom --data-dir / log dir is honoured rather
+# than a hardcoded /var/lib/gpustack path.
+
+SCRIPT_ROOT=/etc/s6-overlay/scripts
+source "$SCRIPT_ROOT/base.sh"
+# base.sh exports GPUSTACK_POSTGRES_CONFIG; fall back to its default path so a
+# custom --data-dir written into that file is still honoured even if the var is
+# somehow unset. The file is written by prerun only when the embedded database
+# is enabled; it is absent for external databases, where there are no
+# embedded-Postgres logs to clean.
+GPUSTACK_POSTGRES_CONFIG="${GPUSTACK_POSTGRES_CONFIG:-${GPUSTACK_RUN_DIR:-/run/gpustack}/postgresql/.env}"
+if [ -f "$GPUSTACK_POSTGRES_CONFIG" ]; then
+	source "$GPUSTACK_POSTGRES_CONFIG"
+fi
+source "$SCRIPT_ROOT/default-variables.sh"
+
+# Number of days of Postgres logs to retain (override via env). Anything last
+# modified more than this many days ago is deleted.
+RETENTION_DAYS="${POSTGRES_LOG_RETENTION_DAYS:-30}"
+if [[ ! "$RETENTION_DAYS" =~ ^[0-9]+$ ]]; then
+	echo "[ERROR] POSTGRES_LOG_RETENTION_DAYS must be a non-negative integer, got: '$RETENTION_DAYS'" >&2
+	exit 1
+fi
+PGLOG="${LOG_DIR}/postgresql"
+
+if [ -d "$PGLOG" ]; then
+	find "$PGLOG" -name 'postgresql-*.log' -type f -mtime "+${RETENTION_DAYS}" -delete
+fi

--- a/pack/rootfs/var/lib/istio/cron.txt
+++ b/pack/rootfs/var/lib/istio/cron.txt
@@ -1,1 +1,6 @@
 0 * * * * /usr/sbin/logrotate /etc/logrotate.d/higress-logrotate
+# Delete old embedded-Postgres logs (default 30d retention). Postgres'
+# logging_collector rotates but never deletes, so without this its logs grow
+# unbounded (#5774). The script resolves the log dir itself so a custom
+# --data-dir is honoured; override the window via POSTGRES_LOG_RETENTION_DAYS.
+0 2 * * * /etc/s6-overlay/scripts/postgres-log-cleanup.sh


### PR DESCRIPTION
- #5774

### Root cause

Commit `ca7b768a` ("fix: add completed field to model_usage_details table", by Yuxing Deng, 2026-06-15) added the `completed` column by **editing the already-released v2.2.0 migration** (`8bf38a6bb3b5`) — the column was appended
to that migration's *create-table* branch (inside `if not table_exists('model_usage_details')`) instead of shipping a dedicated `ALTER TABLE ... ADD COLUMN` migration.

Every metrics flush (every 10s) then fails since lack of field `completed`.

