### PR TITLE
docs: update quickstart model to Qwen3.5-0.8B

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Open your browser and navigate to `http://your_host_ip` to access the GPUStack U
 
 1. Navigate to the `Catalog` page in the GPUStack UI.
 
-2. Select the `Qwen3 0.6B` model from the list of available models.
+2. Select the `Qwen3.5-0.8B` model from the list of available models.
 
 ![deploy qwen3 from catalog](docs/assets/quick-start/quick-start-qwen3.png)
 
@@ -161,7 +161,7 @@ Open your browser and navigate to `http://your_host_ip` to access the GPUStack U
 
 ![model is running](docs/assets/quick-start/model-running.png)
 
-5. Click `Playground - Chat` in the navigation menu, check that the model `qwen3-0.6b` is selected from the top-right `Model` dropdown. Now you can chat with the model in the UI playground.
+5. Click `Playground - Chat` in the navigation menu, check that the model `qwen3.5-0.8b` is selected from the top-right `Model` dropdown. Now you can chat with the model in the UI playground.
 
 ![quick chat](docs/assets/quick-start/quick-chat.png)
 
@@ -183,7 +183,7 @@ curl http://your_gpustack_server_url/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GPUSTACK_API_KEY" \
   -d '{
-    "model": "qwen3-0.6b",
+    "model": "qwen3.5-0.8b",
     "messages": [
       {
         "role": "system",

--- a/README_CN.md
+++ b/README_CN.md
@@ -145,7 +145,7 @@ sudo docker exec gpustack cat /var/lib/gpustack/initial_admin_password
 ### 部署模型
 
 1.  在 GPUStack 用户界面中导航到 `Catalog` 页面。
-2.  从可用模型列表中选择 `Qwen3 0.6B` 模型。
+2.  从可用模型列表中选择 `Qwen3.5-0.8B` 模型。
 
 ![从目录部署 qwen3](docs/assets/quick-start/quick-start-qwen3.png)
 
@@ -155,7 +155,7 @@ sudo docker exec gpustack cat /var/lib/gpustack/initial_admin_password
 
 ![模型运行中](docs/assets/quick-start/model-running.png)
 
-5.  点击导航菜单中的 `Playground - Chat`，检查右上角 `Model` 下拉菜单中是否选中了 `qwen3-0.6b` 模型。现在您可以在 UI  playground 中与模型聊天了。
+5.  点击导航菜单中的 `Playground - Chat`，检查右上角 `Model` 下拉菜单中是否选中了 `qwen3.5-0.8b` 模型。现在您可以在 UI  playground 中与模型聊天了。
 
 ![快速聊天](docs/assets/quick-start/quick-chat.png)
 
@@ -174,7 +174,7 @@ curl http://your_gpustack_server_url/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GPUSTACK_API_KEY" \
   -d '{
-    "model": "qwen3-0.6b",
+    "model": "qwen3.5-0.8b",
     "messages": [
       {
         "role": "system",

--- a/README_JP.md
+++ b/README_JP.md
@@ -144,7 +144,7 @@ sudo docker exec gpustack cat /var/lib/gpustack/initial_admin_password
 
 1. GPUStack UIの`Catalog`ページに移動します。
 
-2. 利用可能なモデルのリストから`Qwen3 0.6B`モデルを選択します。
+2. 利用可能なモデルのリストから`Qwen3.5-0.8B`モデルを選択します。
 
 ![カタログからqwen3をデプロイ](docs/assets/quick-start/quick-start-qwen3.png)
 
@@ -154,7 +154,7 @@ sudo docker exec gpustack cat /var/lib/gpustack/initial_admin_password
 
 ![モデルが実行中](docs/assets/quick-start/model-running.png)
 
-5. ナビゲーションメニューで`Playground - Chat`をクリックし、右上の`Model`ドロップダウンからモデル`qwen3-0.6b`が選択されていることを確認します。これでUIプレイグラウンドでモデルとチャットできるようになります。
+5. ナビゲーションメニューで`Playground - Chat`をクリックし、右上の`Model`ドロップダウンからモデル`qwen3.5-0.8b`が選択されていることを確認します。これでUIプレイグラウンドでモデルとチャットできるようになります。
 
 ![クイックチャット](docs/assets/quick-start/quick-chat.png)
 
@@ -176,7 +176,7 @@ curl http://your_gpustack_server_url/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GPUSTACK_API_KEY" \
   -d '{
-    "model": "qwen3-0.6b",
+    "model": "qwen3.5-0.8b",
     "messages": [
       {
         "role": "system",

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -82,7 +82,7 @@ sudo docker run -d --name gpustack-worker \
 
 1. Navigate to the `Catalog` page in the GPUStack UI.
 
-2. Select the `Qwen3-0.6B` model from the list of available models.
+2. Select the `Qwen3.5-0.8B` model from the list of available models.
 
 3. After the deployment compatibility checks pass, click the `Save` button to deploy the model.
 
@@ -96,7 +96,7 @@ sudo docker run -d --name gpustack-worker \
 
 ![model is running](assets/quick-start/model-running.png)
 
-5. Click `Playground - Chat` in the navigation menu, check that the model `qwen3-0.6b` is selected from the top-right `Model` dropdown. Now you can chat with the model in the UI playground.
+5. Click `Playground - Chat` in the navigation menu, check that the model `qwen3.5-0.8b` is selected from the top-right `Model` dropdown. Now you can chat with the model in the UI playground.
 
 ![quick chat](assets/quick-start/quick-chat.png)
 
@@ -118,7 +118,7 @@ curl http://your_gpustack_server_url/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GPUSTACK_API_KEY" \
   -d '{
-    "model": "qwen3-0.6b",
+    "model": "qwen3.5-0.8b",
     "messages": [
       {
         "role": "system",


### PR DESCRIPTION
The catalog screenshots now use Qwen3.5-0.8B, so align the model name and id referenced in the deploy, playground, and API steps across the READMEs and quickstart.