### PR TITLE
fix: add cluster validation for model deployments

### DIFF
--- a/gpustack/api/tenant.py
+++ b/gpustack/api/tenant.py
@@ -611,7 +611,7 @@ def assert_org_owned_writable(
         raise OrgRoleError(
             message=(
                 f"{resource_label.capitalize()} does not belong to "
-                "current organization"
+                "the current organization"
             )
         )
     # Platform admin acting-as the Org passes the role check unconditionally.

--- a/gpustack/routes/models.py
+++ b/gpustack/routes/models.py
@@ -14,6 +14,8 @@ from gpustack.api.exceptions import (
     AlreadyExistsException,
     InternalServerErrorException,
     BadRequestException,
+    ForbiddenException,
+    NotFoundException,
 )
 from gpustack.schemas.common import Pagination
 from gpustack.schemas.inference_backend import is_custom_backend
@@ -26,7 +28,9 @@ from gpustack.schemas.models import (
 from gpustack.schemas.clusters import Cluster
 from gpustack.schemas.workers import GPUDeviceStatus, Worker
 from gpustack.api.tenant import (
+    TenantContext,
     bypass_tenant_filter,
+    assert_cluster_visible,
     assert_resource_visible,
     cluster_scoped_system,
     scoped_cluster_row_visible,
@@ -575,6 +579,40 @@ async def validate_distributed_vllm_limit_per_worker(
             )
 
 
+async def assert_cluster_belongs_to_org(
+    ctx: TenantContext,
+    session: AsyncSession,
+    cluster_id: Optional[int],
+    owner_principal_id: int,
+    cluster: Optional[Cluster] = None,
+):
+    """Ensure a chosen cluster is visible to the caller and owned by the
+    given Org.
+
+    A model runs on infrastructure owned by its Org, so its cluster must
+    belong to that Org — otherwise a tenant could target the platform's
+    (or another Org's) cluster, stamping a cross-tenant model. A cluster the
+    caller can't see is reported as missing (404), so cross-tenant cluster
+    ids can't be probed via a 403-vs-404 difference; a visible cluster owned
+    by another Org is a 403. No cluster chosen (``cluster_id is None``)
+    leaves default-cluster resolution to pick the Org's own cluster.
+
+    ``cluster`` may be passed pre-fetched to avoid a duplicate lookup.
+    """
+    if cluster_id is None:
+        return
+    if cluster is None:
+        cluster = await Cluster.one_by_id(session, cluster_id)
+    not_found = f"Cluster {cluster_id} not found"
+    assert_cluster_visible(ctx, cluster, not_found_message=not_found)
+    if cluster.deleted_at is not None:
+        raise NotFoundException(message=not_found)
+    if cluster.owner_principal_id != owner_principal_id:
+        raise ForbiddenException(
+            message="The selected cluster does not belong to the current organization."
+        )
+
+
 @router.post(
     "",
     response_model=ModelPublic,
@@ -589,12 +627,26 @@ async def create_model(
     # front keeps them in sync so the pre-check actually catches a
     # collision in the Org the model will land in.
     target_org_id = ctx.current_principal_id
+    cluster = None
     if target_org_id is None and model_in.cluster_id is not None:
+        # Admin "All" mode has no principal context; derive the owning Org
+        # from the chosen cluster. Reused by the check below to avoid a
+        # second lookup. Under an Org context the helper does the single
+        # lookup itself.
         cluster = await Cluster.one_by_id(session, model_in.cluster_id)
-        if cluster is not None:
-            target_org_id = cluster.owner_principal_id
+        if cluster is None:
+            raise NotFoundException(message=f"Cluster {model_in.cluster_id} not found")
+        target_org_id = cluster.owner_principal_id
     if target_org_id is None:
         target_org_id = platform_principal_id()
+
+    # The chosen cluster must exist, be visible to the caller, and be owned
+    # by the target Org. In admin "All" mode target_org_id was derived from
+    # the cluster above, so the ownership check is trivially satisfied and
+    # this mainly rejects a missing/deleted or non-visible cluster_id.
+    await assert_cluster_belongs_to_org(
+        ctx, session, model_in.cluster_id, target_org_id, cluster=cluster
+    )
 
     # Model & ModelRoute names are unique within their Org. Two Orgs
     # can each have a "llama3" without colliding.
@@ -711,6 +763,13 @@ async def update_model(
 ):
     model = await Model.one_by_id(session, id)
     assert_resource_visible(ctx, model, not_found_message="Model not found")
+
+    # Block re-pointing a model at another Org's (e.g. the Default org's
+    # shared) or a non-visible cluster: its cluster must stay owned by the
+    # model's Org.
+    await assert_cluster_belongs_to_org(
+        ctx, session, model_in.cluster_id, model.owner_principal_id
+    )
 
     await validate_model_in(session, model_in)
 

--- a/tests/routers/test_models.py
+++ b/tests/routers/test_models.py
@@ -1,0 +1,234 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gpustack.api.exceptions import (
+    AlreadyExistsException,
+    ForbiddenException,
+    NotFoundException,
+)
+from gpustack.api.tenant import TenantContext
+from gpustack.routes.models import create_model, update_model
+from gpustack.schemas.models import ModelCreate, ModelUpdate, SourceEnum
+from gpustack.schemas.principals import PrincipalType, platform_principal_id
+
+DEFAULT_ORG_ID = platform_principal_id()
+CUSTOM_ORG_ID = 5
+OTHER_ORG_ID = 7
+CLUSTER_ID = 101
+
+
+def _ctx(current_principal_id, is_admin=False, accessible_cluster_ids=None):
+    user = MagicMock()
+    user.id = 99
+    user.is_admin = is_admin
+    # Tenant helpers compare user.kind against PrincipalType.SYSTEM; pin it
+    # to a non-SYSTEM kind so a bare mock can't drift into the SYSTEM bypass.
+    user.kind = PrincipalType.USER
+    return TenantContext(
+        user=user,
+        is_platform_admin=is_admin,
+        current_principal_id=current_principal_id,
+        org_role=None,
+        accessible_cluster_ids=set(accessible_cluster_ids or []),
+    )
+
+
+def _model_create(cluster_id=None):
+    return ModelCreate(
+        name="m1",
+        source=SourceEnum.HUGGING_FACE,
+        huggingface_repo_id="org/repo",
+        cluster_id=cluster_id,
+    )
+
+
+def _cluster(owner_principal_id, cluster_id=CLUSTER_ID, deleted=False):
+    cluster = MagicMock()
+    cluster.id = cluster_id
+    cluster.owner_principal_id = owner_principal_id
+    cluster.deleted_at = object() if deleted else None
+    return cluster
+
+
+@pytest.mark.asyncio
+async def test_create_model_rejects_default_org_cluster_for_custom_org(monkeypatch):
+    """A custom org cannot deploy onto a visible cluster owned by another
+    org (e.g. the Default org's shared cluster) — 403, not 404."""
+    monkeypatch.setattr(
+        "gpustack.routes.models.Cluster.one_by_id",
+        AsyncMock(return_value=_cluster(DEFAULT_ORG_ID)),
+    )
+
+    with pytest.raises(ForbiddenException):
+        await create_model(
+            MagicMock(),
+            _ctx(CUSTOM_ORG_ID, accessible_cluster_ids=[CLUSTER_ID]),
+            _model_create(cluster_id=CLUSTER_ID),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_model_hides_non_visible_cluster_as_missing(monkeypatch):
+    """A cluster the caller can't see is reported as missing (404), not
+    forbidden (403), so cross-tenant cluster ids can't be probed."""
+    monkeypatch.setattr(
+        "gpustack.routes.models.Cluster.one_by_id",
+        AsyncMock(return_value=_cluster(OTHER_ORG_ID)),
+    )
+
+    with pytest.raises(NotFoundException):
+        await create_model(
+            MagicMock(),
+            _ctx(CUSTOM_ORG_ID),
+            _model_create(cluster_id=CLUSTER_ID),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_model_rejects_missing_cluster(monkeypatch):
+    monkeypatch.setattr(
+        "gpustack.routes.models.Cluster.one_by_id",
+        AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(NotFoundException):
+        await create_model(
+            MagicMock(),
+            _ctx(CUSTOM_ORG_ID),
+            _model_create(cluster_id=CLUSTER_ID),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_model_rejects_deleted_cluster(monkeypatch):
+    """A soft-deleted cluster is treated as missing (404)."""
+    monkeypatch.setattr(
+        "gpustack.routes.models.Cluster.one_by_id",
+        AsyncMock(return_value=_cluster(CUSTOM_ORG_ID, deleted=True)),
+    )
+
+    with pytest.raises(NotFoundException):
+        await create_model(
+            MagicMock(),
+            _ctx(CUSTOM_ORG_ID),
+            _model_create(cluster_id=CLUSTER_ID),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_model_allows_own_org_cluster(monkeypatch):
+    """An own-org cluster passes the org-alignment check and proceeds to
+    the name-uniqueness check (signalled here by AlreadyExists)."""
+    monkeypatch.setattr(
+        "gpustack.routes.models.Cluster.one_by_id",
+        AsyncMock(return_value=_cluster(CUSTOM_ORG_ID)),
+    )
+    monkeypatch.setattr(
+        "gpustack.routes.models.Model.one_by_fields",
+        AsyncMock(return_value=MagicMock()),
+    )
+
+    with pytest.raises(AlreadyExistsException):
+        await create_model(
+            MagicMock(),
+            _ctx(CUSTOM_ORG_ID),
+            _model_create(cluster_id=CLUSTER_ID),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_model_admin_all_mode_derives_owner_from_cluster(monkeypatch):
+    """Admin in "All" mode (no principal context) derives the owning org
+    from the chosen cluster; the ownership check then passes even for a
+    non-default org's cluster, and the model is stamped with that owner."""
+    monkeypatch.setattr(
+        "gpustack.routes.models.Cluster.one_by_id",
+        AsyncMock(return_value=_cluster(OTHER_ORG_ID)),
+    )
+    one_by_fields = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        "gpustack.routes.models.Model.one_by_fields",
+        one_by_fields,
+    )
+
+    with pytest.raises(AlreadyExistsException):
+        await create_model(
+            MagicMock(),
+            _ctx(current_principal_id=None, is_admin=True),
+            _model_create(cluster_id=CLUSTER_ID),
+        )
+
+    # The uniqueness pre-check runs against the org derived from the
+    # cluster, not the platform default.
+    assert one_by_fields.await_args.args[1]["owner_principal_id"] == OTHER_ORG_ID
+
+
+@pytest.mark.asyncio
+async def test_create_model_admin_all_mode_rejects_missing_cluster(monkeypatch):
+    """Admin "All" mode still rejects a non-existent cluster rather than
+    stamping the model with the platform default."""
+    monkeypatch.setattr(
+        "gpustack.routes.models.Cluster.one_by_id",
+        AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(NotFoundException):
+        await create_model(
+            MagicMock(),
+            _ctx(current_principal_id=None, is_admin=True),
+            _model_create(cluster_id=999),
+        )
+
+
+async def _run_update(monkeypatch, ctx, cluster_return):
+    """Drive update_model for an owned model pointed at ``cluster_return``."""
+    model = MagicMock()
+    model.owner_principal_id = CUSTOM_ORG_ID
+    monkeypatch.setattr(
+        "gpustack.routes.models.Model.one_by_id",
+        AsyncMock(return_value=model),
+    )
+    monkeypatch.setattr(
+        "gpustack.routes.models.assert_resource_visible",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "gpustack.routes.models.Cluster.one_by_id",
+        AsyncMock(return_value=cluster_return),
+    )
+    await update_model(
+        MagicMock(),
+        ctx,
+        1,
+        ModelUpdate(
+            name="m1",
+            source=SourceEnum.HUGGING_FACE,
+            huggingface_repo_id="org/repo",
+            cluster_id=CLUSTER_ID,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_model_rejects_cross_org_cluster(monkeypatch):
+    """A visible cluster owned by another org is a 403 on update."""
+    with pytest.raises(ForbiddenException):
+        await _run_update(
+            monkeypatch,
+            _ctx(CUSTOM_ORG_ID, accessible_cluster_ids=[CLUSTER_ID]),
+            _cluster(DEFAULT_ORG_ID),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_model_hides_non_visible_cluster_as_missing(monkeypatch):
+    """A non-visible cluster is a 404 on update, not a 403 — no probing."""
+    with pytest.raises(NotFoundException):
+        await _run_update(monkeypatch, _ctx(CUSTOM_ORG_ID), _cluster(OTHER_ORG_ID))
+
+
+@pytest.mark.asyncio
+async def test_update_model_rejects_missing_cluster(monkeypatch):
+    with pytest.raises(NotFoundException):
+        await _run_update(monkeypatch, _ctx(CUSTOM_ORG_ID), None)


### PR DESCRIPTION
A model runs on infrastructure owned by its org, so its cluster must belong to that org. create_model stamped the model's owner as the current org but never checked the chosen cluster's owner, so a member of a custom org could deploy onto another org's cluster (surfaced via the platform org's "shared with everyone" grant), stamping a cross-tenant model.

Reject a cluster whose owner differs from the resolved owning org on both create and update, via a shared assert_cluster_belongs_to_org helper. Admin "All" mode derives the owner from the chosen cluster, so the pair stays aligned there.

Add tests covering the reject, missing-cluster, own-org-allow, and admin-all paths.