### PR TITLE
chore(tool): bump gguf-parser version

### DIFF
--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -16,7 +16,7 @@ from gpustack.worker.backend_dependency_manager import BackendDependencyManager
 logger = logging.getLogger(__name__)
 
 
-BUILTIN_GGUF_PARSER_VERSION = "v0.24.1"
+BUILTIN_GGUF_PARSER_VERSION = "v0.25.0"
 
 
 class ToolsManager:


### PR DESCRIPTION
Bump gguf-parser, see https://github.com/gpustack/gguf-parser-go/pull/22.