### PR TITLE
feat(usage): add organization breakdown and org/user-group filters

### DIFF
--- a/gpustack/migrations/versions/2026_06_24_1100-c4d7e8f9a0b1_v2_2_2_database_changes.py
+++ b/gpustack/migrations/versions/2026_06_24_1100-c4d7e8f9a0b1_v2_2_2_database_changes.py
@@ -41,6 +41,14 @@ Bundles the pre-release schema tweaks for v2.2.2:
    ``phase=Deleting`` and the finalizer controllers track downstream CR
    cleanup in ``finalizing`` before the row is hard-deleted.
 
+6. Snapshot the consumer principal name / kind onto the usage tables for the
+   Organization breakdown: ``model_usages`` gains ``consumer_name`` +
+   ``consumer_principal_kind`` (it had neither), while ``metered_usage`` /
+   ``resource_events`` (+archives) — which already carry ``consumer_name`` —
+   gain just ``consumer_principal_kind``. All nullable, no backfill; the read
+   path resolves the name live for pre-upgrade rows and only relies on the
+   snapshot for hard-deleted principals.
+
 Revision ID: c4d7e8f9a0b1
 Revises: b2c3d4e5f6a7
 Create Date: 2026-06-24 11:00:00.000000
@@ -51,6 +59,7 @@ from typing import Optional, Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+import sqlmodel
 import gpustack
 
 
@@ -210,10 +219,62 @@ def upgrade() -> None:
             sa.Column('status', gpustack.schemas.common.JSON(), nullable=True)
         )
 
+    # Part 6: snapshot the consumer principal name / kind onto the usage tables
+    # so the Organization breakdown keeps a deleted org's name and can tag a
+    # personal (USER) consumer — parity with the other ``*_name`` denorms.
+    # ``model_usages`` never carried a consumer name, so it gets both columns;
+    # ``metered_usage`` / ``resource_events`` (+archives) already carry
+    # ``consumer_name`` from their create migration, so they only add the kind.
+    # All nullable, no backfill: pre-upgrade rows resolve the name via a live
+    # principals lookup at read time.
+    with op.batch_alter_table('model_usages', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'consumer_name',
+                sqlmodel.sql.sqltypes.AutoString(),
+                nullable=True,
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                'consumer_principal_kind',
+                sqlmodel.sql.sqltypes.AutoString(),
+                nullable=True,
+            )
+        )
+
+    for table in (
+        'metered_usage',
+        'metered_usage_archive',
+        'resource_events',
+        'resource_events_archive',
+    ):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    'consumer_principal_kind',
+                    sqlmodel.sql.sqltypes.AutoString(),
+                    nullable=True,
+                )
+            )
+
 
 def downgrade() -> None:
     bind = op.get_bind()
     dialect = bind.dialect.name
+
+    # Revert part 6: drop the consumer name / kind snapshot columns.
+    for table in (
+        'resource_events_archive',
+        'resource_events',
+        'metered_usage_archive',
+        'metered_usage',
+    ):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_column('consumer_principal_kind')
+    with op.batch_alter_table('model_usages', schema=None) as batch_op:
+        batch_op.drop_column('consumer_principal_kind')
+        batch_op.drop_column('consumer_name')
 
     # Revert part 5: drop the pv/pvt status column.
     with op.batch_alter_table(

--- a/gpustack/routes/resource_usage.py
+++ b/gpustack/routes/resource_usage.py
@@ -23,8 +23,12 @@ from sqlalchemy import and_, case, desc, func, literal_column, or_
 from sqlmodel import select
 
 from gpustack import envs
-from gpustack.api.exceptions import InvalidException
-from gpustack.routes.usage import _resolve_effective_scope
+from gpustack.api.exceptions import ForbiddenException, InvalidException
+from gpustack.routes.usage import (
+    _group_member_user_ids,
+    _organization_info_by_id,
+    _resolve_effective_scope,
+)
 from gpustack.schemas.common import Pagination
 from gpustack.schemas.metered_usage import (
     METER_INSTANCE_UPTIME,
@@ -39,7 +43,11 @@ from gpustack.schemas.gpu_instance_persistent_volumes import (
 )
 from gpustack.schemas.gpu_instances import GPUInstance
 from gpustack.schemas.model_usage import ModelUsage
-from gpustack.schemas.principals import Principal
+from gpustack.schemas.principals import (
+    Principal,
+    PrincipalType,
+    is_reserved_principal_name,
+)
 from gpustack.schemas.usage import (
     USAGE_GRANULARITY_DAY,
     USAGE_GRANULARITY_MONTH,
@@ -119,6 +127,12 @@ class ResourceBreakdownRequest(BaseModel):
     # receives the kind that matches its ``base_filter``.
     instance_ids: Optional[List[int]] = None
     volume_ids: Optional[List[int]] = None
+    # Platform-wide "All" view only (admin, no selected Org). ``organization_ids``
+    # narrows ``consumer_principal_id``; ``user_group_ids`` is expanded to the
+    # groups' direct USER members and narrows ``creator_id``. Both are gated in
+    # ``_run_breakdown`` (org: admin-only; user-group: non-self scope).
+    organization_ids: Optional[List[int]] = None
+    user_group_ids: Optional[List[int]] = None
     # ``-1`` is the no-pagination sentinel (return all buckets) used by the
     # trend chart and the export path; any other value must be positive.
     page: int = 1
@@ -157,6 +171,48 @@ def _parse_id_csv(value: Optional[str]) -> Optional[List[int]]:
             except ValueError:
                 continue
     return out or None
+
+
+def _is_platform_wide(user, ctx) -> bool:
+    """Platform admin acting without a pinned Org — the only context where the
+    cross-tenant Organization dimension / filter is meaningful (mirrors
+    ``/usage`` and the meta gating)."""
+    return bool(getattr(user, "is_admin", False)) and (
+        ctx is None or getattr(ctx, "current_principal_id", None) is None
+    )
+
+
+def _check_resource_filter_permission(
+    user,
+    ctx,
+    effective_scope: str,
+    *,
+    organization_ids=None,
+    user_group_ids=None,
+) -> None:
+    """Gate the cross-tenant filters (shared by breakdown + GET endpoints).
+
+    Organization filtering is the platform-wide "All" view — a platform admin
+    without a pinned Org. The user-group filter is a cross-user surface, so
+    it's forbidden in self scope (mirrors the token usage gating)."""
+    if organization_ids and not _is_platform_wide(user, ctx):
+        raise ForbiddenException(message="No permission to filter by organization")
+    if user_group_ids and effective_scope == USAGE_SCOPE_SELF:
+        raise ForbiddenException(message="No permission to filter by user group")
+
+
+def _check_resource_permission(user, ctx, request, effective_scope: str) -> None:
+    """Breakdown gating — the filter checks plus the organization group-by
+    dimension (also platform-wide-only)."""
+    if "organization" in request.group_by and not _is_platform_wide(user, ctx):
+        raise ForbiddenException(message="No permission to group by organization")
+    _check_resource_filter_permission(
+        user,
+        ctx,
+        effective_scope,
+        organization_ids=request.organization_ids,
+        user_group_ids=request.user_group_ids,
+    )
 
 
 # group_by token → (label column expr factory). resource/user/sku/date.
@@ -199,6 +255,14 @@ def _group_columns(
                 MeteredUsage.creator_name.label("group_key"),
             ],
             [MeteredUsage.creator_id, MeteredUsage.creator_name],
+        )
+    if group_by == "organization":
+        # Consumer Org (``consumer_principal_id``). No name is denormalized on
+        # metered_usage, so ``_enrich_items`` resolves it live from principals
+        # (same as the token side). Only the id column is carried here.
+        return (
+            [MeteredUsage.consumer_principal_id.label("group_id")],
+            [MeteredUsage.consumer_principal_id],
         )
     if group_by == "date":
         expr = _bucket_expr(session, granularity)
@@ -320,6 +384,8 @@ def _apply_scope(
     base_filter=None,
     creator_ids=None,
     resource_ids=None,
+    organization_ids=None,
+    group_member_ids=None,
 ):
     if base_filter is not None:
         statement = statement.where(base_filter)
@@ -336,10 +402,18 @@ def _apply_scope(
         statement = statement.where(MeteredUsage.creator_id.in_(creator_ids))
     if resource_ids:
         statement = statement.where(MeteredUsage.resource_id.in_(resource_ids))
+    if organization_ids:
+        statement = statement.where(
+            MeteredUsage.consumer_principal_id.in_(organization_ids)
+        )
+    # ``None`` → no user-group filter; an empty set → the group has no members,
+    # so match nothing rather than silently ignoring the filter.
+    if group_member_ids is not None:
+        statement = statement.where(MeteredUsage.creator_id.in_(group_member_ids))
     return statement
 
 
-async def _enrich_items(session, gb: str, items: List[dict]) -> None:
+async def _enrich_items(session, gb: str, items: List[dict]) -> None:  # noqa: C901
     """Post-query enrichment of breakdown rows (mutates ``items`` in place).
 
     * entity groupings (user / instance / volume): resolve display names
@@ -382,6 +456,28 @@ async def _enrich_items(session, gb: str, items: List[dict]) -> None:
             if gb == "user" and names.get(rid):
                 i["key"] = names[rid]
             i["deleted"] = rid not in existing
+
+    # Organization grouping: prefer the LIVE principal name (fresh on rename,
+    # consistent with the token breakdown); fall back to the row
+    # ``consumer_name`` / kind snapshot only when the principal is gone
+    # (hard-deleted), then to ``Org #{id}`` so a pre-upgrade deleted row never
+    # renders an empty label. The live map doubles as the existence check (id
+    # absent → gone → deleted). A NULL consumer id is un-attributed usage —
+    # left keyless ("Untracked").
+    if gb == "organization":
+        ids = [i["id"] for i in items if i.get("id") is not None]
+        info = await _organization_info_by_id(session, ids)
+        for i in items:
+            rid = i.get("id")
+            if rid is None:
+                i["deleted"] = False
+                continue
+            live = info.get(rid)
+            snapshot_name = i.pop("_org_name", None)
+            snapshot_kind = i.pop("_org_kind", None)
+            i["key"] = (live[0] if live else None) or snapshot_name or f"Org {rid}"
+            i["organization_kind"] = (live[1] if live else None) or snapshot_kind
+            i["deleted"] = live is None
 
     # Per-entity rows carry their owner (``creator_id``/``creator_name``); flag
     # whether that principal still exists so the UI can tag a since-deleted
@@ -560,8 +656,16 @@ async def _run_breakdown(  # noqa: C901
     join_volumes: bool = True,
 ):
     effective_scope = _resolve_effective_scope(user, ctx, request.scope)
+    _check_resource_permission(user, ctx, request, effective_scope)
     metrics = _metric_columns()
     metric_keys = [k for k in metric_keys if k in metrics]
+
+    # Expand any user-group filter to its direct USER members before building
+    # the query so the (sync) scope application can apply a plain creator_id
+    # membership.
+    group_member_ids = None
+    if request.user_group_ids:
+        group_member_ids = await _group_member_user_ids(session, request.user_group_ids)
 
     resource_ids = (request.instance_ids or []) + (request.volume_ids or [])
     base = select().select_from(MeteredUsage)
@@ -573,6 +677,8 @@ async def _run_breakdown(  # noqa: C901
         base_filter=base_filter,
         creator_ids=request.creator_ids,
         resource_ids=resource_ids or None,
+        organization_ids=request.organization_ids,
+        group_member_ids=group_member_ids,
     )
     base = _bucket_in_range(base, request.start_date, request.end_date)
 
@@ -657,6 +763,15 @@ async def _run_breakdown(  # noqa: C901
             func.max(MeteredUsage.creator_id).label("creator_id"),
             func.max(MeteredUsage.creator_name).label("creator_name"),
         ]
+    # Organization grouping is by consumer_principal_id only; carry the
+    # consumer name / kind snapshot (MAX picks up whichever rows have it —
+    # pre-upgrade rows are NULL) so a deleted Org keeps its name and personal
+    # (USER) rows are taggable, resolved in ``_enrich_items``.
+    if "organization" in request.group_by:
+        agg_cols += [
+            func.max(MeteredUsage.consumer_name).label("org_name"),
+            func.max(MeteredUsage.consumer_principal_kind).label("org_kind"),
+        ]
     grouped = base.with_only_columns(*select_cols, *agg_cols).group_by(*group_cols)
 
     order_key = request.order_by or (metric_keys[0] if metric_keys else None)
@@ -719,6 +834,11 @@ async def _run_breakdown(  # noqa: C901
         # enrichment can fetch the right per-shape representative for display.
         if hasattr(row, "group_sku_count"):
             item["_sku_count"] = getattr(row, "group_sku_count", None)
+        # Organization grouping: carry the consumer name / kind snapshot for
+        # ``_enrich_items`` (popped there once the display key is resolved).
+        if hasattr(row, "org_name"):
+            item["_org_name"] = getattr(row, "org_name", None)
+            item["_org_kind"] = getattr(row, "org_kind", None)
         item["sku"] = getattr(row, "sku", None)
         # Owner of the resource, present only for resource-dimension groupings
         # (see ``carries_creator``) so per-instance / per-volume (and
@@ -793,7 +913,7 @@ async def gpu_instances_breakdown(
     ctx: TenantContextDep,
     request: ResourceBreakdownRequest,
 ):
-    allowed = {"instance_type", "instance", "user", "date"}
+    allowed = {"instance_type", "instance", "user", "date", "organization"}
     request.group_by = [g for g in request.group_by if g in allowed] or [
         "instance_type"
     ]
@@ -823,7 +943,7 @@ async def storage_breakdown(
     ctx: TenantContextDep,
     request: ResourceBreakdownRequest,
 ):
-    allowed = {"type", "volume", "user", "date"}
+    allowed = {"type", "volume", "user", "date", "organization"}
     request.group_by = [g for g in request.group_by if g in allowed] or ["type"]
     return await _run_breakdown(
         session,
@@ -845,15 +965,35 @@ async def usage_summary(
     end_date: date,
     scope: str = USAGE_SCOPE_ALL,
     creator_ids: Optional[str] = None,
+    organization_ids: Optional[str] = None,
+    user_group_ids: Optional[str] = None,
 ):
     effective_scope = _resolve_effective_scope(user, ctx, scope)
     org_id = ctx.current_principal_id if ctx is not None else None
     creator_id_list = _parse_id_csv(creator_ids)
+    organization_id_list = _parse_id_csv(organization_ids)
+    user_group_id_list = _parse_id_csv(user_group_ids)
+    _check_resource_filter_permission(
+        user,
+        ctx,
+        effective_scope,
+        organization_ids=organization_id_list,
+        user_group_ids=user_group_id_list,
+    )
+    group_member_ids = None
+    if user_group_id_list:
+        group_member_ids = await _group_member_user_ids(session, user_group_id_list)
 
     # metered_usage side (instances + storage)
     mu = select().select_from(MeteredUsage)
     mu = _apply_scope(
-        mu, user=user, ctx=ctx, scope=effective_scope, creator_ids=creator_id_list
+        mu,
+        user=user,
+        ctx=ctx,
+        scope=effective_scope,
+        creator_ids=creator_id_list,
+        organization_ids=organization_id_list,
+        group_member_ids=group_member_ids,
     )
     mu = _bucket_in_range(mu, start_date, end_date)
     metrics = _metric_columns()
@@ -880,6 +1020,10 @@ async def usage_summary(
         tu = tu.where(ModelUsage.consumer_principal_id == org_id)
     if creator_id_list:
         tu = tu.where(ModelUsage.user_id.in_(creator_id_list))
+    if organization_id_list:
+        tu = tu.where(ModelUsage.consumer_principal_id.in_(organization_id_list))
+    if group_member_ids is not None:
+        tu = tu.where(ModelUsage.user_id.in_(group_member_ids))
     tu = tu.where(ModelUsage.date >= start_date).where(ModelUsage.date <= end_date)
     tu_row = (
         await session.exec(
@@ -933,7 +1077,7 @@ def _phase_message_of(spec_snapshot) -> Optional[str]:
 
 
 @router.get("/resource-events")
-async def resource_events(
+async def resource_events(  # noqa: C901
     session: SessionDep,
     user: CurrentUserDep,
     ctx: TenantContextDep,
@@ -944,12 +1088,26 @@ async def resource_events(
     event_types: Optional[str] = None,
     scope: str = USAGE_SCOPE_ALL,
     creator_ids: Optional[str] = None,
+    organization_ids: Optional[str] = None,
+    user_group_ids: Optional[str] = None,
     page: int = 1,
     perPage: int = 50,
 ):
     effective_scope = _resolve_effective_scope(user, ctx, scope)
     org_id = ctx.current_principal_id if ctx is not None else None
     creator_id_list = _parse_id_csv(creator_ids)
+    organization_id_list = _parse_id_csv(organization_ids)
+    user_group_id_list = _parse_id_csv(user_group_ids)
+    _check_resource_filter_permission(
+        user,
+        ctx,
+        effective_scope,
+        organization_ids=organization_id_list,
+        user_group_ids=user_group_id_list,
+    )
+    group_member_ids = None
+    if user_group_id_list:
+        group_member_ids = await _group_member_user_ids(session, user_group_id_list)
     # Comma-separated event types (e.g. "created,deleted"); the only emitted
     # types are created / deleted / phase_to_metered / phase_left_metered.
     event_type_list = (
@@ -966,6 +1124,10 @@ async def resource_events(
         stmt = stmt.where(ResourceEvent.consumer_principal_id == org_id)
     if creator_id_list:
         stmt = stmt.where(ResourceEvent.creator_id.in_(creator_id_list))
+    if organization_id_list:
+        stmt = stmt.where(ResourceEvent.consumer_principal_id.in_(organization_id_list))
+    if group_member_ids is not None:
+        stmt = stmt.where(ResourceEvent.creator_id.in_(group_member_ids))
     if resource_type:
         stmt = stmt.where(ResourceEvent.resource_type == resource_type)
     if event_type_list:
@@ -1058,7 +1220,7 @@ async def _creator_name_snapshots(session, ids: Set[int]) -> Dict[int, str]:
 
 
 @router.get("/resource/meta")
-async def resource_meta(
+async def resource_meta(  # noqa: C901
     session: SessionDep,
     user: CurrentUserDep,
     ctx: TenantContextDep,
@@ -1169,4 +1331,82 @@ async def resource_meta(
         [RESOURCE_TYPE_PERSISTENT_VOLUME], GPUInstancePersistentVolume
     )
 
-    return {"creators": creators, "instances": instances, "volumes": volumes}
+    # Organization + user-group filter sources — both are the cross-tenant
+    # "All" view only: admin acting without a selected Org. A caller scoped to
+    # a single Org (org owner, or admin with a pinned Org) sees neither, since
+    # cross-Org grouping / group filtering is meaningless within one tenant
+    # (mirrors the Tokens tab's /usage/meta gating).
+    organizations: List[Dict[str, Any]] = []
+    user_groups: List[Dict[str, Any]] = []
+    if user.is_admin and org_id is None:
+        groups = (
+            await session.exec(
+                select(Principal)
+                .where(
+                    Principal.kind == PrincipalType.GROUP,
+                    Principal.deleted_at.is_(None),
+                )
+                .order_by(Principal.display_name, Principal.name)
+            )
+        ).all()
+        user_groups = [
+            {"id": g.id, "label": g.display_name or g.name or f"Group {g.id}"}
+            for g in groups
+            if not is_reserved_principal_name(g.name)
+        ]
+        # Platform-wide: no scope filter applies, so a plain distinct over
+        # both sources yields every consumer Org that has usage.
+        org_ids: Set[int] = set()
+        for scope_col in (
+            MeteredUsage.consumer_principal_id,
+            ResourceEvent.consumer_principal_id,
+        ):
+            rows = (
+                await session.exec(
+                    select(scope_col).where(scope_col.isnot(None)).distinct()
+                )
+            ).all()
+            org_ids |= set(rows)
+        org_ids.discard(None)
+        if org_ids:
+            info = await _organization_info_by_id(session, org_ids)
+            # Snapshot ``consumer_name`` per consumer id (from both sources) —
+            # the fallback label for a since-deleted Org so it shows its real
+            # name instead of a bare id, matching the breakdown table.
+            snapshot_names: Dict[int, str] = {}
+            for id_col, name_col in (
+                (MeteredUsage.consumer_principal_id, MeteredUsage.consumer_name),
+                (ResourceEvent.consumer_principal_id, ResourceEvent.consumer_name),
+            ):
+                rows = (
+                    await session.exec(
+                        select(id_col, func.max(name_col))
+                        .where(id_col.in_(org_ids), name_col.isnot(None))
+                        .group_by(id_col)
+                    )
+                ).all()
+                for cid, nm in rows:
+                    if cid is not None and nm:
+                        snapshot_names.setdefault(cid, nm)
+            organizations = [
+                {
+                    "id": oid,
+                    "label": (info[oid][0] if oid in info else None)
+                    or snapshot_names.get(oid)
+                    or f"Org {oid}",
+                    "deleted": oid not in info,
+                    # ``kind`` (org / user / group) so the filter can tag a
+                    # personal (USER) consumer, matching the breakdown table.
+                    "kind": info[oid][1] if oid in info else None,
+                }
+                for oid in org_ids
+            ]
+            organizations.sort(key=lambda o: (o["label"] or "").lower())
+
+    return {
+        "creators": creators,
+        "instances": instances,
+        "volumes": volumes,
+        "organizations": organizations,
+        "user_groups": user_groups,
+    }

--- a/gpustack/routes/usage.py
+++ b/gpustack/routes/usage.py
@@ -12,13 +12,20 @@ from gpustack.schemas.api_keys import ApiKey
 from gpustack.schemas.model_routes import ModelRoute
 from gpustack.schemas.model_usage import ModelUsage
 from gpustack.schemas.users import User
-from gpustack.schemas.principals import OrgRole, Principal
+from gpustack.schemas.principals import (
+    OrgRole,
+    Principal,
+    PrincipalMembership,
+    PrincipalType,
+    is_reserved_principal_name,
+)
 from gpustack.schemas.usage import (
     USAGE_GRANULARITY_MONTH,
     USAGE_GRANULARITY_DAY,
     USAGE_GRANULARITY_WEEK,
     USAGE_GROUP_BY_API_KEY,
     USAGE_GROUP_BY_DATE,
+    USAGE_GROUP_BY_ORGANIZATION,
     USAGE_GROUP_BY_ROUTE,
     USAGE_GROUP_BY_USER,
     USAGE_SCOPE_ALL,
@@ -54,6 +61,7 @@ from gpustack.server.deps import CurrentUserDep, SessionDep, TenantContextDep
 from gpustack.utils.usage_snapshots import (
     format_usage_api_key_label,
     format_usage_date_label,
+    format_usage_organization_label,
     format_usage_route_label,
     format_usage_user_label,
 )
@@ -153,6 +161,15 @@ def _group_columns(group_by: str, *, date_bucket_expr=None):
             ModelUsage.model_route_name.label("group_model_route_name"),
             ModelUsage.model_route_id.label("group_model_route_id"),
         ], [ModelUsage.model_route_name, ModelUsage.model_route_id]
+    if group_by == USAGE_GROUP_BY_ORGANIZATION:
+        # Group by the consumer principal id only. The display name / kind
+        # snapshot (``consumer_name`` / ``consumer_principal_kind``) is added
+        # as MAX() aggregates in the breakdown handler (so a mix of pre- and
+        # post-upgrade rows for one Org still collapses to a single row), with
+        # a live ``_organization_info_by_id`` fallback for pre-upgrade rows.
+        return [
+            ModelUsage.consumer_principal_id.label("group_organization_id"),
+        ], [ModelUsage.consumer_principal_id]
     return [
         ModelUsage.user_name.label("group_user_name"),
         ModelUsage.api_key_name.label("group_api_key_name"),
@@ -313,6 +330,39 @@ def _row_dimension(
     )
 
 
+def _row_org_dimension(
+    row: Any, org_info_by_id: Optional[Dict[int, tuple]] = None
+) -> UsageBreakdownDimension:
+    # The consumer name / kind is snapshotted on the row (``consumer_name`` /
+    # ``consumer_principal_kind``, carried as MAX() aggregates), so a deleted
+    # Org keeps its real name and a personal (USER) row is taggable — parity
+    # with the other dimensions. Pre-upgrade rows have no snapshot, so fall
+    # back to the live lookup. Deletion is by live existence (the id-set
+    # doubles as the existence check). A NULL consumer id is un-attributed
+    # direct traffic (cookie-authed, no api_key) → "Untracked", not deleted.
+    org_info_by_id = org_info_by_id or {}
+    org_id = getattr(row, "group_organization_id", None)
+    if org_id is None:
+        return UsageBreakdownDimension(identity=None, label="Untracked", deleted=False)
+    live = org_info_by_id.get(org_id)
+    snapshot_name = getattr(row, "group_organization_name", None)
+    snapshot_kind = getattr(row, "group_organization_kind", None)
+    # Prefer the LIVE principal name so the label stays consistent across the
+    # token / resource tabs and fresh on rename; fall back to the row snapshot
+    # only when the principal is gone (hard-deleted) — the snapshot's sole
+    # purpose. Standardized on ``name`` (slug), not display_name.
+    name = (live[0] if live else None) or snapshot_name
+    kind = (live[1] if live else None) or snapshot_kind
+    return UsageBreakdownDimension(
+        identity=UsageIdentity(
+            value=UsageIdentityValue(organization_name=name, organization_kind=kind),
+            current=UsageIdentityCurrent(organization_id=org_id),
+        ),
+        label=format_usage_organization_label(name),
+        deleted=live is None,
+    )
+
+
 def _identity_deleted(
     group_by: str, identity: UsageIdentity, existing_ids: Optional[set] = None
 ) -> bool:
@@ -371,6 +421,55 @@ async def _existing_ids_for_dimension(session, group_by: str, ids) -> Optional[s
     return await _existing_entity_ids(session, model, ids)
 
 
+async def _organization_info_by_id(session, ids) -> Dict[int, tuple]:
+    """Map consumer-principal id → ``(name, kind)`` for live principals.
+
+    Used as the fallback when a usage row carries no ``consumer_name`` snapshot
+    (pre-upgrade rows) and to detect deletion: an id missing from the result is
+    a gone principal → the caller tags the row ``(Deleted)``. Existence is by
+    raw id (no soft-delete filter), matching the FK-less attribution contract
+    on model_usages. ``kind`` is the ``PrincipalType`` value.
+    """
+    unique = {i for i in ids if i is not None}
+    if not unique:
+        return {}
+    rows = await _get_rows(session, select(Principal).where(Principal.id.in_(unique)))
+    # Use the principal ``name`` (the stable slug), NOT ``display_name`` — the
+    # Organization breakdown is standardized on ``name`` so the token and
+    # resource tabs stay consistent (resource snapshots ``name`` too).
+    return {
+        p.id: (
+            p.name or "",
+            p.kind.value if hasattr(p.kind, "value") else p.kind,
+        )
+        for p in rows
+    }
+
+
+async def _group_member_user_ids(session, group_ids) -> set:
+    """Direct USER members of the given GROUP principals.
+
+    Nested-group members are intentionally NOT expanded (see the product
+    decision): a user-group filter resolves to the group's direct users
+    only. An empty set (group with no user members) makes the caller match
+    zero rows.
+    """
+    unique = {g for g in group_ids if g is not None}
+    if not unique:
+        return set()
+    stmt = (
+        select(PrincipalMembership.member_principal_id)
+        .join(Principal, Principal.id == PrincipalMembership.member_principal_id)
+        .where(
+            PrincipalMembership.parent_principal_id.in_(unique),
+            PrincipalMembership.deleted_at.is_(None),
+            Principal.kind == PrincipalType.USER,
+            Principal.deleted_at.is_(None),
+        )
+    )
+    return set(await _get_rows(session, stmt))
+
+
 def _filter_condition(group_by: str, item: UsageFilterItem):
     value = item.identity.value
     current = item.identity.current
@@ -391,6 +490,11 @@ def _filter_condition(group_by: str, item: UsageFilterItem):
             conditions.append(ModelUsage.model_route_id.is_(None))
         else:
             conditions.append(ModelUsage.model_route_id == current.route_id)
+    elif group_by == USAGE_GROUP_BY_ORGANIZATION:
+        org_id = current.organization_id if current else None
+        conditions.append(
+            _null_safe_column_filter(ModelUsage.consumer_principal_id, org_id)
+        )
     else:
         conditions.extend(
             [
@@ -481,6 +585,7 @@ def _apply_usage_scope_and_filters(
     filters,
     scope: str,
     org_id: Optional[int] = None,
+    group_member_user_ids: Optional[set] = None,
 ) -> Select:
     # ``self`` scope always restricts to the caller's own rows and
     # current Org. ``all`` scope restricts to the current Org unless
@@ -501,6 +606,7 @@ def _apply_usage_scope_and_filters(
         (USAGE_GROUP_BY_USER, filters.users),
         (USAGE_GROUP_BY_API_KEY, filters.api_keys),
         (USAGE_GROUP_BY_ROUTE, filters.routes),
+        (USAGE_GROUP_BY_ORGANIZATION, filters.organizations),
     ]:
         if not items:
             continue
@@ -509,6 +615,13 @@ def _apply_usage_scope_and_filters(
         statement = statement.where(
             or_(*[_filter_condition(group_by, item) for item in items])
         )
+
+    # User-group filter is resolved (async) to its direct USER members by the
+    # caller and applied here as a user_id membership. ``None`` → no group
+    # filter requested; an empty set → the group has no members, so match
+    # nothing rather than silently ignoring the filter.
+    if group_member_user_ids is not None:
+        statement = statement.where(ModelUsage.user_id.in_(group_member_user_ids))
     return statement
 
 
@@ -609,8 +722,84 @@ async def _get_filter_options(
     ]
 
 
+async def _get_organization_filter_options(
+    session, *, base_statement: Select
+) -> List[UsageFilterOption]:
+    """Consumer Orgs that appear in the (scoped) usage rows, resolved to
+    display names. NULL consumer ids (un-attributed direct traffic) are
+    dropped — there's no Org to filter on. Prefer the live principal name;
+    fall back to the row ``consumer_name`` snapshot so a since-deleted Org
+    still shows its real name (not a bare id) — matching the breakdown table
+    and the user/route/api_key filters."""
+    rows = await _get_rows(
+        session,
+        base_statement.with_only_columns(
+            ModelUsage.consumer_principal_id.label("group_organization_id"),
+            func.max(ModelUsage.consumer_name).label("group_organization_name"),
+            func.max(ModelUsage.consumer_principal_kind).label(
+                "group_organization_kind"
+            ),
+        ).group_by(ModelUsage.consumer_principal_id),
+    )
+    ids = [getattr(row, "group_organization_id", None) for row in rows]
+    info = await _organization_info_by_id(session, ids)
+    options: List[UsageFilterOption] = []
+    for row in rows:
+        org_id = getattr(row, "group_organization_id", None)
+        if org_id is None:
+            continue
+        live = info.get(org_id)
+        snapshot_name = getattr(row, "group_organization_name", None)
+        snapshot_kind = getattr(row, "group_organization_kind", None)
+        name = (live[0] if live else None) or snapshot_name
+        kind = (live[1] if live else None) or snapshot_kind
+        options.append(
+            UsageFilterOption(
+                identity=UsageIdentity(
+                    value=UsageIdentityValue(
+                        organization_name=name, organization_kind=kind
+                    ),
+                    current=UsageIdentityCurrent(organization_id=org_id),
+                ),
+                label=format_usage_organization_label(name),
+                deleted=live is None,
+            )
+        )
+    return options
+
+
+async def _get_user_group_filter_options(session) -> List[UsageFilterOption]:
+    """All non-reserved GROUP principals, offered as user-group filters.
+
+    Unlike the other filter options this isn't derived from the usage rows
+    (a group has no column on model_usages) — it lists the groups an admin
+    can filter by; the group is expanded to its members at query time."""
+    groups = await _get_rows(
+        session,
+        select(Principal)
+        .where(Principal.kind == PrincipalType.GROUP, Principal.deleted_at.is_(None))
+        .order_by(Principal.display_name, Principal.name),
+    )
+    options: List[UsageFilterOption] = []
+    for group in groups:
+        if is_reserved_principal_name(group.name):
+            continue
+        label = group.display_name or group.name or ""
+        options.append(
+            UsageFilterOption(
+                identity=UsageIdentity(
+                    value=UsageIdentityValue(group_name=label),
+                    current=UsageIdentityCurrent(group_id=group.id),
+                ),
+                label=label,
+                deleted=False,
+            )
+        )
+    return options
+
+
 @router.get("/meta", response_model=UsageMetaResponse, response_model_exclude_none=True)
-async def get_usage_meta(
+async def get_usage_meta(  # noqa: C901
     session: SessionDep,
     user: CurrentUserDep,
     ctx: TenantContextDep,
@@ -635,6 +824,12 @@ async def get_usage_meta(
             ModelUsage.consumer_principal_id == ctx.current_principal_id
         )
 
+    # The Organization dimension is the cross-tenant "All" view — platform
+    # admin acting without a selected Org (``current_principal_id is None``).
+    # An Org owner scoped to their own Org would only ever see one Org, so
+    # the dimension is hidden for them.
+    is_platform_wide = user.is_admin and ctx.current_principal_id is None
+
     user_options: List[UsageFilterOption] = []
     if scope == USAGE_SCOPE_ALL:
         user_options = await _get_filter_options(
@@ -647,18 +842,38 @@ async def get_usage_meta(
         session, base_statement=base_statement, group_by=USAGE_GROUP_BY_ROUTE
     )
 
+    # Org / user-group options are queried last so the earlier
+    # user/api_key/route option query order stays stable. Both are
+    # platform-wide-only (admin acting across all Orgs): a caller scoped to a
+    # single Org — org owner, or admin with a pinned Org — sees neither, since
+    # cross-Org grouping / group filtering is meaningless within one tenant.
+    user_group_options: List[UsageFilterOption] = []
+    organization_options: List[UsageFilterOption] = []
+    if is_platform_wide:
+        user_group_options = await _get_user_group_filter_options(session)
+        organization_options = await _get_organization_filter_options(
+            session, base_statement=base_statement
+        )
+
+    if scope == USAGE_SCOPE_ALL:
+        group_by_options = list(ADMIN_GROUP_BY_OPTIONS)
+        if is_platform_wide:
+            group_by_options.append(
+                UsageOption(key=USAGE_GROUP_BY_ORGANIZATION, label="Organization")
+            )
+    else:
+        group_by_options = SELF_GROUP_BY_OPTIONS
+
     return UsageMetaResponse(
         metrics=METRIC_OPTIONS,
         granularities=GRANULARITY_OPTIONS,
-        group_bys=(
-            ADMIN_GROUP_BY_OPTIONS
-            if scope == USAGE_SCOPE_ALL
-            else SELF_GROUP_BY_OPTIONS
-        ),
+        group_bys=group_by_options,
         filters=UsageFilters(
             users=user_options,
             api_keys=api_key_options,
             routes=route_options,
+            organizations=organization_options,
+            user_groups=user_group_options,
         ),
     )
 
@@ -666,7 +881,14 @@ async def get_usage_meta(
 def _check_permission(user: User, ctx, request, effective_scope: str) -> None:
     """``mine`` view forbids the user-grouping / user-filter dimensions
     (privacy: a user can only see their own rows). ``org`` view allows
-    them since the caller is admin / owner / manager."""
+    them since the caller is admin / owner / manager.
+
+    The Organization dimension (group-by + filter) is the platform-wide
+    "All" view — allowed only for a platform admin acting WITHOUT a pinned
+    Org (``current_principal_id is None``); an admin scoped to one Org sees
+    a single consumer and ``/usage/meta`` hides the option, so reject it
+    here too. The user-group filter reveals which users belong to a group's
+    usage, so it's gated like the user filter (forbidden in ``self`` scope)."""
     group_by = request.group_by
     group_bys = group_by if isinstance(group_by, list) else [group_by]
     if effective_scope == USAGE_SCOPE_SELF:
@@ -674,6 +896,16 @@ def _check_permission(user: User, ctx, request, effective_scope: str) -> None:
             raise ForbiddenException(message="No permission to group by user")
         if request.filters.users:
             raise ForbiddenException(message="No permission to filter by user")
+        if request.filters.user_groups:
+            raise ForbiddenException(message="No permission to filter by user group")
+    is_platform_wide = (
+        user.is_admin and getattr(ctx, "current_principal_id", None) is None
+    )
+    if not is_platform_wide:
+        if USAGE_GROUP_BY_ORGANIZATION in group_bys:
+            raise ForbiddenException(message="No permission to group by organization")
+        if request.filters.organizations:
+            raise ForbiddenException(message="No permission to filter by organization")
 
 
 def _sort_expression(sort_by: str, metric_columns: Dict[str, Any], date_sort_expr=None):
@@ -730,6 +962,7 @@ def _build_breakdown_item(
     row: Any,
     granularity: str,
     existing_ids_by_dim: Optional[Dict[str, set]] = None,
+    org_info_by_id: Optional[Dict[int, tuple]] = None,
 ) -> UsageBreakdownItem:
     existing_ids_by_dim = existing_ids_by_dim or {}
     api_requests = int(getattr(row, USAGE_METRIC_API_REQUESTS, 0) or 0)
@@ -759,6 +992,8 @@ def _build_breakdown_item(
         breakdown_item.route = _row_dimension(
             USAGE_GROUP_BY_ROUTE, row, existing_ids_by_dim.get(USAGE_GROUP_BY_ROUTE)
         )
+    if USAGE_GROUP_BY_ORGANIZATION in group_bys:
+        breakdown_item.organization = _row_org_dimension(row, org_info_by_id)
 
     if _single_group_by(group_bys, USAGE_GROUP_BY_USER):
         breakdown_item.models_called = int(
@@ -772,6 +1007,13 @@ def _build_breakdown_item(
             getattr(row, USAGE_METRIC_MODELS_CALLED, 0) or 0
         )
     elif _single_group_by(group_bys, USAGE_GROUP_BY_ROUTE):
+        breakdown_item.models_called = int(
+            getattr(row, USAGE_METRIC_MODELS_CALLED, 0) or 0
+        )
+        breakdown_item.api_keys_used = int(
+            getattr(row, USAGE_METRIC_API_KEYS_USED, 0) or 0
+        )
+    elif _single_group_by(group_bys, USAGE_GROUP_BY_ORGANIZATION):
         breakdown_item.models_called = int(
             getattr(row, USAGE_METRIC_MODELS_CALLED, 0) or 0
         )
@@ -795,6 +1037,19 @@ async def get_usage_breakdown(
     effective_scope = _resolve_effective_scope(user, ctx, request.scope)
     _check_permission(user, ctx, request, effective_scope)
 
+    # Expand any user-group filter to its direct USER members before
+    # building the query so the (sync) filter application can apply a plain
+    # user_id membership.
+    group_member_user_ids: Optional[set] = None
+    if request.filters.user_groups:
+        group_ids = [
+            item.identity.current.group_id
+            for item in request.filters.user_groups
+            if item.identity.current is not None
+            and item.identity.current.group_id is not None
+        ]
+        group_member_user_ids = await _group_member_user_ids(session, group_ids)
+
     metric_columns = _metric_columns()
     base_statement = _apply_usage_scope_and_filters(
         _base_statement(),
@@ -802,6 +1057,7 @@ async def get_usage_breakdown(
         filters=request.filters,
         scope=effective_scope,
         org_id=ctx.current_principal_id,
+        group_member_user_ids=group_member_user_ids,
     )
     if _single_group_by(request.group_by, USAGE_GROUP_BY_API_KEY):
         base_statement = _exclude_incomplete_api_key_identity(base_statement)
@@ -832,6 +1088,15 @@ async def get_usage_breakdown(
         ),
         func.max(ModelUsage.date).label(USAGE_METRIC_LAST_ACTIVE),
     ]
+    if USAGE_GROUP_BY_ORGANIZATION in request.group_by:
+        # Grouped by consumer_principal_id only; MAX() picks up the snapshot
+        # name / kind from whichever rows carry it (pre-upgrade rows are NULL).
+        aggregate_columns += [
+            func.max(ModelUsage.consumer_name).label("group_organization_name"),
+            func.max(ModelUsage.consumer_principal_kind).label(
+                "group_organization_kind"
+            ),
+        ]
     grouped_statement = scoped_statement.with_only_columns(
         *select_columns, *aggregate_columns
     ).group_by(*group_columns)
@@ -878,6 +1143,15 @@ async def get_usage_breakdown(
                 session, dim, [getattr(r, id_attr, None) for r in item_rows]
             )
 
+    # Organization: resolve live (name, kind) as the fallback for rows without
+    # a snapshot, and to detect deletion (id no longer among live principals).
+    org_info_by_id: Dict[int, tuple] = {}
+    if USAGE_GROUP_BY_ORGANIZATION in request.group_by:
+        org_info_by_id = await _organization_info_by_id(
+            session,
+            [getattr(r, "group_organization_id", None) for r in item_rows],
+        )
+
     return UsageBreakdownResponse(
         summary=_summary_from_row(summary_row),
         group_by=request.group_by,
@@ -894,7 +1168,11 @@ async def get_usage_breakdown(
         ),
         items=[
             _build_breakdown_item(
-                request.group_by, row, granularity, existing_ids_by_dim
+                request.group_by,
+                row,
+                granularity,
+                existing_ids_by_dim,
+                org_info_by_id,
             )
             for row in item_rows
         ],

--- a/gpustack/schemas/metered_usage.py
+++ b/gpustack/schemas/metered_usage.py
@@ -151,6 +151,9 @@ class MeteredUsage(SQLModel, BaseModelMixin, table=True):
         default=None, sa_column=Column(Integer)
     )
     consumer_name: Optional[str] = Field(default=None)
+    # Consumer principal kind (``org`` / ``user`` / ``group``) snapshot, so the
+    # Organization breakdown can tag personal (USER) consumers. NULL pre-upgrade.
+    consumer_principal_kind: Optional[str] = Field(default=None)
     creator_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
     creator_name: Optional[str] = Field(default=None)
     cluster_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
@@ -259,6 +262,9 @@ class MeteredUsageArchive(SQLModel, BaseModelMixin, table=True):
         default=None, sa_column=Column(Integer)
     )
     consumer_name: Optional[str] = Field(default=None)
+    # Consumer principal kind (``org`` / ``user`` / ``group``) snapshot, so the
+    # Organization breakdown can tag personal (USER) consumers. NULL pre-upgrade.
+    consumer_principal_kind: Optional[str] = Field(default=None)
     creator_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
     creator_name: Optional[str] = Field(default=None)
     cluster_id: Optional[int] = Field(default=None, sa_column=Column(Integer))

--- a/gpustack/schemas/model_usage.py
+++ b/gpustack/schemas/model_usage.py
@@ -52,6 +52,15 @@ class ModelUsage(SQLModel, ActiveRecordMixin, table=True):
     consumer_principal_id: Optional[int] = Field(
         default=None, sa_column=Column(Integer)
     )
+    # Display-name + kind snapshot of the consumer principal, captured at
+    # ingest so the Organization breakdown keeps showing the real name / can
+    # tag personal (USER-kind) rows even after the principal is hard-deleted —
+    # the same denormalization the ``*_name`` columns give the other
+    # dimensions. ``kind`` is the ``PrincipalType`` value (``org`` / ``user`` /
+    # ``group``). NULL on pre-upgrade rows (no backfill); the read path falls
+    # back to a live principal lookup then.
+    consumer_name: Optional[str] = Field(default=None)
+    consumer_principal_kind: Optional[str] = Field(default=None)
     date: date
     prompt_token_count: int = Field(
         default=..., sa_column=Column(BigInteger, nullable=False)

--- a/gpustack/schemas/resource_events.py
+++ b/gpustack/schemas/resource_events.py
@@ -82,6 +82,8 @@ class ResourceEvent(SQLModel, BaseModelMixin, table=True):
         default=None, sa_column=Column(Integer)
     )
     consumer_name: Optional[str] = Field(default=None)
+    # Consumer principal kind (``org`` / ``user`` / ``group``) snapshot.
+    consumer_principal_kind: Optional[str] = Field(default=None)
     creator_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
     creator_name: Optional[str] = Field(default=None)
 
@@ -137,6 +139,8 @@ class ResourceEventArchive(SQLModel, BaseModelMixin, table=True):
         default=None, sa_column=Column(Integer)
     )
     consumer_name: Optional[str] = Field(default=None)
+    # Consumer principal kind (``org`` / ``user`` / ``group``) snapshot.
+    consumer_principal_kind: Optional[str] = Field(default=None)
     creator_id: Optional[int] = Field(default=None, sa_column=Column(Integer))
     creator_name: Optional[str] = Field(default=None)
     cluster_id: Optional[int] = Field(default=None, sa_column=Column(Integer))

--- a/gpustack/schemas/usage.py
+++ b/gpustack/schemas/usage.py
@@ -22,6 +22,10 @@ USAGE_GROUP_BY_DATE = "date"
 USAGE_GROUP_BY_USER = "user"
 USAGE_GROUP_BY_API_KEY = "api_key"
 USAGE_GROUP_BY_ROUTE = "route"
+# Groups by the consumer principal (``consumer_principal_id`` — the
+# API-key owner Org). Reserved for the platform-wide "All" view (admin
+# in cross-org context); enforced in the route handler.
+USAGE_GROUP_BY_ORGANIZATION = "organization"
 
 USAGE_GRANULARITY_DAY = "day"
 USAGE_GRANULARITY_WEEK = "week"
@@ -44,6 +48,7 @@ USAGE_GROUP_BYS = {
     USAGE_GROUP_BY_USER,
     USAGE_GROUP_BY_API_KEY,
     USAGE_GROUP_BY_ROUTE,
+    USAGE_GROUP_BY_ORGANIZATION,
 }
 USAGE_GRANULARITIES = {
     USAGE_GRANULARITY_DAY,
@@ -75,12 +80,22 @@ class UsageIdentityValue(BaseModel):
     access_key: Optional[str] = None
     api_key_is_custom: Optional[bool] = None
     route_name: Optional[str] = None
+    # ``organization_name`` — consumer Org display name (snapshotted on
+    # model_usages at ingest, with a live fallback for pre-upgrade rows);
+    # ``organization_kind`` — the consumer principal's kind (``org`` / ``user``
+    # / ``group``) so the client can tag a personal (USER) row; ``group_name``
+    # — user-group display name (filter-only dimension).
+    organization_name: Optional[str] = None
+    organization_kind: Optional[str] = None
+    group_name: Optional[str] = None
 
 
 class UsageIdentityCurrent(BaseModel):
     user_id: Optional[int] = None
     api_key_id: Optional[int] = None
     route_id: Optional[int] = None
+    organization_id: Optional[int] = None
+    group_id: Optional[int] = None
 
 
 class UsageIdentity(BaseModel):
@@ -101,6 +116,10 @@ class UsageFilters(BaseModel):
     users: List[UsageFilterOption] = Field(default_factory=list)
     api_keys: List[UsageFilterOption] = Field(default_factory=list)
     routes: List[UsageFilterOption] = Field(default_factory=list)
+    # Platform-wide "All" view only. ``organizations`` — consumer Orgs
+    # with usage; ``user_groups`` — groups whose members can be filtered on.
+    organizations: List[UsageFilterOption] = Field(default_factory=list)
+    user_groups: List[UsageFilterOption] = Field(default_factory=list)
 
 
 class UsageMetaResponse(BaseModel):
@@ -114,6 +133,11 @@ class UsageFilterRequest(BaseModel):
     users: List[UsageFilterItem] = Field(default_factory=list)
     api_keys: List[UsageFilterItem] = Field(default_factory=list)
     routes: List[UsageFilterItem] = Field(default_factory=list)
+    # Consumer-Org filter (``consumer_principal_id``) and user-group
+    # filter (expanded to the group's direct USER members). Both are
+    # platform-admin-only; enforced in the route handler.
+    organizations: List[UsageFilterItem] = Field(default_factory=list)
+    user_groups: List[UsageFilterItem] = Field(default_factory=list)
 
 
 class UsageBaseRequest(BaseModel):
@@ -250,6 +274,7 @@ class UsageBreakdownItem(BaseModel):
     user: Optional[UsageBreakdownDimension] = None
     api_key: Optional[UsageBreakdownDimension] = None
     route: Optional[UsageBreakdownDimension] = None
+    organization: Optional[UsageBreakdownDimension] = None
     input_tokens: int = 0
     output_tokens: int = 0
     input_cached_tokens: int = 0

--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -561,6 +561,47 @@ def _build_metric_snapshot(
     return snapshot
 
 
+async def _resolve_consumer_info_by_id(
+    session, api_keys, all_metrics, users
+) -> Dict[int, tuple]:
+    """``consumer_principal_id → (name, kind)`` for every consumer referenced by
+    the batch.
+
+    The consumer is the API-key owner Org, a personal USER-principal, or the
+    cookie-auth ``X-Organization-Id`` header. Snapshotting the display name +
+    kind onto ``ModelUsage`` lets the Organization breakdown keep the real name
+    after a hard-delete and tag personal (USER) rows — parity with the other
+    ``*_name`` denorms. ``name`` (slug) is used, NOT display_name, so the token
+    and resource tabs stay consistent.
+    """
+    consumer_ids: set = {
+        k.owner_principal_id for k in api_keys if k.owner_principal_id is not None
+    }
+    # ``organization_id`` comes from the ``X-Organization-Id`` wire header, so it
+    # may be a non-numeric / empty string — coerce defensively (mirrors the
+    # guarded parse in _build_metric_snapshot) rather than crashing the batch.
+    for m in all_metrics:
+        org = getattr(m, "organization_id", None)
+        if not org:
+            continue
+        try:
+            consumer_ids.add(int(org))
+        except (TypeError, ValueError):
+            continue
+    consumer_ids |= {u.id for u in users}
+    if not consumer_ids:
+        return {}
+    consumer_principals = await Principal.all_by_fields(
+        session=session,
+        fields={},
+        extra_conditions=[Principal.id.in_(consumer_ids)],
+    )
+    return {
+        p.id: (p.name, p.kind.value if hasattr(p.kind, "value") else p.kind)
+        for p in consumer_principals
+    }
+
+
 async def store_usage_metrics(
     metrics: List[ModelUsageMetrics],
     detail_metrics: Optional[List[ModelUsageMetrics]] = None,
@@ -655,6 +696,10 @@ async def store_usage_metrics(
             cluster_names_by_id = {c.id: c.name for c in clusters}
             provider_by_id = {p.id: p for p in providers}
 
+            consumer_info_by_id = await _resolve_consumer_info_by_id(
+                session, api_keys, all_metrics, users
+            )
+
             for metric in metrics:
                 if not _validate_usage_metric(
                     metric,
@@ -679,6 +724,14 @@ async def store_usage_metrics(
                     metric, model_by_id.get(metric.model_id)
                 )
                 metric_date, _ = _resolve_metric_datetime(metric)
+                # Consumer display-name + kind snapshot (ModelUsage-only; kept
+                # out of the shared snapshot so the detail table isn't touched).
+                consumer_id = snapshot.get("consumer_principal_id")
+                consumer_info = (
+                    consumer_info_by_id.get(consumer_id)
+                    if consumer_id is not None
+                    else None
+                )
                 model_usage = ModelUsage(
                     date=metric_date,
                     prompt_token_count=prompt_tokens,
@@ -686,6 +739,10 @@ async def store_usage_metrics(
                     prompt_cached_token_count=metric.input_cached_token,
                     request_count=metric.request_count,
                     operation=metric.operation,
+                    consumer_name=consumer_info[0] if consumer_info else None,
+                    consumer_principal_kind=(
+                        consumer_info[1] if consumer_info else None
+                    ),
                     **snapshot,
                 )
                 await create_or_update_model_usage(

--- a/gpustack/server/resource_event_logger.py
+++ b/gpustack/server/resource_event_logger.py
@@ -118,24 +118,43 @@ async def _resolve_principals(
             owner_principal_id = c.owner_principal_id
 
     principals = PrincipalService(session)
-    # Per-call memo so owner == consumer (self-owned) resolves once even on a
-    # cold cache; the service cache then makes it cheap across events.
-    name_cache: Dict[int, Optional[str]] = {}
+    # Per-call memo of the principal ROW so owner == consumer (self-owned)
+    # resolves once even on a cold cache; the service cache then makes it cheap
+    # across events. Caching the row (not just the name) lets the consumer kind
+    # come from the same lookup — no extra round-trip.
+    principal_cache: Dict[int, Any] = {}
 
-    async def name_of(pid: Optional[int]) -> Optional[str]:
+    async def principal_of(pid: Optional[int]):
         if pid is None:
             return None
-        if pid not in name_cache:
-            p = await principals.get_by_id(pid)
-            name_cache[pid] = p.name if p else None
-        return name_cache[pid]
+        if pid not in principal_cache:
+            principal_cache[pid] = await principals.get_by_id(pid)
+        return principal_cache[pid]
+
+    async def name_of(pid: Optional[int]) -> Optional[str]:
+        p = await principal_of(pid)
+        return p.name if p else None
+
+    owner_name = await name_of(owner_principal_id)
+    consumer_name = await name_of(consumer_principal_id)
+    creator_name = await name_of(creator_id)
+
+    # Consumer principal kind (``org`` / ``user`` / ``group``) snapshot, so the
+    # Organization breakdown can tag a personal (USER) consumer. Reuses the
+    # cached principal row resolved for ``consumer_name`` above.
+    consumer_principal = await principal_of(consumer_principal_id)
+    consumer_kind: Optional[str] = None
+    if consumer_principal is not None:
+        kind = consumer_principal.kind
+        consumer_kind = kind.value if hasattr(kind, "value") else kind
 
     return (
         owner_principal_id,
-        await name_of(owner_principal_id),
-        await name_of(consumer_principal_id),
-        await name_of(creator_id),
+        owner_name,
+        consumer_name,
+        creator_name,
         cluster_name,
+        consumer_kind,
     )
 
 
@@ -379,6 +398,7 @@ class ResourceEventLogger:
                 consumer_name,
                 creator_name,
                 cluster_name,
+                consumer_principal_kind,
             ) = await _resolve_principals(
                 session, consumer_principal_id, creator_id, cluster_id
             )
@@ -388,6 +408,7 @@ class ResourceEventLogger:
                 owner_name=owner_name,
                 consumer_principal_id=consumer_principal_id,
                 consumer_name=consumer_name,
+                consumer_principal_kind=consumer_principal_kind,
                 creator_id=creator_id,
                 creator_name=creator_name,
                 cluster_id=cluster_id,

--- a/gpustack/server/resource_usage_collector.py
+++ b/gpustack/server/resource_usage_collector.py
@@ -107,6 +107,7 @@ class _OpenWindow:
     owner_name: Optional[str]
     consumer_principal_id: Optional[int]
     consumer_name: Optional[str]
+    consumer_principal_kind: Optional[str]
     creator_id: Optional[int]
     creator_name: Optional[str]
     cluster_id: Optional[int]
@@ -258,6 +259,7 @@ def _open_window_from_event(evt: ResourceEvent) -> Optional[_OpenWindow]:
         owner_name=evt.owner_name,
         consumer_principal_id=evt.consumer_principal_id,
         consumer_name=evt.consumer_name,
+        consumer_principal_kind=getattr(evt, "consumer_principal_kind", None),
         creator_id=evt.creator_id,
         creator_name=evt.creator_name,
         cluster_id=evt.cluster_id,
@@ -521,7 +523,7 @@ class ResourceUsageCollector:
         ):
             window.settled_through = end_ts
 
-    async def _upsert_bucket(
+    async def _upsert_bucket(  # noqa: C901
         self,
         session,
         window: _OpenWindow,
@@ -569,6 +571,8 @@ class ResourceUsageCollector:
                 row.owner_name = window.owner_name
             if window.consumer_name is not None:
                 row.consumer_name = window.consumer_name
+            if window.consumer_principal_kind is not None:
+                row.consumer_principal_kind = window.consumer_principal_kind
             if window.creator_name is not None:
                 row.creator_name = window.creator_name
             if window.cluster_name is not None:
@@ -587,6 +591,7 @@ class ResourceUsageCollector:
                 owner_name=window.owner_name,
                 consumer_principal_id=window.consumer_principal_id,
                 consumer_name=window.consumer_name,
+                consumer_principal_kind=window.consumer_principal_kind,
                 creator_id=window.creator_id,
                 creator_name=window.creator_name,
                 cluster_id=window.cluster_id,

--- a/gpustack/server/storage_usage_collector.py
+++ b/gpustack/server/storage_usage_collector.py
@@ -66,6 +66,7 @@ class _OpenVolume:
     owner_name: Optional[str]
     consumer_principal_id: Optional[int]
     consumer_name: Optional[str]
+    consumer_principal_kind: Optional[str]
     creator_id: Optional[int]
     creator_name: Optional[str]
     window_start: datetime
@@ -94,6 +95,7 @@ def _open_volume_from_event(evt: ResourceEvent) -> Optional[_OpenVolume]:
         owner_name=evt.owner_name,
         consumer_principal_id=evt.consumer_principal_id,
         consumer_name=evt.consumer_name,
+        consumer_principal_kind=getattr(evt, "consumer_principal_kind", None),
         creator_id=evt.creator_id,
         creator_name=evt.creator_name,
         window_start=_naive_utc(evt.occurred_at),
@@ -330,7 +332,7 @@ class StorageUsageCollector:
         if vol.settled_through is None or end_ts > vol.settled_through:
             vol.settled_through = end_ts
 
-    async def _upsert_bucket(
+    async def _upsert_bucket(  # noqa: C901
         self,
         session,
         vol: _OpenVolume,
@@ -383,6 +385,8 @@ class StorageUsageCollector:
                 row.owner_name = vol.owner_name
             if vol.consumer_name is not None:
                 row.consumer_name = vol.consumer_name
+            if vol.consumer_principal_kind is not None:
+                row.consumer_principal_kind = vol.consumer_principal_kind
             if vol.creator_name is not None:
                 row.creator_name = vol.creator_name
             row.sku = sku
@@ -398,6 +402,7 @@ class StorageUsageCollector:
                 owner_name=vol.owner_name,
                 consumer_principal_id=vol.consumer_principal_id,
                 consumer_name=vol.consumer_name,
+                consumer_principal_kind=vol.consumer_principal_kind,
                 creator_id=vol.creator_id,
                 creator_name=vol.creator_name,
                 cluster_id=None,

--- a/gpustack/utils/usage_snapshots.py
+++ b/gpustack/utils/usage_snapshots.py
@@ -49,6 +49,20 @@ def format_usage_route_label(route_name: Optional[str]) -> str:
     return route_name or "Untracked"
 
 
+def format_usage_organization_label(organization_name: Optional[str]) -> str:
+    # The Org (consumer principal) name is now denormalized onto model_usages
+    # (``consumer_name``) — like user / route / api_key — with a live
+    # principals lookup as the fallback for pre-upgrade rows. When neither
+    # resolves (a hard-deleted principal on a pre-upgrade row) fall back to a
+    # generic label; the ``(Deleted)`` marker is carried by the dimension's
+    # ``deleted`` flag, composed client-side.
+    return organization_name or "Unknown Organization"
+
+
+def format_usage_user_group_label(group_name: Optional[str]) -> str:
+    return group_name or "Unknown Group"
+
+
 def format_usage_api_key_label(
     user_name: Optional[str] = None,
     api_key_name: Optional[str] = None,

--- a/tests/routers/test_usage.py
+++ b/tests/routers/test_usage.py
@@ -104,18 +104,48 @@ async def test_get_usage_meta_returns_identity_filters_for_admin():
             ),
             # route existence: route 21 still exists.
             _mock_exec_result([21]),
+            # user-group options: one non-reserved group + one reserved
+            # (filtered out).
+            _mock_exec_result(
+                [
+                    SimpleNamespace(
+                        id=50, name="engineering", display_name="Engineering"
+                    ),
+                    SimpleNamespace(
+                        id=51, name="system/authenticated", display_name="All"
+                    ),
+                ]
+            ),
+            # organization options: distinct consumer ids (NULL dropped).
+            _mock_exec_result(
+                [
+                    SimpleNamespace(group_organization_id=7),
+                    SimpleNamespace(group_organization_id=None),
+                ]
+            ),
+            # org name resolution: principal 7 → name "acme" (not display_name).
+            _mock_exec_result(
+                [SimpleNamespace(id=7, display_name="Acme", name="acme", kind="org")]
+            ),
         ]
     )
     user = User(id=1, name="admin", is_admin=True)
 
     response = await get_usage_meta(session=session, user=user, ctx=_ctx_for(user))
 
+    # Platform-wide admin (no current Org) also gets the Organization dimension.
     assert [item.key for item in response.group_bys] == [
         "date",
         "user",
         "api_key",
         "route",
+        "organization",
     ]
+    # Reserved groups are hidden; the org filter drops the NULL-consumer row.
+    assert [g.label for g in response.filters.user_groups] == ["Engineering"]
+    assert response.filters.user_groups[0].identity.current.group_id == 50
+    assert [o.label for o in response.filters.organizations] == ["acme"]
+    assert response.filters.organizations[0].identity.current.organization_id == 7
     assert [item.key for item in response.metrics] == [
         "input_tokens",
         "output_tokens",
@@ -189,6 +219,51 @@ async def test_get_usage_meta_hides_admin_only_options_for_regular_user():
     assert response.filters.users == []
     assert response.filters.routes == []
     assert response.filters.api_keys[0].label == "alice / test"
+
+
+@pytest.mark.asyncio
+async def test_get_usage_meta_hides_org_and_group_for_admin_pinned_to_org():
+    # A platform admin who has pinned a single Org (current_principal_id set)
+    # is NOT platform-wide: the Organization group-by and BOTH the org and
+    # user-group filters are hidden (cross-Org views are meaningless inside
+    # one tenant). Only user/api_key/route options are queried.
+    session = MagicMock()
+    session.exec = AsyncMock(
+        side_effect=[
+            # user options (scope=all) + existence.
+            _mock_exec_result(
+                [SimpleNamespace(group_user_name="alice", group_user_id=12)]
+            ),
+            _mock_exec_result([12]),
+            # api_key options + existence.
+            _mock_exec_result(
+                [
+                    SimpleNamespace(
+                        group_user_name="alice",
+                        group_api_key_name="k",
+                        group_access_key="abcd1234",
+                        group_api_key_is_custom=False,
+                        group_user_id=12,
+                        group_api_key_id=34,
+                    )
+                ]
+            ),
+            _mock_exec_result([34]),
+            # route options (empty → no existence query follows).
+            _mock_exec_result([]),
+        ]
+    )
+    user = User(id=1, name="admin", is_admin=True)
+    ctx = _ctx_for(user)
+    ctx.current_principal_id = 5  # pinned to a specific Org
+
+    response = await get_usage_meta(session=session, user=user, ctx=ctx)
+
+    # Organization is absent from the group-by list, and neither the org nor
+    # the user-group filter options are returned.
+    assert "organization" not in [item.key for item in response.group_bys]
+    assert response.filters.organizations == []
+    assert response.filters.user_groups == []
 
 
 def test_self_scope_personal_includes_null_consumer_rows():
@@ -908,3 +983,299 @@ async def test_get_usage_breakdown_rejects_regular_user_user_group():
         await get_usage_breakdown(
             session=session, user=user, ctx=_ctx_for(user), request=request
         )
+
+
+@pytest.mark.asyncio
+async def test_get_usage_breakdown_groups_by_organization_for_admin():
+    # Platform-wide admin can group by organization; the consumer principal
+    # id is resolved to a display name live, and a gone principal is deleted.
+    session = MagicMock()
+    session.exec = AsyncMock(
+        side_effect=[
+            _mock_exec_result(
+                [
+                    SimpleNamespace(
+                        input_tokens=500,
+                        output_tokens=200,
+                        input_cached_tokens=120,
+                        total_tokens=700,
+                        api_requests=9,
+                        models_called=3,
+                    ),
+                ]
+            ),
+            _mock_exec_result([2]),
+            _mock_exec_result(
+                [
+                    SimpleNamespace(
+                        group_organization_id=7,
+                        input_tokens=400,
+                        output_tokens=160,
+                        input_cached_tokens=100,
+                        total_tokens=560,
+                        api_requests=6,
+                        models_called=2,
+                        api_keys_used=3,
+                        last_active=date(2026, 4, 2),
+                    ),
+                    SimpleNamespace(
+                        group_organization_id=8,
+                        input_tokens=100,
+                        output_tokens=40,
+                        input_cached_tokens=20,
+                        total_tokens=140,
+                        api_requests=3,
+                        models_called=1,
+                        api_keys_used=1,
+                        last_active=date(2026, 4, 1),
+                    ),
+                ]
+            ),
+            # org name resolution: principal 7 → name "acme"; 8 is gone → deleted.
+            _mock_exec_result(
+                [SimpleNamespace(id=7, display_name="Acme", name="acme", kind="org")]
+            ),
+        ]
+    )
+    user = User(id=1, name="admin", is_admin=True)
+    request = UsageBreakdownRequest(
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 2),
+        group_by=["organization"],
+        sort_by="-total_tokens",
+        page=1,
+        perPage=20,
+    )
+
+    response = await get_usage_breakdown(
+        session=session, user=user, ctx=_ctx_for(user), request=request
+    )
+
+    assert response.group_by == ["organization"]
+    assert len(response.items) == 2
+    acme = response.items[0]
+    assert acme.organization.identity.current.organization_id == 7
+    assert acme.organization.identity.value.organization_name == "acme"
+    assert acme.organization.label == "acme"
+    assert acme.organization.deleted is False
+    assert acme.models_called == 2
+    assert acme.api_keys_used == 3
+    gone = response.items[1]
+    assert gone.organization.identity.current.organization_id == 8
+    assert gone.organization.deleted is True
+    assert gone.organization.label == "Unknown Organization"
+
+
+@pytest.mark.asyncio
+async def test_get_usage_breakdown_rejects_organization_group_by_for_non_admin():
+    session = MagicMock()
+    user = User(id=2, name="alice", is_admin=False)
+    request = UsageBreakdownRequest(
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 2),
+        group_by=["organization"],
+    )
+    with pytest.raises(ForbiddenException):
+        await get_usage_breakdown(
+            session=session, user=user, ctx=_ctx_for(user), request=request
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_usage_breakdown_rejects_organization_filter_for_non_admin():
+    session = MagicMock()
+    user = User(id=2, name="alice", is_admin=False)
+    request = UsageBreakdownRequest(
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 2),
+        group_by=["route"],
+        filters=UsageFilterRequest(
+            organizations=[
+                UsageFilterItem(
+                    identity=UsageIdentity(value={}, current={"organization_id": 7})
+                )
+            ]
+        ),
+    )
+    with pytest.raises(ForbiddenException):
+        await get_usage_breakdown(
+            session=session, user=user, ctx=_ctx_for(user), request=request
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_usage_breakdown_rejects_user_group_filter_in_self_scope():
+    # A regular user is forced to self scope; the user-group filter is a
+    # cross-user surface and must be rejected there (mirrors the user filter).
+    session = MagicMock()
+    user = User(id=2, name="alice", is_admin=False)
+    request = UsageBreakdownRequest(
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 2),
+        group_by=["route"],
+        filters=UsageFilterRequest(
+            user_groups=[
+                UsageFilterItem(
+                    identity=UsageIdentity(value={}, current={"group_id": 50})
+                )
+            ]
+        ),
+    )
+    with pytest.raises(ForbiddenException):
+        await get_usage_breakdown(
+            session=session, user=user, ctx=_ctx_for(user), request=request
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_usage_breakdown_expands_user_group_filter_to_members():
+    # The user-group filter is expanded to the group's direct USER members
+    # (first query) and applied as a user_id membership on every usage query.
+    session = MagicMock()
+    session.exec = AsyncMock(
+        side_effect=[
+            # group member expansion → users 12 and 13.
+            _mock_exec_result([12, 13]),
+            # summary.
+            _mock_exec_result(
+                [
+                    SimpleNamespace(
+                        input_tokens=300,
+                        output_tokens=100,
+                        input_cached_tokens=60,
+                        total_tokens=400,
+                        api_requests=5,
+                        models_called=2,
+                    ),
+                ]
+            ),
+            _mock_exec_result([1]),
+            _mock_exec_result(
+                [
+                    SimpleNamespace(
+                        group_model_route_name="qwen-route",
+                        group_model_route_id=21,
+                        input_tokens=300,
+                        output_tokens=100,
+                        input_cached_tokens=60,
+                        total_tokens=400,
+                        api_requests=5,
+                        models_called=1,
+                        api_keys_used=2,
+                        last_active=date(2026, 4, 2),
+                    ),
+                ]
+            ),
+            _mock_exec_result([21]),
+        ]
+    )
+    user = User(id=1, name="admin", is_admin=True)
+    request = UsageBreakdownRequest(
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 2),
+        group_by=["route"],
+        filters=UsageFilterRequest(
+            user_groups=[
+                UsageFilterItem(
+                    identity=UsageIdentity(value={}, current={"group_id": 50})
+                )
+            ]
+        ),
+    )
+
+    response = await get_usage_breakdown(
+        session=session, user=user, ctx=_ctx_for(user), request=request
+    )
+
+    # First query expands the group membership.
+    group_sql = str(session.exec.call_args_list[0].args[0])
+    assert "principal_memberships" in group_sql
+    # The summary query filters usage rows to the resolved member user ids.
+    summary_sql = str(session.exec.call_args_list[1].args[0])
+    assert "model_usages.user_id IN" in summary_sql
+    assert len(response.items) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_usage_breakdown_organization_uses_snapshot_name_and_kind():
+    # The consumer name / kind snapshot on the row (group_organization_name /
+    # _kind) is preferred over the live lookup: a hard-deleted Org keeps its
+    # real name (not "Unknown") and a personal (USER) consumer is tagged.
+    session = MagicMock()
+    session.exec = AsyncMock(
+        side_effect=[
+            _mock_exec_result(
+                [
+                    SimpleNamespace(
+                        input_tokens=100,
+                        output_tokens=40,
+                        input_cached_tokens=0,
+                        total_tokens=140,
+                        api_requests=2,
+                        models_called=1,
+                    )
+                ]
+            ),
+            _mock_exec_result([2]),
+            _mock_exec_result(
+                [
+                    # Hard-deleted Org (id 8 absent from principals) but the row
+                    # snapshotted its name + kind at ingest.
+                    SimpleNamespace(
+                        group_organization_id=8,
+                        group_organization_name="GoneCorp",
+                        group_organization_kind="org",
+                        input_tokens=80,
+                        output_tokens=30,
+                        input_cached_tokens=0,
+                        total_tokens=110,
+                        api_requests=1,
+                        models_called=1,
+                        api_keys_used=1,
+                        last_active=date(2026, 4, 2),
+                    ),
+                    # Personal (USER) consumer — still live.
+                    SimpleNamespace(
+                        group_organization_id=11,
+                        group_organization_name="g1",
+                        group_organization_kind="user",
+                        input_tokens=20,
+                        output_tokens=10,
+                        input_cached_tokens=0,
+                        total_tokens=30,
+                        api_requests=1,
+                        models_called=1,
+                        api_keys_used=1,
+                        last_active=date(2026, 4, 1),
+                    ),
+                ]
+            ),
+            # Live principal lookup: only 11 (g1, user) exists; 8 is gone.
+            _mock_exec_result(
+                [SimpleNamespace(id=11, display_name=None, name="g1", kind="user")]
+            ),
+        ]
+    )
+    user = User(id=1, name="admin", is_admin=True)
+    request = UsageBreakdownRequest(
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 2),
+        group_by=["organization"],
+    )
+
+    response = await get_usage_breakdown(
+        session=session, user=user, ctx=_ctx_for(user), request=request
+    )
+
+    by_id = {
+        it.organization.identity.current.organization_id: it.organization
+        for it in response.items
+    }
+    # Deleted Org keeps its snapshot name (not "Unknown Organization").
+    assert by_id[8].label == "GoneCorp"
+    assert by_id[8].deleted is True
+    assert by_id[8].identity.value.organization_kind == "org"
+    # Personal consumer is tagged via kind for the client "Personal" label.
+    assert by_id[11].label == "g1"
+    assert by_id[11].deleted is False
+    assert by_id[11].identity.value.organization_kind == "user"

--- a/tests/routes/test_resource_usage_api.py
+++ b/tests/routes/test_resource_usage_api.py
@@ -9,6 +9,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from gpustack.api.exceptions import ForbiddenException
 from gpustack.routes.resource_usage import (
     ResourceBreakdownRequest,
     _phase_message_of,
@@ -97,7 +98,7 @@ async def _seed(session):
 
 @pytest_asyncio.fixture
 async def session():
-    from gpustack.schemas.principals import Principal
+    from gpustack.schemas.principals import Principal, PrincipalMembership
     from gpustack.schemas.gpu_instances import GPUInstance
     from gpustack.schemas.gpu_instance_persistent_volumes import (
         GPUInstancePersistentVolume,
@@ -110,6 +111,7 @@ async def session():
             MeteredUsage.__table__,
             ModelUsage.__table__,
             Principal.__table__,
+            PrincipalMembership.__table__,
             GPUInstance.__table__,
             GPUInstancePersistentVolume.__table__,
             ResourceEvent.__table__,
@@ -1157,3 +1159,258 @@ async def test_breakdown_range_boundary_includes_shifted_edge(session, monkeypat
         metric_keys=["gpu_hours"],
     )
     assert "edge-sku" in {i.get("key") for i in out["items"]}
+
+
+@pytest.mark.asyncio
+async def test_breakdown_groups_by_organization_for_admin(session):
+    # Two consumer Orgs; the consumer principal id is resolved to a display
+    # name live, and a gone principal (no Principal row) is flagged deleted.
+    from gpustack.schemas.principals import Principal
+
+    session.add(Principal(id=100, kind="org", name="acme", display_name="Acme"))
+    # org 200 intentionally left unseeded → since-deleted.
+    session.add_all(
+        [
+            _mu(
+                meter_key=METER_INSTANCE_UPTIME,
+                resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+                resource_id=701,
+                resource_name="org-a-gpu",
+                sku="h100x1",
+                sku_count=1,
+                quantity=3600,
+                unit="seconds",
+                consumer_principal_id=100,
+                creator_id=7,
+            ),
+            _mu(
+                meter_key=METER_INSTANCE_UPTIME,
+                resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+                resource_id=702,
+                resource_name="org-b-gpu",
+                sku="h100x1",
+                sku_count=1,
+                quantity=3600,
+                unit="seconds",
+                consumer_principal_id=200,
+                creator_id=7,
+            ),
+        ]
+    )
+    await session.commit()
+
+    out = await _run_breakdown(
+        session,
+        user=USER,
+        ctx=CTX,  # admin, cross-org (current_principal_id=None)
+        request=ResourceBreakdownRequest(
+            scope="all", start_date=D, end_date=D, group_by=["organization"]
+        ),
+        base_filter=(MeteredUsage.meter_key == METER_INSTANCE_UPTIME),
+        metric_keys=["gpu_hours"],
+    )
+    by_id = {i["id"]: i for i in out["items"]}
+    assert by_id[100]["key"] == "acme"
+    assert by_id[100]["deleted"] is False
+    assert by_id[200]["deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_breakdown_filters_by_organization(session):
+    session.add_all(
+        [
+            _mu(
+                meter_key=METER_INSTANCE_UPTIME,
+                resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+                resource_id=711,
+                resource_name="org-a-gpu",
+                sku="h100x1",
+                sku_count=1,
+                quantity=3600,
+                unit="seconds",
+                consumer_principal_id=100,
+                creator_id=7,
+            ),
+            _mu(
+                meter_key=METER_INSTANCE_UPTIME,
+                resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+                resource_id=712,
+                resource_name="org-b-gpu",
+                sku="h100x1",
+                sku_count=1,
+                quantity=3600,
+                unit="seconds",
+                consumer_principal_id=200,
+                creator_id=7,
+            ),
+        ]
+    )
+    await session.commit()
+
+    out = await _run_breakdown(
+        session,
+        user=USER,
+        ctx=CTX,
+        request=ResourceBreakdownRequest(
+            scope="all",
+            start_date=D,
+            end_date=D,
+            group_by=["instance"],
+            organization_ids=[100],
+        ),
+        base_filter=(MeteredUsage.meter_key == METER_INSTANCE_UPTIME),
+        metric_keys=["gpu_hours"],
+    )
+    names = {i["key"] for i in out["items"]}
+    assert "org-a-gpu" in names
+    assert "org-b-gpu" not in names
+
+
+@pytest.mark.asyncio
+async def test_breakdown_filters_by_user_group_members(session):
+    # Group 50 has one direct user member (creator 7); a row from creator 9
+    # must be excluded when filtering by that group.
+    from gpustack.schemas.principals import Principal, PrincipalMembership
+
+    session.add(Principal(id=50, kind="group", name="eng", display_name="Eng"))
+    session.add(Principal(id=9, kind="user", name="bob", display_name="Bob"))
+    session.add(PrincipalMembership(parent_principal_id=50, member_principal_id=7))
+    session.add(
+        _mu(
+            meter_key=METER_INSTANCE_UPTIME,
+            resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+            resource_id=721,
+            resource_name="bob-gpu",
+            sku="h100x1",
+            sku_count=1,
+            quantity=3600,
+            unit="seconds",
+            creator_id=9,
+        )
+    )
+    await session.commit()
+
+    out = await _run_breakdown(
+        session,
+        user=USER,
+        ctx=CTX,
+        request=ResourceBreakdownRequest(
+            scope="all",
+            start_date=D,
+            end_date=D,
+            group_by=["user"],
+            user_group_ids=[50],
+        ),
+        base_filter=(MeteredUsage.meter_key == METER_INSTANCE_UPTIME),
+        metric_keys=["gpu_hours"],
+    )
+    creator_ids = {i["id"] for i in out["items"]}
+    assert creator_ids == {7}  # only the group member; bob (9) excluded
+
+
+@pytest.mark.asyncio
+async def test_breakdown_rejects_organization_group_by_for_non_admin(session):
+    regular = SimpleNamespace(id=7, is_admin=False)
+    with pytest.raises(ForbiddenException):
+        await _run_breakdown(
+            session,
+            user=regular,
+            ctx=SimpleNamespace(
+                current_principal_id=1,
+                org_role=None,
+                current_is_personal_scope=False,
+            ),
+            request=ResourceBreakdownRequest(
+                scope="all", start_date=D, end_date=D, group_by=["organization"]
+            ),
+            base_filter=None,
+            metric_keys=["gpu_hours"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_breakdown_rejects_user_group_filter_in_self_scope(session):
+    regular = SimpleNamespace(id=7, is_admin=False)
+    with pytest.raises(ForbiddenException):
+        await _run_breakdown(
+            session,
+            user=regular,
+            ctx=SimpleNamespace(
+                current_principal_id=1,
+                org_role=None,
+                current_is_personal_scope=False,
+            ),
+            request=ResourceBreakdownRequest(
+                scope="self",
+                start_date=D,
+                end_date=D,
+                group_by=["user"],
+                user_group_ids=[50],
+            ),
+            base_filter=None,
+            metric_keys=["gpu_hours"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_resource_meta_lists_organizations_and_user_groups(session):
+    from gpustack.routes.resource_usage import resource_meta
+    from gpustack.schemas.principals import Principal
+
+    session.add(Principal(id=100, kind="org", name="acme", display_name="Acme"))
+    session.add(Principal(id=50, kind="group", name="eng", display_name="Eng"))
+    session.add(
+        Principal(id=51, kind="group", name="system/authenticated", display_name="All")
+    )
+    session.add(
+        _mu(
+            meter_key=METER_INSTANCE_UPTIME,
+            resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+            resource_id=731,
+            resource_name="org-a-gpu",
+            sku="h100x1",
+            sku_count=1,
+            quantity=3600,
+            unit="seconds",
+            consumer_principal_id=100,
+            creator_id=7,
+        )
+    )
+    await session.commit()
+
+    out = await resource_meta(session, USER, CTX, scope="all")
+    assert [g["label"] for g in out["user_groups"]] == ["Eng"]  # reserved hidden
+    assert [o["id"] for o in out["organizations"]] == [100]
+    assert out["organizations"][0]["label"] == "acme"
+
+
+@pytest.mark.asyncio
+async def test_resource_meta_hides_org_and_group_when_pinned_to_org(session):
+    # An admin pinned to a single Org (current_principal_id set) is NOT
+    # platform-wide: both the org and the user-group filter sources are empty
+    # (cross-Org filtering is meaningless within one tenant).
+    from gpustack.routes.resource_usage import resource_meta
+    from gpustack.schemas.principals import Principal
+
+    session.add(Principal(id=100, kind="org", name="acme", display_name="Acme"))
+    session.add(Principal(id=50, kind="group", name="eng", display_name="Eng"))
+    session.add(
+        _mu(
+            meter_key=METER_INSTANCE_UPTIME,
+            resource_type=RESOURCE_TYPE_GPU_INSTANCE,
+            resource_id=741,
+            resource_name="org-a-gpu",
+            sku="h100x1",
+            sku_count=1,
+            quantity=3600,
+            unit="seconds",
+            consumer_principal_id=100,
+            creator_id=7,
+        )
+    )
+    await session.commit()
+
+    pinned_ctx = SimpleNamespace(current_principal_id=100)
+    out = await resource_meta(session, USER, pinned_ctx, scope="all")
+    assert out["organizations"] == []
+    assert out["user_groups"] == []

--- a/tests/server/test_resource_event_logger.py
+++ b/tests/server/test_resource_event_logger.py
@@ -70,24 +70,25 @@ def _patch_services(principals: dict, clusters: dict):
 async def test_resolve_principals_derives_owner_from_cluster():
     # consumer 5 created an instance on cluster 1, owned by provider 3.
     principals = {
-        3: SimpleNamespace(name="provider-org"),
-        5: SimpleNamespace(name="acme-org"),
-        7: SimpleNamespace(name="bob"),
+        3: SimpleNamespace(name="provider-org", kind="org"),
+        5: SimpleNamespace(name="acme-org", kind="org"),
+        7: SimpleNamespace(name="bob", kind="user"),
     }
     clusters = {1: SimpleNamespace(name="default", owner_principal_id=3)}
     with _patch_services(principals, clusters):
         out = await _resolve_principals(None, 5, 7, 1)
-    # (owner_principal_id, owner_name, consumer_name, creator_name, cluster_name)
-    assert out == (3, "provider-org", "acme-org", "bob", "default")
+    # (owner_principal_id, owner_name, consumer_name, creator_name,
+    #  cluster_name, consumer_kind)
+    assert out == (3, "provider-org", "acme-org", "bob", "default", "org")
 
 
 @pytest.mark.asyncio
 async def test_resolve_principals_no_cluster_owner_equals_consumer():
     # No cluster (e.g. PV) → provider == consumer; resolved once (per-call memo).
-    principals = {9: SimpleNamespace(name="alice")}
+    principals = {9: SimpleNamespace(name="alice", kind="user")}
     with _patch_services(principals, clusters={}) as principal_get:
         out = await _resolve_principals(None, 9, 9, None)
-    assert out == (9, "alice", "alice", "alice", None)
+    assert out == (9, "alice", "alice", "alice", None, "user")
     assert principal_get.await_count == 1  # owner==consumer==creator → one lookup
 
 
@@ -95,8 +96,9 @@ async def test_resolve_principals_no_cluster_owner_equals_consumer():
 async def test_resolve_principals_missing_entity_yields_none():
     with _patch_services(principals={}, clusters={}):  # nothing resolves
         out = await _resolve_principals(None, 404, 404, 404)
-    # cluster 404 missing → owner falls back to consumer id (404), name None
-    assert out == (404, None, None, None, None)
+    # cluster 404 missing → owner falls back to consumer id (404), name None,
+    # and the gone consumer principal yields a None kind.
+    assert out == (404, None, None, None, None, None)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add an "organization" group-by dimension plus organization and user-group filters to the token (model_usages) and resource (metered_usage) usage APIs, for the platform-wide "All" view (admin acting without a pinned org).

- group by consumer_principal_id; filter by consumer org, and by the direct USER members of the selected user groups
- snapshot the consumer principal name + kind onto model_usages / metered_usage / resource_events so a deleted org keeps its name and a personal (USER) consumer is taggable; live-lookup fallback, no backfill
- gate the org dimension / filter to platform-wide admin; the user-group filter is forbidden in self scope
- meta endpoints return org / user-group filter options (platform-wide only), with the deleted-org name resolved from the snapshot
- alembic migration adds the nullable consumer_name / consumer_principal_kind columns