### PR TITLE
feat(chart): add server.extraVolumes/extraVolumeMounts

### DIFF
--- a/charts/gpustack-chart/README.md
+++ b/charts/gpustack-chart/README.md
@@ -111,6 +111,8 @@ If you need to customize Higress parameters, refer to the [Higress documentation
 | server.apiPort                           | 30080                             | API service port                                                          |
 | server.metricsPort                       | 10161                             | Metrics port                                                              |
 | server.environmentConfig                 | {}                                | Extra environment variables for GPUStack server                           |
+| server.extraVolumeMounts                 | []                                | Extra volume mounts appended to the server container                      |
+| server.extraVolumes                      | []                                | Extra volumes appended to the server StatefulSet                          |
 | server.nodeSelector                      | {}                                | Server pod nodeSelector; replaces `global.nodeSelector` when non-empty    |
 | gateway.ingressClassname                 | higress                           | Higress IngressClass name; enables in-cluster mode when found             |
 | higress-core.enabled                     | true                              | Deploy Higress gateway as a sub-chart; disable if already installed       |

--- a/charts/gpustack-chart/templates/server-statefulset.yaml
+++ b/charts/gpustack-chart/templates/server-statefulset.yaml
@@ -90,6 +90,9 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/gpustack
               name: gpustack-data-dir
+            {{- with .Values.server.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -100,12 +103,17 @@ spec:
       nodeSelector:
         {{- nindent 8 . }}
       {{- end }}
-      {{- if .Values.server.dataVolume.hostPath }}
+      {{- if or .Values.server.dataVolume.hostPath .Values.server.extraVolumes }}
       volumes:
+        {{- if .Values.server.dataVolume.hostPath }}
         - name: gpustack-data-dir
           hostPath:
             path: {{ .Values.server.dataVolume.hostPath }}
             type: DirectoryOrCreate
+        {{- end }}
+        {{- with .Values.server.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
   {{- if not .Values.server.dataVolume.hostPath }}
   volumeClaimTemplates:

--- a/charts/gpustack-chart/values.yaml
+++ b/charts/gpustack-chart/values.yaml
@@ -82,6 +82,19 @@ server:
   apiPort: 30080
   metricsPort: 10161
   environmentConfig: {}
+  # Extra volume mounts for the server container. Use together with
+  # `extraVolumes` to mount additional files into the server pod, e.g. a
+  # private/self-signed CA into /usr/local/share/ca-certificates/ so that
+  # gpustack-prerun.sh merges it into the OS CA bundle at startup.
+  extraVolumeMounts: []
+  # - name: private-ca
+  #   mountPath: /usr/local/share/ca-certificates/my-ca.crt
+  #   subPath: my-ca.crt
+  #   readOnly: true
+  extraVolumes: []
+  # - name: private-ca
+  #   configMap:
+  #     name: private-ca
   # Node selector for the server pod. When non-empty, REPLACES
   # `global.nodeSelector` entirely (no merging). Leave empty/null to fall
   # back to `global.nodeSelector`.


### PR DESCRIPTION
Mirror the existing worker.extraVolumes/extraVolumeMounts support on the server component so extra files can be mounted into the server pod via values alone. The primary use case is trusting a private/self-signed CA by dropping a .crt into /usr/local/share/ca-certificates/, which gpustack-prerun.sh merges into the OS CA bundle at startup (needed for CAS/OIDC validation against a self-signed IdP).

The server StatefulSet only rendered a `volumes:` block when dataVolume.hostPath was set (default uses a volumeClaimTemplate), so the block now renders when either hostPath or extraVolumes is present to avoid silently dropping extra volumes in the default deployment.

Refer to issue:
- #5848 