### PR TITLE
feat: add state filter to /my-models

### DIFF
--- a/gpustack/routes/model_common.py
+++ b/gpustack/routes/model_common.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, Union
+from enum import Enum
+from typing import Any, List, Optional, Union
 from sqlalchemy import bindparam, cast
 from sqlmodel import func
 from sqlalchemy.dialects.postgresql import JSONB
@@ -11,6 +12,41 @@ category_classes = Union[
     ModelRoute,
     MyModel,
 ]
+
+
+class ModelStateFilterEnum(str, Enum):
+    READY = "ready"
+    NOT_READY = "not_ready"
+    STOPPED = "stopped"
+
+
+def state_stream_filter(
+    data: Any,
+    state: Optional[ModelStateFilterEnum],
+    ready_attr: str,
+    total_attr: str,
+) -> bool:
+    """Python-side mirror of the SQL readiness filter for watch streams.
+
+    ``ready_attr``/``total_attr`` name the readiness counters that differ
+    per resource (``ready_replicas``/``replicas`` for a Model,
+    ``ready_targets``/``targets`` for a route)."""
+    if state is None:
+        return True
+    ready = getattr(data, ready_attr, None)
+    total = getattr(data, total_attr, None)
+    # Partial payloads (e.g. ID-only DELETED events shaped ``{"id": ...}``)
+    # don't carry readiness counters. Let them through so watch clients can
+    # still drop the row by ID instead of holding a stale copy forever.
+    if ready is None or total is None:
+        return True
+    if state == ModelStateFilterEnum.READY:
+        return ready > 0
+    if state == ModelStateFilterEnum.NOT_READY:
+        return ready == 0 and total > 0
+    if state == ModelStateFilterEnum.STOPPED:
+        return total == 0
+    return True
 
 
 def build_pg_category_condition(target_class: category_classes, category: str):
@@ -48,6 +84,12 @@ def build_category_conditions(session, target_class: category_classes, categorie
 
 def categories_filter(data: category_classes, categories: Optional[List[str]]):
     if not categories:
+        return True
+
+    # Partial payloads (e.g. ID-only DELETED events shaped ``{"id": ...}``)
+    # don't carry categories. Let them through so watch clients can drop the
+    # row by ID instead of the stream erroring on a missing attribute.
+    if not hasattr(data, "categories"):
         return True
 
     data_categories = data.categories or []

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -2,7 +2,7 @@ import logging
 import secrets
 from sqlalchemy import true
 from sqlalchemy.orm import selectinload
-from sqlmodel import col, func, or_, select
+from sqlmodel import and_, col, func, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from typing import Any, Callable, List, Optional, Set, Tuple, Union, Dict
 from fastapi import APIRouter, Depends, Query
@@ -55,8 +55,10 @@ from gpustack.server.services import (
     revoke_model_access_cache,
 )
 from gpustack.routes.model_common import (
+    ModelStateFilterEnum,
     build_category_conditions,
     categories_filter,
+    state_stream_filter,
 )
 
 logger = logging.getLogger(__name__)
@@ -253,11 +255,33 @@ def _model_route_grant_predicate(
     return _ok
 
 
+def _state_conditions(
+    target_class: Union[ModelRoute, MyModel],
+    state: Optional[ModelStateFilterEnum],
+) -> list:
+    """Route readiness mirrors Model state: a route is READY when at least
+    one target is ready, NOT_READY when it has targets but none ready, and
+    STOPPED when it has no targets at all."""
+    if state == ModelStateFilterEnum.READY:
+        return [col(target_class.ready_targets) > 0]
+    if state == ModelStateFilterEnum.NOT_READY:
+        return [
+            and_(
+                col(target_class.ready_targets) == 0,
+                col(target_class.targets) > 0,
+            )
+        ]
+    if state == ModelStateFilterEnum.STOPPED:
+        return [col(target_class.targets) == 0]
+    return []
+
+
 async def _get_model_routes(
     params: ModelRouteListParams,
     name: str = None,
     search: str = None,
     categories: Optional[List[str]] = None,
+    state: Optional[ModelStateFilterEnum] = None,
     user_id: Optional[int] = None,
     owner_principal_id: Optional[int] = None,
     target_class: Union[ModelRoute, MyModel] = ModelRoute,
@@ -307,14 +331,30 @@ async def _get_model_routes(
             ctx, target_class, include_grants
         )
 
+        stream_predicates = [
+            p
+            for p in (
+                my_model_stream_filter,
+                route_grant_stream_filter,
+                (
+                    (
+                        lambda d: state_stream_filter(
+                            d, state, "ready_targets", "targets"
+                        )
+                    )
+                    if state is not None
+                    else None
+                ),
+                (lambda d: categories_filter(d, categories)) if categories else None,
+            )
+            if p is not None
+        ]
+
         def _stream_filter(data: Any) -> bool:
-            if my_model_stream_filter is not None and not my_model_stream_filter(data):
-                return False
-            if route_grant_stream_filter is not None and not route_grant_stream_filter(
-                data
-            ):
-                return False
-            return categories_filter(data, categories)
+            for p in stream_predicates:
+                if not p(data):
+                    return False
+            return True
 
         return StreamingResponse(
             target_class.streaming(
@@ -342,6 +382,8 @@ async def _get_model_routes(
         if categories:
             conditions = build_category_conditions(session, target_class, categories)
             extra_conditions.append(or_(*conditions))
+
+        extra_conditions.extend(_state_conditions(target_class, state))
 
         result = await target_class.paginated_by_query(
             session=session,
@@ -1487,6 +1529,10 @@ async def add_model_authorization(
 async def get_my_models(
     ctx: TenantContextDep,
     params: ModelRouteListParams = Depends(),
+    state: Optional[ModelStateFilterEnum] = Query(
+        default=None,
+        description="Filter by model state.",
+    ),
     search: str = None,
     categories: Optional[List[str]] = Query(None, description="Filter by categories."),
 ):
@@ -1517,6 +1563,7 @@ async def get_my_models(
         params=params,
         search=search,
         categories=categories,
+        state=state,
         target_class=target_class,
         user_id=user_id,
         ctx=ctx,

--- a/gpustack/routes/models.py
+++ b/gpustack/routes/models.py
@@ -8,7 +8,6 @@ from gpustack_runtime.detector import ManufacturerEnum
 from sqlalchemy.orm import selectinload
 from sqlmodel import and_, or_
 from sqlmodel.ext.asyncio.session import AsyncSession
-from enum import Enum
 
 from gpustack.api.exceptions import (
     AlreadyExistsException,
@@ -77,8 +76,10 @@ from gpustack.policies.utils import manual_distributed_from_env
 from gpustack.utils.convert import safe_int
 from gpustack.utils.gpu import parse_gpu_id
 from gpustack.routes.model_common import (
+    ModelStateFilterEnum,
     build_category_conditions,
     categories_filter,
+    state_stream_filter,
 )
 from gpustack.config.config import get_global_config
 from gpustack.utils.grafana import resolve_grafana_base_url
@@ -89,20 +90,26 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-class ModelStateFilterEnum(str, Enum):
-    READY = "ready"
-    NOT_READY = "not_ready"
-    STOPPED = "stopped"
-
-
-def _make_model_watch_filter(ctx, categories):
+def _make_model_watch_filter(ctx, categories, state=None):
     """Watch-stream visibility: cluster-bound service accounts only see
-    their own cluster's models; everyone keeps the categories filter."""
+    their own cluster's models; everyone keeps the categories and state
+    filters. Predicates are pre-built so inactive filters cost nothing on
+    the per-event hot path."""
+    predicates = []
+    if cluster_scoped_system(ctx):
+        predicates.append(lambda data: scoped_cluster_row_visible(ctx, data))
+    if state is not None:
+        predicates.append(
+            lambda data: state_stream_filter(data, state, "ready_replicas", "replicas")
+        )
+    if categories:
+        predicates.append(lambda data: categories_filter(data, categories))
 
     def _visible(data) -> bool:
-        if cluster_scoped_system(ctx) and not scoped_cluster_row_visible(ctx, data):
-            return False
-        return categories_filter(data, categories)
+        for p in predicates:
+            if not p(data):
+                return False
+        return True
 
     return _visible
 
@@ -145,7 +152,7 @@ async def get_models(
             Model.streaming(
                 fields=fields,
                 fuzzy_fields=fuzzy_fields,
-                filter_func=_make_model_watch_filter(ctx, categories),
+                filter_func=_make_model_watch_filter(ctx, categories, state),
             ),
             media_type="text/event-stream",
         )

--- a/tests/routers/test_models.py
+++ b/tests/routers/test_models.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -8,7 +9,9 @@ from gpustack.api.exceptions import (
     NotFoundException,
 )
 from gpustack.api.tenant import TenantContext
+from gpustack.routes import models as models_route
 from gpustack.routes.models import create_model, update_model
+from gpustack.routes.model_common import ModelStateFilterEnum
 from gpustack.schemas.models import ModelCreate, ModelUpdate, SourceEnum
 from gpustack.schemas.principals import PrincipalType, platform_principal_id
 
@@ -232,3 +235,39 @@ async def test_update_model_hides_non_visible_cluster_as_missing(monkeypatch):
 async def test_update_model_rejects_missing_cluster(monkeypatch):
     with pytest.raises(NotFoundException):
         await _run_update(monkeypatch, _ctx(CUSTOM_ORG_ID), None)
+
+
+@pytest.mark.parametrize(
+    "ready, replicas, state, expected",
+    [
+        (2, 3, ModelStateFilterEnum.READY, True),
+        (0, 3, ModelStateFilterEnum.READY, False),
+        (0, 3, ModelStateFilterEnum.NOT_READY, True),
+        (2, 3, ModelStateFilterEnum.NOT_READY, False),
+        (0, 0, ModelStateFilterEnum.STOPPED, True),
+        (0, 3, ModelStateFilterEnum.STOPPED, False),
+        (0, 3, None, True),
+    ],
+)
+def test_model_watch_filter_applies_state(
+    monkeypatch, ready, replicas, state, expected
+):
+    """The /models watch stream honors ``state`` via replica counts."""
+    monkeypatch.setattr(models_route, "cluster_scoped_system", lambda ctx: False)
+
+    visible = models_route._make_model_watch_filter(
+        ctx=None, categories=None, state=state
+    )
+    data = SimpleNamespace(ready_replicas=ready, replicas=replicas)
+    assert visible(data) is expected
+
+
+def test_model_watch_filter_passes_id_only_delete_events(monkeypatch):
+    """ID-only DELETED payloads lack replica counts and must not be dropped
+    by the state filter, else watch clients hold stale rows."""
+    monkeypatch.setattr(models_route, "cluster_scoped_system", lambda ctx: False)
+
+    visible = models_route._make_model_watch_filter(
+        ctx=None, categories=None, state=ModelStateFilterEnum.READY
+    )
+    assert visible({"id": 7}) is True

--- a/tests/routes/test_model_routes.py
+++ b/tests/routes/test_model_routes.py
@@ -11,6 +11,11 @@ from sqlalchemy import true
 from gpustack.api.exceptions import InvalidException
 from gpustack.api.tenant import TenantContext
 from gpustack.routes import model_routes
+from gpustack.routes.model_common import (
+    ModelStateFilterEnum,
+    categories_filter,
+    state_stream_filter,
+)
 from gpustack.schemas.common import Pagination
 from gpustack.schemas.model_routes import (
     AccessPolicyEnum,
@@ -90,6 +95,149 @@ async def test_get_model_routes_filters_categories_on_target_class(monkeypatch):
     assert captured["categories"] == ["image"]
     assert captured["fields"]["user_id"] == 123
     assert captured["extra_conditions"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_class", [MyModel, ModelRoute])
+@pytest.mark.parametrize(
+    "state, expected_fragments",
+    [
+        (ModelStateFilterEnum.READY, ["ready_targets > 0"]),
+        (ModelStateFilterEnum.NOT_READY, ["ready_targets = 0", "targets > 0"]),
+        (ModelStateFilterEnum.STOPPED, ["targets = 0"]),
+    ],
+)
+async def test_get_model_routes_filters_state_on_target_class(
+    monkeypatch, target_class, state, expected_fragments
+):
+    """The ``state`` filter mirrors Model readiness against a route's
+    target counts, on both the MyModel view and the ModelRoute table."""
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_async_session():
+        yield object()
+
+    async def fake_paginated_by_query(**kwargs):
+        captured["extra_conditions"] = kwargs["extra_conditions"]
+        return ModelRoutesPublic(
+            items=[],
+            pagination=Pagination(page=1, perPage=24, total=0, totalPage=0),
+        )
+
+    monkeypatch.setattr(model_routes, "async_session", fake_async_session)
+    monkeypatch.setattr(target_class, "paginated_by_query", fake_paginated_by_query)
+
+    await model_routes._get_model_routes(
+        params=ModelRouteListParams(page=1, perPage=24),
+        state=state,
+        target_class=target_class,
+    )
+
+    rendered = " ".join(_compile(c) for c in captured["extra_conditions"])
+    for fragment in expected_fragments:
+        assert fragment in rendered
+
+
+@pytest.mark.asyncio
+async def test_get_model_routes_without_state_adds_no_readiness_condition(monkeypatch):
+    """Omitting ``state`` leaves the query unconstrained by target counts."""
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_async_session():
+        yield object()
+
+    async def fake_paginated_by_query(**kwargs):
+        captured["extra_conditions"] = kwargs["extra_conditions"]
+        return ModelRoutesPublic(
+            items=[],
+            pagination=Pagination(page=1, perPage=24, total=0, totalPage=0),
+        )
+
+    monkeypatch.setattr(model_routes, "async_session", fake_async_session)
+    monkeypatch.setattr(MyModel, "paginated_by_query", fake_paginated_by_query)
+
+    await model_routes._get_model_routes(
+        params=ModelRouteListParams(page=1, perPage=24),
+        target_class=MyModel,
+        user_id=123,
+    )
+
+    rendered = " ".join(_compile(c) for c in captured["extra_conditions"])
+    assert "ready_targets" not in rendered
+    assert "targets >" not in rendered
+    assert "targets =" not in rendered
+
+
+@pytest.mark.parametrize(
+    "ready, total, state, expected",
+    [
+        (2, 3, ModelStateFilterEnum.READY, True),
+        (0, 3, ModelStateFilterEnum.READY, False),
+        (0, 3, ModelStateFilterEnum.NOT_READY, True),
+        (2, 3, ModelStateFilterEnum.NOT_READY, False),
+        (0, 0, ModelStateFilterEnum.NOT_READY, False),
+        (0, 0, ModelStateFilterEnum.STOPPED, True),
+        (0, 3, ModelStateFilterEnum.STOPPED, False),
+        (0, 3, None, True),
+    ],
+)
+def test_state_stream_filter_matches_sql_semantics(ready, total, state, expected):
+    """The watch-path predicate agrees with the SQL branch for routes."""
+    data = SimpleNamespace(ready_targets=ready, targets=total)
+    assert state_stream_filter(data, state, "ready_targets", "targets") is expected
+
+
+def test_state_stream_filter_passes_id_only_delete_events():
+    """ID-only DELETED payloads carry no target counts; the filter must let
+    them through so watch clients drop the row instead of going stale."""
+    assert (
+        state_stream_filter(
+            {"id": 9}, ModelStateFilterEnum.READY, "ready_targets", "targets"
+        )
+        is True
+    )
+
+
+def test_categories_filter_matches_and_passes_id_only_events():
+    """Categories match against ``data.categories``; ID-only payloads that
+    lack the attribute pass through rather than erroring the stream."""
+    assert categories_filter(SimpleNamespace(categories=["image"]), ["image"]) is True
+    assert categories_filter(SimpleNamespace(categories=["text"]), ["image"]) is False
+    assert categories_filter(SimpleNamespace(categories=None), [""]) is True
+    # No categories requested is always a match, regardless of payload shape.
+    assert categories_filter({"id": 9}, None) is True
+    # ID-only DELETED payload with an active category filter must not raise.
+    assert categories_filter({"id": 9}, ["image"]) is True
+
+
+@pytest.mark.asyncio
+async def test_get_model_routes_stream_applies_state_filter(monkeypatch):
+    """The watch/streaming branch honors ``state`` too, not just the
+    paginated query."""
+    captured = {}
+
+    def fake_streaming(**kwargs):
+        captured["filter_func"] = kwargs["filter_func"]
+
+        async def _gen():
+            return
+            yield
+
+        return _gen()
+
+    monkeypatch.setattr(MyModel, "streaming", fake_streaming)
+
+    await model_routes._get_model_routes(
+        params=ModelRouteListParams(page=1, perPage=24, watch=True),
+        state=ModelStateFilterEnum.READY,
+        target_class=MyModel,
+    )
+
+    filter_func = captured["filter_func"]
+    assert filter_func(SimpleNamespace(ready_targets=1, targets=1)) is True
+    assert filter_func(SimpleNamespace(ready_targets=0, targets=1)) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Mirror the /models state filter (ready/not_ready/stopped) on the my-models consumption endpoint, computed from a route's target counts: READY when any target is ready, NOT_READY when it has targets but none ready, STOPPED when it has no targets. Works on both the non-admin MyModel view and the admin ModelRoute table.