### PR TITLE
refactor(usage): rename rollup timezone env to GPUSTACK_TIMEZONE

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,7 +84,7 @@ The **Applies to** column indicates where the environment variable should be set
 
 | Variable                                           | Description                                                                                                                                                                                                                                        | Default      | Applies to |
 | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ---------- |
-| `GPUSTACK_USAGE_ROLLUP_TIMEZONE`                   | IANA timezone (e.g. `Asia/Shanghai`) for bucketing all usage views and rendering Last Active / event times (see note below). Empty ⇒ use OS local timezone (`TZ` / `/etc/localtime`).                                                              | (empty)      | Server     |
+| `GPUSTACK_TIMEZONE`                                | Platform-wide IANA timezone (e.g. `Asia/Shanghai`) for bucketing all usage views and rendering Last Active / event times (see note below). Empty ⇒ use OS local timezone (`TZ` / `/etc/localtime`). Replaces the deprecated `GPUSTACK_USAGE_ROLLUP_TIMEZONE` (still honored as an alias). | (empty)      | Server     |
 | `GPUSTACK_USAGE_ESTIMATED_BYTES_PER_INPUT_TOKEN`   | Bytes-per-token divisor used to estimate prompt tokens when a gateway report arrives with `completed=false` and `input_token` is blank. Defaults target English-leaning GPT-style tokenizers; lower it (e.g. `2`) for CJK-heavy workloads.         | `4`          | Server     |
 | `GPUSTACK_USAGE_ESTIMATED_TOKENS_PER_OUTPUT_CHUNK` | Tokens-per-chunk multiplier used to estimate completion tokens for incomplete streams when `output_token` is blank.                                                                                                                                | `1`          | Server     |
 | `GPUSTACK_USAGE_DETAILS_RETENTION_MONTHS`          | Retention window for `model_usage_details` (the per-request audit table). Rows older than this (anchored on `COALESCE(completed_at, created_at)`) are moved to `model_usage_details_archive` by the leader-only archiver.                          | `13`         | Server     |
@@ -102,7 +102,7 @@ The **Applies to** column indicates where the environment variable should be set
 | `GPUSTACK_USAGE_EVENTS_ARCHIVE_BATCH_SIZE`         | Per-batch row count for resource-events archival moves.                                                                                                                                                                                            | `5000`       | Server     |
 | `GPUSTACK_USAGE_BREAKDOWN_MAX_NO_PAGINATION_ROWS`  | Max buckets an unpaginated (`page=-1`) breakdown may return; trend charts and exports fetch the whole series at once. A request exceeding it is rejected (HTTP 400), not silently truncated. Raise for wide dashboards, lower to cap memory.       | `50000`      | Server     |
 
-!!! note "`GPUSTACK_USAGE_ROLLUP_TIMEZONE` scope & DST"
+!!! note "`GPUSTACK_TIMEZONE` scope & DST"
 
     This one timezone governs every usage view: the daily `model_usages` token
     rollup, the GPU/storage time buckets, and the displayed Last Active and

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -142,8 +142,9 @@ Filters: **date range**, **resource type** (GPU Instance / Storage), **event typ
 
 All dates and times on the Usage page — trend buckets, **Last Active**, and resource-event
 times — are shown in a single configurable **rollup timezone**, so every tab lines up on the same
-calendar boundaries. It is controlled by the `GPUSTACK_USAGE_ROLLUP_TIMEZONE` server environment
-variable and defaults to the server's OS local timezone. See
+calendar boundaries. It is controlled by the `GPUSTACK_TIMEZONE` server environment
+variable (the legacy `GPUSTACK_USAGE_ROLLUP_TIMEZONE` still works as a deprecated alias) and
+defaults to the server's OS local timezone. See
 [Environment Variables](../environment-variables.md#usage-tracking-configuration) for details,
 including the note on Daylight Saving Time.
 

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -176,13 +176,26 @@ USAGE_ESTIMATED_TOKENS_PER_OUTPUT_CHUNK = max(
     1, int(os.getenv("GPUSTACK_USAGE_ESTIMATED_TOKENS_PER_OUTPUT_CHUNK", 1))
 )
 
-# Timezone used to bucket the ``model_usages.date`` daily rollup (and the
-# matching ``model_usage_details.date`` audit column). Empty (default) ⇒ use
-# the operating system's local timezone (resolved from ``TZ`` env var /
-# ``/etc/localtime``). Set to an IANA name (``Asia/Shanghai``, ``UTC``, ...)
-# to override — useful when the server container runs in UTC but operators
-# expect rollups to follow a different region's calendar day.
-USAGE_ROLLUP_TIMEZONE = os.getenv("GPUSTACK_USAGE_ROLLUP_TIMEZONE", "")
+# Platform-wide timezone for calendar-based rollups and time-of-day display.
+# It buckets the ``model_usages.date`` daily rollup (and the matching
+# ``model_usage_details.date`` audit column), the ``metered_usage`` GPU/storage
+# time buckets, and renders Last Active / resource-event times — and is the
+# canonical calendar for any other feature that needs an operator-chosen
+# timezone. Empty (default) ⇒ use the operating system's local timezone
+# (resolved from ``TZ`` env var / ``/etc/localtime``). Set to an IANA name
+# (``Asia/Shanghai``, ``UTC``, ...) to override — useful when the server
+# container runs in UTC but operators expect a different region's calendar.
+#
+# ``GPUSTACK_USAGE_ROLLUP_TIMEZONE`` is the pre-rename name, kept as a
+# deprecated alias: ``GPUSTACK_TIMEZONE`` wins when both are set; otherwise the
+# legacy value is honored. ``USING_DEPRECATED_TIMEZONE`` records that the value
+# came from the legacy var so ``resolve_rollup_tz`` can emit a one-time
+# deprecation warning — deferred out of import time, since this module loads
+# before logging is configured (logging here is a Python anti-pattern).
+_timezone = os.getenv("GPUSTACK_TIMEZONE", "")
+_legacy_rollup_timezone = os.getenv("GPUSTACK_USAGE_ROLLUP_TIMEZONE", "")
+USING_DEPRECATED_TIMEZONE = bool(_legacy_rollup_timezone and not _timezone)
+TIMEZONE = _timezone or _legacy_rollup_timezone
 
 # Usage details archival.
 # Rows in ``model_usage_details`` older than the retention threshold (anchored

--- a/gpustack/utils/rollup_tz.py
+++ b/gpustack/utils/rollup_tz.py
@@ -6,7 +6,8 @@ GPU-instance / storage breakdowns, Last Active and resource-event times all
 line up in one operator-chosen calendar instead of a mix of UTC and local.
 
 Resolution (``resolve_rollup_tz``):
-  1. ``GPUSTACK_USAGE_ROLLUP_TIMEZONE`` (IANA name, e.g. ``Asia/Shanghai``)
+  1. ``GPUSTACK_TIMEZONE`` (IANA name, e.g. ``Asia/Shanghai``; the legacy
+     ``GPUSTACK_USAGE_ROLLUP_TIMEZONE`` is still honored as a deprecated alias)
   2. the OS local timezone (``TZ`` / ``/etc/localtime``)
   3. UTC as a last resort.
 
@@ -22,18 +23,35 @@ from gpustack import envs
 
 logger = logging.getLogger(__name__)
 
+# Emit the deprecation warning at most once, and only when the timezone is
+# actually resolved — envs is imported before logging is configured, so the
+# warning is deferred here rather than logged at import time.
+_legacy_tz_warned = False
+
 
 def resolve_rollup_tz() -> tzinfo:
-    tz_name = envs.USAGE_ROLLUP_TIMEZONE
+    global _legacy_tz_warned
+    using_legacy = getattr(envs, "USING_DEPRECATED_TIMEZONE", False)
+    if using_legacy and not _legacy_tz_warned:
+        logger.warning(
+            "GPUSTACK_USAGE_ROLLUP_TIMEZONE is deprecated; use GPUSTACK_TIMEZONE "
+            "instead. Honoring the legacy value for now."
+        )
+        _legacy_tz_warned = True
+
+    tz_name = envs.TIMEZONE
     if tz_name:
         try:
             return ZoneInfo(tz_name)
         except (ZoneInfoNotFoundError, ValueError):
-            logger.warning(
-                "Invalid GPUSTACK_USAGE_ROLLUP_TIMEZONE=%r, falling back to OS "
-                "local tz",
-                tz_name,
+            # Name the variable the value actually came from, so the message
+            # isn't misleading when it was set via the legacy alias.
+            var = (
+                "GPUSTACK_USAGE_ROLLUP_TIMEZONE"
+                if using_legacy
+                else "GPUSTACK_TIMEZONE"
             )
+            logger.warning("Invalid %s=%r, falling back to OS local tz", var, tz_name)
     return datetime.now(timezone.utc).astimezone().tzinfo or timezone.utc
 
 

--- a/tests/routes/test_resource_usage_api.py
+++ b/tests/routes/test_resource_usage_api.py
@@ -948,7 +948,7 @@ async def test_buckets_and_last_active_use_rollup_tz(session, monkeypatch):
     from gpustack import envs
     from sqlalchemy import and_
 
-    monkeypatch.setattr(envs, "USAGE_ROLLUP_TIMEZONE", "Asia/Shanghai")
+    monkeypatch.setattr(envs, "TIMEZONE", "Asia/Shanghai")
 
     session.add(
         _mu(
@@ -1024,7 +1024,7 @@ async def test_resource_events_filter_uses_rollup_tz_day(session, monkeypatch):
     from gpustack.routes.resource_usage import resource_events
     from gpustack.schemas.resource_events import EVENT_TYPE_CREATED, ResourceEvent
 
-    monkeypatch.setattr(envs, "USAGE_ROLLUP_TIMEZONE", "Asia/Shanghai")
+    monkeypatch.setattr(envs, "TIMEZONE", "Asia/Shanghai")
     session.add(
         ResourceEvent(
             occurred_at=datetime(2026, 5, 26, 20, 0, 0),
@@ -1076,7 +1076,7 @@ async def test_buckets_use_negative_offset_rollup_tz(session, monkeypatch):
     from gpustack import envs
     from sqlalchemy import and_
 
-    monkeypatch.setattr(envs, "USAGE_ROLLUP_TIMEZONE", "America/Bogota")
+    monkeypatch.setattr(envs, "TIMEZONE", "America/Bogota")
     session.add(
         _mu(
             meter_key=METER_INSTANCE_UPTIME,
@@ -1125,7 +1125,7 @@ async def test_breakdown_range_boundary_includes_shifted_edge(session, monkeypat
     from gpustack import envs
     from sqlalchemy import and_
 
-    monkeypatch.setattr(envs, "USAGE_ROLLUP_TIMEZONE", "Asia/Shanghai")
+    monkeypatch.setattr(envs, "TIMEZONE", "Asia/Shanghai")
     session.add(
         _mu(
             meter_key=METER_INSTANCE_UPTIME,


### PR DESCRIPTION
The timezone controls not just the usage rollup but every calendar-based view (model_usages daily rollup, metered_usage GPU/storage buckets, Last Active / resource-event display), so give it a platform-wide name.

- Add GPUSTACK_TIMEZONE; keep GPUSTACK_USAGE_ROLLUP_TIMEZONE as a deprecated alias (new wins when both set, legacy honored with a one-time deprecation warning).
- Rename the internal constant envs.USAGE_ROLLUP_TIMEZONE -> envs.TIMEZONE.
- Update rollup_tz docstring/warning, env-var and usage docs, and tests.

Refer to issue:
- #5900