### PR TITLE
fix(exporter): collapse duplicate bus metrics per (topic, source)

### DIFF
--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -199,14 +199,14 @@ These metrics are mapped from various runtime engines (vLLM, SGLang, MindIE) as 
 
 ### Event Bus Metrics
 
-| Metric Name                         | Type    | Description                                                       |
-| ----------------------------------- | ------- | ----------------------------------------------------------------- |
-| gpustack:bus_subscribers            | Gauge   | Active bus subscribers per topic.                                 |
-| gpustack:bus_queue_depth            | Gauge   | Per-subscriber queue depth at scrape time.                        |
-| gpustack:bus_queue_capacity         | Gauge   | Per-subscriber queue maxsize (see env knob below).                |
-| gpustack:bus_queue_full             | Gauge   | 1 if the queue is full at scrape time, 0 otherwise.               |
-| gpustack:bus_queue_saturation_ratio | Gauge   | `qsize / maxsize` in `[0, 1]`. Sustained > 0.8 ⇒ slow consumer.   |
-| gpustack:bus_subscriber_latest_keys | Gauge   | Ids pending coalesced UPDATED delivery (size of `latest_by_key`). |
-| gpustack:bus_events_total           | Counter | Cumulative event counts. Extra labels: `kind`, `event_type`.      |
+| Metric Name                         | Type    | Description                                                                                                      |
+| ----------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| gpustack:bus_subscribers            | Gauge   | Active bus subscribers per `topic` + `source` (several may share `source=streaming`, one per open watch stream). |
+| gpustack:bus_queue_depth            | Gauge   | Max queue depth across subscribers sharing `topic`+`source`.                                                     |
+| gpustack:bus_queue_capacity         | Gauge   | Per-subscriber queue maxsize (see env knob below).                                                               |
+| gpustack:bus_queue_full             | Gauge   | 1 if any subscriber sharing `topic`+`source` has a full queue.                                                   |
+| gpustack:bus_queue_saturation_ratio | Gauge   | Max `qsize / maxsize` in `[0, 1]`. Sustained > 0.8 ⇒ slow consumer.                                              |
+| gpustack:bus_subscriber_latest_keys | Gauge   | Max ids pending coalesced UPDATED delivery (size of `latest_by_key`).                                            |
+| gpustack:bus_events_total           | Counter | Cumulative event counts summed across subscribers sharing `topic`+`source`. Extra labels: `kind`, `event_type`.  |
 
 > **Note**: All metrics are labeled with relevant identifiers (cluster, worker, model, instance, user) for fine-grained monitoring and filtering.

--- a/gpustack/exporter/bus_metrics.py
+++ b/gpustack/exporter/bus_metrics.py
@@ -1,6 +1,6 @@
 """Prometheus metrics for the in-process event bus, pulled at scrape time."""
 
-from typing import Iterator
+from typing import Dict, Iterator, Tuple
 
 from prometheus_client.registry import Collector
 from prometheus_client.core import (
@@ -14,68 +14,118 @@ from gpustack.utils.name import metric_name
 
 
 class BusMetricsCollector(Collector):
+    """Expose event-bus health as Prometheus metrics.
+
+    A ``(topic, source)`` pair does NOT uniquely identify a subscriber:
+    every open watch/SSE stream subscribes with ``source="streaming"``, so a
+    hot topic routinely carries several subscribers sharing one label set.
+    Emitting one series per subscriber would then produce duplicate label sets
+    (invalid exposition, see #5902), and adding a per-subscriber label would
+    blow up cardinality as ephemeral streams come and go. So metrics are
+    aggregated per ``(topic, source)``: the worst-case (max) subscriber for the
+    gauges — which is what "is a consumer backpressuring?" cares about — and
+    the sum for cumulative event counts. ``bus_subscribers`` additionally gains
+    a ``source`` dimension so the collapsed subscriber count stays visible.
+    """
+
     def collect(self) -> Iterator[Metric]:
         subscribers = GaugeMetricFamily(
             metric_name("bus_subscribers"),
-            "Number of active bus subscribers per topic.",
-            labels=["topic"],
+            "Number of active bus subscribers per topic and source. "
+            "Several may share source=streaming (one per open watch stream).",
+            labels=["topic", "source"],
         )
         queue_depth = GaugeMetricFamily(
             metric_name("bus_queue_depth"),
-            "Current per-subscriber queue depth at scrape time.",
+            "Max queue depth at scrape time across subscribers sharing "
+            "topic+source (worst-case consumer).",
             labels=["topic", "source"],
         )
         queue_capacity = GaugeMetricFamily(
             metric_name("bus_queue_capacity"),
-            "Per-subscriber queue maxsize.",
+            "Per-subscriber queue maxsize (identical across subscribers "
+            "sharing topic+source).",
             labels=["topic", "source"],
         )
         queue_full = GaugeMetricFamily(
             metric_name("bus_queue_full"),
-            "1 if the subscriber queue is full at scrape time, 0 otherwise. "
-            "A sustained 1 indicates a slow consumer holding back the bus.",
+            "1 if any subscriber sharing topic+source has a full queue at "
+            "scrape time, 0 otherwise. A sustained 1 indicates a slow "
+            "consumer holding back the bus.",
             labels=["topic", "source"],
         )
         queue_saturation = GaugeMetricFamily(
             metric_name("bus_queue_saturation_ratio"),
-            "Per-subscriber queue depth as a fraction of capacity "
-            "(qsize / maxsize).",
+            "Max queue depth as a fraction of capacity (qsize / maxsize) "
+            "across subscribers sharing topic+source.",
             labels=["topic", "source"],
         )
         latest_keys = GaugeMetricFamily(
             metric_name("bus_subscriber_latest_keys"),
-            "Number of distinct ids pending coalesced UPDATED delivery "
-            "per subscriber (size of latest_by_key).",
+            "Max number of distinct ids pending coalesced UPDATED delivery "
+            "(size of latest_by_key) across subscribers sharing topic+source.",
             labels=["topic", "source"],
         )
         events = CounterMetricFamily(
             metric_name("bus_events"),
-            "Cumulative event counts per subscriber. Kinds: "
-            "received, filtered, coalesced, enqueued, backpressured "
-            "(see EventCountKind).",
+            "Cumulative event counts summed across subscribers sharing "
+            "topic+source. Kinds: received, filtered, coalesced, enqueued, "
+            "backpressured (see EventCountKind).",
             labels=["topic", "source", "kind", "event_type"],
         )
 
         # Copy in case subscribe/unsubscribe races with collection.
         snapshot = {topic: list(subs) for topic, subs in event_bus.subscribers.items()}
 
+        # Aggregate per (topic, source) so subscribers sharing a label set
+        # (notably source="streaming", one per open watch stream) collapse to
+        # a single series instead of emitting duplicate lines.
+        count: Dict[Tuple[str, str], int] = {}
+        depth_max: Dict[Tuple[str, str], int] = {}
+        capacity: Dict[Tuple[str, str], int] = {}
+        full: Dict[Tuple[str, str], bool] = {}
+        saturation_max: Dict[Tuple[str, str], float] = {}
+        latest_keys_max: Dict[Tuple[str, str], int] = {}
+        events_sum: Dict[Tuple[str, str, str, str], int] = {}
+
         for topic, subs in snapshot.items():
-            subscribers.add_metric([topic], len(subs))
             for sub in subs:
-                source = sub.source or ""
+                key = (topic, sub.source or "")
                 qsize = sub.queue.qsize()
                 maxsize = sub.queue.maxsize
-                queue_depth.add_metric([topic, source], qsize)
-                queue_capacity.add_metric([topic, source], maxsize)
-                queue_full.add_metric([topic, source], 1.0 if sub.queue.full() else 0.0)
-                queue_saturation.add_metric(
-                    [topic, source], qsize / maxsize if maxsize else 0.0
+                count[key] = count.get(key, 0) + 1
+                depth_max[key] = max(depth_max.get(key, 0), qsize)
+                capacity[key] = max(capacity.get(key, 0), maxsize)
+                full[key] = full.get(key, False) or sub.queue.full()
+                saturation_max[key] = max(
+                    saturation_max.get(key, 0.0),
+                    qsize / maxsize if maxsize else 0.0,
                 )
-                latest_keys.add_metric([topic, source], len(sub.latest_by_key))
-                for (kind, event_type_name), count in sub.event_counts.items():
-                    events.add_metric(
-                        [topic, source, kind.value, event_type_name], count
-                    )
+                latest_keys_max[key] = max(
+                    latest_keys_max.get(key, 0), len(sub.latest_by_key)
+                )
+                # Copy the items: ``enqueue`` mutates ``event_counts`` on the
+                # event loop while ``/metrics`` collects from the scrape thread,
+                # so iterating the live dict can raise "dictionary changed size
+                # during iteration".
+                for (kind, event_type_name), c in list(sub.event_counts.items()):
+                    ekey = (topic, sub.source or "", kind.value, event_type_name)
+                    events_sum[ekey] = events_sum.get(ekey, 0) + c
+
+        for (topic, source), n in count.items():
+            subscribers.add_metric([topic, source], n)
+            queue_depth.add_metric([topic, source], depth_max[(topic, source)])
+            queue_capacity.add_metric([topic, source], capacity[(topic, source)])
+            queue_full.add_metric(
+                [topic, source], 1.0 if full[(topic, source)] else 0.0
+            )
+            queue_saturation.add_metric(
+                [topic, source], saturation_max[(topic, source)]
+            )
+            latest_keys.add_metric([topic, source], latest_keys_max[(topic, source)])
+
+        for (topic, source, kind, event_type_name), total in events_sum.items():
+            events.add_metric([topic, source, kind, event_type_name], total)
 
         yield subscribers
         yield queue_depth

--- a/gpustack/exporter/bus_metrics.py
+++ b/gpustack/exporter/bus_metrics.py
@@ -26,6 +26,12 @@ class BusMetricsCollector(Collector):
     gauges — which is what "is a consumer backpressuring?" cares about — and
     the sum for cumulative event counts. ``bus_subscribers`` additionally gains
     a ``source`` dimension so the collapsed subscriber count stays visible.
+
+    The event counter sum spans both live subscribers and the bus-level
+    ``retired_event_counts`` accumulator (counts of already-unsubscribed
+    subscribers). Without the retired term, a short-lived source's series
+    would drop as streams close and Prometheus would read the drop as a
+    counter reset, so ``bus_events_total`` stays monotonic.
     """
 
     def collect(self) -> Iterator[Metric]:
@@ -86,7 +92,12 @@ class BusMetricsCollector(Collector):
         full: Dict[Tuple[str, str], bool] = {}
         saturation_max: Dict[Tuple[str, str], float] = {}
         latest_keys_max: Dict[Tuple[str, str], int] = {}
-        events_sum: Dict[Tuple[str, str, str, str], int] = {}
+        # Seed with the counts of already-unsubscribed subscribers so the
+        # counter never drops when a subscriber departs. list() copies in
+        # case unsubscribe folds a new entry in mid-collection.
+        events_sum: Dict[Tuple[str, str, str, str], int] = dict(
+            list(event_bus.retired_event_counts.items())
+        )
 
         for topic, subs in snapshot.items():
             for sub in subs:

--- a/gpustack/server/bus.py
+++ b/gpustack/server/bus.py
@@ -214,6 +214,16 @@ class EventBus:
         # doesn't reap them mid-execution (Python's create_task only
         # holds a weak reference to the task it returns).
         self._pending_tasks: Set[asyncio.Task] = set()
+        # Event counts of unsubscribed subscribers, folded in on unsubscribe
+        # and never decremented. ``BusMetricsCollector`` adds these to the
+        # live subscribers' counts so ``bus_events_total`` stays monotonic
+        # even for short-lived sources (notably source="streaming", one
+        # subscriber per open watch stream): without this, a stream closing
+        # would drop the summed series and Prometheus would read it as a
+        # counter reset, mis-counting rate()/increase(). Keyed by
+        # ``(topic, source, kind, event_type)`` — a bounded label space, so
+        # this dict cannot grow without limit.
+        self.retired_event_counts: Dict[Tuple[str, str, str, str], int] = {}
 
     def _spawn(self, coro) -> asyncio.Task:
         """``asyncio.create_task`` plus retain-and-discard bookkeeping."""
@@ -433,14 +443,28 @@ class EventBus:
         unwind. Without this, ``_pending_tasks`` would retain those tasks —
         and through them the subscriber + its 1024 queued events — forever.
         """
+        removed = False
         if topic in self.subscribers:
             try:
                 self.subscribers[topic].remove(subscriber)
+                removed = True
             except ValueError:
                 # Defensive: tolerate double-unsubscribe.
                 pass
             if not self.subscribers[topic]:
                 del self.subscribers[topic]
+        # Fold this subscriber's counts into the bus-level accumulator so
+        # bus_events_total keeps the departed subscriber's contribution
+        # instead of dropping it. Only on the first (successful) removal, so
+        # a double-unsubscribe can't double-count. list() copies in case an
+        # in-flight enqueue is still bumping the dict.
+        if removed:
+            source = subscriber.source or ""
+            for (kind, event_type_name), count in list(subscriber.event_counts.items()):
+                key = (topic, source, kind.value, event_type_name)
+                self.retired_event_counts[key] = (
+                    self.retired_event_counts.get(key, 0) + count
+                )
         subscriber.close()
 
     async def publish(self, topic: str, event: Event):

--- a/tests/exporter/test_bus_metrics.py
+++ b/tests/exporter/test_bus_metrics.py
@@ -50,9 +50,14 @@ async def test_bus_metrics_collector_reflects_subscriber_state():
 
         metrics = list(BusMetricsCollector().collect())
 
-        # 2 subscribers under our topic.
-        sample = _sample_for(metrics, "gpustack:bus_subscribers", {"topic": topic})
-        assert sample.value == 2
+        # 1 subscriber per (topic, source) — the metric is now source-scoped.
+        for source in ("test_a", "test_b"):
+            sample = _sample_for(
+                metrics,
+                "gpustack:bus_subscribers",
+                {"topic": topic, "source": source},
+            )
+            assert sample.value == 1
 
         # sub_a — RECEIVED total = 3.
         sample = _sample_for(
@@ -170,6 +175,69 @@ async def test_bus_metrics_collector_reflects_subscriber_state():
     finally:
         event_bus.unsubscribe(topic, sub_a)
         event_bus.unsubscribe(topic, sub_b)
+
+
+@pytest.mark.asyncio
+async def test_subscribers_sharing_source_collapse_to_one_series():
+    """#5902: multiple subscribers with the same (topic, source) — e.g. one
+    per open source="streaming" watch stream — must aggregate into a single
+    series instead of emitting duplicate label sets.
+    """
+    topic = "_test_bus_metrics_collapse"
+    # Three streaming subscribers on the same topic, mirroring three open
+    # watch connections.
+    subs = [event_bus.subscribe(topic, source="streaming") for _ in range(3)]
+
+    try:
+        # Give each a different queue depth so max-aggregation is observable.
+        await subs[0].enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+        await subs[1].enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+        await subs[1].enqueue(Event(type=EventType.CREATED, data={"id": 2}, id=2))
+        # subs[2] left empty.
+
+        metrics = list(BusMetricsCollector().collect())
+
+        label = {"topic": topic, "source": "streaming"}
+
+        # Exactly one series per metric for this label set — no duplicates.
+        for metric_name in (
+            "gpustack:bus_subscribers",
+            "gpustack:bus_queue_depth",
+            "gpustack:bus_queue_capacity",
+            "gpustack:bus_queue_full",
+            "gpustack:bus_queue_saturation_ratio",
+            "gpustack:bus_subscriber_latest_keys",
+        ):
+            matching = [
+                s
+                for s in _all_samples(metrics, metric_name)
+                if all(s.labels.get(k) == v for k, v in label.items())
+            ]
+            assert len(matching) == 1, (
+                f"{metric_name} emitted {len(matching)} series for {label}, "
+                "expected 1 (duplicate label sets)"
+            )
+
+        # bus_subscribers = 3 collapsed subscribers.
+        assert _sample_for(metrics, "gpustack:bus_subscribers", label).value == 3
+        # queue_depth = max across subscribers (subs[1] has 2 queued).
+        assert _sample_for(metrics, "gpustack:bus_queue_depth", label).value == 2
+        # bus_events CREATED ENQUEUED summed across all three (1 + 2 + 0 = 3).
+        assert (
+            _sample_for(
+                metrics,
+                "gpustack:bus_events",
+                {
+                    **label,
+                    "kind": EventCountKind.ENQUEUED.value,
+                    "event_type": EventType.CREATED.name,
+                },
+            ).value
+            == 3
+        )
+    finally:
+        for sub in subs:
+            event_bus.unsubscribe(topic, sub)
 
 
 @pytest.mark.asyncio

--- a/tests/exporter/test_bus_metrics.py
+++ b/tests/exporter/test_bus_metrics.py
@@ -241,6 +241,55 @@ async def test_subscribers_sharing_source_collapse_to_one_series():
 
 
 @pytest.mark.asyncio
+async def test_bus_events_total_stays_monotonic_across_unsubscribe():
+    """A departing subscriber's counts must not drop the summed counter.
+
+    Short-lived source="streaming" subscribers unsubscribe when their watch
+    stream closes; folding their counts into the bus-level accumulator keeps
+    bus_events_total monotonic so rate()/increase() stay correct.
+    """
+    topic = "_test_bus_metrics_monotonic"
+    sub_a = event_bus.subscribe(topic, source="streaming")
+    sub_b = event_bus.subscribe(topic, source="streaming")
+    sub_c = None
+
+    def enqueued_total():
+        return _sample_for(
+            list(BusMetricsCollector().collect()),
+            "gpustack:bus_events",
+            {
+                "topic": topic,
+                "source": "streaming",
+                "kind": EventCountKind.ENQUEUED.value,
+                "event_type": EventType.CREATED.name,
+            },
+        ).value
+
+    try:
+        await sub_a.enqueue(Event(type=EventType.CREATED, data={"id": 1}, id=1))
+        await sub_a.enqueue(Event(type=EventType.CREATED, data={"id": 2}, id=2))
+        await sub_b.enqueue(Event(type=EventType.CREATED, data={"id": 3}, id=3))
+
+        before = enqueued_total()
+        assert before == 3  # 2 from sub_a + 1 from sub_b
+
+        # Closing one stream must not lower the counter.
+        event_bus.unsubscribe(topic, sub_a)
+        after = enqueued_total()
+        assert after == before == 3
+
+        # A new stream keeps accumulating on top of the retired total.
+        sub_c = event_bus.subscribe(topic, source="streaming")
+        await sub_c.enqueue(Event(type=EventType.CREATED, data={"id": 4}, id=4))
+        assert enqueued_total() == 4
+    finally:
+        for sub in (sub_a, sub_b, sub_c):
+            if sub is not None:
+                event_bus.unsubscribe(topic, sub)
+        event_bus.retired_event_counts.clear()
+
+
+@pytest.mark.asyncio
 async def test_bus_metrics_collector_reports_backpressure_and_queue_full():
     topic = "_test_bus_metrics_qfull"
     sub = Subscriber(topic=topic, source="slow", queue_size=1)


### PR DESCRIPTION
The bus metrics collector emitted one series per subscriber but labeled them only by topic+source. Since every open watch/SSE stream subscribes with source="streaming", a hot topic carries several subscribers sharing one label set, producing duplicate label lines (invalid exposition, #5902).

Aggregate per (topic, source) instead: max for the gauges (worst-case consumer, which is what backpressure monitoring cares about), sum for the cumulative event counts. bus_subscribers gains a source dimension so the collapsed subscriber count stays visible. Avoids the cardinality blowup a per-subscriber label would cause as ephemeral streams come and go.