### PR TITLE
fix: ignore unauthorized config endpoint after local apply

### DIFF
--- a/gpustack/cmd/reload_config.py
+++ b/gpustack/cmd/reload_config.py
@@ -23,7 +23,6 @@ from gpustack.utils.config import (
 from gpustack.logging import setup_logging
 from gpustack.client.generated_http_client import default_versioned_prefix
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -219,6 +218,23 @@ def resolve_scope_headers(args: argparse.Namespace) -> Dict[str, Dict[str, str]]
     return headers
 
 
+def record_runtime_update_response(
+    url: str,
+    status_code: int,
+    failures: list[str],
+    auth_failures: list[str],
+) -> bool:
+    if status_code == 200:
+        logger.info(f"Applied runtime config via {url}")
+        return True
+    logger.warning(f"Failed to apply config via {url}: {status_code}")
+    if status_code in (401, 403):
+        auth_failures.append(f"{url}: HTTP {status_code}")
+    else:
+        failures.append(f"{url}: HTTP {status_code}")
+    return False
+
+
 def apply_runtime_updates(
     payload: Dict[str, Any],
     args: argparse.Namespace,
@@ -240,6 +256,7 @@ def apply_runtime_updates(
     }
     applied = False
     failures: list[str] = []
+    auth_failures: list[str] = []
     for scope, url in endpoints.items():
         if scope not in scope_headers:
             # No credential for this endpoint's auth scheme. Skip rather than
@@ -250,12 +267,12 @@ def apply_runtime_updates(
             resp = requests.put(
                 url, json=payload, headers=scope_headers[scope], timeout=5
             )
-            if resp.status_code == 200:
-                logger.info(f"Applied runtime config via {url}")
-                applied = True
-            else:
-                logger.warning(f"Failed to apply config via {url}: {resp.status_code}")
-                failures.append(f"{url}: HTTP {resp.status_code}")
+            applied = (
+                record_runtime_update_response(
+                    url, resp.status_code, failures, auth_failures
+                )
+                or applied
+            )
         except requests.exceptions.ConnectionError:
             # This endpoint's role (server/worker) isn't running on this host —
             # e.g. on a worker host where the server port is not bound. Expected;
@@ -268,6 +285,10 @@ def apply_runtime_updates(
     if failures:
         raise Exception("Failed to apply runtime config to: " + "; ".join(failures))
     if not applied:
+        if auth_failures:
+            raise Exception(
+                "Failed to apply runtime config to: " + "; ".join(auth_failures)
+            )
         raise Exception(
             "No reachable config endpoint accepted the update. Ensure the "
             "gpustack server or worker is running on this host, or target it "

--- a/tests/cmd/test_reload_config_auth.py
+++ b/tests/cmd/test_reload_config_auth.py
@@ -1,11 +1,15 @@
 import argparse
+from types import SimpleNamespace
+
+import pytest
 
 from gpustack.api.auth import SESSION_COOKIE_NAME
 from gpustack.cmd.local_auth import (
     mint_admin_jwt,
     read_local_jwt_secret,
 )
-from gpustack.cmd.reload_config import resolve_scope_headers
+from gpustack.cmd import reload_config
+from gpustack.cmd.reload_config import apply_runtime_updates, resolve_scope_headers
 from gpustack.security import JWTManager
 
 
@@ -96,6 +100,56 @@ def test_api_key_falls_back_for_worker_when_no_token(tmp_path):
 
 def test_no_credentials_yields_empty(tmp_path):
     assert resolve_scope_headers(_args(tmp_path)) == {}
+
+
+# ---------------------------------------------------------------------------
+# apply_runtime_updates — endpoint fallback behavior
+# ---------------------------------------------------------------------------
+
+
+def test_apply_runtime_updates_ignores_unauthorized_endpoint_after_worker_success(
+    monkeypatch,
+):
+    calls = []
+
+    monkeypatch.setattr(
+        reload_config,
+        "resolve_scope_headers",
+        lambda args: {
+            "server": {"Authorization": "Bearer admin"},
+            "worker": {"Authorization": "Bearer worker"},
+        },
+    )
+
+    def fake_put(url, json, headers, timeout):
+        calls.append((url, headers))
+        if ":30080" in url:
+            return SimpleNamespace(status_code=401)
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(reload_config.requests, "put", fake_put)
+
+    apply_runtime_updates({"debug": True}, argparse.Namespace())
+
+    assert len(calls) == 2
+
+
+def test_apply_runtime_updates_still_fails_when_only_endpoint_is_unauthorized(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        reload_config,
+        "resolve_scope_headers",
+        lambda args: {"server": {"Authorization": "Bearer admin"}},
+    )
+    monkeypatch.setattr(
+        reload_config.requests,
+        "put",
+        lambda url, json, headers, timeout: SimpleNamespace(status_code=401),
+    )
+
+    with pytest.raises(Exception, match="HTTP 401"):
+        apply_runtime_updates({"debug": True}, argparse.Namespace())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `reload-config` so a worker-local config update can succeed even when the server endpoint responds with 401/403.

## Changes

- Split runtime config endpoint failures into regular failures and auth failures.
- Keep 401/403 fatal when no endpoint accepts the update.
- Allow the command to succeed when another local endpoint, such as the worker endpoint, already applied the runtime config.
- Add regression tests for the worker-success/server-401 case and the auth-only failure case.

## Real behavior proof

- behavior: `gpustack reload-config --set debug=true` on a worker should not fail the whole command after the worker endpoint accepts the update, even if the server endpoint returns 401/403.
- environment: latest `origin/main` at `7ab7bf76`, local Python 3.12.12 virtualenv created by `uv`, branch `fix/reload-config-worker-target`.
- steps: inspected `gpustack/cmd/reload_config.py`; added tests that mock `resolve_scope_headers` and `requests.put` to simulate server `:30080` returning 401 and worker `:10150` returning 200; ran targeted auth/reload tests plus formatting/lint/compile checks.
- evidence: `.venv/bin/python -m pytest tests/cmd/test_reload_config_auth.py -q -p no:cacheprovider` => `13 passed, 6 warnings in 34.26s`; `.venv/bin/python -m black --check gpustack/cmd/reload_config.py tests/cmd/test_reload_config_auth.py` => `2 files would be left unchanged`; `.venv/bin/python -m flake8 gpustack/cmd/reload_config.py tests/cmd/test_reload_config_auth.py` => no output; `git diff --check` => no output; `.venv/bin/python -m py_compile gpustack/cmd/reload_config.py tests/cmd/test_reload_config_auth.py` => no output.
- observedResult: mocked server 401 + worker 200 no longer raises, while a single unauthorized endpoint still raises with `HTTP 401`.
- notTested: did not run a live Kubernetes worker container because this environment does not have a GPUStack K8s deployment; the regression is covered at the request/endpoint handling layer.

## Test Plan

- `git diff --check`
- `.venv/bin/python -m black --check gpustack/cmd/reload_config.py tests/cmd/test_reload_config_auth.py`
- `.venv/bin/python -m flake8 gpustack/cmd/reload_config.py tests/cmd/test_reload_config_auth.py`
- `.venv/bin/python -m py_compile gpustack/cmd/reload_config.py tests/cmd/test_reload_config_auth.py`
- `.venv/bin/python -m pytest tests/cmd/test_reload_config_auth.py -q -p no:cacheprovider`

## Risk

Low. The change only softens 401/403 from a non-applicable endpoint when another local endpoint has already accepted the update; non-auth failures and auth-only failures remain fatal.

Fixes #5867
