### PR TITLE
fix(clusters): prefix operator image with server-wide default registry

### DIFF
--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -775,7 +775,8 @@ async def get_cluster_manifests(
         "cluster_owner_principal_identifier": principal_namespace_identifier(principal),
         "runtimes": runtime,
         "k8s_options": k8s_options,
-        "system_default_container_registry": cluster.system_default_container_registry,
+        "system_default_container_registry": cluster.system_default_container_registry
+        or cfg.system_default_container_registry,
     }
     if worker_config:
         if worker_config.worker_port is not None:


### PR DESCRIPTION
The generated cluster manifest resolved system_default_container_registry only from the cluster, so creating a cluster without a registry left the operator image unprefixed (e.g. gpustack/gpustack-operator:v0.5.4) and unpullable in air-gapped/private-registry installs. Fall back to the server-wide cfg.system_default_container_registry (set from global.hub via GPUSTACK_SYSTEM_DEFAULT_CONTAINER_REGISTRY), mirroring the existing namespace/operator_image fallbacks and get_cluster_image_name.

Refer to issue:
- #5866 