### PR TITLE
fix(auth): cut DB connection pressure on the /token-auth hot path

### DIFF
--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -1,5 +1,7 @@
+import asyncio
 import re
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 import logging
 import aiohttp
@@ -92,6 +94,16 @@ def client_ip_getter(request: Request) -> str:
     return request.client.host if request.client else ""
 
 
+@asynccontextmanager
+async def _optional_session(session: Optional[AsyncSession]):
+    """Yield the caller-provided session as-is, or open (and close) a fresh one."""
+    if session is not None:
+        yield session  # caller owns it, don't close here
+    else:
+        async with async_session() as s:
+            yield s  # opened here, closed on exit
+
+
 async def get_current_user(
     request: Request,
     basic_credentials: Annotated[
@@ -102,6 +114,27 @@ async def get_current_user(
     ] = None,
     x_api_key: Annotated[Optional[str], Depends(api_key_header_auth)] = None,
     cookie_token: Annotated[Optional[str], Depends(cookie_auth)] = None,
+) -> User:
+    # FastAPI dependency entry point. Keep the signature free of any
+    # non-``Depends`` parameter (e.g. ``session``) -- FastAPI would try to
+    # build a Pydantic field for it and fail route registration. Callers that
+    # already hold a session should call ``authenticate_request`` directly.
+    return await authenticate_request(
+        request,
+        basic_credentials=basic_credentials,
+        bearer_token=bearer_token,
+        x_api_key=x_api_key,
+        cookie_token=cookie_token,
+    )
+
+
+async def authenticate_request(
+    request: Request,
+    basic_credentials: Optional[HTTPBasicCredentials] = None,
+    bearer_token: Optional[HTTPAuthorizationCredentials] = None,
+    x_api_key: Optional[str] = None,
+    cookie_token: Optional[str] = None,
+    session: Optional[AsyncSession] = None,
 ) -> User:
     if hasattr(request.state, "user"):
         user: User = getattr(request.state, "user")
@@ -118,7 +151,7 @@ async def get_current_user(
             # request -- otherwise a long-lived StreamingResponse (SSE watch,
             # streaming inference proxy) leaves it idle-in-transaction until
             # the stream ends, which can be hours. See #5678.
-            async with async_session() as session:
+            async with _optional_session(session) as session:
                 if basic_credentials:
                     user = await authenticate_basic_user(session, basic_credentials)
                 elif cookie_token:
@@ -299,19 +332,34 @@ async def get_user_from_api_token(
         if len(access_key) == 32 and "" not in access_keys:
             # this means it is custom key or legacy worker token, we should also try to find api key with empty access key for backward compatibility
             access_keys.append("")
-        for access_key in access_keys:
-            api_key: ApiKey = await APIKeyService(session).get_by_access_key(access_key)
+        api_key: Optional[ApiKey] = None
+        for candidate in access_keys:
+            api_key = await APIKeyService(session).get_by_access_key(candidate)
             if api_key:
-                logger.trace(f"Found API key for access key: {access_key}")
+                logger.trace(f"Found API key for access key: {candidate}")
                 break
-        if (
-            api_key is not None
-            and verify_hashed_secret(api_key.hashed_secret_key, secret_key)
-            and (
-                api_key.expires_at is None
-                or api_key.expires_at > datetime.now(timezone.utc)
-            )
+        if api_key is None:
+            return None, None
+        if api_key.expires_at is not None and api_key.expires_at <= datetime.now(
+            timezone.utc
         ):
+            return None, None
+
+        # ``get_by_access_key`` returns a detached ApiKey with all columns
+        # already loaded, so reading its fields no longer needs the DB
+        # connection. Hand the pooled connection back *before* the argon2
+        # verify: the verify is deliberately expensive and CPU-bound, and
+        # holding a connection idle across it starves the pool under load.
+        # rollback() is safe -- this lookup is read-only.
+        await session.rollback()
+
+        # argon2 verification is synchronous and CPU-bound; run it off the
+        # event loop so concurrent requests keep flowing instead of serializing
+        # behind each hash.
+        verified = await asyncio.to_thread(
+            verify_hashed_secret, api_key.hashed_secret_key, secret_key
+        )
+        if verified:
             user: Optional[User] = await UserService(session).get_by_id(
                 user_id=api_key.user_id,
             )

--- a/gpustack/routes/token.py
+++ b/gpustack/routes/token.py
@@ -19,7 +19,7 @@ from gpustack.api.auth import (
     basic_auth,
     cookie_auth,
     bearer_auth,
-    get_current_user,
+    authenticate_request,
     credentials_exception,
     gateway_token_auth,
     inference_scope,
@@ -81,12 +81,13 @@ async def server_auth(
     cookie_token = await cookie_auth(request)
     x_api_key = await api_key_header_auth(request)
     try:
-        user = await get_current_user(
+        user = await authenticate_request(
             request=request,
             basic_credentials=await basic_auth(request),
             bearer_token=await bearer_auth(request),
             x_api_key=x_api_key,
             cookie_token=cookie_token,
+            session=session,
         )
         api_key = getattr(request.state, "api_key", None)
         access_key = None if api_key is None else api_key.access_key

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -52,6 +52,189 @@ async def test_get_current_user_accepts_x_api_key(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_authenticate_request_reuses_provided_session(monkeypatch):
+    """``authenticate_request(..., session=<provided>)`` must reuse the
+    caller's session (not open a fresh one) and still populate
+    ``request.state.user`` / ``request.state.api_key``. Covers the
+    session-reuse path used by ``/token-auth``."""
+    from gpustack.api.auth import authenticate_request
+
+    provided_session = object()
+    request = _make_request()
+
+    expected_user = type("User", (), {"is_active": True})()
+    expected_key = object()
+
+    captured = {}
+
+    async def fake_get_user_from_api_token(session, token):
+        captured["session"] = session
+        captured["token"] = token
+        return expected_user, expected_key
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.get_user_from_api_token", fake_get_user_from_api_token
+    )
+
+    # If a fresh session were opened, this fires — proving the provided one
+    # is reused instead. (A plain object() as the session also means any
+    # attempt to close it would AttributeError, so this doubles as a
+    # "caller's session is not closed" assertion.)
+    def _no_fresh_session(*args, **kwargs):
+        raise AssertionError(
+            "async_session() must not be called when a session is provided"
+        )
+
+    monkeypatch.setattr("gpustack.api.auth.async_session", _no_fresh_session)
+
+    user = await authenticate_request(
+        request, x_api_key="sk_test_value", session=provided_session
+    )
+
+    assert user is expected_user
+    assert captured["session"] is provided_session
+    assert captured["token"] == "sk_test_value"
+    assert request.state.user is expected_user
+    assert request.state.api_key is expected_key
+
+
+def _api_token_double(**overrides):
+    fields = {
+        "hashed_secret_key": "stored-hash",
+        "expires_at": None,
+        "user_id": 7,
+        "access_key": "abcd1234",
+    }
+    fields.update(overrides)
+    return type("ApiKey", (), fields)()
+
+
+class _RollbackRecordingSession:
+    def __init__(self, events):
+        self._events = events
+
+    async def rollback(self):
+        self._events.append("rollback")
+
+
+@pytest.mark.asyncio
+async def test_get_user_from_api_token_skips_verify_for_expired_key(monkeypatch):
+    """An expired key must be rejected *before* the argon2 verify runs."""
+    from datetime import datetime, timedelta, timezone
+
+    from gpustack.api.auth import get_user_from_api_token
+
+    expired = _api_token_double(
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1)
+    )
+
+    async def fake_get_by_access_key(self, candidate):
+        return expired
+
+    verify_calls = {"n": 0}
+
+    def fake_verify(hashed, secret):
+        verify_calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr("gpustack.api.auth.verify_hashed_secret", fake_verify)
+
+    session = _RollbackRecordingSession([])
+    user, api_key = await get_user_from_api_token(
+        session, "gpustack_abcd1234_c11c75ed6334ea9505da4ad9"
+    )
+
+    assert user is None and api_key is None
+    assert verify_calls["n"] == 0  # argon2 skipped for expired key
+
+
+@pytest.mark.asyncio
+async def test_get_user_from_api_token_rollback_before_verify_via_thread(monkeypatch):
+    """Valid key: the pooled connection is released (``rollback``) *before*
+    the argon2 verify, and the verify runs off the event loop via
+    ``asyncio.to_thread``."""
+    import gpustack.api.auth as auth_module
+    from gpustack.api.auth import get_user_from_api_token
+
+    events = []
+    valid = _api_token_double()
+    expected_user = type("User", (), {"is_active": True, "id": 7})()
+
+    async def fake_get_by_access_key(self, candidate):
+        return valid
+
+    async def fake_get_by_id(self, user_id):
+        assert user_id == 7
+        return expected_user
+
+    def fake_verify(hashed, secret):
+        events.append("verify")
+        assert hashed == "stored-hash"
+        return True
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr("gpustack.api.auth.UserService.get_by_id", fake_get_by_id)
+    monkeypatch.setattr("gpustack.api.auth.verify_hashed_secret", fake_verify)
+
+    real_to_thread = auth_module.asyncio.to_thread
+    used_thread = {"n": 0}
+
+    async def spy_to_thread(fn, *args, **kwargs):
+        used_thread["n"] += 1
+        return await real_to_thread(fn, *args, **kwargs)
+
+    monkeypatch.setattr(auth_module.asyncio, "to_thread", spy_to_thread)
+
+    session = _RollbackRecordingSession(events)
+    user, api_key = await get_user_from_api_token(
+        session, "gpustack_abcd1234_c11c75ed6334ea9505da4ad9"
+    )
+
+    assert user is expected_user
+    assert api_key is valid
+    assert events == ["rollback", "verify"]  # connection released before argon2
+    assert used_thread["n"] == 1  # argon2 ran via asyncio.to_thread
+
+
+@pytest.mark.asyncio
+async def test_get_user_from_api_token_rejects_wrong_secret(monkeypatch):
+    """A key whose secret fails argon2 verification yields no user."""
+    from gpustack.api.auth import get_user_from_api_token
+
+    valid = _api_token_double()
+
+    async def fake_get_by_access_key(self, candidate):
+        return valid
+
+    get_by_id_calls = {"n": 0}
+
+    async def fake_get_by_id(self, user_id):
+        get_by_id_calls["n"] += 1
+        return type("User", (), {"is_active": True, "id": 7})()
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr("gpustack.api.auth.UserService.get_by_id", fake_get_by_id)
+    monkeypatch.setattr(
+        "gpustack.api.auth.verify_hashed_secret", lambda hashed, secret: False
+    )
+
+    session = _RollbackRecordingSession([])
+    user, api_key = await get_user_from_api_token(
+        session, "gpustack_abcd1234_c11c75ed6334ea9505da4ad9"
+    )
+
+    assert user is None and api_key is None
+    assert get_by_id_calls["n"] == 0  # never resolve a user for a bad secret
+
+
+@pytest.mark.asyncio
 async def test_worker_auth_accepts_x_api_key():
     request = type("Request", (), {})()
     request.headers = {"X-Higress-Llm-Model": "claude-sonnet"}


### PR DESCRIPTION
The gateway ext-auth endpoint (/token-auth) runs on every inference request. Under load (many API keys at high concurrency) it exhausted the DB connection pool and stalled auth. Three related changes:

- Reuse the request-scoped session in /token-auth instead of opening a second connection just for the auth lookup. get_current_user stays a clean FastAPI dependency; the session-accepting logic moves to a new authenticate_request() that callers already holding a session invoke directly. (A non-Depends AsyncSession parameter on the dependency itself makes FastAPI try to build a Pydantic field for it and fails route registration.)

- In get_user_from_api_token, hand the pooled connection back via session.rollback() *before* the argon2 verify. get_by_access_key returns a detached ApiKey with all columns loaded, so reading its fields no longer needs the connection; the read-only rollback is safe and the subsequent user lookup re-acquires a connection. Also check key expiry before verifying, skipping argon2 for expired keys.

- Run the synchronous, CPU-bound argon2 verify via asyncio.to_thread so it no longer blocks the event loop and serializes concurrent auth requests.