### PR TITLE
fix(mixins): propagate asyncio cancellation and eliminate mutable default arguments

### DIFF
--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -223,7 +223,7 @@ class ActiveRecordMixin:
     async def all_by_fields(
         cls,
         session: AsyncSession,
-        fields: dict = {},
+        fields: Optional[dict] = None,
         fuzzy_fields: Optional[dict] = None,
         extra_conditions: Optional[List] = None,
         options: Optional[List] = None,
@@ -232,7 +232,8 @@ class ActiveRecordMixin:
         Return all objects with the given fields and values.
         Return an empty list if not found.
         """
-
+        if fields is None:
+            fields = {}
         statement = select(cls)
         for key, value in fields.items():
             statement = statement.where(getattr(cls, key) == value)
@@ -423,7 +424,7 @@ class ActiveRecordMixin:
                     f"COALESCE(jsonb_array_length(({column_name}->{json_path_str})::jsonb), 0)"
                 )
             else:
-                # Build PGSQL JSON path like '(status#>>{"memory","utilization_rate"})::numeric'
+                # Build PGSQL JSON path like '(status#>>{\"/memory\","utilization_rate"})::numeric'
                 json_path_str = ",".join([f'"{part}"' for part in json_path_parts])
                 if not cast_type:
                     cast_type = "numeric"
@@ -564,13 +565,14 @@ class ActiveRecordMixin:
     async def count_by_fields(
         cls,
         session: AsyncSession,
-        fields: dict = {},
+        fields: Optional[dict] = None,
         extra_conditions: Optional[List] = None,
     ) -> int:
         """
         Return the number of records matching the given fields and conditions.
         """
-
+        if fields is None:
+            fields = {}
         statement = select(func.count(cls.id))
         for key, value in fields.items():
             statement = statement.where(getattr(cls, key) == value)
@@ -890,7 +892,8 @@ class ActiveRecordMixin:
                 if formatted is not None:
                     yield formatted
         except asyncio.CancelledError:
-            pass
+            # Re-raise to ensure proper structured concurrency cancellation state
+            raise
         except Exception as e:
             logger.error(f"Error in streaming {cls.__name__}: {e}")
 

--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -424,7 +424,7 @@ class ActiveRecordMixin:
                     f"COALESCE(jsonb_array_length(({column_name}->{json_path_str})::jsonb), 0)"
                 )
             else:
-                # Build PGSQL JSON path like '(status#>>{\"/memory\","utilization_rate"})::numeric'
+                # Build PGSQL JSON path like '(status#>>'{"memory","utilization_rate"}')::numeric'
                 json_path_str = ",".join([f'"{part}"' for part in json_path_parts])
                 if not cast_type:
                     cast_type = "numeric"

--- a/gpustack/routes/workers.py
+++ b/gpustack/routes/workers.py
@@ -372,8 +372,10 @@ def _matches_fuzzy_fields(worker: Worker, fuzzy_fields: Dict[str, str]) -> bool:
 def filter_workers_by_fields(
     workers: List[Worker],
     fields: Optional[Dict[str, Any]],
-    fuzzy_fields: Dict[str, str] = {},
+    fuzzy_fields: Optional[Dict[str, str]] = None,
 ) -> List[Worker]:
+    if fuzzy_fields is None:
+        fuzzy_fields = {}
     if not fields and not fuzzy_fields:
         return workers
 


### PR DESCRIPTION
While evaluating the asynchronous task management and route definitions inside gpustack, we identified two core code quality regressions that affect runtime reliability and structured concurrency guarantees under load.

1. Swallowed asyncio.CancelledError in SSE Streams:
: Inside `gpustack/mixins/active_record.py`, the `streaming()` generator catches `asyncio.CancelledError` and executes a silent `pass`.
: In Python 3.8+, breaking the propagation of `CancelledError` causes the active task to transition to a `DONE` state instead of `CANCELLED` when a client disconnects from an SSE watch endpoint (such as models or workers). This prevents the event loop from performing accurate structured cleanup, leading to task accumulation.

2. Mutable Default Arguments in Route Handlers:
: Multiple core endpoints and ORM mixin functions utilize `fields: dict = {}` as a default parameter definition.
: Since default arguments are evaluated once at function definition time, this pattern introduces a shared mutable singleton object across execution threads, creating risks of latent cross-request state leakage and triggering static analysis alerts (e.g., Bandit B006 / Pylint W0102).

The Fix:
: Explicitly re-raised `asyncio.CancelledError` within the active record stream handler to ensure cancellation states propagate correctly to the parent lifecycle task.
: Refactored all instances of `fields: dict = {}` to `fields: Optional[dict] = None` with clean initialization guards inside the function bodies across the mixin and all affected route modules.