### PR TITLE
fix: add trailing newline to auto-generated bootstrap password file

### DIFF
--- a/charts/gpustack-chart/templates/server-bootstrap-password.yaml
+++ b/charts/gpustack-chart/templates/server-bootstrap-password.yaml
@@ -17,7 +17,9 @@ guide; it is reused across upgrades via lookup so the value stays stable.
   {{- if and $secret (hasKey ($secret.data | default dict) "password") -}}
     {{- $password = index $secret.data "password" | b64dec -}}
   {{- else -}}
-    {{- $password = randAlphaNum 16 -}}
+    {{- /* Trailing newline so `cat`-ing the mounted file is friendly; the
+           server strips it when reading. */ -}}
+    {{- $password = printf "%s\n" (randAlphaNum 16) -}}
   {{- end -}}
 {{- end -}}
 apiVersion: v1


### PR DESCRIPTION
Append a newline to the generated value only (the server strips it on read). The pinned password path is untouched since it is injected as the GPUSTACK_BOOTSTRAP_PASSWORD env var, where a newline would corrupt it.