### PR TITLE
feat(model-catalog): add Tencent Hy3 (standard + throughput)

### DIFF
--- a/gpustack/assets/model-catalog-modelscope.yaml
+++ b/gpustack/assets/model-catalog-modelscope.yaml
@@ -1005,6 +1005,44 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=glm45
         - --max-model-len=65536
+- name: Hy3
+  description: Hy3 is Tencent Hunyuan's open-weight Mixture-of-Experts model (295B total, 21B active) built for reasoning and agentic tasks, with strong tool use, coding, and long-context retrieval and a 256K-token context window.
+  home: https://github.com/Tencent-Hunyuan/Hy3
+  icon: /static/catalog_icons/hunyuan.png
+  size: 295
+  activated_size: 21
+  categories:
+    - llm
+  capabilities:
+    - context/256K
+    - reasoning
+    - tools
+  licenses:
+    - apache-2.0
+  release_date: "2026-07-06"
+  specs:
+    # Throughput (vLLM, FP8)
+    - mode: throughput
+      quantization: FP8
+      source: model_scope
+      model_scope_model_id: Tencent-Hunyuan/Hy3-FP8
+      backend: vLLM
+      backend_parameters:
+        - --tool-call-parser=hy_v3
+        - --reasoning-parser=hy_v3
+        - --enable-auto-tool-choice
+        - --max-model-len=65536
+    # Standard (BF16, vLLM)
+    - mode: standard
+      quantization: BF16
+      source: model_scope
+      model_scope_model_id: Tencent-Hunyuan/Hy3
+      backend: vLLM
+      backend_parameters:
+        - --tool-call-parser=hy_v3
+        - --reasoning-parser=hy_v3
+        - --enable-auto-tool-choice
+        - --max-model-len=65536
 - name: GLM-5.2
   description: GLM-5.2 is Z.ai's flagship Mixture-of-Experts model built on the glm_moe_dsa architecture (DeepSeek Sparse Attention), with strong agentic, reasoning, and coding capabilities and a 1M-token context window.
   home: https://z.ai

--- a/gpustack/assets/model-catalog.yaml
+++ b/gpustack/assets/model-catalog.yaml
@@ -984,6 +984,44 @@ model_sets:
       backend_parameters:
         - --reasoning-parser=glm45
         - --max-model-len=65536
+- name: Hy3
+  description: Hy3 is Tencent Hunyuan's open-weight Mixture-of-Experts model (295B total, 21B active) built for reasoning and agentic tasks, with strong tool use, coding, and long-context retrieval and a 256K-token context window.
+  home: https://github.com/Tencent-Hunyuan/Hy3
+  icon: /static/catalog_icons/hunyuan.png
+  size: 295
+  activated_size: 21
+  categories:
+    - llm
+  capabilities:
+    - context/256K
+    - reasoning
+    - tools
+  licenses:
+    - apache-2.0
+  release_date: "2026-07-06"
+  specs:
+    # Throughput (vLLM, FP8)
+    - mode: throughput
+      quantization: FP8
+      source: huggingface
+      huggingface_repo_id: tencent/Hy3-FP8
+      backend: vLLM
+      backend_parameters:
+        - --tool-call-parser=hy_v3
+        - --reasoning-parser=hy_v3
+        - --enable-auto-tool-choice
+        - --max-model-len=65536
+    # Standard (BF16, vLLM)
+    - mode: standard
+      quantization: BF16
+      source: huggingface
+      huggingface_repo_id: tencent/Hy3
+      backend: vLLM
+      backend_parameters:
+        - --tool-call-parser=hy_v3
+        - --reasoning-parser=hy_v3
+        - --enable-auto-tool-choice
+        - --max-model-len=65536
 - name: GLM-5.2
   description: GLM-5.2 is Z.ai's flagship Mixture-of-Experts model built on the glm_moe_dsa architecture (DeepSeek Sparse Attention), with strong agentic, reasoning, and coding capabilities and a 1M-token context window.
   home: https://z.ai


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5695
Add Hy3 (295B MoE, 21B active, 256K context, Apache 2.0) to the HuggingFace and ModelScope catalogs with two specs: throughput vLLM FP8 for all other GPUs, and a standard BF16 vLLM fallback.