### PR TITLE
fix: show first-login admin password guide across all server replicas

### DIFF
--- a/charts/gpustack-chart/templates/server-bootstrap-password.yaml
+++ b/charts/gpustack-chart/templates/server-bootstrap-password.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.server.bootstrapPasswordSecret.enabled -}}
+{{- /*
+Shared initial admin password for the server replicas. A pinned password
+(`password` set) is injected into every replica as GPUSTACK_BOOTSTRAP_PASSWORD
+and treated as operator-chosen (no forced first-login change, no guide). An
+auto-generated password is instead mounted at
+/var/lib/gpustack/initial_admin_password on every pod so that, unlike a file
+generated per-replica, all replicas surface the same first-login retrieval
+guide; it is reused across upgrades via lookup so the value stays stable.
+*/ -}}
+{{- $secretName := printf "%s-server-bootstrap-password" .Release.Name -}}
+{{- $password := "" -}}
+{{- if .Values.server.bootstrapPasswordSecret.password -}}
+  {{- $password = .Values.server.bootstrapPasswordSecret.password | toString -}}
+{{- else -}}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+  {{- if and $secret (hasKey ($secret.data | default dict) "password") -}}
+    {{- $password = index $secret.data "password" | b64dec -}}
+  {{- else -}}
+    {{- $password = randAlphaNum 16 -}}
+  {{- end -}}
+{{- end -}}
+apiVersion: v1
+data:
+  password: {{ $password | b64enc }}
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "chart_labels" . | indent 4 }}
+type: Opaque
+{{- end }}

--- a/charts/gpustack-chart/templates/server-statefulset.yaml
+++ b/charts/gpustack-chart/templates/server-statefulset.yaml
@@ -1,3 +1,12 @@
+{{- /*
+Bootstrap admin password delivery. A pinned password is injected as an env var
+(the same channel as --bootstrap-password), so the server treats it as
+operator-chosen — no forced first-login change, no retrieval guide. An
+auto-generated password is mounted as a shared file so every replica surfaces
+the same first-login retrieval guide regardless of round-robin routing.
+*/ -}}
+{{- $bootstrapPinned := and .Values.server.bootstrapPasswordSecret.enabled .Values.server.bootstrapPasswordSecret.password -}}
+{{- $bootstrapFile := and .Values.server.bootstrapPasswordSecret.enabled (not .Values.server.bootstrapPasswordSecret.password) -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -57,6 +66,13 @@ spec:
               value: {{ include "gpustack.hub" . }}
             - name: GPUSTACK_IMAGE_NAME_OVERRIDE
               value: {{ include "gpustack.image" . }}:{{ include "gpustack.imageTag" . }}
+            {{- if $bootstrapPinned }}
+            - name: GPUSTACK_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-server-bootstrap-password
+                  key: password
+            {{- end }}
           envFrom:
             {{- if .Values.worker.enabled }}
             - secretRef:
@@ -102,6 +118,15 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/gpustack
               name: gpustack-data-dir
+            {{- if $bootstrapFile }}
+            # Machine-generated shared initial admin password, mounted so every
+            # replica shows the same first-login retrieval guide regardless of
+            # round-robin routing.
+            - mountPath: /var/lib/gpustack/initial_admin_password
+              name: bootstrap-password
+              subPath: password
+              readOnly: true
+            {{- end }}
             {{- with .Values.server.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -129,8 +154,13 @@ spec:
                   app: {{ .Release.Name }}-server
       {{- end }}
       {{- end }}
-      {{- if or .Values.server.dataVolume.hostPath .Values.server.extraVolumes }}
+      {{- if or $bootstrapFile .Values.server.dataVolume.hostPath .Values.server.extraVolumes }}
       volumes:
+        {{- if $bootstrapFile }}
+        - name: bootstrap-password
+          secret:
+            secretName: {{ .Release.Name }}-server-bootstrap-password
+        {{- end }}
         {{- if .Values.server.dataVolume.hostPath }}
         - name: gpustack-data-dir
           hostPath:

--- a/charts/gpustack-chart/values.yaml
+++ b/charts/gpustack-chart/values.yaml
@@ -81,6 +81,27 @@ server:
     size: 100Gi
   apiPort: 30080
   metricsPort: 10161
+  # Shared initial admin password across server replicas. Creates a Secret so
+  # every replica bootstraps the same admin password behind the load balancer.
+  # Only needed for multi-replica (HA) setups; single-node installs generate a
+  # per-node password without it. Enterprise enables this by default.
+  bootstrapPasswordSecret:
+    enabled: false
+    # Pin a known initial password. When set, it is injected into every replica
+    # as GPUSTACK_BOOTSTRAP_PASSWORD and treated as operator-chosen: no forced
+    # first-login change and no password-retrieval guide (same behavior as
+    # --bootstrap-password on CLI/Docker).
+    #
+    # Leave null to auto-generate a random password instead. The random value is
+    # mounted as a shared file on every replica so all of them show the same
+    # first-login retrieval guide, and forces a first-login change.
+    #
+    # GitOps note (auto-generated case only): the random value is kept stable
+    # across upgrades via Helm's `lookup`, which cannot read the cluster during
+    # template rendering (ArgoCD/Flux, `helm template`). In those environments a
+    # new random value is produced on every sync; set a static `password` here
+    # to pin it.
+    password: null
   environmentConfig: {}
   # Extra volume mounts for the server container. Use together with
   # `extraVolumes` to mount additional files into the server pod, e.g. a

--- a/gpustack/migrations/versions/2026_01_05_1048-53667f33f000_v2_1_0_database_changes.py
+++ b/gpustack/migrations/versions/2026_01_05_1048-53667f33f000_v2_1_0_database_changes.py
@@ -19,8 +19,6 @@ from sqlalchemy.dialects import postgresql
 from gpustack.migrations.utils import table_exists
 import gpustack.utils.sql_enum as sql_enum
 from gpustack.schemas.stmt import model_user_after_drop_view_stmt
-from gpustack.config.config import get_global_config
-from gpustack.routes.auth import remove_initial_password_file_if_exists
 
 
 # revision identifiers, used by Alembic.
@@ -133,10 +131,6 @@ def upgrade() -> None:
     recalculate_index_for_modelscope_sources()
     
     upgrade_model_usage_integer_overflow()
-
-    config = get_global_config()
-    if config:
-        remove_initial_password_file_if_exists(config)
 
 
 def downgrade() -> None:

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -31,7 +31,7 @@ from gpustack.api.auth import (
     authenticate_user,
 )
 from gpustack.server.deps import CurrentUserDep, SessionDep
-from gpustack.server.passwords import change_password
+from gpustack.server.passwords import change_password, is_password_change_required
 from gpustack.server.services import sync_user_group_memberships
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from fastapi.responses import RedirectResponse
@@ -1279,7 +1279,7 @@ _EXTERNAL_AUTH_PROVIDERS = (
 
 
 @router.get("/config")
-async def get_auth_config(request: Request):
+async def get_auth_config(request: Request, session: SessionDep):
     config: Config = request.app.state.server_config
 
     external_auth = None
@@ -1302,22 +1302,52 @@ async def get_auth_config(request: Request):
         "is_saml": auth_type == AuthProviderEnum.SAML,
     }
 
-    initial_password_file = Path(config.data_dir) / "initial_admin_password"
-    if initial_password_file.exists():
-        req_dict["first_time_setup"] = True
-        req_dict["get_initial_password_command"] = _get_initial_password_command(
-            initial_password_file
-        )
+    # First-login state is keyed off the shared DB ``require_password_change``
+    # flag on the bootstrap admin, so every replica reports it consistently
+    # behind a load balancer — a file check would not, since the password file
+    # only exists on replicas where it was written / mounted. The retrieval
+    # command is only advertised while that password file is still present.
+    #
+    # Scope the lookup to the default ``admin`` account that bootstrap creates,
+    # not any admin: extra admins added later must not resurface the guide, and
+    # once the default admin is renamed (only possible after logging in) the
+    # first-login window is over.
+    #
+    # FastAPI always injects a session for real requests; direct (non-FastAPI)
+    # callers that only need the external-auth config pass ``session=None`` and
+    # skip the first-login lookup.
+    if session is None:
+        return req_dict
+
+    admin = await User.first_by_fields(
+        session=session,
+        fields={
+            "name": "admin",
+            "is_admin": True,
+            "kind": PrincipalType.USER,
+            "is_active": True,
+        },
+    )
+    if admin and await is_password_change_required(session, admin.id):
+        command = _get_initial_password_command(config)
+        if command:
+            req_dict["first_time_setup"] = True
+            req_dict["get_initial_password_command"] = command
 
     return req_dict
 
 
-def _get_initial_password_command(initial_password_file: Path) -> str:
+def _get_initial_password_command(config: Config) -> Optional[str]:
+    """Command an operator runs to retrieve the machine-generated initial admin
+    password, or ``None`` when the password file is no longer present.
+
+    In HA the Helm chart mounts a shared Secret at this path on every replica;
+    single-node installs write it there when generating the password.
     """
-    Get the command to retrieve the initial admin password.
-    """
+    initial_password_file = Path(config.data_dir) / "initial_admin_password"
+    if not initial_password_file.exists():
+        return None
     if os.getenv("KUBERNETES_SERVICE_HOST") is not None:
-        # Kubernetes
         pod_name = os.getenv("HOSTNAME", "<pod_name>")
         namespace_file = Path("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
         namespace = (
@@ -1327,21 +1357,20 @@ def _get_initial_password_command(initial_password_file: Path) -> str:
         )
         return f"kubectl exec {pod_name} -n {namespace} -- cat {initial_password_file}"
     elif Path("/.dockerenv").exists():
-        # Docker
         return f"docker exec <container_name_or_id> cat {initial_password_file}"
-    else:
-        # Non-containerized
-        return f"cat {initial_password_file}"
+    return f"cat {initial_password_file}"
 
 
-def remove_initial_password_file_if_exists(config: Config):
-    """
-    Remove the initial admin password file if it exists.
+def remove_initial_password_file_if_exists(config: Config) -> None:
+    """Remove the initial admin password file if it exists.
+
+    A shared/read-only mount (e.g. the HA password mounted into every replica)
+    may be un-removable; that is fine and not treated as an error. The
+    first-login guide hides via the DB ``require_password_change`` flag, not the
+    file's presence, so leaving the file in place is harmless.
     """
     initial_password_file = Path(config.data_dir) / "initial_admin_password"
-    if initial_password_file.exists():
-        try:
-            initial_password_file.unlink()
-            logger.debug(f"Initial password file deleted: {initial_password_file}")
-        except Exception as e:
-            logger.warning(f"Failed to delete initial password file: {e}")
+    try:
+        initial_password_file.unlink(missing_ok=True)
+    except OSError as e:
+        logger.debug(f"Left initial password file in place: {e}")

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -41,7 +41,6 @@ from gpustack.security import (
     get_secret_hash,
     API_KEY_PREFIX,
 )
-from gpustack.routes.auth import remove_initial_password_file_if_exists
 from gpustack.server.app import create_app
 from gpustack.server.passwords import set_password
 from gpustack.server.services import provision_bootstrap_admin_orgs
@@ -778,25 +777,47 @@ class Server:
         if existing_admin:
             return
 
-        # Drop any stale initial password file from a prior bootstrap before
-        # generating a new one, so the login page does not show an outdated
-        # "retrieve initial password" hint.
-        remove_initial_password_file_if_exists(self._config)
-
+        # A machine-generated bootstrap password forces a first-login change
+        # and surfaces the retrieval guide; an operator-supplied one does not.
+        # The machine-generated password lives in the ``initial_admin_password``
+        # file under ``data_dir``: in HA the Helm chart mounts a shared Secret
+        # there so every replica reads the same value, and single-node installs
+        # generate it locally and write it there. An explicit
+        # ``--bootstrap-password`` takes precedence and is not force-changed.
         bootstrap_password = self._config.bootstrap_password
         require_password_change = False
+        password_file = os.path.join(self._config.data_dir, "initial_admin_password")
         if not bootstrap_password:
             require_password_change = True
-            bootstrap_password = generate_secure_password()
-            bootstrap_password_file = os.path.join(
-                self._config.data_dir, "initial_admin_password"
-            )
-            with open(bootstrap_password_file, "w") as file:
-                file.write(bootstrap_password + "\n")
-            logger.info(
-                "Generated initial admin password. "
-                f"You can get it from {bootstrap_password_file}"
-            )
+            if os.path.exists(password_file):
+                try:
+                    with open(password_file, encoding="utf-8") as file:
+                        bootstrap_password = file.read().strip()
+                except (OSError, ValueError) as e:
+                    # ValueError covers UnicodeDecodeError on a corrupted /
+                    # non-UTF-8 file, which is not an OSError.
+                    logger.warning(
+                        f"Failed to read initial admin password from {password_file}: {e}"
+                    )
+            # An empty / whitespace-only / unreadable file (interrupted write,
+            # empty Secret mount, permission issue) must never yield an empty
+            # admin password — fall back to a freshly generated one.
+            if bootstrap_password:
+                logger.info(f"Using initial admin password from {password_file}.")
+            else:
+                bootstrap_password = generate_secure_password()
+                try:
+                    with open(password_file, "w", encoding="utf-8") as file:
+                        file.write(bootstrap_password + "\n")
+                    logger.info(
+                        "Generated initial admin password. "
+                        f"You can get it from {password_file}"
+                    )
+                except OSError as e:
+                    logger.warning(
+                        "Generated initial admin password but could not persist it "
+                        f"to {password_file}: {e}"
+                    )
 
         user = User(
             name="admin",

--- a/tests/api/test_cas.py
+++ b/tests/api/test_cas.py
@@ -447,7 +447,7 @@ async def test_get_auth_config_advertises_cas_external_auth():
     request = _request_with_config(
         _auth_config(external_auth_type=AuthProviderEnum.CAS)
     )
-    result = await auth_route.get_auth_config(request=request)
+    result = await auth_route.get_auth_config(request=request, session=None)
     assert result["external_auth"] == {
         "type": AuthProviderEnum.CAS,
         "login_url": "/auth/cas/login",
@@ -466,7 +466,7 @@ async def test_get_auth_config_advertises_oidc_external_auth():
     request = _request_with_config(
         _auth_config(external_auth_type=AuthProviderEnum.OIDC)
     )
-    result = await auth_route.get_auth_config(request=request)
+    result = await auth_route.get_auth_config(request=request, session=None)
     assert result["external_auth"] == {
         "type": AuthProviderEnum.OIDC,
         "login_url": "/auth/oidc/login",
@@ -571,7 +571,7 @@ def test_cas_service_url_falls_back_to_request_when_neither_set():
 @pytest.mark.asyncio
 async def test_get_auth_config_returns_null_external_auth_when_local():
     request = _request_with_config(_auth_config(external_auth_type=None))
-    result = await auth_route.get_auth_config(request=request)
+    result = await auth_route.get_auth_config(request=request, session=None)
     assert result["external_auth"] is None
     assert result["is_oidc"] is False
     assert result["is_saml"] is False

--- a/tests/routes/test_auth_config.py
+++ b/tests/routes/test_auth_config.py
@@ -1,0 +1,127 @@
+"""``/auth/config`` first-login guide.
+
+The guide is keyed off the shared DB ``require_password_change`` flag (so every
+replica reports it consistently behind a load balancer), and the retrieval
+command is only advertised while the password file is still present.
+"""
+
+import errno
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from gpustack.routes import auth as auth_mod
+from gpustack.schemas.users import User
+
+PASSWORD_FILE = "initial_admin_password"
+
+
+def _request(tmp_path):
+    config = SimpleNamespace(external_auth_type=None, data_dir=str(tmp_path))
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(server_config=config))
+    )
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    state = {"admin": User(id=1, name="admin", is_admin=True), "require_change": True}
+
+    async def fake_first_by_fields(**kwargs):
+        state["queried_fields"] = kwargs.get("fields")
+        return state["admin"]
+
+    async def fake_is_password_change_required(session, principal_id):
+        return state["require_change"]
+
+    monkeypatch.setattr(User, "first_by_fields", fake_first_by_fields)
+    monkeypatch.setattr(
+        auth_mod, "is_password_change_required", fake_is_password_change_required
+    )
+    return state
+
+
+@pytest.mark.asyncio
+async def test_guide_shown_when_change_required_and_file_present(tmp_path, stub):
+    (tmp_path / PASSWORD_FILE).write_text("pw\n")
+
+    result = await auth_mod.get_auth_config(_request(tmp_path), session=object())
+
+    assert result["first_time_setup"] is True
+    assert str(tmp_path / PASSWORD_FILE) in result["get_initial_password_command"]
+    # Scoped to the default bootstrap admin, not just any admin.
+    assert stub["queried_fields"]["name"] == "admin"
+    assert stub["queried_fields"]["is_admin"] is True
+
+
+@pytest.mark.asyncio
+async def test_guide_hidden_when_change_not_required(tmp_path, stub):
+    (tmp_path / PASSWORD_FILE).write_text("pw\n")
+    stub["require_change"] = False
+
+    result = await auth_mod.get_auth_config(_request(tmp_path), session=object())
+
+    assert "first_time_setup" not in result
+    assert "get_initial_password_command" not in result
+
+
+@pytest.mark.asyncio
+async def test_guide_hidden_when_no_admin(tmp_path, stub):
+    (tmp_path / PASSWORD_FILE).write_text("pw\n")
+    stub["admin"] = None
+
+    result = await auth_mod.get_auth_config(_request(tmp_path), session=object())
+
+    assert "first_time_setup" not in result
+
+
+@pytest.mark.asyncio
+async def test_guide_hidden_when_file_missing(tmp_path, stub):
+    # Change still required but the password is no longer retrievable.
+    result = await auth_mod.get_auth_config(_request(tmp_path), session=object())
+
+    assert "first_time_setup" not in result
+
+
+@pytest.mark.asyncio
+async def test_no_session_skips_first_login_lookup(tmp_path):
+    # Direct (non-FastAPI) callers pass session=None; the external-auth config
+    # must still return without touching the DB.
+    result = await auth_mod.get_auth_config(_request(tmp_path), session=None)
+
+    assert result["external_auth"] is None
+    assert "first_time_setup" not in result
+
+
+def test_remove_password_file_unremovable_is_not_an_error(
+    tmp_path, monkeypatch, caplog
+):
+    # An un-removable file (e.g. a read-only shared password mount) is left in
+    # place without raising or warning: guide visibility is driven by the DB
+    # require_password_change flag, not the file's presence.
+    (tmp_path / PASSWORD_FILE).write_text("pw\n")
+
+    def failing_unlink(self, *args, **kwargs):
+        raise OSError(errno.EROFS, "Read-only file system")
+
+    monkeypatch.setattr("pathlib.Path.unlink", failing_unlink)
+    config = SimpleNamespace(data_dir=str(tmp_path))
+
+    with caplog.at_level(logging.DEBUG, logger=auth_mod.logger.name):
+        auth_mod.remove_initial_password_file_if_exists(config)
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+@pytest.mark.asyncio
+async def test_command_uses_kubectl_in_kubernetes(tmp_path, stub, monkeypatch):
+    (tmp_path / PASSWORD_FILE).write_text("pw\n")
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("HOSTNAME", "gpustack-server-1")
+
+    result = await auth_mod.get_auth_config(_request(tmp_path), session=object())
+
+    command = result["get_initial_password_command"]
+    assert command.startswith("kubectl exec gpustack-server-1")
+    assert str(tmp_path / PASSWORD_FILE) in command

--- a/tests/server/test_init_user.py
+++ b/tests/server/test_init_user.py
@@ -1,0 +1,146 @@
+"""Bootstrap admin creation (``Server._init_user``).
+
+Covers where the initial admin password comes from and whether the first-login
+change is forced:
+- a pre-existing file (HA: the Helm-mounted shared Secret; or a prior single
+  node bootstrap) is read as-is and forces a change,
+- with no file and no explicit password, one is generated, persisted, and
+  forces a change,
+- an explicit ``--bootstrap-password`` is used verbatim and is not forced.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gpustack.server import server as server_mod
+from gpustack.schemas.users import User
+
+PASSWORD_FILE = "initial_admin_password"
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Stub out the DB writes ``_init_user`` performs and capture what password
+    / force-change flag it would persist."""
+    state = {"set_password_calls": 0}
+
+    async def fake_first_by_fields(**kwargs):
+        return state.get("existing_admin")
+
+    async def fake_create(session, source, update=None, auto_commit=True):
+        source.id = 1
+        return source
+
+    async def fake_set_password(
+        session, user_id, password, require_password_change=False, auto_commit=True
+    ):
+        state["set_password_calls"] += 1
+        state["password"] = password
+        state["require_password_change"] = require_password_change
+
+    async def fake_provision(session, user):
+        pass
+
+    monkeypatch.setattr(User, "first_by_fields", fake_first_by_fields)
+    monkeypatch.setattr(User, "create", fake_create)
+    monkeypatch.setattr(server_mod, "set_password", fake_set_password)
+    monkeypatch.setattr(server_mod, "provision_bootstrap_admin_orgs", fake_provision)
+    return state
+
+
+def _server(tmp_path, bootstrap_password=None):
+    config = SimpleNamespace(
+        data_dir=str(tmp_path),
+        bootstrap_password=bootstrap_password,
+    )
+    return SimpleNamespace(_config=config)
+
+
+class _FakeSession:
+    async def commit(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_reads_password_from_existing_file(tmp_path, captured):
+    file = tmp_path / PASSWORD_FILE
+    file.write_text("from-secret\n")
+
+    await server_mod.Server._init_user(_server(tmp_path), _FakeSession())
+
+    assert captured["password"] == "from-secret"
+    assert captured["require_password_change"] is True
+    # The mounted / existing file is used as-is, never rewritten.
+    assert file.read_text() == "from-secret\n"
+
+
+@pytest.mark.asyncio
+async def test_generates_and_persists_when_no_file(tmp_path, captured, monkeypatch):
+    monkeypatch.setattr(server_mod, "generate_secure_password", lambda: "generated")
+
+    await server_mod.Server._init_user(_server(tmp_path), _FakeSession())
+
+    assert captured["password"] == "generated"
+    assert captured["require_password_change"] is True
+    assert (tmp_path / PASSWORD_FILE).read_text().strip() == "generated"
+
+
+@pytest.mark.asyncio
+async def test_generates_when_file_is_empty(tmp_path, captured, monkeypatch):
+    # An empty / whitespace-only file must not yield an empty admin password.
+    (tmp_path / PASSWORD_FILE).write_text("   \n")
+    monkeypatch.setattr(server_mod, "generate_secure_password", lambda: "generated")
+
+    await server_mod.Server._init_user(_server(tmp_path), _FakeSession())
+
+    assert captured["password"] == "generated"
+    assert captured["require_password_change"] is True
+    assert (tmp_path / PASSWORD_FILE).read_text().strip() == "generated"
+
+
+@pytest.mark.asyncio
+async def test_survives_unreadable_password_file(tmp_path, captured, monkeypatch):
+    # A path that cannot be read or written as a file (here a directory) must
+    # not crash bootstrap; fall back to a generated password.
+    (tmp_path / PASSWORD_FILE).mkdir()
+    monkeypatch.setattr(server_mod, "generate_secure_password", lambda: "generated")
+
+    await server_mod.Server._init_user(_server(tmp_path), _FakeSession())
+
+    assert captured["password"] == "generated"
+    assert captured["require_password_change"] is True
+
+
+@pytest.mark.asyncio
+async def test_generates_when_file_is_invalid_utf8(tmp_path, captured, monkeypatch):
+    # A corrupted / non-UTF-8 file raises UnicodeDecodeError on read; it must
+    # not crash bootstrap.
+    (tmp_path / PASSWORD_FILE).write_bytes(b"\xff\xfe\x00bad")
+    monkeypatch.setattr(server_mod, "generate_secure_password", lambda: "generated")
+
+    await server_mod.Server._init_user(_server(tmp_path), _FakeSession())
+
+    assert captured["password"] == "generated"
+    assert captured["require_password_change"] is True
+
+
+@pytest.mark.asyncio
+async def test_explicit_password_is_not_forced_and_writes_no_file(tmp_path, captured):
+    await server_mod.Server._init_user(
+        _server(tmp_path, bootstrap_password="operator-chosen"), _FakeSession()
+    )
+
+    assert captured["password"] == "operator-chosen"
+    assert captured["require_password_change"] is False
+    assert not (tmp_path / PASSWORD_FILE).exists()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_admin_already_exists(tmp_path, captured):
+    captured["existing_admin"] = User(id=1, name="admin", is_admin=True)
+
+    await server_mod.Server._init_user(_server(tmp_path), _FakeSession())
+
+    assert captured["set_password_calls"] == 0
+    assert not (tmp_path / PASSWORD_FILE).exists()


### PR DESCRIPTION
When the server runs multiple replicas behind a load balancer, the initial admin password was written to a file on the single replica that won the bootstrap race, and /auth/config decided whether to show the "retrieve initial password" guide by checking that local file. Because each replica has its own data_dir PVC, requests round-robined to other replicas never saw the file and never showed the guide.

Drive the guide off shared state instead:

- The Helm chart (when server.bootstrapPasswordSecret.enabled) generates a random password Secret and mounts it at data_dir/initial_admin_password on every replica, so all replicas read the same value and surface the same retrieval command. Disabled by default; single-node installs generate a per-node password as before.
- Bootstrap reads the password from that file when present instead of generating one, forcing a first-login change.
- /auth/config keys first_time_setup off the default admin's DB require_password_change flag, which is shared across replicas and cleared on password change, so the guide shows and hides consistently everywhere.

Add unit tests for the bootstrap password sourcing and the /auth/config guide visibility.