### PR TITLE
feat(chart): add stable ClusterIP service for server discovery

### DIFF
--- a/charts/gpustack-chart/templates/server-service.yaml
+++ b/charts/gpustack-chart/templates/server-service.yaml
@@ -25,6 +25,33 @@ spec:
       port: {{ .Values.server.metricsPort }}
       targetPort: {{ .Values.server.metricsPort }}
 ---
+# ClusterIP service with a stable virtual IP for the server. Used as the
+# service discovery target for both the Ingress backend and the gateway
+# ext-auth MCP bridge registry, so that kube-proxy routes traffic only to
+# ready endpoints and switchover between StatefulSet pods is handled
+# automatically (unlike the headless service above, which resolves to raw
+# pod IPs that can go stale during a rollover/failover).
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-server-cluster-ip
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "chart_labels" . | indent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Release.Name }}-server
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.server.apiPort }}
+      targetPort: {{ .Values.server.apiPort }}
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.server.metricsPort }}
+      targetPort: {{ .Values.server.metricsPort }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -42,7 +69,7 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ .Release.Name }}-server
+                name: {{ .Release.Name }}-server-cluster-ip
                 port:
                   number: {{ .Values.server.apiPort }}
             path: /

--- a/charts/gpustack-chart/templates/server-statefulset.yaml
+++ b/charts/gpustack-chart/templates/server-statefulset.yaml
@@ -76,6 +76,18 @@ spec:
             - containerPort: {{ .Values.server.metricsPort }}
               name: metrics
               protocol: TCP
+          {{- with .Values.server.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: {{ include "gpustack.image" . }}:{{ include "gpustack.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Release.Name }}-server
@@ -107,7 +119,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- else }}
-      {{- if gt (int .Values.server.replicas) 1 }}
+      {{- if gt (int (.Values.server.replicas | default 1)) 1 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/gpustack-chart/templates/server-statefulset.yaml
+++ b/charts/gpustack-chart/templates/server-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
             - name: GPUSTACK_DISABLE_WORKER
               value: 'true'
             - name: GPUSTACK_SERVICE_DISCOVERY_NAME
-              value: "{{ .Release.Name }}-server"
+              value: "{{ .Release.Name }}-server-cluster-ip"
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/gpustack-chart/templates/server-statefulset.yaml
+++ b/charts/gpustack-chart/templates/server-statefulset.yaml
@@ -103,6 +103,20 @@ spec:
       nodeSelector:
         {{- nindent 8 . }}
       {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      {{- if gt (int .Values.server.replicas) 1 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: {{ .Release.Name }}-server
+      {{- end }}
+      {{- end }}
       {{- if or .Values.server.dataVolume.hostPath .Values.server.extraVolumes }}
       volumes:
         {{- if .Values.server.dataVolume.hostPath }}

--- a/charts/gpustack-chart/values.yaml
+++ b/charts/gpustack-chart/values.yaml
@@ -107,6 +107,37 @@ server:
   # replicas, otherwise extra replicas stay Pending; override this knob (e.g.
   # with a `preferred` rule) for smaller clusters.
   affinity: {}
+  # Server pod probes. Each is rendered verbatim when non-empty; set to null/{}
+  # to disable a probe. The server only starts serving HTTP after DB migrations
+  # and init complete, so the startupProbe (up to ~300s here) guards the
+  # slow-start window before livenessProbe takes over — increase its
+  # `failureThreshold` for slow/remote databases. Ports refer to the container's
+  # named `http` port.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 30
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 5
+    successThreshold: 1
 clusterDomain: cluster.local
 gateway:
   # IngressClass name for the Higress gateway; GPUStack checks if it exists in the cluster to enable in-cluster gateway mode

--- a/charts/gpustack-chart/values.yaml
+++ b/charts/gpustack-chart/values.yaml
@@ -99,6 +99,14 @@ server:
   # `global.nodeSelector` entirely (no merging). Leave empty/null to fall
   # back to `global.nodeSelector`.
   nodeSelector: {}
+  # Affinity for the server pod. When non-empty, REPLACES the built-in default
+  # entirely (no merging). Leave empty/null to use the default: when
+  # `replicas > 1`, a hard (required) podAntiAffinity by `kubernetes.io/hostname`
+  # spreads replicas across nodes so a single node failure only takes down one
+  # replica. NOTE: the hard rule requires at least as many schedulable nodes as
+  # replicas, otherwise extra replicas stay Pending; override this knob (e.g.
+  # with a `preferred` rule) for smaller clusters.
+  affinity: {}
 clusterDomain: cluster.local
 gateway:
   # IngressClass name for the Higress gateway; GPUStack checks if it exists in the cluster to enable in-cluster gateway mode


### PR DESCRIPTION
Point GPUSTACK_SERVICE_DISCOVERY_NAME and the Ingress backend at a new gpustack-system-cluster-ip service so ext-auth and ingress route through a stable virtual IP, avoiding stale pod IPs during StatefulSet switchover.