### PR TITLE
docs: update API key entry to Access Control and reorder catalog screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ Open your browser and navigate to `http://your_host_ip` to access the GPUStack U
 
 2. Select the `Qwen3 0.6B` model from the list of available models.
 
-3. After the deployment compatibility checks pass, click the `Save` button to deploy the model.
-
 ![deploy qwen3 from catalog](docs/assets/quick-start/quick-start-qwen3.png)
+
+3. After the deployment compatibility checks pass, click the `Save` button to deploy the model.
 
 4. GPUStack will start downloading the model files and deploying the model. When the deployment status shows `Running`, the model has been deployed successfully.
 
@@ -167,7 +167,7 @@ Open your browser and navigate to `http://your_host_ip` to access the GPUStack U
 
 ### Use the model via API
 
-1. Hover over the user avatar and navigate to the `API Keys` page, then click the `New API Key` button.
+1. Navigate to the `Access Control` > `API Keys` page, then click the `New API Key` button.
 
 2. Fill in the `Name` and click the `Save` button.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -146,9 +146,10 @@ sudo docker exec gpustack cat /var/lib/gpustack/initial_admin_password
 
 1.  在 GPUStack 用户界面中导航到 `Catalog` 页面。
 2.  从可用模型列表中选择 `Qwen3 0.6B` 模型。
-3.  部署兼容性检查通过后，点击 `Save` 按钮部署模型。
 
 ![从目录部署 qwen3](docs/assets/quick-start/quick-start-qwen3.png)
+
+3.  部署兼容性检查通过后，点击 `Save` 按钮部署模型。
 
 4.  GPUStack 将开始下载模型文件并部署模型。当部署状态显示为 `Running` 时，表示模型已成功部署。
 
@@ -160,7 +161,7 @@ sudo docker exec gpustack cat /var/lib/gpustack/initial_admin_password
 
 ### 通过 API 使用模型
 
-1.  将鼠标悬停在用户头像上，导航到 `API Keys` 页面，然后点击 `New API Key` 按钮。
+1.  导航到 `Access Control` > `API Keys` 页面，然后点击 `New API Key` 按钮。
 2.  填写 `Name` 并点击 `Save` 按钮。
 3.  复制生成的 API 密钥并将其保存在安全的地方。请注意，该密钥仅在创建时可见一次。
 4.  您现在可以使用该 API 密钥访问 GPUStack 提供的 OpenAI 兼容 API 端点。例如，使用 curl 如下所示：

--- a/README_JP.md
+++ b/README_JP.md
@@ -146,9 +146,9 @@ sudo docker exec gpustack cat /var/lib/gpustack/initial_admin_password
 
 2. 利用可能なモデルのリストから`Qwen3 0.6B`モデルを選択します。
 
-3. デプロイ互換性チェックが通過した後、`Save`ボタンをクリックしてモデルをデプロイします。
-
 ![カタログからqwen3をデプロイ](docs/assets/quick-start/quick-start-qwen3.png)
+
+3. デプロイ互換性チェックが通過した後、`Save`ボタンをクリックしてモデルをデプロイします。
 
 4. GPUStackはモデルファイルのダウンロードとモデルのデプロイを開始します。デプロイステータスが`Running`と表示されたら、モデルは正常にデプロイされています。
 
@@ -160,7 +160,7 @@ sudo docker exec gpustack cat /var/lib/gpustack/initial_admin_password
 
 ### API経由でモデルを使用
 
-1. ユーザーアバターにカーソルを合わせて`API Keys`ページに移動し、`New API Key`ボタンをクリックします。
+1. `Access Control` > `API Keys`ページに移動し、`New API Key`ボタンをクリックします。
 
 2. `Name`を入力し、`Save`ボタンをクリックします。
 


### PR DESCRIPTION
The API key management page moved from the user avatar dropdown to the left-nav Access Control > API Keys. Update the wording in all READMEs to match, and move the catalog screenshot to directly follow the model selection step.