### PR TITLE
fix(k8s): apply worker_port/worker_metrics_port to rendered manifests

### DIFF
--- a/gpustack/k8s/daemonset.jinja
+++ b/gpustack/k8s/daemonset.jinja
@@ -30,6 +30,10 @@ spec:
         - env:
             - name: GPUSTACK_SERVER_URL
               value: {{ config.server_url }}
+            - name: GPUSTACK_WORKER_PORT
+              value: "{{ config.worker_port }}"
+            - name: GPUSTACK_WORKER_METRICS_PORT
+              value: "{{ config.worker_metrics_port }}"
             - name: GPUSTACK_WORKER_NAME
               valueFrom:
                 fieldRef:
@@ -139,10 +143,10 @@ spec:
             {%- endif %}
           ports:
             - name: api
-              containerPort: 10150
+              containerPort: {{ config.worker_port }}
               protocol: TCP
             - name: metrics
-              containerPort: 10151
+              containerPort: {{ config.worker_metrics_port }}
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/gpustack/k8s/manifest_template.py
+++ b/gpustack/k8s/manifest_template.py
@@ -95,6 +95,13 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
     # image registry prefix and the GPUSTACK_CONTAINER_REGISTRY env var
     # surfaced to the operator at runtime.
     system_default_container_registry: Optional[str] = None
+    # Worker listen/metrics ports, sourced from ``cluster.worker_config``
+    # (``worker_port``/``worker_metrics_port``). Threaded into the worker
+    # container env (so the worker binds these ports), the DaemonSet
+    # containerPorts, and the Service ports + prometheus scrape annotation.
+    # Fall back to the built-in defaults when the cluster doesn't override them.
+    worker_port: int = 10150
+    worker_metrics_port: int = 10151
     workers: List[WorkerRenderSpec] = []
     # Pre-computed Secret render data, one per K8sOptions.image_credentials
     # entry. Both image_pull_secrets.jinja (Secret resource) and the

--- a/gpustack/k8s/manifests.jinja
+++ b/gpustack/k8s/manifests.jinja
@@ -43,7 +43,7 @@ metadata:
   namespace: {{ config.namespace }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "10151"
+    prometheus.io/port: "{{ config.worker_metrics_port }}"
     prometheus.io/path: "/metrics"
 spec:
   type: ClusterIP
@@ -55,8 +55,8 @@ spec:
     {%- endif %}
   ports:
     - name: api
-      port: 10150
-      targetPort: 10150
+      port: {{ config.worker_port }}
+      targetPort: {{ config.worker_port }}
     - name: metrics
-      port: 10151
-      targetPort: 10151
+      port: {{ config.worker_metrics_port }}
+      targetPort: {{ config.worker_metrics_port }}

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -766,13 +766,24 @@ async def get_cluster_manifests(
     if not k8s_options.operator_image:
         k8s_options.operator_image = cfg.operator_image
 
-    config = TemplateConfig(
-        registration=get_registration_from_cluster(request, cluster),
-        cluster_owner_principal_identifier=principal_namespace_identifier(principal),
-        runtimes=runtime,
-        k8s_options=k8s_options,
-        system_default_container_registry=cluster.system_default_container_registry,
-    )
+    # Only forward worker ports when the cluster explicitly overrides them;
+    # otherwise let TemplateConfig fall back to its own defaults rather than
+    # duplicating the default constants here.
+    worker_config = cluster.worker_config
+    config_kwargs = {
+        "registration": get_registration_from_cluster(request, cluster),
+        "cluster_owner_principal_identifier": principal_namespace_identifier(principal),
+        "runtimes": runtime,
+        "k8s_options": k8s_options,
+        "system_default_container_registry": cluster.system_default_container_registry,
+    }
+    if worker_config:
+        if worker_config.worker_port is not None:
+            config_kwargs["worker_port"] = worker_config.worker_port
+        if worker_config.worker_metrics_port is not None:
+            config_kwargs["worker_metrics_port"] = worker_config.worker_metrics_port
+
+    config = TemplateConfig(**config_kwargs)
     yaml_content = config.render()
     return Response(
         content=yaml_content,

--- a/tests/k8s/test_template_render.py
+++ b/tests/k8s/test_template_render.py
@@ -614,3 +614,74 @@ def test_operator_env_vars_absent_when_not_set():
     env_names = {e["name"] for e in env}
     assert "MY_VAR" not in env_names
     assert "OTHER_VAR" not in env_names
+
+
+# ---------------------------------------------------------------------------
+# Worker ports — worker_port / worker_metrics_port from the cluster config
+# must flow into the worker container (env, so prerun binds them), the
+# DaemonSet containerPorts, and the Service ports + prometheus scrape
+# annotation. Otherwise a cluster overriding the defaults renders a Service
+# that routes to the wrong port and a worker that binds the defaults.
+# ---------------------------------------------------------------------------
+
+
+def _worker_service(docs):
+    return next(
+        d
+        for d in docs
+        if d.get("kind") == "Service" and d["metadata"]["name"] == "worker"
+    )
+
+
+def _worker_container(ds):
+    return _pod_spec(ds)["containers"][0]
+
+
+def _container_env_map(container):
+    return {e["name"]: e.get("value") for e in container.get("env", []) if "value" in e}
+
+
+def _container_port_map(container):
+    return {p["name"]: p["containerPort"] for p in container.get("ports", [])}
+
+
+def test_worker_ports_default_to_10150_10151():
+    """With no override, the worker api/metrics ports fall back to the
+    built-in defaults across the Service, containerPorts, env, and the
+    prometheus annotation."""
+    docs = _render_docs()
+
+    svc = _worker_service(docs)
+    port_by_name = {
+        p["name"]: (p["port"], p["targetPort"]) for p in svc["spec"]["ports"]
+    }
+    assert port_by_name["api"] == (10150, 10150)
+    assert port_by_name["metrics"] == (10151, 10151)
+    assert svc["metadata"]["annotations"]["prometheus.io/port"] == "10151"
+
+    container = _worker_container(_daemonsets(docs)[WORKER_DS_BASENAME])
+    assert _container_port_map(container) == {"api": 10150, "metrics": 10151}
+    env = _container_env_map(container)
+    assert env["GPUSTACK_WORKER_PORT"] == "10150"
+    assert env["GPUSTACK_WORKER_METRICS_PORT"] == "10151"
+
+
+def test_worker_ports_override_propagates_everywhere():
+    """A cluster overriding worker_port/worker_metrics_port renders those
+    ports into the Service, containerPorts, worker env, and the prometheus
+    annotation — so routing and the worker's own bind agree."""
+    docs = _render_docs(worker_port=10152, worker_metrics_port=10153)
+
+    svc = _worker_service(docs)
+    port_by_name = {
+        p["name"]: (p["port"], p["targetPort"]) for p in svc["spec"]["ports"]
+    }
+    assert port_by_name["api"] == (10152, 10152)
+    assert port_by_name["metrics"] == (10153, 10153)
+    assert svc["metadata"]["annotations"]["prometheus.io/port"] == "10153"
+
+    container = _worker_container(_daemonsets(docs)[WORKER_DS_BASENAME])
+    assert _container_port_map(container) == {"api": 10152, "metrics": 10153}
+    env = _container_env_map(container)
+    assert env["GPUSTACK_WORKER_PORT"] == "10152"
+    assert env["GPUSTACK_WORKER_METRICS_PORT"] == "10153"


### PR DESCRIPTION
The worker api/metrics ports configured on cluster.worker_config were ignored when rendering a Kubernetes cluster's manifests: the Service ports, the prometheus scrape annotation, and the DaemonSet containerPorts were all hardcoded to the defaults 10150/10151, and the worker container never received the configured ports.

The worker does learn non-sensitive config (worker_port included) via the registration response and applies it at runtime, but that happens only after the container's s6 `prerun` port-availability check has run. prerun sees local env/CLI config only, so it checked the default ports, found them occupied, and aborted the container before the worker could register and rebind. A cluster that overrode the ports (e.g. to dodge a 10150/10151 conflict) therefore failed to start with "Port 10150 ... is not available".

Thread worker_port/worker_metrics_port from cluster.worker_config into TemplateConfig and render them into:
- the worker Service port/targetPort and the prometheus.io/port annotation, so gateway/metrics routing reaches the worker;
- the DaemonSet containerPorts;
- GPUSTACK_WORKER_PORT / GPUSTACK_WORKER_METRICS_PORT env on the worker container, so prerun and the worker bind the configured ports at startup (env-set fields take precedence over the registration-delivered values, keeping the two channels consistent).


Refer to issue:
- #5846