### PR TITLE
fix: rename worker service of imported k8s cluster

### DIFF
--- a/gpustack/k8s/manifests.jinja
+++ b/gpustack/k8s/manifests.jinja
@@ -39,7 +39,7 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: worker
+  name: gpustack-worker
   namespace: {{ config.namespace }}
   annotations:
     prometheus.io/scrape: "true"

--- a/tests/k8s/test_template_render.py
+++ b/tests/k8s/test_template_render.py
@@ -629,7 +629,7 @@ def _worker_service(docs):
     return next(
         d
         for d in docs
-        if d.get("kind") == "Service" and d["metadata"]["name"] == "worker"
+        if d.get("kind") == "Service" and d["metadata"]["name"] == "gpustack-worker"
     )
 
 


### PR DESCRIPTION
Rename from worker to gpustack-worker

Refer to issue:
- #5891 