### PR TITLE
fix(worker): require auth on debug and logs routers

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -28,16 +28,22 @@ gpustack reload-config --set debug=true
 
 ## Configure Log Level
 
-You can configure log level of the GPUStack server at runtime by running the following command inside the **server container**:
+The log level endpoints require authentication.
+
+You can configure log level of the GPUStack server at runtime by running the following command inside the **server container**. Authenticate with an admin API key:
 
 ```bash
-curl -X PUT http://localhost/debug/log_level -d "debug"
+curl -X PUT http://localhost/debug/log_level \
+    -H "Authorization: Bearer <YOUR_API_KEY>" \
+    -d "debug"
 ```
 
-The same applies to GPUStack workers:
+The same applies to GPUStack workers. Authenticate with the local worker token (defaults to `/var/lib/gpustack/worker_token`):
 
 ```bash
-curl -X PUT http://localhost:10150/debug/log_level -d "debug"
+curl -X PUT http://localhost:10150/debug/log_level \
+    -H "Authorization: Bearer $(cat /var/lib/gpustack/worker_token)" \
+    -d "debug"
 ```
 
 The available log levels are: `trace`, `debug`, `info`, `warning`, `error`, `critical`.

--- a/gpustack/worker/worker.py
+++ b/gpustack/worker/worker.py
@@ -371,9 +371,16 @@ class Worker:
             prefix=default_versioned_prefix,
             dependencies=[Depends(worker_request_auth)],
         )
-        app.include_router(debug.router, prefix="/debug")
+        app.include_router(
+            debug.router,
+            prefix="/debug",
+            dependencies=[Depends(worker_request_auth)],
+        )
         app.include_router(probes.router)
-        app.include_router(logs.router)
+        app.include_router(
+            logs.router,
+            dependencies=[Depends(worker_request_auth)],
+        )
         app.include_router(proxy.router)
         app.include_router(filesystem.router)
         app.include_router(cluster_proxy.router)


### PR DESCRIPTION
The worker HTTP server mounted debug.router (/debug) and logs.router (/serveLogs, /serveLogOptions, /benchmark_logs) without any auth dependency, unlike filesystem/proxy/cluster_proxy which require worker_auth. An unauthenticated attacker reaching the worker port (default 10150, bound to 0.0.0.0) could read model-serving logs (prompt/completion content), change the worker log level, and read memory profiling output.

#5836

