### PR TITLE
fix: large worker fleet db load

### DIFF
--- a/gpustack/api/middlewares.py
+++ b/gpustack/api/middlewares.py
@@ -208,13 +208,13 @@ async def _resolve_direct_consumer_org(
     falls back to attributing the usage to the caller themselves. Best-effort —
     attribution must never break usage recording.
     """
-    from gpustack.api.tenant import get_tenant_context
+    from gpustack.api.tenant import resolve_tenant_context
     from gpustack.server.db import async_session
 
     try:
         async with async_session() as session:
-            ctx = await get_tenant_context(
-                request, session, user, x_organization_id=raw_header
+            ctx = await resolve_tenant_context(
+                request, user, x_organization_id=raw_header, session=session
             )
         cpid = ctx.current_principal_id
         return str(cpid) if cpid is not None else None

--- a/gpustack/api/tenant.py
+++ b/gpustack/api/tenant.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import aliased
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from gpustack.api.auth import get_current_user
+from gpustack.api.auth import _optional_session, get_current_user
 from gpustack.api.exceptions import (
     ForbiddenException,
     InvalidException,
@@ -47,8 +47,6 @@ from gpustack.schemas.principals import (
     get_authenticated_principal_id,
 )
 from gpustack.schemas.users import User
-from gpustack.server.db import get_session
-
 
 PlatformAdminError = ForbiddenException
 OrgRoleError = ForbiddenException
@@ -279,14 +277,34 @@ def _resolve_requested_principal_id(
 
 async def get_tenant_context(
     request: Request,
-    session: Annotated[AsyncSession, Depends(get_session)],
     user: Annotated[User, Depends(get_current_user)],
     x_organization_id: Annotated[Optional[str], Header()] = None,
+) -> TenantContext:
+    """FastAPI entry point for the per-request TenantContext.
+
+    Resolves the context without holding a ``Depends(get_session)``
+    connection, so it can front a long-lived StreamingResponse (SSE watch,
+    streaming inference proxy) without pinning a pooled connection
+    idle-in-transaction for the whole stream.
+    """
+    return await resolve_tenant_context(
+        request, user, x_organization_id=x_organization_id
+    )
+
+
+async def resolve_tenant_context(
+    request: Request,
+    user: User,
+    x_organization_id: Optional[str] = None,
+    session: Optional[AsyncSession] = None,
 ) -> TenantContext:
     """Resolve the per-request TenantContext.
 
     Result is cached on `request.state.tenant_context` so multiple downstream
-    dependencies in the same request share one resolution.
+    dependencies in the same request share one resolution. The DB session is
+    scoped to just this resolution and returned to the pool before any
+    streaming response begins; callers that already hold a session may pass
+    it in.
     """
     if hasattr(request.state, "tenant_context"):
         return request.state.tenant_context
@@ -307,57 +325,60 @@ async def get_tenant_context(
         # resolve. Group grants still apply (the user's groups are
         # principals in their own right), so include them in the
         # cluster_access lookup.
-        if current_principal_id == user.id:
-            current_is_personal_scope = True
-            group_ids = await _user_group_principal_ids(session, user.id)
-            (
-                accessible_cluster_ids,
-                accessible_cluster_owner_ids,
-            ) = await _accessible_clusters(
-                session,
-                user.id,
-                None,
-                group_ids,
-            )
-        else:
-            org_role = await _resolve_effective_org_role(
-                session, user.id, current_principal_id
-            )
-            if org_role is None and not is_platform_admin:
-                # Non-admin users cannot operate as a principal they are
-                # not a member of (directly or via a Group).
-                raise ForbiddenException(
-                    message=(f"Not a member of organization " f"{current_principal_id}")
+        async with _optional_session(session) as session:
+            if current_principal_id == user.id:
+                current_is_personal_scope = True
+                group_ids = await _user_group_principal_ids(session, user.id)
+                (
+                    accessible_cluster_ids,
+                    accessible_cluster_owner_ids,
+                ) = await _accessible_clusters(
+                    session,
+                    user.id,
+                    None,
+                    group_ids,
+                )
+            else:
+                org_role = await _resolve_effective_org_role(
+                    session, user.id, current_principal_id
+                )
+                if org_role is None and not is_platform_admin:
+                    # Non-admin users cannot operate as a principal they are
+                    # not a member of (directly or via a Group).
+                    raise ForbiddenException(
+                        message=(
+                            f"Not a member of organization " f"{current_principal_id}"
+                        )
+                    )
+
+                group_ids = await _user_group_principal_ids(session, user.id)
+                (
+                    accessible_cluster_ids,
+                    accessible_cluster_owner_ids,
+                ) = await _accessible_clusters(
+                    session,
+                    user.id,
+                    current_principal_id,
+                    group_ids,
                 )
 
-            group_ids = await _user_group_principal_ids(session, user.id)
-            (
-                accessible_cluster_ids,
-                accessible_cluster_owner_ids,
-            ) = await _accessible_clusters(
-                session,
-                user.id,
-                current_principal_id,
-                group_ids,
-            )
-
-            # Validate the org-principal exists and isn't soft-deleted
-            # before letting the request continue. Org soft-delete is
-            # "removed for users" — block context resolution against it
-            # so the membership row (still present, since CASCADE
-            # doesn't fire on soft delete) can't be used to keep
-            # operating in a logically-removed Org.
-            org_row = await Principal.first_by_field(
-                session, "id", current_principal_id
-            )
-            if (
-                org_row is None
-                or org_row.deleted_at is not None
-                or org_row.kind != PrincipalType.ORG
-            ):
-                raise NotFoundException(
-                    message=(f"Organization {current_principal_id} not found")
+                # Validate the org-principal exists and isn't soft-deleted
+                # before letting the request continue. Org soft-delete is
+                # "removed for users" — block context resolution against it
+                # so the membership row (still present, since CASCADE
+                # doesn't fire on soft delete) can't be used to keep
+                # operating in a logically-removed Org.
+                org_row = await Principal.first_by_field(
+                    session, "id", current_principal_id
                 )
+                if (
+                    org_row is None
+                    or org_row.deleted_at is not None
+                    or org_row.kind != PrincipalType.ORG
+                ):
+                    raise NotFoundException(
+                        message=(f"Organization {current_principal_id} not found")
+                    )
 
     # Resolve the cluster a SYSTEM service account belongs to. The
     # ``worker`` / ``cluster`` back-references are eager-loaded by

--- a/gpustack/client/generated_benchmark_client.py
+++ b/gpustack/client/generated_benchmark_client.py
@@ -52,6 +52,14 @@ class BenchmarkClient:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "benchmarks cache not authoritative; " "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_inference_backend_client.py
+++ b/gpustack/client/generated_inference_backend_client.py
@@ -52,6 +52,15 @@ class InferenceBackendClient:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "inference-backends cache not authoritative; "
+                "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_model_client.py
+++ b/gpustack/client/generated_model_client.py
@@ -52,6 +52,14 @@ class ModelClient:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "models cache not authoritative; " "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_model_file_client.py
+++ b/gpustack/client/generated_model_file_client.py
@@ -52,6 +52,14 @@ class ModelFileClient:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "model-files cache not authoritative; " "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_model_instance_client.py
+++ b/gpustack/client/generated_model_instance_client.py
@@ -52,6 +52,15 @@ class ModelInstanceClient:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "model-instances cache not authoritative; "
+                "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_model_route_target_client.py
+++ b/gpustack/client/generated_model_route_target_client.py
@@ -52,6 +52,15 @@ class ModelRouteTargetClient:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "model-route-targets cache not authoritative; "
+                "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_user_client.py
+++ b/gpustack/client/generated_user_client.py
@@ -52,6 +52,14 @@ class UserClient:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "users cache not authoritative; " "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/client/generated_worker_client.py
+++ b/gpustack/client/generated_worker_client.py
@@ -52,6 +52,14 @@ class WorkerClient:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "workers cache not authoritative; " "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/codegen/templates/client.py.jinja
+++ b/gpustack/codegen/templates/client.py.jinja
@@ -52,6 +52,15 @@ class {{ class_name }}Client:
             cached = self._list_from_cache(params)
             if cached is not None:
                 return cached
+            # Cache was eligible but not authoritative (watch not started /
+            # mid-reconnect). The caller expects the full set the cache would
+            # have returned, so fetch unpaginated -- otherwise the server's
+            # default perPage=100 silently truncates this fallback.
+            logger.debug(
+                "{{ class_name | to_dash_plural }} cache not authoritative; "
+                "fetching unpaginated from API"
+            )
+            params = {**(params or {}), "page": -1}
 
         # Fall back to API call
         response = self._client.get_httpx_client().get(self._url, params=params)

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -4,6 +4,11 @@ import os
 
 # Database configuration
 DB_ECHO = os.getenv("GPUSTACK_DB_ECHO", "false").lower() == "true"
+# Diagnostic: when non-empty, every executed SQL whose text contains this
+# substring gets its Python call stack logged once per distinct call site
+# (deduplicated), so a high-frequency query can be attributed to its caller
+# without drowning the log. Empty (default) disables the check entirely.
+DB_TRACE_SQL_SUBSTR = os.getenv("GPUSTACK_DB_TRACE_SQL_SUBSTR", "")
 DB_POOL_SIZE = int(os.getenv("GPUSTACK_DB_POOL_SIZE", 30))
 DB_MAX_OVERFLOW = int(os.getenv("GPUSTACK_DB_MAX_OVERFLOW", 20))
 DB_POOL_TIMEOUT = int(os.getenv("GPUSTACK_DB_POOL_TIMEOUT", 30))

--- a/gpustack/exporter/exporter.py
+++ b/gpustack/exporter/exporter.py
@@ -22,7 +22,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import selectinload
 from fastapi import FastAPI, Response
 
-
 logger = logging.getLogger(__name__)
 
 # Prometheus label name pattern
@@ -42,8 +41,17 @@ class MetricExporter(Collector):
 
     async def generate_metrics_cache(self):
         while True:
-            async with async_session() as session:
-                self._cache_metrics = await self._collect_metrics(session)
+            try:
+                async with async_session() as session:
+                    self._cache_metrics = await self._collect_metrics(session)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # A transient DB error here (e.g. a pool-exhaustion timeout)
+                # must not escape the loop -- an unhandled exception propagates
+                # through the server's asyncio.gather and takes the whole
+                # process down. Keep the last cache, log, and retry next tick.
+                logger.exception("Failed to refresh metrics cache")
             await asyncio.sleep(3)
 
     async def _collect_metrics(self, session: AsyncSession):

--- a/gpustack/routes/api_keys.py
+++ b/gpustack/routes/api_keys.py
@@ -13,6 +13,7 @@ from gpustack.api.exceptions import (
     NotFoundException,
 )
 from gpustack.security import API_KEY_PREFIX, get_secret_hash, get_key_pair
+from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 from gpustack.schemas.api_keys import (
     ApiKey,
@@ -106,7 +107,6 @@ def _api_key_list_fields(ctx, user_id: Optional[str]) -> dict:
 
 @router.get("", response_model=ApiKeysPublic)
 async def get_api_keys(
-    session: SessionDep,
     ctx: TenantContextDep,
     params: ApiKeyListParams = Depends(),
     user_id: Optional[str] = Query(
@@ -140,20 +140,21 @@ async def get_api_keys(
             media_type="text/event-stream",
         )
 
-    result = await ApiKey.paginated_by_query(
-        session=session,
-        fields=fields,
-        fuzzy_fields=fuzzy_fields,
-        extra_conditions=extra_conditions,
-        page=params.page,
-        per_page=params.perPage,
-        order_by=params.order_by,
-        options=[selectinload(ApiKey.user)],
-    )
+    async with async_session() as session:
+        result = await ApiKey.paginated_by_query(
+            session=session,
+            fields=fields,
+            fuzzy_fields=fuzzy_fields,
+            extra_conditions=extra_conditions,
+            page=params.page,
+            per_page=params.perPage,
+            order_by=params.order_by,
+            options=[selectinload(ApiKey.user)],
+        )
 
-    # Convert ApiKey to ApiKeyPublic
-    items = [_api_key_to_public(item) for item in result.items]
-    result.items = items
+        # Convert ApiKey to ApiKeyPublic
+        items = [_api_key_to_public(item) for item in result.items]
+        result.items = items
     return result
 
 

--- a/gpustack/routes/benchmarks.py
+++ b/gpustack/routes/benchmarks.py
@@ -465,24 +465,26 @@ async def delete_benchmark(session: SessionDep, ctx: TenantContextDep, id: int):
 @router.get("/{id}/logs")
 async def get_benchmark_logs(  # noqa: C901
     request: Request,
-    session: SessionDep,
     ctx: TenantContextDep,
     id: int,
     log_options: LogOptionsDep,
 ):
-    benchmark = await Benchmark.one_by_id(session, id)
-    assert_resource_visible(ctx, benchmark, not_found_message="Benchmark not found")
+    # Inline session released after the initial lookups so a long-lived
+    # follow-log stream doesn't hold a database connection for its duration.
+    async with async_session() as session:
+        benchmark = await Benchmark.one_by_id(session, id)
+        assert_resource_visible(ctx, benchmark, not_found_message="Benchmark not found")
 
-    worker = await Worker.one_by_id(session, benchmark.worker_id)
-    if not worker:
-        raise NotFoundException(message="Benchmark's worker not found")
+        worker = await Worker.one_by_id(session, benchmark.worker_id)
+        if not worker:
+            raise NotFoundException(message="Benchmark's worker not found")
 
-    if benchmark.state in [
-        BenchmarkStateEnum.ERROR,
-        BenchmarkStateEnum.STOPPED,
-        BenchmarkStateEnum.COMPLETED,
-    ]:
-        log_options.follow = False
+        if benchmark.state in [
+            BenchmarkStateEnum.ERROR,
+            BenchmarkStateEnum.STOPPED,
+            BenchmarkStateEnum.COMPLETED,
+        ]:
+            log_options.follow = False
 
     timeout = aiohttp.ClientTimeout(total=envs.PROXY_TIMEOUT, sock_connect=5)
 

--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -227,55 +227,59 @@ async def fetch_worker(session, worker_id):
 @router.get("/{id}/logs")
 async def get_serving_logs(  # noqa: C901
     request: Request,
-    session: SessionDep,
     id: int,
     log_options: LogOptionsDep,
     worker_id: Optional[int] = None,
     container_name: Optional[str] = None,
 ):
-    model_instance = await fetch_model_instance(session, id)
+    # Inline session released after the initial lookups so a long-lived
+    # follow-log stream doesn't hold a database connection for its duration.
+    async with async_session() as session:
+        model_instance = await fetch_model_instance(session, id)
 
-    # Reverse-map: convert UI display name back to internal container name.
-    if container_name:
-        is_main = (worker_id or model_instance.worker_id) == model_instance.worker_id
-        container_name = _unmap_container_display_name(
-            container_name, model_instance, is_main
-        )
+        # Reverse-map: convert UI display name back to internal container name.
+        if container_name:
+            is_main = (
+                worker_id or model_instance.worker_id
+            ) == model_instance.worker_id
+            container_name = _unmap_container_display_name(
+                container_name, model_instance, is_main
+            )
 
-    # Build valid worker IDs (main worker + subordinate workers for distributed instances)
-    valid_worker_ids = {model_instance.worker_id}
-    if (
-        model_instance.distributed_servers
-        and model_instance.distributed_servers.subordinate_workers
-    ):
-        valid_worker_ids.update(
-            sw.worker_id
-            for sw in model_instance.distributed_servers.subordinate_workers
-        )
+        # Build valid worker IDs (main worker + subordinate workers for distributed instances)
+        valid_worker_ids = {model_instance.worker_id}
+        if (
+            model_instance.distributed_servers
+            and model_instance.distributed_servers.subordinate_workers
+        ):
+            valid_worker_ids.update(
+                sw.worker_id
+                for sw in model_instance.distributed_servers.subordinate_workers
+            )
 
-    # Determine target worker ID
-    target_worker_id = worker_id or model_instance.worker_id
-    if target_worker_id not in valid_worker_ids:
-        raise NotFoundException(
-            message=f"Worker {target_worker_id} not found for model instance {id}"
-        )
+        # Determine target worker ID
+        target_worker_id = worker_id or model_instance.worker_id
+        if target_worker_id not in valid_worker_ids:
+            raise NotFoundException(
+                message=f"Worker {target_worker_id} not found for model instance {id}"
+            )
 
-    worker = await fetch_worker(session, target_worker_id)
+        worker = await fetch_worker(session, target_worker_id)
 
-    params = {
-        "tail": log_options.tail,
-        "follow": log_options.follow,
-        "model_instance_name": model_instance.name,
-        "previous": log_options.previous,
-    }
-    if container_name:
-        params["container_name"] = container_name
-    if (
-        model_instance.state != ModelInstanceStateEnum.RUNNING
-        and model_instance.model_files
-        and model_instance.model_files[0].state != ModelFileStateEnum.READY
-    ):
-        params["model_file_id"] = model_instance.model_files[0].id
+        params = {
+            "tail": log_options.tail,
+            "follow": log_options.follow,
+            "model_instance_name": model_instance.name,
+            "previous": log_options.previous,
+        }
+        if container_name:
+            params["container_name"] = container_name
+        if (
+            model_instance.state != ModelInstanceStateEnum.RUNNING
+            and model_instance.model_files
+            and model_instance.model_files[0].state != ModelFileStateEnum.READY
+        ):
+            params["model_file_id"] = model_instance.model_files[0].id
 
     timeout = aiohttp.ClientTimeout(total=envs.PROXY_TIMEOUT, sock_connect=5)
 

--- a/gpustack/routes/model_routes.py
+++ b/gpustack/routes/model_routes.py
@@ -1105,7 +1105,6 @@ def validate_provider_model_name(
     "", response_model=ModelRouteTargetsPublic, response_model_exclude_none=True
 )
 async def get_model_route_targets(
-    session: SessionDep,
     params: ModelRouteTargetListParams = Depends(),
     name: str = None,
     search: str = None,
@@ -1135,14 +1134,15 @@ async def get_model_route_targets(
             media_type="text/event-stream",
         )
 
-    return await ModelRouteTarget.paginated_by_query(
-        session=session,
-        fields=fields,
-        fuzzy_fields=fuzzy_fields,
-        page=params.page,
-        per_page=params.perPage,
-        order_by=params.order_by,
-    )
+    async with async_session() as session:
+        return await ModelRouteTarget.paginated_by_query(
+            session=session,
+            fields=fields,
+            fuzzy_fields=fuzzy_fields,
+            page=params.page,
+            per_page=params.perPage,
+            order_by=params.order_by,
+        )
 
 
 @target_router.put(

--- a/gpustack/routes/organizations.py
+++ b/gpustack/routes/organizations.py
@@ -11,6 +11,8 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 from sqlmodel import select
 
+from gpustack.server.db import async_session
+
 from gpustack.api.exceptions import (
     AlreadyExistsException,
     ConflictException,
@@ -45,7 +47,6 @@ def _to_public(p: Principal) -> OrganizationPublic:
 
 @router.get("", response_model=OrganizationsPublic)
 async def get_organizations(
-    session: SessionDep,
     params: OrganizationListParams = Depends(),
     search: Optional[str] = None,
 ):
@@ -61,15 +62,16 @@ async def get_organizations(
             media_type="text/event-stream",
         )
 
-    page = await Principal.paginated_by_query(
-        session=session,
-        fields=fields,
-        fuzzy_fields=fuzzy_fields,
-        page=params.page,
-        per_page=params.perPage,
-        order_by=params.order_by,
-    )
-    page.items = [_to_public(p) for p in page.items]
+    async with async_session() as session:
+        page = await Principal.paginated_by_query(
+            session=session,
+            fields=fields,
+            fuzzy_fields=fuzzy_fields,
+            page=params.page,
+            per_page=params.perPage,
+            order_by=params.order_by,
+        )
+        page.items = [_to_public(p) for p in page.items]
     return page
 
 

--- a/gpustack/routes/worker/logs.py
+++ b/gpustack/routes/worker/logs.py
@@ -21,7 +21,6 @@ from gpustack.worker.log_sources import (
     LogSourceChain,
     MainLogSource,
 )
-from gpustack.server.deps import SessionDep
 
 router = APIRouter()
 
@@ -581,7 +580,6 @@ async def get_serve_log_options(request: Request, id: int):
 @router.get("/serveLogs/{id}")
 async def get_serve_logs(
     request: Request,
-    session: SessionDep,
     id: int,
     log_options: LogOptionsDep,
     model_instance_name: str = Query(default=""),
@@ -614,7 +612,6 @@ async def get_serve_logs(
 @router.get("/benchmark_logs/{id}")
 async def get_benchmark_logs(
     request: Request,
-    session: SessionDep,
     id: int,
     log_options: LogOptionsDep,
     benchmark_name: str = Query(default=""),

--- a/gpustack/server/init_db.py
+++ b/gpustack/server/init_db.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import threading
 import time
+import traceback
 import re
 from urllib.parse import urlparse, parse_qs, urlunparse
 from sqlalchemy.ext.asyncio import (
@@ -199,6 +200,37 @@ def listen_events(engine: AsyncEngine):
 def count_query(conn, cursor, statement, parameters, context, executemany):
     """Increment the global query counter for each query executed."""
     increment_query_count_sync()
+    _maybe_trace_sql(statement)
+
+
+# Distinct call sites already logged, so a query that fires thousands of times
+# is attributed once per caller rather than flooding the log.
+_traced_call_sites = set()
+
+
+def _maybe_trace_sql(statement: str):
+    """When GPUSTACK_DB_TRACE_SQL_SUBSTR matches ``statement``, log the Python
+    call stack once per distinct call site. Used to attribute a high-frequency
+    query seen in DB_ECHO to the code that issues it."""
+    substr = envs.DB_TRACE_SQL_SUBSTR
+    if not substr or substr not in statement:
+        return
+    stack = traceback.extract_stack()
+    frames = [
+        f
+        for f in stack
+        if "/gpustack/" in f.filename and "server/init_db.py" not in f.filename
+    ][-8:]
+    sig = tuple((f.filename, f.lineno) for f in frames)
+    if sig in _traced_call_sites:
+        return
+    _traced_call_sites.add(sig)
+    logger.info(
+        "[DB TRACE] matched %r; new call site:\n%s\nSQL: %s",
+        substr,
+        "".join(traceback.format_list(frames)),
+        statement,
+    )
 
 
 def setup_sqlite_pragmas(conn, record):

--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -333,7 +333,15 @@ async def flush_gateway_metrics():
 async def flush_gateway_metrics_to_db():
     while True:
         await asyncio.sleep(FLUSH_INTERVAL_SECONDS)
-        await flush_gateway_metrics()
+        try:
+            await flush_gateway_metrics()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Never let a flush error escape this loop -- an unhandled
+            # exception propagates through the server's asyncio.gather and
+            # crashes the whole process. Log and retry on the next tick.
+            logger.exception("Error in gateway metrics flush loop")
 
 
 async def create_or_update_model_usage(

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -247,10 +247,6 @@ class ServeManager:
         - If everything is fine, update the model instance state to RUNNING.
         """
 
-        # Get all model instances assigned to this worker.
-        #
-        # FIXME(thxCode): This may cause performance issues when there are many model instances in the system.
-        #                 A mechanism is needed to improve efficiency here.
         # Snapshot local state BEFORE the list call. Reversing this order
         # races with CREATED events and reaps freshly-assigned instances.
         local_assigned_ids = {
@@ -259,26 +255,42 @@ class ServeManager:
             if mi.get_deployment_metadata(self._worker_id) is not None
         }
 
-        # page=-1 returns all rows — needed because the default perPage=100
-        # would have the reap below missing workloads on page 2+.
-        response = self._clientset.model_instances.list(
-            params={"page": -1},
-            use_cache=False,
-        )
+        # Read from the watch-backed cache. It holds the full set, so the
+        # common (nothing-to-reap) path stays O(1) with no server/DB round
+        # trip and scales independently of worker count — a direct per-worker
+        # poll here is one SELECT over model_instances per worker every few
+        # seconds, which does not scale to hundreds of workers.
+        response = self._clientset.model_instances.list()
         all_items = response.items or []
-
-        # Reap entries the server no longer reports — watch streams can drop
-        # DELETED events on disconnect, and when the user stops every model
-        # the server legitimately reports zero instances. list() raises on
-        # API failure rather than returning empty, so an empty result is
-        # authoritative — local_assigned_ids - ∅ = local_assigned_ids and
-        # everything still tracked locally is correctly reaped.
-        authoritative_ids: Set[int] = {
+        reap_ids = local_assigned_ids - {
             mi.id
             for mi in all_items
             if mi.get_deployment_metadata(self._worker_id) is not None
         }
-        for stale_id in local_assigned_ids - authoritative_ids:
+
+        # Reaping tears down live workloads, so it must act on an authoritative
+        # snapshot. The cache is not one at every instant: awatch clears it and
+        # flips _watch_started before the replay snapshot arrives, so a read
+        # during a reconnect window can see an empty-but-"authoritative" cache
+        # and surface healthy instances as stale. So confirm any reap candidates
+        # against a fresh, unpaginated, uncached fetch — this only touches the
+        # DB when something actually looks reapable.
+        if reap_ids:
+            response = self._clientset.model_instances.list(
+                params={"page": -1},
+                use_cache=False,
+            )
+            all_items = response.items or []
+            reap_ids = local_assigned_ids - {
+                mi.id
+                for mi in all_items
+                if mi.get_deployment_metadata(self._worker_id) is not None
+            }
+
+        # An empty authoritative result is legitimate (user stopped every
+        # model); list() raises on API failure rather than returning empty, so
+        # local_assigned_ids - ∅ correctly reaps everything still tracked.
+        for stale_id in reap_ids:
             stale = self._model_instance_by_instance_id.get(stale_id)
             if stale is None:
                 continue

--- a/tests/api/test_middlewares.py
+++ b/tests/api/test_middlewares.py
@@ -16,7 +16,7 @@ from gpustack.api.exceptions import ForbiddenException, NotFoundException
 
 class _FakeSessionCtx:
     """Minimal ``async with async_session() as session`` stand-in — the real
-    session is never touched because ``get_tenant_context`` is stubbed."""
+    session is never touched because ``resolve_tenant_context`` is stubbed."""
 
     async def __aenter__(self):
         return SimpleNamespace()
@@ -31,12 +31,12 @@ def _stub_async_session(monkeypatch):
 
 
 def _stub_tenant_context(monkeypatch, *, result=None, exc=None):
-    async def _fake(request, session, user, x_organization_id=None):
+    async def _fake(request, user, x_organization_id=None, session=None):
         if exc is not None:
             raise exc
         return result
 
-    monkeypatch.setattr("gpustack.api.tenant.get_tenant_context", _fake)
+    monkeypatch.setattr("gpustack.api.tenant.resolve_tenant_context", _fake)
 
 
 _REQUEST = SimpleNamespace(state=SimpleNamespace())
@@ -60,7 +60,7 @@ async def test_resolve_direct_consumer_org_none_when_no_context(monkeypatch):
 @pytest.mark.asyncio
 async def test_resolve_direct_consumer_org_nonexistent_id_dropped(monkeypatch):
     # A stale / spoofed id that doesn't resolve to a principal must NOT be
-    # trusted — get_tenant_context raises NotFound, we swallow it and return
+    # trusted — resolve_tenant_context raises NotFound, we swallow it and return
     # None so the FK can't be violated.
     _stub_tenant_context(
         monkeypatch, exc=NotFoundException(message="Organization 999999999 not found")

--- a/tests/api/test_tenant.py
+++ b/tests/api/test_tenant.py
@@ -7,7 +7,7 @@ import pytest
 from gpustack.api.exceptions import ForbiddenException, InvalidException
 from gpustack.api.tenant import (
     _resolve_requested_principal_id,
-    get_tenant_context,
+    resolve_tenant_context,
     require_org_role,
     require_platform_admin,
 )
@@ -152,7 +152,7 @@ async def test_platform_admin_without_header_has_no_org_filter():
     request = _request()
     session = _session_returning()  # no DB calls expected
 
-    ctx = await get_tenant_context(
+    ctx = await resolve_tenant_context(
         request=request,
         session=session,
         user=user,
@@ -177,7 +177,7 @@ async def test_member_uses_team_org_via_header():
         _principal(id=5, kind=PrincipalType.ORG),  # org existence check
     )
 
-    ctx = await get_tenant_context(
+    ctx = await resolve_tenant_context(
         request=request,
         session=session,
         user=user,
@@ -207,7 +207,7 @@ async def test_member_inherits_role_via_group_membership():
         _principal(id=5, kind=PrincipalType.ORG),
     )
 
-    ctx = await get_tenant_context(
+    ctx = await resolve_tenant_context(
         request=request,
         session=session,
         user=user,
@@ -230,7 +230,7 @@ async def test_personal_scope_short_circuits():
         _cluster_rows(),  # _accessible_clusters
     )
 
-    ctx = await get_tenant_context(
+    ctx = await resolve_tenant_context(
         request=request,
         session=session,
         user=user,
@@ -250,7 +250,7 @@ async def test_non_member_request_to_other_org_is_rejected():
     session = _session_returning([])  # union: no membership at all
 
     with pytest.raises(ForbiddenException):
-        await get_tenant_context(
+        await resolve_tenant_context(
             request=request,
             session=session,
             user=user,
@@ -269,7 +269,7 @@ async def test_platform_admin_can_act_in_org_without_membership():
         _principal(id=7, kind=PrincipalType.ORG),
     )
 
-    ctx = await get_tenant_context(
+    ctx = await resolve_tenant_context(
         request=request,
         session=session,
         user=user,
@@ -292,7 +292,7 @@ async def test_api_key_overrides_header():
         _principal(id=42, kind=PrincipalType.ORG),
     )
 
-    ctx = await get_tenant_context(
+    ctx = await resolve_tenant_context(
         request=request,
         session=session,
         user=user,

--- a/tests/exporter/test_exporter.py
+++ b/tests/exporter/test_exporter.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -74,3 +75,49 @@ async def test_model_instance_restart_metrics_are_collected():
         "model_name": "qwen",
         "model_instance_name": "qwen-1",
     }
+
+
+class _NoopSession:
+    async def __aenter__(self):
+        return SimpleNamespace()
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_generate_metrics_cache_survives_transient_db_error(monkeypatch):
+    """A transient DB error while refreshing the cache must not escape the
+    loop. If it did, the exception would propagate through the server's
+    asyncio.gather and take the whole process down (the #5839 restart). The
+    loop should keep the last cache and retry on the next tick.
+    """
+    exporter = MetricExporter(SimpleNamespace(metrics_port=10162))
+    exporter._cache_metrics = ["stale"]
+
+    collect_calls = {"n": 0}
+
+    async def _boom(session):
+        collect_calls["n"] += 1
+        raise TimeoutError(
+            "QueuePool limit of size 30 overflow 20 reached, connection timed out"
+        )
+
+    async def _sleep_then_stop(_seconds):
+        # Break the otherwise-infinite loop the way a real shutdown would.
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(exporter, "_collect_metrics", _boom)
+    monkeypatch.setattr(
+        "gpustack.exporter.exporter.async_session", lambda: _NoopSession()
+    )
+    monkeypatch.setattr("gpustack.exporter.exporter.asyncio.sleep", _sleep_then_stop)
+
+    # The transient error is swallowed; the loop proceeds to the sleep, where
+    # our stand-in raises CancelledError to end the test. CancelledError itself
+    # must propagate (clean shutdown), unlike the DB error.
+    with pytest.raises(asyncio.CancelledError):
+        await exporter.generate_metrics_cache()
+
+    assert collect_calls["n"] == 1  # ran once, error swallowed, reached sleep
+    assert exporter._cache_metrics == ["stale"]  # kept last cache, no crash

--- a/tests/routes/test_api_keys.py
+++ b/tests/routes/test_api_keys.py
@@ -24,6 +24,18 @@ def _ctx(*, user_id=1, is_admin=False, current_principal_id=10, org_role=None):
     )
 
 
+class _NoopSession:
+    """Stand-in for the session get_api_keys opens via async_session(); the DB
+    query itself is monkeypatched, so it only needs the async context manager
+    protocol."""
+
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, *exc):
+        return False
+
+
 @pytest.mark.asyncio
 async def test_org_owner_lists_all_api_keys_in_current_org(monkeypatch):
     captured = {}
@@ -36,9 +48,9 @@ async def test_org_owner_lists_all_api_keys_in_current_org(monkeypatch):
         )
 
     monkeypatch.setattr(ApiKey, "paginated_by_query", fake_paginated_by_query)
+    monkeypatch.setattr(api_keys, "async_session", lambda: _NoopSession())
 
     await api_keys.get_api_keys(
-        session=object(),
         ctx=_ctx(org_role=OrgRole.OWNER),
         params=ApiKeyListParams(),
         user_id=None,
@@ -59,9 +71,9 @@ async def test_org_member_lists_only_own_api_keys_in_current_org(monkeypatch):
         )
 
     monkeypatch.setattr(ApiKey, "paginated_by_query", fake_paginated_by_query)
+    monkeypatch.setattr(api_keys, "async_session", lambda: _NoopSession())
 
     await api_keys.get_api_keys(
-        session=object(),
         ctx=_ctx(user_id=2, org_role=OrgRole.MEMBER),
         params=ApiKeyListParams(),
         user_id=None,

--- a/tests/server/test_metrics_collector_resilience.py
+++ b/tests/server/test_metrics_collector_resilience.py
@@ -1,0 +1,34 @@
+import asyncio
+
+import pytest
+
+import gpustack.server.metrics_collector as mc
+
+
+@pytest.mark.asyncio
+async def test_flush_gateway_metrics_loop_survives_error(monkeypatch):
+    """A flush error must not escape the loop. If it did, the exception would
+    propagate through the server's asyncio.gather and crash the whole process;
+    the loop should log and retry on the next tick.
+    """
+    calls = {"flush": 0, "sleep": 0}
+
+    async def _boom():
+        calls["flush"] += 1
+        raise RuntimeError("db unavailable")
+
+    async def _sleep(_seconds):
+        calls["sleep"] += 1
+        # End the otherwise-infinite loop the way a real shutdown would.
+        if calls["sleep"] >= 2:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(mc, "flush_gateway_metrics", _boom)
+    monkeypatch.setattr("gpustack.server.metrics_collector.asyncio.sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await mc.flush_gateway_metrics_to_db()
+
+    # Iteration 1: sleep ok -> flush raised -> swallowed; iteration 2: sleep
+    # raises CancelledError, which propagates (clean shutdown).
+    assert calls["flush"] == 1

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -278,6 +278,67 @@ def test_reap_stale_instance_purges_logs(tmp_path: Path):
     assert not log.exists()
 
 
+def test_reap_confirmation_skips_when_authoritative_fetch_still_has_instance():
+    """A cache read momentarily missing an instance (e.g. mid-reconnect, before
+    the watch replay repopulates) must not reap it: the authoritative
+    confirmation fetch still lists it, so it is a false positive and the live
+    workload is left alone."""
+    manager, clientset = _build_serve_manager(worker_id=1)
+    mi = new_model_instance(
+        1, "qwen3-0.6b", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    manager._model_instance_by_instance_id[mi.id] = mi
+    # First (cache) read misses it -> reap candidate; the authoritative
+    # confirmation fetch still has it -> not stale.
+    clientset.model_instances.list.side_effect = [
+        SimpleNamespace(items=[]),
+        SimpleNamespace(items=[mi]),
+    ]
+
+    with (
+        patch("gpustack.worker.serve_manager.logger"),
+        patch.object(manager, "_stop_model_instance") as stop_model_instance,
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            return_value=SimpleNamespace(state=WorkloadStatusStateEnum.INITIALIZING),
+        ),
+    ):
+        manager.sync_model_instances_state()
+
+    stop_model_instance.assert_not_called()
+    # Cache read plus exactly one authoritative confirmation fetch.
+    assert clientset.model_instances.list.call_count == 2
+    confirm_call = clientset.model_instances.list.call_args_list[1]
+    assert confirm_call.kwargs.get("params") == {"page": -1}
+    assert confirm_call.kwargs.get("use_cache") is False
+
+
+def test_reap_confirmation_reaps_when_missing_from_authoritative_fetch():
+    """When an instance is absent from both the cache read and the authoritative
+    confirmation fetch, it is genuinely gone and gets reaped."""
+    manager, clientset = _build_serve_manager(worker_id=1)
+    stale = new_model_instance(
+        1, "qwen3-0.6b", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    manager._model_instance_by_instance_id[stale.id] = stale
+    clientset.model_instances.list.side_effect = [
+        SimpleNamespace(items=[]),
+        SimpleNamespace(items=[]),
+    ]
+
+    with (
+        patch("gpustack.worker.serve_manager.logger"),
+        patch.object(manager, "_stop_model_instance") as stop_model_instance,
+        patch.object(manager, "_is_provisioning", return_value=False),
+    ):
+        manager.sync_model_instances_state()
+
+    stop_model_instance.assert_called_once_with(stale, delete_logs=True)
+    # Cache read plus the authoritative confirmation fetch before reaping.
+    assert clientset.model_instances.list.call_count == 2
+
+
 def test_persist_container_logs_reconnects_and_dedupes(tmp_path: Path):
     """On stream EOF while the workload is still running, reconnect and resume
     by skipping already-written history (anchor), appending only new lines."""


### PR DESCRIPTION
  Address: https://github.com/gpustack/gpustack/issues/5892
  Might be related to: https://github.com/gpustack/gpustack/issues/5839

  At ~200 workers the v2.2 server slows to a crawl and hits
  `QueuePool limit ... connection timed out`: DB query load ~1100/min and
  every endpoint takes seconds (even `/healthz`, which is DB-free, blocks
  waiting for a pooled connection).

  Root cause: the worker's `sync_model_instances_state` health loop ran
  `model_instances.list(page=-1, use_cache=False)` every few seconds per
  worker — a full, uncached scan that scales O(workers) and holds a pooled
  connection each time. Under fd pressure this snowballs into pool
  exhaustion that stalls all requests.

  ### Changes
  - **perf(worker):** serve the state-sync loop from the watch-backed
    client cache (O(1), no DB round trip). Reap correctness is preserved:
    reap candidates are confirmed against a fresh authoritative fetch
    before any teardown, so a transiently-empty cache never reaps healthy
    instances. Context: https://github.com/gpustack/gpustack/pull/4783.
  - **fix(server):** don't hold a DB connection across streaming responses. Affects log streaming/tenant streaming.
  - **fix(server):** keep metrics background loops alive on transient DB errors.
  - **chore(db):** opt-in `GPUSTACK_DB_TRACE_SQL_SUBSTR` to attribute a
    high-frequency query to its caller (off by default).


With the changes:
```

ADMIN_PASSWORD=123456 curl -u admin:${ADMIN_PASSWORD} -w "time_total：%{time_total} s\n" -o /dev/null -s http://127.0.0.1:9092 && curl -u admin:${ADMIN_PASSWORD} -w "time_total：%{time_total} s\n" -o /dev/null -s http://127.0.0.1:9092/healthz && curl -u admin:${ADMIN_PASSWORD} -w "time_total：%{time_total} s\n" -o /dev/null -s http://127.0.0.1:9092/v2/workers
time_total：0.016103 s
time_total：0.009040 s
time_total：0.027345 s

2026-07-17 12:02:45.608012+08:00 - gpustack.server.server - DEBUG - [DB QUERY COUNT] Total queries since startup: 11512
2026-07-17 12:10:45.888536+08:00 - gpustack.server.server - DEBUG - [DB QUERY COUNT] Total queries since startup: 13281
```