### PR TITLE
feat: implement container recovery wait logic during log reconnection

### DIFF
--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -22,6 +22,7 @@ from gpustack_runtime.deployer import (
 )
 from gpustack_runtime.deployer.__utils__ import compare_versions
 
+from gpustack import envs
 from gpustack.api.exceptions import NotFoundException
 from gpustack.config.config import Config
 from gpustack.config import registration
@@ -65,11 +66,14 @@ from gpustack.schemas.models import (
 from gpustack.server.bus import Event, EventType
 from gpustack.worker.inference_backend_manager import InferenceBackendManager
 
-
 logger = logging.getLogger(__name__)
 
 # Inference health check error message
 _INFERENCE_HEALTH_CHECK_FAILED_MESSAGE = "Inference health check failed."
+
+# One health-check cycle (+2s margin) to let a container return after a stream
+# EOF; beyond that gpustack marks it ERROR and takes over recovery.
+LOG_RECONNECT_GRACE_SECONDS = envs.MODEL_INSTANCE_HEALTH_CHECK_INTERVAL + 2
 
 # Global lock for port assignment to avoid pickle serialization issues
 _port_lock = threading.Lock()
@@ -843,8 +847,10 @@ class ServeManager:
 
         Reconnects on stream EOF while the workload is still alive, resuming by
         skipping already-written history (matched by an anchor window of the
-        last lines written). Exits once the workload has terminated or is
-        deleted.
+        last lines written). A manual/runtime restart briefly looks terminated
+        at EOF, so it waits a grace window for the container to return before
+        giving up. Exits only if the container stays terminated for that whole
+        window or the thread is asked to stop.
 
         Args:
             workload_name: Name of the container workload
@@ -910,8 +916,10 @@ class ServeManager:
                         first_connect = True
                         anchor_window.clear()
 
-                if stop_event.is_set() or not self._container_still_running(
-                    workload_name
+                # A restart briefly looks terminated at EOF; wait for the
+                # container to return before giving up, so logs aren't dropped.
+                if stop_event.is_set() or not self._wait_for_container_recovery(
+                    workload_name, stop_event
                 ):
                     break
                 logger.debug(
@@ -944,6 +952,27 @@ class ServeManager:
             WorkloadStatusStateEnum.INITIALIZING,
             WorkloadStatusStateEnum.RUNNING,
         )
+
+    def _wait_for_container_recovery(
+        self,
+        workload_name: str,
+        stop_event: threading.Event,
+        grace_seconds: float = LOG_RECONNECT_GRACE_SECONDS,
+        poll_interval: float = 1.0,
+    ) -> bool:
+        """Poll until the workload is alive again (True -> reconnect) or the
+        grace window elapses / stop_event fires (False -> give up). A restart
+        momentarily looks terminated at EOF, which a single check can't tell
+        apart from a real termination.
+        """
+        attempts = max(1, int(grace_seconds / poll_interval))
+        for _ in range(attempts):
+            if stop_event.is_set():
+                return False
+            if self._container_still_running(workload_name):
+                return True
+            stop_event.wait(timeout=poll_interval)
+        return False
 
     def _discover_sidecar_logs(
         self,

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -17,12 +17,40 @@ from gpustack_runtime.deployer import WorkloadStatusStateEnum
 from tests.utils.model import new_model, new_model_instance
 
 
-def _fake_stop_event():
-    """A never-set stop event whose wait() returns instantly, so the log
-    persistence loop is driven purely by the get_workload state sequence."""
+def _fake_stop_event(max_waits: int = 100):
+    """A stop event whose wait() returns instantly (tests aren't driven by real
+    time) and stays unset, so the log persistence loop is driven purely by the
+    get_workload state sequence. It auto-sets after max_waits waits so a
+    mis-sized mock or a runaway loop fails the test fast instead of hanging CI."""
+    state = {"waits": 0, "stopped": False}
+
+    def is_set():
+        return state["stopped"]
+
+    def wait(timeout=None):
+        state["waits"] += 1
+        if state["waits"] >= max_waits:
+            state["stopped"] = True
+        return state["stopped"]
+
     stop_event = MagicMock()
-    stop_event.is_set.return_value = False
+    stop_event.is_set.side_effect = is_set
+    stop_event.wait.side_effect = wait
     return stop_event
+
+
+def _get_workload_sequence(states):
+    """side_effect for a patched get_workload. The recovery grace-poll queries
+    get_workload several times per stream EOF, so once the sequence reaches its
+    terminal state it must keep returning it: a list that runs dry would raise
+    IndexError, which _container_still_running treats as "still alive", spinning
+    the reconnect loop forever."""
+    remaining = list(states)
+
+    def next_state(name):
+        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
+
+    return next_state
 
 
 def _build_serve_manager(worker_id: int = 1):
@@ -129,6 +157,9 @@ def test_restart_model_instance_preserves_transient_backoff_count():
     with (
         patch.object(manager, "_is_provisioning", return_value=False),
         patch.object(manager, "_start_model_instance"),
+        # _stop_model_instance runs for real to exercise clear_restart_backoff=
+        # False, but its delete_workload side effect would hit the runtime socket.
+        patch("gpustack.worker.serve_manager.delete_workload"),
     ):
         manager._restart_model_instance(model_instance)
 
@@ -274,7 +305,7 @@ def test_persist_container_logs_reconnects_and_dedupes(tmp_path: Path):
         ),
         patch(
             "gpustack.worker.serve_manager.get_workload",
-            side_effect=lambda name: states.pop(0),
+            side_effect=_get_workload_sequence(states),
         ),
     ):
         manager._persist_container_logs("wl", log_path, _fake_stop_event())
@@ -330,7 +361,7 @@ def test_persist_container_logs_resets_when_anchor_rotated(tmp_path: Path):
         ),
         patch(
             "gpustack.worker.serve_manager.get_workload",
-            side_effect=lambda name: states.pop(0),
+            side_effect=_get_workload_sequence(states),
         ),
     ):
         manager._persist_container_logs("wl", log_path, _fake_stop_event())
@@ -362,7 +393,7 @@ def test_persist_container_logs_empty_reconnect_keeps_history(tmp_path: Path):
         ),
         patch(
             "gpustack.worker.serve_manager.get_workload",
-            side_effect=lambda name: states.pop(0),
+            side_effect=_get_workload_sequence(states),
         ),
     ):
         manager._persist_container_logs("wl", log_path, _fake_stop_event())
@@ -396,7 +427,7 @@ def test_persist_container_logs_window_anchor_ignores_repeated_line(
         ),
         patch(
             "gpustack.worker.serve_manager.get_workload",
-            side_effect=lambda name: states.pop(0),
+            side_effect=_get_workload_sequence(states),
         ),
     ):
         manager._persist_container_logs("wl", log_path, _fake_stop_event())


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5740#issuecomment-4903257462

Support attempting log reconnect before marking model as ERROR in sync_model_instances_state