### PR TITLE
feat(auth): add optional CAPTCHA protection for local login

### DIFF
--- a/docs/cli-reference/start.md
+++ b/docs/cli-reference/start.md
@@ -106,6 +106,8 @@ gpustack start [OPTIONS]
 | `--external-auth-full-name` value                | (empty)                                          | Mapping of external authentication user information to user's full name. Multiple elements can be combined, e.g., `name` or `firstName+lastName`.                                                                                                                                                                                             |
 | `--external-auth-avatar-url` value               | (empty)                                          | Mapping of external authentication user information to user's avatar URL.                                                                                                                                                                                                                                                                     |
 | `--external-auth-default-inactive`               | `False`                                          | True if new users should be deactivated by default.                                                                                                                                                                                                                                                                                           |
+| `--enable-login-captcha`                         | `False`                                          | Require a short-lived encrypted graphic CAPTCHA for local username/password login.                                                                                                                                                                                                                                                           |
+| `--login-captcha-length` value                   | `4`                                              | Number of characters in the login CAPTCHA. Must be between 4 and 6.                                                                                                                                                                                                                                                                           |
 | `--external-auth-insecure-skip-tls-verify`       | `False`                                          | Skip TLS verification for the external-auth IdP handshake (OIDC/CAS). For testing against self-signed IdPs only; never use in production.                                                                                                                                                                                                     |
 | `--server-external-url` value                    | (empty)                                          | The external server URL for worker registration. This option is required when provisioning workers via cloud providers, ensuring that workers can connect to the server correctly.                                                                                                                                                            |
 | `--trusted-hosts` value                          | (empty)                                          | Allowlist for `the X-Forwarded-Host` header behind a reverse proxy. When unset, derived from `--server-external-url`. If both are unset, it defaults to `*` to trust any host (not recommended unless the server is only reachable via a trusted proxy).                                                                                      |
@@ -203,6 +205,8 @@ cas_full_name_attribute: displayName
 external_auth_name: email
 external_auth_full_name: name
 external_auth_avatar_url: picture
+enable_login_captcha: false
+login_captcha_length: 4
 server_external_url: http://your_gpustack_server_url_for_external_access
 trusted_hosts: [ "your_reverse_proxy_hostname" ]
 disable_builtin_observability: false
@@ -225,3 +229,19 @@ system_reserved:
 enable_hf_transfer: false
 proxy_mode: worker
 ```
+
+### Login CAPTCHA Security Notes
+
+When `enable_login_captcha` is `true`, GPUStack requires the browser-bound
+CAPTCHA for local username/password login. Ordinary user password
+authentication through HTTP Basic is disabled in this mode because it would
+bypass the login challenge; API clients should use an API key instead. Legacy
+GPUStack system principals used by workers are not affected.
+
+CAPTCHA challenges expire after five minutes, are bound to a short-lived
+HttpOnly `SameSite=Strict` cookie, and are single-use across server replicas
+through the shared database. The image and optional audio challenge endpoints,
+and the local login endpoint while CAPTCHA is enabled, also have bounded
+per-process rate limits.
+Multi-replica or Internet-facing deployments should enforce an additional
+global rate limit at their trusted ingress or API gateway.

--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -157,6 +157,13 @@ async def authenticate_request(
         if basic_credentials and is_system_user(basic_credentials.username):
             user = await authenticate_system_principal(server_config, basic_credentials)
         elif basic_credentials or cookie_token or bearer_token or x_api_key:
+            if basic_credentials and server_config.enable_login_captcha:
+                raise UnauthorizedException(
+                    message=(
+                        "Password authentication via HTTP Basic is disabled "
+                        "while login CAPTCHA is enabled; use an API key"
+                    )
+                )
             # Scoped to just the auth lookup (not Depends(get_session)) so the
             # connection/transaction isn't held open for the lifetime of the
             # request -- otherwise a long-lived StreamingResponse (SSE watch,

--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -162,6 +162,13 @@ async def authenticate_request(
         if basic_credentials and is_system_user(basic_credentials.username):
             user = await authenticate_system_principal(server_config, basic_credentials)
         elif basic_credentials or cookie_token or bearer_token or x_api_key:
+            if basic_credentials and server_config.enable_login_captcha:
+                raise UnauthorizedException(
+                    message=(
+                        "Password authentication via HTTP Basic is disabled "
+                        "while login CAPTCHA is enabled; use an API key"
+                    )
+                )
             # Scoped to just the auth lookup (not Depends(get_session)) so the
             # connection/transaction isn't held open for the lifetime of the
             # request -- otherwise a long-lived StreamingResponse (SSE watch,

--- a/gpustack/api/exceptions.py
+++ b/gpustack/api/exceptions.py
@@ -69,6 +69,11 @@ InvalidException = http_exception_factory(
 BadRequestException = http_exception_factory(
     status.HTTP_400_BAD_REQUEST, "BadRequest", "Bad request"
 )
+TooManyRequestsException = http_exception_factory(
+    status.HTTP_429_TOO_MANY_REQUESTS,
+    "TooManyRequests",
+    "Too many requests",
+)
 InternalServerErrorException = http_exception_factory(
     status.HTTP_500_INTERNAL_SERVER_ERROR,
     "InternalServerError",
@@ -160,6 +165,7 @@ error_responses = {
     403: {"model": ErrorResponse},
     422: {"model": ErrorResponse},
     400: {"model": ErrorResponse},
+    429: {"model": ErrorResponse},
     500: {"model": ErrorResponse},
     503: {"model": ErrorResponse},
 }
@@ -183,6 +189,7 @@ openai_api_error_responses = {
     403: {"model": OpenAIAPIErrorResponse},
     422: {"model": OpenAIAPIErrorResponse},
     400: {"model": OpenAIAPIErrorResponse},
+    429: {"model": OpenAIAPIErrorResponse},
     500: {"model": OpenAIAPIErrorResponse},
     503: {"model": OpenAIAPIErrorResponse},
 }

--- a/gpustack/api/exceptions.py
+++ b/gpustack/api/exceptions.py
@@ -88,6 +88,11 @@ InvalidException = http_exception_factory(
 BadRequestException = http_exception_factory(
     status.HTTP_400_BAD_REQUEST, "BadRequest", "Bad request"
 )
+TooManyRequestsException = http_exception_factory(
+    status.HTTP_429_TOO_MANY_REQUESTS,
+    "TooManyRequests",
+    "Too many requests",
+)
 InternalServerErrorException = http_exception_factory(
     status.HTTP_500_INTERNAL_SERVER_ERROR,
     "InternalServerError",
@@ -179,6 +184,7 @@ error_responses = {
     403: {"model": ErrorResponse},
     422: {"model": ErrorResponse},
     400: {"model": ErrorResponse},
+    429: {"model": ErrorResponse},
     500: {"model": ErrorResponse},
     503: {"model": ErrorResponse},
 }
@@ -202,6 +208,7 @@ openai_api_error_responses = {
     403: {"model": OpenAIAPIErrorResponse},
     422: {"model": OpenAIAPIErrorResponse},
     400: {"model": OpenAIAPIErrorResponse},
+    429: {"model": OpenAIAPIErrorResponse},
     500: {"model": OpenAIAPIErrorResponse},
     503: {"model": OpenAIAPIErrorResponse},
 }

--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -537,6 +537,18 @@ def start_cmd_options(parser_server: argparse.ArgumentParser):
         default=get_gpustack_env_bool("EXTERNAL_AUTH_DEFAULT_INACTIVE"),
     )
     server_group.add_argument(
+        "--enable-login-captcha",
+        action=OptionalBoolAction,
+        help="Require a graphic CAPTCHA on the local username/password login form.",
+        default=get_gpustack_env_bool("ENABLE_LOGIN_CAPTCHA"),
+    )
+    server_group.add_argument(
+        "--login-captcha-length",
+        type=int,
+        help="Number of characters in the login CAPTCHA (4-6).",
+        default=get_gpustack_env("LOGIN_CAPTCHA_LENGTH"),
+    )
+    server_group.add_argument(
         "--external-auth-insecure-skip-tls-verify",
         action=OptionalBoolAction,
         help="Skip TLS verification for the external-auth IdP handshake "
@@ -841,6 +853,8 @@ def set_server_options(args, config_data: dict):
         "external_auth_full_name",
         "external_auth_avatar_url",
         "external_auth_default_inactive",
+        "enable_login_captcha",
+        "login_captcha_length",
         "external_auth_insecure_skip_tls_verify",
         "oidc_issuer",
         "oidc_client_id",

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -17,7 +17,7 @@ from gpustack_runtime.detector import (
     available_manufacturers,
     available_backends,
 )
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from gpustack.utils import validators
 from gpustack.schemas.workers import (
@@ -120,6 +120,9 @@ class Config(WorkerConfig, BaseSettings):
         allow_credentials: Indicate that cookies should be supported for cross-origin requests.
         allow_methods: A list of HTTP methods that should be allowed for cross-origin requests.
         allow_headers: A list of HTTP request headers that should be supported for cross-origin requests.
+        enable_login_captcha: Require a graphic CAPTCHA on the local
+            username/password login form. Off by default.
+        login_captcha_length: Number of CAPTCHA characters, from 4 to 6. Default is 4.
         server_external_url: Specified external URL for the server.
         system_default_container_registry: Default registry for container images (server and inference images).
         image_name_override: Force override of the image name.
@@ -236,6 +239,14 @@ class Config(WorkerConfig, BaseSettings):
     cas_username_attribute: Optional[str] = None
     cas_full_name_attribute: Optional[str] = None
     cas_avatar_attribute: Optional[str] = None
+    # Graphic CAPTCHA on the local username/password login form. Off by
+    # default so existing deployments are unaffected; enabling it adds a
+    # challenge image to the login page and requires the solved code on
+    # ``POST /auth/login``. Only guards local login — SSO callbacks are
+    # unaffected.
+    enable_login_captcha: bool = False
+    # Keep the challenge legible while preventing invalid or oversized images.
+    login_captcha_length: int = Field(default=4, ge=4, le=6)
     server_external_url: Optional[str] = None
     # Allowlist for the X-Forwarded-Host header behind a reverse proxy. When
     # unset, derived from server_external_url. If both are unset, it defaults to

--- a/gpustack/migrations/versions/2026_07_17_1000-a91c4f0e2d7b_login_captcha_nonce_ledger.py
+++ b/gpustack/migrations/versions/2026_07_17_1000-a91c4f0e2d7b_login_captcha_nonce_ledger.py
@@ -1,0 +1,42 @@
+"""Add the shared login CAPTCHA nonce ledger.
+
+Revision ID: a91c4f0e2d7b
+Revises: c4d7e8f9a0b1
+Create Date: 2026-07-17 10:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from gpustack.schemas.common import UTCDateTime
+
+
+revision: str = "a91c4f0e2d7b"
+down_revision: Union[str, None] = "c4d7e8f9a0b1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "login_captcha_nonces",
+        sa.Column("nonce_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", UTCDateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("nonce_hash"),
+    )
+    op.create_index(
+        op.f("ix_login_captcha_nonces_expires_at"),
+        "login_captcha_nonces",
+        ["expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_login_captcha_nonces_expires_at"),
+        table_name="login_captcha_nonces",
+    )
+    op.drop_table("login_captcha_nonces")

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -13,7 +13,6 @@ import logging
 import jwt
 from jwt.algorithms import RSAAlgorithm
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import delete
 from gpustack.config.config import Config
 from gpustack.utils import captcha as captcha_util
 from typing import Annotated, Dict, List, Optional
@@ -69,6 +68,7 @@ _captcha_issue_limiter = KeyedRateLimiter(max_requests=30, window_seconds=60)
 _captcha_audio_limiter = KeyedRateLimiter(max_requests=10, window_seconds=60)
 _login_ip_limiter = KeyedRateLimiter(max_requests=30, window_seconds=5 * 60)
 _login_account_limiter = KeyedRateLimiter(max_requests=10, window_seconds=5 * 60)
+_DEFAULT_ORIGIN_PORTS = {"http": 80, "https": 443}
 
 
 def _issue_captcha(request: Request, length: int, binding: str) -> Dict[str, str]:
@@ -114,9 +114,6 @@ async def _consume_captcha_nonce(nonce: str) -> None:
     now = datetime.now(timezone.utc)
     nonce_hash = hashlib.sha256(nonce.encode("utf-8")).hexdigest()
     async with async_session() as session:
-        await session.exec(
-            delete(LoginCaptchaNonce).where(LoginCaptchaNonce.expires_at <= now)
-        )
         session.add(
             LoginCaptchaNonce(
                 nonce_hash=nonce_hash,
@@ -188,20 +185,76 @@ def _enforce_rate_limit(limiter: KeyedRateLimiter, key: str) -> None:
         )
 
 
-def _validate_login_origin(request: Request) -> None:
+def _canonical_http_origin(
+    value: str, *, allow_path: bool = False
+) -> Optional[tuple[str, str, int]]:
+    """Return a normalized HTTP origin, or ``None`` for malformed input."""
+    try:
+        parsed = urlparse(value)
+        scheme = parsed.scheme.casefold()
+        if scheme not in _DEFAULT_ORIGIN_PORTS:
+            return None
+        if (
+            not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            return None
+        if (
+            (not allow_path and parsed.path not in ("", "/"))
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        hostname = parsed.hostname
+        port = parsed.port
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    if not hostname:
+        return None
+    try:
+        normalized_host = hostname.rstrip(".").encode("idna").decode("ascii")
+    except UnicodeError:
+        return None
+    if not normalized_host:
+        return None
+    return (
+        scheme,
+        normalized_host.casefold(),
+        port or _DEFAULT_ORIGIN_PORTS[scheme],
+    )
+
+
+def _validate_login_origin(request: Request, config: Config) -> None:
     """Reject browser cross-site form posts while allowing non-browser clients."""
     if request.headers.get("sec-fetch-site", "").casefold() == "cross-site":
         raise BadRequestException(message="Cross-site login requests are not allowed")
     origin = request.headers.get("origin")
     if not origin:
         return
-    parsed = urlparse(origin)
-    request_host = request.headers.get("host", "").casefold()
-    if (
-        parsed.scheme.casefold() != request.url.scheme.casefold()
-        or not parsed.netloc
-        or parsed.netloc.casefold() != request_host
-    ):
+
+    supplied_origin = _canonical_http_origin(origin)
+    expected_origins = set()
+    request_host = request.headers.get("host", "")
+    request_origin = _canonical_http_origin(
+        f"{request.url.scheme}://{request_host}", allow_path=True
+    )
+    if request_origin:
+        expected_origins.add(request_origin)
+
+    # ``server_external_url`` is authoritative when TLS terminates at a
+    # reverse proxy. Raw X-Forwarded-* headers are deliberately not read here;
+    # Uvicorn and ForwardedHostPortMiddleware already apply trusted values.
+    if config.server_external_url:
+        external_origin = _canonical_http_origin(
+            config.server_external_url, allow_path=True
+        )
+        if external_origin:
+            expected_origins.add(external_origin)
+
+    if supplied_origin is None or supplied_origin not in expected_origins:
         raise BadRequestException(message="Cross-site login requests are not allowed")
 
 
@@ -1384,7 +1437,7 @@ async def login(
 ):
     config: Config = request.app.state.server_config
     if config.enable_login_captcha:
-        _validate_login_origin(request)
+        _validate_login_origin(request, config)
         client_ip = client_ip_getter(request)
         username_hash = hashlib.sha256(
             username.strip().casefold().encode("utf-8")

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -1,23 +1,32 @@
 import base64
 import functools
+import hashlib
 import hmac
 import json
 import os
+import re
 import secrets
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import httpx
 import logging
 import jwt
 from jwt.algorithms import RSAAlgorithm
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import delete
 from gpustack.config.config import Config
+from gpustack.utils import captcha as captcha_util
 from typing import Annotated, Dict, List, Optional
 from fastapi import APIRouter, Form, Request, Response
 from gpustack.api.exceptions import (
     ConflictException,
     InvalidException,
+    NotFoundException,
     UnauthorizedException,
     BadRequestException,
+    TooManyRequestsException,
 )
+from gpustack.schemas.login_captcha import LoginCaptchaNonce
 from gpustack.schemas.users import UpdatePassword
 from gpustack.schemas.principals import PrincipalType
 from gpustack.schemas.users import User, AuthProviderEnum
@@ -29,22 +38,171 @@ from gpustack.api.auth import (
     OIDC_STATE_COOKIE_NAME,
     SSO_LOGIN_COOKIE_NAME,
     authenticate_user,
+    client_ip_getter,
 )
+from gpustack.server.db import async_session
 from gpustack.server.deps import CurrentUserDep, SessionDep
 from gpustack.server.passwords import change_password, is_password_change_required
 from gpustack.server.services import sync_user_group_memberships
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from fastapi.responses import RedirectResponse
 from lxml import etree
+from starlette.concurrency import run_in_threadpool
 from gpustack.utils.convert import safe_b64decode, inflate_data
 from urllib.parse import quote, urlencode, urlparse
 
 from gpustack.ssl_context import make_ssl_context
 from gpustack.utils.network import use_proxy_env_for_url
+from gpustack.utils.rate_limit import KeyedRateLimiter
 
 router = APIRouter()
 timeout = httpx.Timeout(connect=15.0, read=60.0, write=60.0, pool=10.0)
 logger = logging.getLogger(__name__)
+
+# The encrypted challenge is valid long enough to complete the form while
+# keeping the replay window bounded.
+CAPTCHA_TOKEN_TTL_SECONDS = 5 * 60
+CAPTCHA_SESSION_COOKIE_NAME = "gpustack_captcha_session"
+_CAPTCHA_BINDING_PATTERN = re.compile(r"^[A-Za-z0-9_-]{32,128}$")
+
+_captcha_issue_limiter = KeyedRateLimiter(max_requests=30, window_seconds=60)
+_captcha_audio_limiter = KeyedRateLimiter(max_requests=10, window_seconds=60)
+_login_ip_limiter = KeyedRateLimiter(max_requests=30, window_seconds=5 * 60)
+_login_account_limiter = KeyedRateLimiter(max_requests=10, window_seconds=5 * 60)
+
+
+def _issue_captcha(request: Request, length: int, binding: str) -> Dict[str, str]:
+    """Generate an image and encrypt its answer into an opaque token."""
+    code, image = captcha_util.generate_captcha(length)
+    jwt_manager: JWTManager = request.app.state.jwt_manager
+    captcha_id = captcha_util.encrypt_challenge(
+        secret_key=jwt_manager.secret_key,
+        code=code,
+        nonce=secrets.token_urlsafe(16),
+        binding=binding,
+    )
+    encoded = base64.b64encode(image).decode("ascii")
+    return {
+        "captcha_id": captcha_id,
+        "image": f"data:image/png;base64,{encoded}",
+    }
+
+
+def _decode_bound_challenge(request: Request, captcha_id: str):
+    """Decode a challenge and require the browser-bound HttpOnly cookie."""
+    if not captcha_id:
+        raise BadRequestException(message="CAPTCHA is required")
+
+    jwt_manager: JWTManager = request.app.state.jwt_manager
+    try:
+        challenge = captcha_util.decrypt_challenge(
+            secret_key=jwt_manager.secret_key,
+            token=captcha_id,
+            ttl_seconds=CAPTCHA_TOKEN_TTL_SECONDS,
+        )
+    except captcha_util.InvalidCaptchaToken:
+        raise BadRequestException(message="Invalid or expired CAPTCHA") from None
+
+    binding = request.cookies.get(CAPTCHA_SESSION_COOKIE_NAME, "")
+    if not binding or not hmac.compare_digest(challenge.binding, binding):
+        raise BadRequestException(message="Invalid or expired CAPTCHA")
+    return challenge
+
+
+async def _consume_captcha_nonce(nonce: str) -> None:
+    """Atomically spend a nonce in the shared database ledger."""
+    now = datetime.now(timezone.utc)
+    nonce_hash = hashlib.sha256(nonce.encode("utf-8")).hexdigest()
+    async with async_session() as session:
+        await session.exec(
+            delete(LoginCaptchaNonce).where(LoginCaptchaNonce.expires_at <= now)
+        )
+        session.add(
+            LoginCaptchaNonce(
+                nonce_hash=nonce_hash,
+                expires_at=now + timedelta(seconds=CAPTCHA_TOKEN_TTL_SECONDS + 30),
+            )
+        )
+        try:
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            raise BadRequestException(message="CAPTCHA has already been used") from None
+
+
+async def _verify_captcha(request: Request, captcha_id: str, captcha: str) -> None:
+    """Validate a solved CAPTCHA or raise ``BadRequestException``.
+
+    Decrypts the opaque token, compares the answer case-insensitively, and
+    burns the nonce so the same token can't be reused.
+    """
+    if not captcha_id or not captcha:
+        raise BadRequestException(message="CAPTCHA is required")
+
+    challenge = _decode_bound_challenge(request, captcha_id)
+
+    # Burn the nonce before checking the answer so a wrong guess still cannot
+    # be retried, including when the next request reaches another replica.
+    await _consume_captcha_nonce(challenge.nonce)
+
+    # Validate before comparing: compare_digest rejects non-ASCII str values,
+    # and unbounded input should not reach a character-by-character scan.
+    answer = captcha.strip().lower()
+    if (
+        not captcha_util.CAPTCHA_MIN_LENGTH
+        <= len(answer)
+        <= captcha_util.CAPTCHA_MAX_LENGTH
+        or any(char.upper() not in captcha_util.CAPTCHA_ALPHABET for char in answer)
+        or not hmac.compare_digest(challenge.code, answer)
+    ):
+        raise BadRequestException(message="Incorrect CAPTCHA")
+
+
+def _captcha_binding(request: Request) -> str:
+    binding = request.cookies.get(CAPTCHA_SESSION_COOKIE_NAME, "")
+    if not _CAPTCHA_BINDING_PATTERN.fullmatch(binding):
+        return secrets.token_urlsafe(32)
+    return binding
+
+
+def _set_captcha_binding_cookie(
+    request: Request, response: Response, binding: str
+) -> None:
+    response.set_cookie(
+        key=CAPTCHA_SESSION_COOKIE_NAME,
+        value=binding,
+        path="/auth",
+        httponly=True,
+        max_age=CAPTCHA_TOKEN_TTL_SECONDS + 30,
+        expires=CAPTCHA_TOKEN_TTL_SECONDS + 30,
+        samesite="strict",
+        secure=request.url.scheme == "https",
+    )
+
+
+def _enforce_rate_limit(limiter: KeyedRateLimiter, key: str) -> None:
+    retry_after = limiter.check(key)
+    if retry_after:
+        raise TooManyRequestsException(
+            message=f"Too many requests; retry in {retry_after} seconds"
+        )
+
+
+def _validate_login_origin(request: Request) -> None:
+    """Reject browser cross-site form posts while allowing non-browser clients."""
+    if request.headers.get("sec-fetch-site", "").casefold() == "cross-site":
+        raise BadRequestException(message="Cross-site login requests are not allowed")
+    origin = request.headers.get("origin")
+    if not origin:
+        return
+    parsed = urlparse(origin)
+    request_host = request.headers.get("host", "").casefold()
+    if (
+        parsed.scheme.casefold() != request.url.scheme.casefold()
+        or not parsed.netloc
+        or parsed.netloc.casefold() != request_host
+    ):
+        raise BadRequestException(message="Cross-site login requests are not allowed")
 
 
 async def decode_and_validate_token(
@@ -1176,6 +1334,44 @@ async def cas_callback(request: Request, session: SessionDep):
 # Local authentication endpoints
 
 
+@router.get("/captcha")
+async def get_captcha(request: Request, response: Response):
+    """Issue a graphic CAPTCHA challenge for the local login form.
+
+    Only served when ``enable_login_captcha`` is on; otherwise the login form
+    never asks for one, so a request here is a misconfiguration and returns
+    404 rather than a usable challenge.
+    """
+    config: Config = request.app.state.server_config
+    if not config.enable_login_captcha:
+        raise NotFoundException(message="CAPTCHA is not enabled")
+    _enforce_rate_limit(_captcha_issue_limiter, client_ip_getter(request))
+    binding = _captcha_binding(request)
+    _set_captcha_binding_cookie(request, response, binding)
+    response.headers["Cache-Control"] = "no-store"
+    return await run_in_threadpool(
+        _issue_captcha, request, config.login_captcha_length, binding
+    )
+
+
+@router.post("/captcha/audio")
+async def get_captcha_audio(
+    request: Request,
+    response: Response,
+    captcha_id: Annotated[str, Form()] = "",
+):
+    """Return a lazy WAV alternative for the browser-bound challenge."""
+    config: Config = request.app.state.server_config
+    if not config.enable_login_captcha:
+        raise NotFoundException(message="CAPTCHA is not enabled")
+    _enforce_rate_limit(_captcha_audio_limiter, client_ip_getter(request))
+    challenge = _decode_bound_challenge(request, captcha_id)
+    audio = await run_in_threadpool(captcha_util.generate_audio, challenge.code)
+    response.headers["Cache-Control"] = "no-store"
+    encoded = base64.b64encode(audio).decode("ascii")
+    return {"audio": f"data:audio/wav;base64,{encoded}"}
+
+
 @router.post("/login")
 async def login(
     request: Request,
@@ -1183,7 +1379,19 @@ async def login(
     session: SessionDep,
     username: Annotated[str, Form()] = "",
     password: Annotated[str, Form()] = "",
+    captcha_id: Annotated[str, Form()] = "",
+    captcha: Annotated[str, Form()] = "",
 ):
+    config: Config = request.app.state.server_config
+    if config.enable_login_captcha:
+        _validate_login_origin(request)
+        client_ip = client_ip_getter(request)
+        username_hash = hashlib.sha256(
+            username.strip().casefold().encode("utf-8")
+        ).hexdigest()
+        _enforce_rate_limit(_login_ip_limiter, client_ip)
+        _enforce_rate_limit(_login_account_limiter, f"{client_ip}:{username_hash}")
+        await _verify_captcha(request, captcha_id, captcha)
     user = await authenticate_user(session, username, password)
     jwt_manager: JWTManager = request.app.state.jwt_manager
     access_token = jwt_manager.create_jwt_token(
@@ -1198,6 +1406,8 @@ async def login(
         samesite="lax",
         secure=request.url.scheme == "https",
     )
+    if config.enable_login_captcha:
+        response.delete_cookie(key=CAPTCHA_SESSION_COOKIE_NAME, path="/auth")
 
 
 @router.post("/logout")
@@ -1292,6 +1502,10 @@ async def get_auth_config(request: Request, session: SessionDep):
 
     req_dict = {
         "external_auth": external_auth,
+        # Drives whether the login form renders the CAPTCHA row and fetches a
+        # challenge. The login endpoint enforces it regardless; this just lets
+        # the UI avoid asking for a CAPTCHA that would never be checked.
+        "captcha_enabled": config.enable_login_captcha,
         # Deprecated: per-provider booleans kept for UI bundles that
         # pre-date the data-driven ``external_auth`` field. Only the
         # providers that were already public are exposed here — newer

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -13,7 +13,6 @@ import logging
 import jwt
 from jwt.algorithms import RSAAlgorithm
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import delete
 from gpustack.config.config import Config
 from gpustack.utils import captcha as captcha_util
 from typing import Annotated, Dict, List, Optional
@@ -69,6 +68,7 @@ _captcha_issue_limiter = KeyedRateLimiter(max_requests=30, window_seconds=60)
 _captcha_audio_limiter = KeyedRateLimiter(max_requests=10, window_seconds=60)
 _login_ip_limiter = KeyedRateLimiter(max_requests=30, window_seconds=5 * 60)
 _login_account_limiter = KeyedRateLimiter(max_requests=10, window_seconds=5 * 60)
+_DEFAULT_ORIGIN_PORTS = {"http": 80, "https": 443}
 
 
 def _issue_captcha(request: Request, length: int, binding: str) -> Dict[str, str]:
@@ -114,9 +114,6 @@ async def _consume_captcha_nonce(nonce: str) -> None:
     now = datetime.now(timezone.utc)
     nonce_hash = hashlib.sha256(nonce.encode("utf-8")).hexdigest()
     async with async_session() as session:
-        await session.exec(
-            delete(LoginCaptchaNonce).where(LoginCaptchaNonce.expires_at <= now)
-        )
         session.add(
             LoginCaptchaNonce(
                 nonce_hash=nonce_hash,
@@ -188,20 +185,76 @@ def _enforce_rate_limit(limiter: KeyedRateLimiter, key: str) -> None:
         )
 
 
-def _validate_login_origin(request: Request) -> None:
+def _canonical_http_origin(
+    value: str, *, allow_path: bool = False
+) -> Optional[tuple[str, str, int]]:
+    """Return a normalized HTTP origin, or ``None`` for malformed input."""
+    try:
+        parsed = urlparse(value)
+        scheme = parsed.scheme.casefold()
+        if scheme not in _DEFAULT_ORIGIN_PORTS:
+            return None
+        if (
+            not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            return None
+        if (
+            (not allow_path and parsed.path not in ("", "/"))
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        hostname = parsed.hostname
+        port = parsed.port
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    if not hostname:
+        return None
+    try:
+        normalized_host = hostname.rstrip(".").encode("idna").decode("ascii")
+    except UnicodeError:
+        return None
+    if not normalized_host:
+        return None
+    return (
+        scheme,
+        normalized_host.casefold(),
+        port or _DEFAULT_ORIGIN_PORTS[scheme],
+    )
+
+
+def _validate_login_origin(request: Request, config: Config) -> None:
     """Reject browser cross-site form posts while allowing non-browser clients."""
     if request.headers.get("sec-fetch-site", "").casefold() == "cross-site":
         raise BadRequestException(message="Cross-site login requests are not allowed")
     origin = request.headers.get("origin")
     if not origin:
         return
-    parsed = urlparse(origin)
-    request_host = request.headers.get("host", "").casefold()
-    if (
-        parsed.scheme.casefold() != request.url.scheme.casefold()
-        or not parsed.netloc
-        or parsed.netloc.casefold() != request_host
-    ):
+
+    supplied_origin = _canonical_http_origin(origin)
+    expected_origins = set()
+    request_host = request.headers.get("host", "")
+    request_origin = _canonical_http_origin(
+        f"{request.url.scheme}://{request_host}", allow_path=True
+    )
+    if request_origin:
+        expected_origins.add(request_origin)
+
+    # ``server_external_url`` is authoritative when TLS terminates at a
+    # reverse proxy. Raw X-Forwarded-* headers are deliberately not read here;
+    # Uvicorn and ForwardedHostPortMiddleware already apply trusted values.
+    if config.server_external_url:
+        external_origin = _canonical_http_origin(
+            config.server_external_url, allow_path=True
+        )
+        if external_origin:
+            expected_origins.add(external_origin)
+
+    if supplied_origin is None or supplied_origin not in expected_origins:
         raise BadRequestException(message="Cross-site login requests are not allowed")
 
 
@@ -1415,7 +1468,7 @@ async def login(
 ):
     config: Config = request.app.state.server_config
     if config.enable_login_captcha:
-        _validate_login_origin(request)
+        _validate_login_origin(request, config)
         client_ip = client_ip_getter(request)
         username_hash = hashlib.sha256(
             username.strip().casefold().encode("utf-8")

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -1,23 +1,32 @@
 import base64
 import functools
+import hashlib
 import hmac
 import json
 import os
+import re
 import secrets
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import httpx
 import logging
 import jwt
 from jwt.algorithms import RSAAlgorithm
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import delete
 from gpustack.config.config import Config
+from gpustack.utils import captcha as captcha_util
 from typing import Annotated, Dict, List, Optional
 from fastapi import APIRouter, Depends, Form, Request, Response
 from gpustack.api.exceptions import (
     ConflictException,
     InvalidException,
+    NotFoundException,
     UnauthorizedException,
     BadRequestException,
+    TooManyRequestsException,
 )
+from gpustack.schemas.login_captcha import LoginCaptchaNonce
 from gpustack.schemas.users import UpdatePassword
 from gpustack.schemas.principals import PrincipalType
 from gpustack.schemas.users import User, AuthProviderEnum
@@ -29,22 +38,171 @@ from gpustack.api.auth import (
     OIDC_STATE_COOKIE_NAME,
     SSO_LOGIN_COOKIE_NAME,
     authenticate_user,
+    client_ip_getter,
 )
+from gpustack.server.db import async_session
 from gpustack.server.deps import CurrentUserDep, SessionDep
 from gpustack.server.passwords import change_password, is_password_change_required
 from gpustack.server.services import sync_user_group_memberships
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from fastapi.responses import RedirectResponse
 from lxml import etree
+from starlette.concurrency import run_in_threadpool
 from gpustack.utils.convert import safe_b64decode, inflate_data
 from urllib.parse import quote, urlencode, urlparse
 
 from gpustack.ssl_context import make_ssl_context
 from gpustack.utils.network import use_proxy_env_for_url
+from gpustack.utils.rate_limit import KeyedRateLimiter
 
 router = APIRouter()
 timeout = httpx.Timeout(connect=15.0, read=60.0, write=60.0, pool=10.0)
 logger = logging.getLogger(__name__)
+
+# The encrypted challenge is valid long enough to complete the form while
+# keeping the replay window bounded.
+CAPTCHA_TOKEN_TTL_SECONDS = 5 * 60
+CAPTCHA_SESSION_COOKIE_NAME = "gpustack_captcha_session"
+_CAPTCHA_BINDING_PATTERN = re.compile(r"^[A-Za-z0-9_-]{32,128}$")
+
+_captcha_issue_limiter = KeyedRateLimiter(max_requests=30, window_seconds=60)
+_captcha_audio_limiter = KeyedRateLimiter(max_requests=10, window_seconds=60)
+_login_ip_limiter = KeyedRateLimiter(max_requests=30, window_seconds=5 * 60)
+_login_account_limiter = KeyedRateLimiter(max_requests=10, window_seconds=5 * 60)
+
+
+def _issue_captcha(request: Request, length: int, binding: str) -> Dict[str, str]:
+    """Generate an image and encrypt its answer into an opaque token."""
+    code, image = captcha_util.generate_captcha(length)
+    jwt_manager: JWTManager = request.app.state.jwt_manager
+    captcha_id = captcha_util.encrypt_challenge(
+        secret_key=jwt_manager.secret_key,
+        code=code,
+        nonce=secrets.token_urlsafe(16),
+        binding=binding,
+    )
+    encoded = base64.b64encode(image).decode("ascii")
+    return {
+        "captcha_id": captcha_id,
+        "image": f"data:image/png;base64,{encoded}",
+    }
+
+
+def _decode_bound_challenge(request: Request, captcha_id: str):
+    """Decode a challenge and require the browser-bound HttpOnly cookie."""
+    if not captcha_id:
+        raise BadRequestException(message="CAPTCHA is required")
+
+    jwt_manager: JWTManager = request.app.state.jwt_manager
+    try:
+        challenge = captcha_util.decrypt_challenge(
+            secret_key=jwt_manager.secret_key,
+            token=captcha_id,
+            ttl_seconds=CAPTCHA_TOKEN_TTL_SECONDS,
+        )
+    except captcha_util.InvalidCaptchaToken:
+        raise BadRequestException(message="Invalid or expired CAPTCHA") from None
+
+    binding = request.cookies.get(CAPTCHA_SESSION_COOKIE_NAME, "")
+    if not binding or not hmac.compare_digest(challenge.binding, binding):
+        raise BadRequestException(message="Invalid or expired CAPTCHA")
+    return challenge
+
+
+async def _consume_captcha_nonce(nonce: str) -> None:
+    """Atomically spend a nonce in the shared database ledger."""
+    now = datetime.now(timezone.utc)
+    nonce_hash = hashlib.sha256(nonce.encode("utf-8")).hexdigest()
+    async with async_session() as session:
+        await session.exec(
+            delete(LoginCaptchaNonce).where(LoginCaptchaNonce.expires_at <= now)
+        )
+        session.add(
+            LoginCaptchaNonce(
+                nonce_hash=nonce_hash,
+                expires_at=now + timedelta(seconds=CAPTCHA_TOKEN_TTL_SECONDS + 30),
+            )
+        )
+        try:
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            raise BadRequestException(message="CAPTCHA has already been used") from None
+
+
+async def _verify_captcha(request: Request, captcha_id: str, captcha: str) -> None:
+    """Validate a solved CAPTCHA or raise ``BadRequestException``.
+
+    Decrypts the opaque token, compares the answer case-insensitively, and
+    burns the nonce so the same token can't be reused.
+    """
+    if not captcha_id or not captcha:
+        raise BadRequestException(message="CAPTCHA is required")
+
+    challenge = _decode_bound_challenge(request, captcha_id)
+
+    # Burn the nonce before checking the answer so a wrong guess still cannot
+    # be retried, including when the next request reaches another replica.
+    await _consume_captcha_nonce(challenge.nonce)
+
+    # Validate before comparing: compare_digest rejects non-ASCII str values,
+    # and unbounded input should not reach a character-by-character scan.
+    answer = captcha.strip().lower()
+    if (
+        not captcha_util.CAPTCHA_MIN_LENGTH
+        <= len(answer)
+        <= captcha_util.CAPTCHA_MAX_LENGTH
+        or any(char.upper() not in captcha_util.CAPTCHA_ALPHABET for char in answer)
+        or not hmac.compare_digest(challenge.code, answer)
+    ):
+        raise BadRequestException(message="Incorrect CAPTCHA")
+
+
+def _captcha_binding(request: Request) -> str:
+    binding = request.cookies.get(CAPTCHA_SESSION_COOKIE_NAME, "")
+    if not _CAPTCHA_BINDING_PATTERN.fullmatch(binding):
+        return secrets.token_urlsafe(32)
+    return binding
+
+
+def _set_captcha_binding_cookie(
+    request: Request, response: Response, binding: str
+) -> None:
+    response.set_cookie(
+        key=CAPTCHA_SESSION_COOKIE_NAME,
+        value=binding,
+        path="/auth",
+        httponly=True,
+        max_age=CAPTCHA_TOKEN_TTL_SECONDS + 30,
+        expires=CAPTCHA_TOKEN_TTL_SECONDS + 30,
+        samesite="strict",
+        secure=request.url.scheme == "https",
+    )
+
+
+def _enforce_rate_limit(limiter: KeyedRateLimiter, key: str) -> None:
+    retry_after = limiter.check(key)
+    if retry_after:
+        raise TooManyRequestsException(
+            message=f"Too many requests; retry in {retry_after} seconds"
+        )
+
+
+def _validate_login_origin(request: Request) -> None:
+    """Reject browser cross-site form posts while allowing non-browser clients."""
+    if request.headers.get("sec-fetch-site", "").casefold() == "cross-site":
+        raise BadRequestException(message="Cross-site login requests are not allowed")
+    origin = request.headers.get("origin")
+    if not origin:
+        return
+    parsed = urlparse(origin)
+    request_host = request.headers.get("host", "").casefold()
+    if (
+        parsed.scheme.casefold() != request.url.scheme.casefold()
+        or not parsed.netloc
+        or parsed.netloc.casefold() != request_host
+    ):
+        raise BadRequestException(message="Cross-site login requests are not allowed")
 
 
 async def decode_and_validate_token(
@@ -1207,6 +1365,44 @@ async def cas_callback(request: Request, session: SessionDep):
 # Local authentication endpoints
 
 
+@router.get("/captcha")
+async def get_captcha(request: Request, response: Response):
+    """Issue a graphic CAPTCHA challenge for the local login form.
+
+    Only served when ``enable_login_captcha`` is on; otherwise the login form
+    never asks for one, so a request here is a misconfiguration and returns
+    404 rather than a usable challenge.
+    """
+    config: Config = request.app.state.server_config
+    if not config.enable_login_captcha:
+        raise NotFoundException(message="CAPTCHA is not enabled")
+    _enforce_rate_limit(_captcha_issue_limiter, client_ip_getter(request))
+    binding = _captcha_binding(request)
+    _set_captcha_binding_cookie(request, response, binding)
+    response.headers["Cache-Control"] = "no-store"
+    return await run_in_threadpool(
+        _issue_captcha, request, config.login_captcha_length, binding
+    )
+
+
+@router.post("/captcha/audio")
+async def get_captcha_audio(
+    request: Request,
+    response: Response,
+    captcha_id: Annotated[str, Form()] = "",
+):
+    """Return a lazy WAV alternative for the browser-bound challenge."""
+    config: Config = request.app.state.server_config
+    if not config.enable_login_captcha:
+        raise NotFoundException(message="CAPTCHA is not enabled")
+    _enforce_rate_limit(_captcha_audio_limiter, client_ip_getter(request))
+    challenge = _decode_bound_challenge(request, captcha_id)
+    audio = await run_in_threadpool(captcha_util.generate_audio, challenge.code)
+    response.headers["Cache-Control"] = "no-store"
+    encoded = base64.b64encode(audio).decode("ascii")
+    return {"audio": f"data:audio/wav;base64,{encoded}"}
+
+
 @router.post("/login")
 async def login(
     request: Request,
@@ -1214,7 +1410,19 @@ async def login(
     session: SessionDep,
     username: Annotated[str, Form()] = "",
     password: Annotated[str, Form()] = "",
+    captcha_id: Annotated[str, Form()] = "",
+    captcha: Annotated[str, Form()] = "",
 ):
+    config: Config = request.app.state.server_config
+    if config.enable_login_captcha:
+        _validate_login_origin(request)
+        client_ip = client_ip_getter(request)
+        username_hash = hashlib.sha256(
+            username.strip().casefold().encode("utf-8")
+        ).hexdigest()
+        _enforce_rate_limit(_login_ip_limiter, client_ip)
+        _enforce_rate_limit(_login_account_limiter, f"{client_ip}:{username_hash}")
+        await _verify_captcha(request, captcha_id, captcha)
     user = await authenticate_user(session, username, password)
     jwt_manager: JWTManager = request.app.state.jwt_manager
     access_token = jwt_manager.create_jwt_token(
@@ -1229,6 +1437,8 @@ async def login(
         samesite="lax",
         secure=request.url.scheme == "https",
     )
+    if config.enable_login_captcha:
+        response.delete_cookie(key=CAPTCHA_SESSION_COOKIE_NAME, path="/auth")
 
 
 @router.post("/logout")
@@ -1323,6 +1533,10 @@ async def get_auth_config(request: Request, session: SessionDep):
 
     req_dict = {
         "external_auth": external_auth,
+        # Drives whether the login form renders the CAPTCHA row and fetches a
+        # challenge. The login endpoint enforces it regardless; this just lets
+        # the UI avoid asking for a CAPTCHA that would never be checked.
+        "captcha_enabled": config.enable_login_captcha,
         # Deprecated: per-provider booleans kept for UI bundles that
         # pre-date the data-driven ``external_auth`` field. Only the
         # providers that were already public are exposed here — newer

--- a/gpustack/schemas/__init__.py
+++ b/gpustack/schemas/__init__.py
@@ -146,6 +146,7 @@ from gpustack.schemas.cluster_access import (
     ClusterAccessPublic,
 )
 from gpustack.schemas.links import ModelRoutePrincipalLink  # noqa: F401
+from gpustack.schemas.login_captcha import LoginCaptchaNonce  # noqa: F401
 from gpustack.schemas.gpu_instance_persistent_volume_types import (
     GPUInstancePersistentVolumeType,
     GPUInstancePersistentVolumeTypeListParams,
@@ -314,6 +315,7 @@ __all__ = [
     "UserGroupMembershipPublic",
     "ClusterAccess",
     "ClusterAccessPublic",
+    "LoginCaptchaNonce",
     "GPUInstancePersistentVolumeType",
     "GPUInstancePersistentVolumeTypeListParams",
     "GPUInstancePersistentVolumeTypeCreate",

--- a/gpustack/schemas/__init__.py
+++ b/gpustack/schemas/__init__.py
@@ -146,6 +146,7 @@ from gpustack.schemas.cluster_access import (
     ClusterAccessPublic,
 )
 from gpustack.schemas.links import ModelRoutePrincipalLink  # noqa: F401
+from gpustack.schemas.login_captcha import LoginCaptchaNonce  # noqa: F401
 from gpustack.schemas.gpu_instance_persistent_volume_types import (
     GPUInstancePersistentVolumeType,
     GPUInstancePersistentVolumeTypeListParams,
@@ -325,6 +326,7 @@ __all__ = [
     "UserGroupMembershipPublic",
     "ClusterAccess",
     "ClusterAccessPublic",
+    "LoginCaptchaNonce",
     "GPUInstancePersistentVolumeType",
     "GPUInstancePersistentVolumeTypeListParams",
     "GPUInstancePersistentVolumeTypeCreate",

--- a/gpustack/schemas/login_captcha.py
+++ b/gpustack/schemas/login_captcha.py
@@ -1,0 +1,18 @@
+"""Database ledger for globally single-use login CAPTCHA challenges."""
+
+from datetime import datetime
+from typing import ClassVar
+
+from sqlalchemy import Column
+from sqlmodel import Field, SQLModel
+
+from gpustack.schemas.common import UTCDateTime
+
+
+class LoginCaptchaNonce(SQLModel, table=True):
+    __tablename__: ClassVar[str] = "login_captcha_nonces"
+
+    nonce_hash: str = Field(primary_key=True, max_length=64)
+    expires_at: datetime = Field(
+        sa_column=Column(UTCDateTime, nullable=False, index=True)
+    )

--- a/gpustack/server/login_captcha_nonce_cleaner.py
+++ b/gpustack/server/login_captcha_nonce_cleaner.py
@@ -1,0 +1,41 @@
+"""Periodic cleanup for the shared login CAPTCHA nonce ledger."""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import delete
+
+from gpustack.schemas.login_captcha import LoginCaptchaNonce
+from gpustack.server.db import async_session
+
+logger = logging.getLogger(__name__)
+DEFAULT_CLEANUP_INTERVAL_SECONDS = 5 * 60
+
+
+class LoginCaptchaNonceCleaner:
+    """Remove expired nonce hashes without adding writes to the login path."""
+
+    def __init__(self, interval: int = DEFAULT_CLEANUP_INTERVAL_SECONDS):
+        if interval < 1:
+            raise ValueError("Cleanup interval must be positive")
+        self._interval = interval
+
+    async def start(self) -> None:
+        while True:
+            try:
+                await self.cleanup_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Failed to clean expired login CAPTCHA nonces")
+            await asyncio.sleep(self._interval)
+
+    async def cleanup_once(self) -> None:
+        async with async_session() as session:
+            await session.exec(
+                delete(LoginCaptchaNonce).where(
+                    LoginCaptchaNonce.expires_at <= datetime.now(timezone.utc)
+                )
+            )
+            await session.commit()

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -85,6 +85,7 @@ from gpustack import envs
 from gpustack.server.usage_archiver import TableArchiver
 from gpustack.schemas.metered_usage import MeteredUsage, MeteredUsageArchive
 from gpustack.schemas.resource_events import ResourceEvent, ResourceEventArchive
+from gpustack.server.login_captcha_nonce_cleaner import LoginCaptchaNonceCleaner
 from gpustack.server.worker_instance_cleaner import WorkerInstanceCleaner
 from gpustack.server.worker_syncer import WorkerSyncer
 from gpustack.utils.process import add_signal_handlers_in_loop
@@ -478,6 +479,14 @@ class Server:
         self._create_async_task(worker_instance_cleaner.start())
 
         logger.debug("Worker instance cleaner started.")
+
+    def _start_login_captcha_nonce_cleaner(self):
+        if not self._config.enable_login_captcha:
+            return
+        cleaner = LoginCaptchaNonceCleaner()
+        self._create_async_task(cleaner.start())
+
+        logger.debug("Login CAPTCHA nonce cleaner started.")
 
     def _start_usage_details_archiver(self):
         # Construction can fail on schema drift between hot/archive tables or
@@ -1316,6 +1325,9 @@ class Server:
 
         # Worker Instance Cleaner
         self._start_worker_instance_cleaner()
+
+        # Login CAPTCHA Nonce Cleaner
+        self._start_login_captcha_nonce_cleaner()
 
         # Usage Details Archiver (move aged rows to archive table)
         self._start_usage_details_archiver()

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -89,6 +89,7 @@ from gpustack import envs
 from gpustack.server.usage_archiver import TableArchiver
 from gpustack.schemas.metered_usage import MeteredUsage, MeteredUsageArchive
 from gpustack.schemas.resource_events import ResourceEvent, ResourceEventArchive
+from gpustack.server.login_captcha_nonce_cleaner import LoginCaptchaNonceCleaner
 from gpustack.server.worker_instance_cleaner import WorkerInstanceCleaner
 from gpustack.server.worker_syncer import WorkerSyncer
 from gpustack.server.scaling_scheduler import ScalingScheduler
@@ -494,6 +495,14 @@ class Server:
         self._create_async_task(scaling_scheduler.start())
 
         logger.debug("Scaling scheduler started.")
+
+    def _start_login_captcha_nonce_cleaner(self):
+        if not self._config.enable_login_captcha:
+            return
+        cleaner = LoginCaptchaNonceCleaner()
+        self._create_async_task(cleaner.start())
+
+        logger.debug("Login CAPTCHA nonce cleaner started.")
 
     def _start_usage_details_archiver(self):
         # Construction can fail on schema drift between hot/archive tables or
@@ -1377,6 +1386,9 @@ class Server:
 
         # Worker Instance Cleaner
         self._start_worker_instance_cleaner()
+
+        # Login CAPTCHA Nonce Cleaner
+        self._start_login_captcha_nonce_cleaner()
 
         # Usage Details Archiver (move aged rows to archive table)
         self._start_usage_details_archiver()

--- a/gpustack/utils/captcha.py
+++ b/gpustack/utils/captcha.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import json
 import secrets
+import threading
 from dataclasses import dataclass
 
 from captcha.audio import AudioCaptcha
@@ -22,6 +23,7 @@ _TOKEN_KEY_CONTEXT = b"gpustack-login-captcha-token-v1"
 _IMAGE_WIDTH = 160
 _IMAGE_HEIGHT = 60
 _IMAGE_FONT_SIZES = (36, 42, 48)
+_generators = threading.local()
 
 
 class InvalidCaptchaToken(ValueError):
@@ -48,12 +50,7 @@ def generate_code(length: int = 4) -> str:
 def generate_captcha(length: int = 4) -> tuple[str, bytes]:
     """Generate a CAPTCHA and return its code with PNG image bytes."""
     code = generate_code(length)
-    generator = ImageCaptcha(
-        width=_IMAGE_WIDTH,
-        height=_IMAGE_HEIGHT,
-        font_sizes=_IMAGE_FONT_SIZES,
-    )
-    image = generator.generate(code, format="png")
+    image = _get_image_generator().generate(code, format="png")
     return code, image.getvalue()
 
 
@@ -63,7 +60,27 @@ def generate_audio(code: str) -> bytes:
         raise ValueError("Invalid CAPTCHA code length")
     if any(char.upper() not in CAPTCHA_ALPHABET for char in code):
         raise ValueError("Invalid CAPTCHA code")
-    return bytes(AudioCaptcha().generate(code.upper()))
+    return bytes(_get_audio_generator().generate(code.upper()))
+
+
+def _get_image_generator() -> ImageCaptcha:
+    generator = getattr(_generators, "image", None)
+    if generator is None:
+        generator = ImageCaptcha(
+            width=_IMAGE_WIDTH,
+            height=_IMAGE_HEIGHT,
+            font_sizes=_IMAGE_FONT_SIZES,
+        )
+        _generators.image = generator
+    return generator
+
+
+def _get_audio_generator() -> AudioCaptcha:
+    generator = getattr(_generators, "audio", None)
+    if generator is None:
+        generator = AudioCaptcha()
+        _generators.audio = generator
+    return generator
 
 
 def encrypt_challenge(secret_key: str, code: str, nonce: str, binding: str) -> str:

--- a/gpustack/utils/captcha.py
+++ b/gpustack/utils/captcha.py
@@ -1,0 +1,125 @@
+"""Graphic CAPTCHA generation and opaque challenge tokens."""
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+from dataclasses import dataclass
+
+from captcha.audio import AudioCaptcha
+from captcha.image import ImageCaptcha
+from cryptography.fernet import Fernet, InvalidToken
+
+# Avoid characters that are easy to confuse in the generated image.
+CAPTCHA_ALPHABET = "23456789ACDEFGHJKMNPRTUVWXY"
+CAPTCHA_MIN_LENGTH = 4
+CAPTCHA_MAX_LENGTH = 6
+
+_TOKEN_PURPOSE = "login_captcha"
+_TOKEN_VERSION = 2
+_TOKEN_KEY_CONTEXT = b"gpustack-login-captcha-token-v1"
+_IMAGE_WIDTH = 160
+_IMAGE_HEIGHT = 60
+_IMAGE_FONT_SIZES = (36, 42, 48)
+
+
+class InvalidCaptchaToken(ValueError):
+    """Raised when a CAPTCHA challenge token is invalid or expired."""
+
+
+@dataclass(frozen=True)
+class CaptchaChallenge:
+    code: str
+    nonce: str
+    binding: str
+
+
+def generate_code(length: int = 4) -> str:
+    """Return a random code drawn from the unambiguous alphabet."""
+    if not CAPTCHA_MIN_LENGTH <= length <= CAPTCHA_MAX_LENGTH:
+        raise ValueError(
+            f"CAPTCHA length must be between {CAPTCHA_MIN_LENGTH} "
+            f"and {CAPTCHA_MAX_LENGTH}"
+        )
+    return "".join(secrets.choice(CAPTCHA_ALPHABET) for _ in range(length))
+
+
+def generate_captcha(length: int = 4) -> tuple[str, bytes]:
+    """Generate a CAPTCHA and return its code with PNG image bytes."""
+    code = generate_code(length)
+    generator = ImageCaptcha(
+        width=_IMAGE_WIDTH,
+        height=_IMAGE_HEIGHT,
+        font_sizes=_IMAGE_FONT_SIZES,
+    )
+    image = generator.generate(code, format="png")
+    return code, image.getvalue()
+
+
+def generate_audio(code: str) -> bytes:
+    """Generate a WAV rendering of a validated CAPTCHA code."""
+    if not CAPTCHA_MIN_LENGTH <= len(code) <= CAPTCHA_MAX_LENGTH:
+        raise ValueError("Invalid CAPTCHA code length")
+    if any(char.upper() not in CAPTCHA_ALPHABET for char in code):
+        raise ValueError("Invalid CAPTCHA code")
+    return bytes(AudioCaptcha().generate(code.upper()))
+
+
+def encrypt_challenge(secret_key: str, code: str, nonce: str, binding: str) -> str:
+    """Encrypt a short-lived CAPTCHA challenge for delivery to the browser."""
+    payload = {
+        "purpose": _TOKEN_PURPOSE,
+        "version": _TOKEN_VERSION,
+        "code": code.lower(),
+        "nonce": nonce,
+        "binding": binding,
+    }
+    plaintext = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return _build_cipher(secret_key).encrypt(plaintext).decode("ascii")
+
+
+def decrypt_challenge(
+    secret_key: str, token: str, ttl_seconds: int
+) -> CaptchaChallenge:
+    """Decrypt and validate a CAPTCHA challenge token."""
+    try:
+        plaintext = _build_cipher(secret_key).decrypt(
+            token.encode("ascii"), ttl=ttl_seconds
+        )
+        payload = json.loads(plaintext)
+    except (InvalidToken, UnicodeError, json.JSONDecodeError, TypeError) as exc:
+        raise InvalidCaptchaToken from exc
+
+    if not isinstance(payload, dict):
+        raise InvalidCaptchaToken
+    if (
+        payload.get("purpose") != _TOKEN_PURPOSE
+        or payload.get("version") != _TOKEN_VERSION
+    ):
+        raise InvalidCaptchaToken
+
+    code = payload.get("code")
+    nonce = payload.get("nonce")
+    binding = payload.get("binding")
+    if not isinstance(code, str) or not (
+        CAPTCHA_MIN_LENGTH <= len(code) <= CAPTCHA_MAX_LENGTH
+    ):
+        raise InvalidCaptchaToken
+    if any(char.upper() not in CAPTCHA_ALPHABET for char in code):
+        raise InvalidCaptchaToken
+    if not isinstance(nonce, str) or not 16 <= len(nonce) <= 128:
+        raise InvalidCaptchaToken
+    if not isinstance(binding, str) or not 32 <= len(binding) <= 128:
+        raise InvalidCaptchaToken
+    return CaptchaChallenge(code=code, nonce=nonce, binding=binding)
+
+
+def _build_cipher(secret_key: str) -> Fernet:
+    if not secret_key:
+        raise ValueError("CAPTCHA token secret must not be empty")
+    # Domain-separate CAPTCHA encryption from the JWT use of the same root key.
+    derived_key = hmac.new(
+        secret_key.encode("utf-8"), _TOKEN_KEY_CONTEXT, hashlib.sha256
+    ).digest()
+    return Fernet(base64.urlsafe_b64encode(derived_key))

--- a/gpustack/utils/rate_limit.py
+++ b/gpustack/utils/rate_limit.py
@@ -1,0 +1,53 @@
+"""Small bounded, process-local rate limiter for public HTTP endpoints."""
+
+import threading
+import time
+from collections import OrderedDict, deque
+from typing import Deque
+
+
+class KeyedRateLimiter:
+    """Sliding-window limiter with bounded key and timestamp storage.
+
+    This protects each GPUStack server process from accidental or abusive
+    bursts. Multi-replica deployments should additionally enforce a global
+    limit at their trusted ingress.
+    """
+
+    def __init__(self, max_requests: int, window_seconds: int, max_keys: int = 10_000):
+        if max_requests < 1 or window_seconds < 1 or max_keys < 1:
+            raise ValueError("Rate-limit values must be positive")
+        self._max_requests = max_requests
+        self._window_seconds = window_seconds
+        self._max_keys = max_keys
+        self._requests: OrderedDict[str, Deque[float]] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def check(self, key: str) -> int:
+        """Record a request and return zero, or seconds until retry is allowed."""
+        now = time.monotonic()
+        cutoff = now - self._window_seconds
+        normalized_key = key or "unknown"
+
+        with self._lock:
+            attempts = self._requests.get(normalized_key)
+            if attempts is None:
+                if len(self._requests) >= self._max_keys:
+                    self._requests.popitem(last=False)
+                attempts = deque()
+                self._requests[normalized_key] = attempts
+            else:
+                self._requests.move_to_end(normalized_key)
+
+            while attempts and attempts[0] <= cutoff:
+                attempts.popleft()
+            if len(attempts) >= self._max_requests:
+                return max(1, int(attempts[0] + self._window_seconds - now) + 1)
+
+            attempts.append(now)
+            return 0
+
+    def clear(self) -> None:
+        """Clear limiter state, primarily for isolated tests."""
+        with self._lock:
+            self._requests.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "kubernetes-asyncio>=33.1.0,<34.0.0",
     "msgpack>=1.1.2",
     "cachetools>=6.0.0",
+    "captcha>=0.7.1,<0.8.0",
     "gpustack-runner==0.1.27.post4",
     "gpustack-runtime==0.2.1",
     "gpustack-higress-plugins==0.2.3.post5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     "kubernetes-asyncio>=33.1.0,<34.0.0",
     "msgpack>=1.1.2",
     "cachetools>=6.0.0",
+    "captcha>=0.7.1,<0.8.0",
     "gpustack-runner==0.1.27.post4",
     "gpustack-runtime==0.2.2.post8",
     "gpustack-higress-plugins==0.3.0.post1",

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -104,6 +104,56 @@ async def test_authenticate_request_reuses_provided_session(monkeypatch):
     assert request.state.api_key is expected_key
 
 
+@pytest.mark.asyncio
+async def test_captcha_disables_ordinary_user_basic_auth(monkeypatch):
+    from fastapi.security import HTTPBasicCredentials
+
+    from gpustack.api.auth import authenticate_request
+
+    request = _make_request()
+    request.app.state.server_config.enable_login_captcha = True
+    basic_auth_mock = AsyncMock()
+    monkeypatch.setattr("gpustack.api.auth.authenticate_basic_user", basic_auth_mock)
+
+    def no_database_session():
+        raise AssertionError("Rejected Basic auth must not open a database session")
+
+    monkeypatch.setattr("gpustack.api.auth.async_session", no_database_session)
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await authenticate_request(
+            request,
+            basic_credentials=HTTPBasicCredentials(
+                username="admin", password="guessed-password"
+            ),
+        )
+
+    assert "HTTP Basic is disabled" in exc_info.value.message
+    basic_auth_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_captcha_keeps_system_principal_basic_auth():
+    from fastapi.security import HTTPBasicCredentials
+
+    from gpustack.api.auth import authenticate_request
+    from gpustack.schemas.principals import PrincipalType
+
+    request = _make_request()
+    request.app.state.server_config.enable_login_captcha = True
+    request.app.state.server_config.token = "server-token"
+
+    principal = await authenticate_request(
+        request,
+        basic_credentials=HTTPBasicCredentials(
+            username="system/worker/abc", password="server-token"
+        ),
+    )
+
+    assert principal.kind == PrincipalType.SYSTEM
+    assert principal.name == "system/worker/abc"
+
+
 def _api_token_double(**overrides):
     fields = {
         "hashed_secret_key": "stored-hash",

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -110,6 +110,56 @@ async def test_authenticate_request_reuses_provided_session(monkeypatch):
     assert request.state.api_key is expected_key
 
 
+@pytest.mark.asyncio
+async def test_captcha_disables_ordinary_user_basic_auth(monkeypatch):
+    from fastapi.security import HTTPBasicCredentials
+
+    from gpustack.api.auth import authenticate_request
+
+    request = _make_request()
+    request.app.state.server_config.enable_login_captcha = True
+    basic_auth_mock = AsyncMock()
+    monkeypatch.setattr("gpustack.api.auth.authenticate_basic_user", basic_auth_mock)
+
+    def no_database_session():
+        raise AssertionError("Rejected Basic auth must not open a database session")
+
+    monkeypatch.setattr("gpustack.api.auth.async_session", no_database_session)
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await authenticate_request(
+            request,
+            basic_credentials=HTTPBasicCredentials(
+                username="admin", password="guessed-password"
+            ),
+        )
+
+    assert "HTTP Basic is disabled" in exc_info.value.message
+    basic_auth_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_captcha_keeps_system_principal_basic_auth():
+    from fastapi.security import HTTPBasicCredentials
+
+    from gpustack.api.auth import authenticate_request
+    from gpustack.schemas.principals import PrincipalType
+
+    request = _make_request()
+    request.app.state.server_config.enable_login_captcha = True
+    request.app.state.server_config.token = "server-token"
+
+    principal = await authenticate_request(
+        request,
+        basic_credentials=HTTPBasicCredentials(
+            username="system/worker/abc", password="server-token"
+        ),
+    )
+
+    assert principal.kind == PrincipalType.SYSTEM
+    assert principal.name == "system/worker/abc"
+
+
 def _api_token_double(**overrides):
     fields = {
         "id": 11,

--- a/tests/cmd/test_start_captcha.py
+++ b/tests/cmd/test_start_captcha.py
@@ -1,0 +1,32 @@
+"""Regression tests for login CAPTCHA server configuration."""
+
+import argparse
+import sys
+
+import pytest
+
+if sys.platform == "win32":
+    pytest.skip(
+        "The server CLI imports Unix-only worker modules.",
+        allow_module_level=True,
+    )
+
+from gpustack.cmd.start import set_server_options, start_cmd_options
+
+
+def _parse_server_options(arguments):
+    parser = argparse.ArgumentParser()
+    start_cmd_options(parser)
+    args = parser.parse_args(arguments)
+    server_options = {}
+    set_server_options(args, server_options)
+    return server_options
+
+
+def test_captcha_cli_options_are_forwarded_to_server_config():
+    server_options = _parse_server_options(
+        ["--enable-login-captcha", "--login-captcha-length", "6"]
+    )
+
+    assert server_options["enable_login_captcha"] is True
+    assert server_options["login_captcha_length"] == 6

--- a/tests/routes/test_auth_config.py
+++ b/tests/routes/test_auth_config.py
@@ -18,7 +18,11 @@ PASSWORD_FILE = "initial_admin_password"
 
 
 def _request(tmp_path):
-    config = SimpleNamespace(external_auth_type=None, data_dir=str(tmp_path))
+    config = SimpleNamespace(
+        external_auth_type=None,
+        data_dir=str(tmp_path),
+        enable_login_captcha=False,
+    )
     return SimpleNamespace(
         app=SimpleNamespace(state=SimpleNamespace(server_config=config))
     )

--- a/tests/routes/test_captcha.py
+++ b/tests/routes/test_captcha.py
@@ -1,0 +1,458 @@
+"""Tests for login CAPTCHA generation, tokens, and HTTP integration."""
+
+import base64
+from contextlib import asynccontextmanager
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from gpustack.api import exceptions
+from gpustack.config.config import Config
+from gpustack.routes import auth as auth_routes
+from gpustack.schemas.config import GatewayModeEnum
+from gpustack.schemas.login_captcha import LoginCaptchaNonce
+from gpustack.security import JWTManager
+from gpustack.server.db import get_session
+from gpustack.utils import captcha as captcha_util
+
+_SECRET_KEY = "test-secret-key-with-enough-entropy"
+_BINDING = "test-browser-binding-value-1234567890"
+_REAL_CONSUME_CAPTCHA_NONCE = auth_routes._consume_captcha_nonce
+
+
+def _request(config, secret_key: str = _SECRET_KEY):
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                server_config=config,
+                jwt_manager=JWTManager(secret_key),
+            )
+        ),
+        cookies={auth_routes.CAPTCHA_SESSION_COOKIE_NAME: _BINDING},
+        headers={"host": "testserver"},
+        client=SimpleNamespace(host="testclient"),
+        url=SimpleNamespace(scheme="http"),
+    )
+
+
+def _config(enabled: bool = True, length: int = 4):
+    return SimpleNamespace(
+        enable_login_captcha=enabled,
+        login_captcha_length=length,
+        external_auth_type=None,
+        gateway_mode=GatewayModeEnum.disabled,
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolate_captcha_guards(monkeypatch):
+    spent_nonces = set()
+
+    async def consume_once(nonce):
+        if nonce in spent_nonces:
+            raise exceptions.BadRequestException(
+                message="CAPTCHA has already been used"
+            )
+        spent_nonces.add(nonce)
+
+    monkeypatch.setattr(auth_routes, "_consume_captcha_nonce", consume_once)
+    limiters = (
+        auth_routes._captcha_issue_limiter,
+        auth_routes._captcha_audio_limiter,
+        auth_routes._login_ip_limiter,
+        auth_routes._login_account_limiter,
+    )
+    for limiter in limiters:
+        limiter.clear()
+    yield
+    for limiter in limiters:
+        limiter.clear()
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = FastAPI()
+    app.include_router(auth_routes.router, prefix="/auth")
+    exceptions.register_handlers(app)
+
+    config = _config()
+    app.state.server_config = config
+    app.state.jwt_manager = JWTManager(_SECRET_KEY)
+
+    async def session_override():
+        yield object()
+
+    app.dependency_overrides[get_session] = session_override
+    authenticate_user = AsyncMock(return_value=SimpleNamespace(name="admin"))
+    monkeypatch.setattr(auth_routes, "authenticate_user", authenticate_user)
+
+    with TestClient(app) as test_client:
+        yield test_client, config, authenticate_user
+
+
+def test_generate_code_uses_unambiguous_characters():
+    code = captcha_util.generate_code(6)
+
+    assert len(code) == 6
+    assert set(code) <= set(captcha_util.CAPTCHA_ALPHABET)
+    assert not set("01BILOQSZ") & set(code)
+
+
+@pytest.mark.parametrize("length", [3, 7])
+def test_generate_code_rejects_out_of_range_length(length):
+    with pytest.raises(ValueError, match="between 4 and 6"):
+        captcha_util.generate_code(length)
+
+
+def test_generate_captcha_returns_valid_png():
+    code, image_bytes = captcha_util.generate_captcha(4)
+
+    with Image.open(BytesIO(image_bytes)) as image:
+        assert image.format == "PNG"
+        assert image.size == (160, 60)
+    assert len(code) == 4
+
+
+def test_generate_audio_returns_valid_wav():
+    audio = captcha_util.generate_audio("ACDE")
+
+    assert audio.startswith(b"RIFF")
+    assert audio[8:12] == b"WAVE"
+
+
+def test_challenge_token_is_opaque_and_authenticated(monkeypatch):
+    image_bytes = captcha_util.generate_captcha(4)[1]
+    monkeypatch.setattr(
+        captcha_util,
+        "generate_captcha",
+        lambda length: ("ACDE", image_bytes),
+    )
+
+    issued = auth_routes._issue_captcha(_request(_config()), 4, _BINDING)
+    token = issued["captcha_id"]
+    decoded_token = base64.urlsafe_b64decode(token)
+    challenge = captcha_util.decrypt_challenge(
+        _SECRET_KEY,
+        token,
+        ttl_seconds=auth_routes.CAPTCHA_TOKEN_TTL_SECONDS,
+    )
+
+    assert b"acde" not in decoded_token.lower()
+    assert challenge.code == "acde"
+    assert challenge.nonce
+    assert challenge.binding == _BINDING
+    assert issued["image"].startswith("data:image/png;base64,")
+
+
+def test_challenge_token_rejects_wrong_secret():
+    token = captcha_util.encrypt_challenge(_SECRET_KEY, "ACDE", "nonce-value", _BINDING)
+
+    with pytest.raises(captcha_util.InvalidCaptchaToken):
+        captcha_util.decrypt_challenge(
+            "different-secret-key",
+            token,
+            ttl_seconds=auth_routes.CAPTCHA_TOKEN_TTL_SECONDS,
+        )
+
+
+def test_challenge_token_rejects_tampering():
+    token = captcha_util.encrypt_challenge(_SECRET_KEY, "ACDE", "nonce-value", _BINDING)
+    token_bytes = bytearray(base64.urlsafe_b64decode(token))
+    token_bytes[-33] ^= 1
+    tampered_token = base64.urlsafe_b64encode(token_bytes).decode("ascii")
+
+    with pytest.raises(captcha_util.InvalidCaptchaToken):
+        captcha_util.decrypt_challenge(
+            _SECRET_KEY,
+            tampered_token,
+            ttl_seconds=auth_routes.CAPTCHA_TOKEN_TTL_SECONDS,
+        )
+
+
+def test_challenge_token_expires(monkeypatch):
+    now = [1_700_000_000]
+    monkeypatch.setattr("cryptography.fernet.time.time", lambda: now[0])
+    token = captcha_util.encrypt_challenge(_SECRET_KEY, "ACDE", "nonce-value", _BINDING)
+    now[0] += auth_routes.CAPTCHA_TOKEN_TTL_SECONDS + 1
+
+    with pytest.raises(captcha_util.InvalidCaptchaToken):
+        captcha_util.decrypt_challenge(
+            _SECRET_KEY,
+            token,
+            ttl_seconds=auth_routes.CAPTCHA_TOKEN_TTL_SECONDS,
+        )
+
+
+@pytest.mark.parametrize("length", [3, 7])
+def test_config_rejects_invalid_captcha_length(length):
+    with pytest.raises(ValidationError):
+        Config(login_captcha_length=length)
+
+
+@pytest.mark.asyncio
+async def test_verify_captcha_accepts_once_and_burns_the_challenge(monkeypatch):
+    image_bytes = captcha_util.generate_captcha(4)[1]
+    monkeypatch.setattr(
+        captcha_util,
+        "generate_captcha",
+        lambda length: ("ACDE", image_bytes),
+    )
+    request = _request(_config())
+    issued = auth_routes._issue_captcha(request, 4, _BINDING)
+
+    await auth_routes._verify_captcha(request, issued["captcha_id"], " acde ")
+
+    with pytest.raises(exceptions.BadRequestException):
+        await auth_routes._verify_captcha(request, issued["captcha_id"], "ACDE")
+
+
+@pytest.mark.asyncio
+async def test_verify_captcha_burns_challenge_after_wrong_answer(monkeypatch):
+    image_bytes = captcha_util.generate_captcha(4)[1]
+    monkeypatch.setattr(
+        captcha_util,
+        "generate_captcha",
+        lambda length: ("ACDE", image_bytes),
+    )
+    request = _request(_config())
+    issued = auth_routes._issue_captcha(request, 4, _BINDING)
+
+    with pytest.raises(exceptions.BadRequestException):
+        await auth_routes._verify_captcha(request, issued["captcha_id"], "WRONG")
+
+    with pytest.raises(exceptions.BadRequestException):
+        await auth_routes._verify_captcha(request, issued["captcha_id"], "ACDE")
+
+
+@pytest.mark.asyncio
+async def test_verify_captcha_rejects_non_ascii_answer(monkeypatch):
+    image_bytes = captcha_util.generate_captcha(4)[1]
+    monkeypatch.setattr(
+        captcha_util,
+        "generate_captcha",
+        lambda length: ("ACDE", image_bytes),
+    )
+    request = _request(_config())
+    issued = auth_routes._issue_captcha(request, 4, _BINDING)
+
+    with pytest.raises(exceptions.BadRequestException) as exc_info:
+        await auth_routes._verify_captcha(request, issued["captcha_id"], "验证码")
+    assert exc_info.value.message == "Incorrect CAPTCHA"
+
+
+def test_http_captcha_login_and_replay(client):
+    test_client, _, authenticate_user = client
+    captcha_response = test_client.get("/auth/captcha")
+
+    assert captcha_response.status_code == 200
+    assert captcha_response.headers["cache-control"] == "no-store"
+    set_cookie = captcha_response.headers["set-cookie"].lower()
+    assert "httponly" in set_cookie
+    assert "samesite=strict" in set_cookie
+    assert "path=/auth" in set_cookie
+    issued = captcha_response.json()
+    challenge = captcha_util.decrypt_challenge(
+        _SECRET_KEY,
+        issued["captcha_id"],
+        ttl_seconds=auth_routes.CAPTCHA_TOKEN_TTL_SECONDS,
+    )
+
+    login_response = test_client.post(
+        "/auth/login",
+        data={
+            "username": "admin",
+            "password": "password",
+            "captcha_id": issued["captcha_id"],
+            "captcha": challenge.code,
+        },
+    )
+
+    assert login_response.status_code == 200
+    assert "session=" in login_response.headers["set-cookie"]
+    authenticate_user.assert_awaited_once()
+
+    replay_response = test_client.post(
+        "/auth/login",
+        data={
+            "username": "admin",
+            "password": "password",
+            "captcha_id": issued["captcha_id"],
+            "captcha": challenge.code,
+        },
+    )
+    assert replay_response.status_code == 400
+    authenticate_user.assert_awaited_once()
+
+
+def test_http_captcha_audio_uses_bound_challenge(client):
+    test_client, _, _ = client
+    issued = test_client.get("/auth/captcha").json()
+
+    response = test_client.post(
+        "/auth/captcha/audio", data={"captcha_id": issued["captcha_id"]}
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    prefix, encoded = response.json()["audio"].split(",", 1)
+    assert prefix == "data:audio/wav;base64"
+    assert base64.b64decode(encoded).startswith(b"RIFF")
+
+
+def test_http_login_rejects_challenge_from_another_browser(client):
+    test_client, _, authenticate_user = client
+    issued = test_client.get("/auth/captcha").json()
+    challenge = captcha_util.decrypt_challenge(
+        _SECRET_KEY,
+        issued["captcha_id"],
+        ttl_seconds=auth_routes.CAPTCHA_TOKEN_TTL_SECONDS,
+    )
+    test_client.cookies.clear()
+
+    response = test_client.post(
+        "/auth/login",
+        data={
+            "username": "admin",
+            "password": "password",
+            "captcha_id": issued["captcha_id"],
+            "captcha": challenge.code,
+        },
+    )
+
+    assert response.status_code == 400
+    authenticate_user.assert_not_awaited()
+
+
+def test_http_login_rejects_cross_site_origin(client):
+    test_client, _, authenticate_user = client
+
+    response = test_client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "password"},
+        headers={"Origin": "https://attacker.example"},
+    )
+
+    assert response.status_code == 400
+    authenticate_user.assert_not_awaited()
+
+
+def test_http_login_rejects_cross_site_fetch_metadata(client):
+    test_client, _, authenticate_user = client
+
+    response = test_client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "password"},
+        headers={"Sec-Fetch-Site": "cross-site"},
+    )
+
+    assert response.status_code == 400
+    authenticate_user.assert_not_awaited()
+
+
+def test_disabled_captcha_preserves_cross_site_login_behavior(client):
+    test_client, config, authenticate_user = client
+    config.enable_login_captcha = False
+
+    response = test_client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "password"},
+        headers={"Origin": "https://attacker.example"},
+    )
+
+    assert response.status_code == 200
+    authenticate_user.assert_awaited_once()
+
+
+def test_http_captcha_issue_is_rate_limited(client, monkeypatch):
+    from gpustack.utils.rate_limit import KeyedRateLimiter
+
+    test_client, _, _ = client
+    monkeypatch.setattr(
+        auth_routes,
+        "_captcha_issue_limiter",
+        KeyedRateLimiter(max_requests=1, window_seconds=60),
+    )
+
+    assert test_client.get("/auth/captcha").status_code == 200
+    assert test_client.get("/auth/captcha").status_code == 429
+
+
+def test_http_login_is_rate_limited_when_captcha_is_enabled(client, monkeypatch):
+    from gpustack.utils.rate_limit import KeyedRateLimiter
+
+    test_client, _, authenticate_user = client
+    monkeypatch.setattr(
+        auth_routes,
+        "_login_account_limiter",
+        KeyedRateLimiter(max_requests=1, window_seconds=60),
+    )
+
+    assert (
+        test_client.post(
+            "/auth/login", data={"username": "admin", "password": "password"}
+        ).status_code
+        == 400
+    )
+    assert (
+        test_client.post(
+            "/auth/login", data={"username": "admin", "password": "password"}
+        ).status_code
+        == 429
+    )
+    authenticate_user.assert_not_awaited()
+
+
+def test_http_login_requires_captcha_fields(client):
+    test_client, _, authenticate_user = client
+
+    response = test_client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "password"},
+    )
+
+    assert response.status_code == 400
+    authenticate_user.assert_not_awaited()
+
+
+def test_http_captcha_is_hidden_and_login_unchanged_when_disabled(client):
+    test_client, config, authenticate_user = client
+    config.enable_login_captcha = False
+
+    captcha_response = test_client.get("/auth/captcha")
+    login_response = test_client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "password"},
+    )
+
+    assert captcha_response.status_code == 404
+    assert login_response.status_code == 200
+    authenticate_user.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_database_nonce_ledger_is_single_use_across_sessions(monkeypatch):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(LoginCaptchaNonce.__table__.create)
+
+    @asynccontextmanager
+    async def session_factory():
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            yield session
+
+    monkeypatch.setattr(auth_routes, "async_session", session_factory)
+    try:
+        await _REAL_CONSUME_CAPTCHA_NONCE("shared-nonce")
+        with pytest.raises(exceptions.BadRequestException) as exc_info:
+            await _REAL_CONSUME_CAPTCHA_NONCE("shared-nonce")
+        assert exc_info.value.message == "CAPTCHA has already been used"
+    finally:
+        await engine.dispose()

--- a/tests/routes/test_captcha.py
+++ b/tests/routes/test_captcha.py
@@ -1,6 +1,8 @@
 """Tests for login CAPTCHA generation, tokens, and HTTP integration."""
 
 import base64
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from io import BytesIO
 from types import SimpleNamespace
@@ -47,6 +49,7 @@ def _config(enabled: bool = True, length: int = 4):
     return SimpleNamespace(
         enable_login_captcha=enabled,
         login_captcha_length=length,
+        server_external_url=None,
         external_auth_type=None,
         gateway_mode=GatewayModeEnum.disabled,
     )
@@ -98,6 +101,16 @@ def client(monkeypatch):
         yield test_client, config, authenticate_user
 
 
+def _solved_challenge(test_client):
+    issued = test_client.get("/auth/captcha").json()
+    challenge = captcha_util.decrypt_challenge(
+        _SECRET_KEY,
+        issued["captcha_id"],
+        ttl_seconds=auth_routes.CAPTCHA_TOKEN_TTL_SECONDS,
+    )
+    return issued, challenge.code
+
+
 def test_generate_code_uses_unambiguous_characters():
     code = captcha_util.generate_code(6)
 
@@ -126,6 +139,28 @@ def test_generate_audio_returns_valid_wav():
 
     assert audio.startswith(b"RIFF")
     assert audio[8:12] == b"WAVE"
+
+
+def test_generators_are_reused_per_thread(monkeypatch):
+    monkeypatch.setattr(captcha_util, "_generators", threading.local())
+    barrier = threading.Barrier(2)
+
+    def generators():
+        image = captcha_util._get_image_generator()
+        audio = captcha_util._get_audio_generator()
+        assert image is captcha_util._get_image_generator()
+        assert audio is captcha_util._get_audio_generator()
+        barrier.wait()
+        return image, audio
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(generators)
+        second_future = executor.submit(generators)
+        first_image, first_audio = first_future.result()
+        second_image, second_audio = second_future.result()
+
+    assert first_image is not second_image
+    assert first_audio is not second_audio
 
 
 def test_challenge_token_is_opaque_and_authenticated(monkeypatch):
@@ -355,6 +390,75 @@ def test_http_login_rejects_cross_site_fetch_metadata(client):
 
     assert response.status_code == 400
     authenticate_user.assert_not_awaited()
+
+
+def test_http_login_accepts_external_origin_behind_tls_proxy(client):
+    test_client, config, authenticate_user = client
+    config.server_external_url = "https://public.example/gpustack"
+    issued, code = _solved_challenge(test_client)
+
+    response = test_client.post(
+        "/auth/login",
+        data={
+            "username": "admin",
+            "password": "password",
+            "captcha_id": issued["captcha_id"],
+            "captcha": code,
+        },
+        headers={"Origin": "https://public.example:443"},
+    )
+
+    assert response.status_code == 200
+    authenticate_user.assert_awaited_once()
+
+
+def test_http_login_does_not_trust_raw_forwarded_proto(client):
+    test_client, _, authenticate_user = client
+    issued, code = _solved_challenge(test_client)
+
+    response = test_client.post(
+        "/auth/login",
+        data={
+            "username": "admin",
+            "password": "password",
+            "captcha_id": issued["captcha_id"],
+            "captcha": code,
+        },
+        headers={
+            "Origin": "https://testserver",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+
+    assert response.status_code == 400
+    authenticate_user.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("https://EXAMPLE.com", ("https", "example.com", 443)),
+        ("https://example.com:443", ("https", "example.com", 443)),
+        ("http://[::1]:80", ("http", "::1", 80)),
+        ("null", None),
+        ("https://user@example.com", None),
+        ("https://example.com/path", None),
+    ],
+)
+def test_canonical_http_origin(value, expected):
+    assert auth_routes._canonical_http_origin(value) == expected
+
+
+def test_canonical_http_origin_allows_deployment_path_only_when_requested():
+    assert auth_routes._canonical_http_origin(
+        "https://example.com/gpustack", allow_path=True
+    ) == ("https", "example.com", 443)
+    assert (
+        auth_routes._canonical_http_origin(
+            "https://example.com/gpustack?source=test", allow_path=True
+        )
+        is None
+    )
 
 
 def test_disabled_captcha_preserves_cross_site_login_behavior(client):

--- a/tests/server/test_login_captcha_nonce_cleaner.py
+++ b/tests/server/test_login_captcha_nonce_cleaner.py
@@ -1,0 +1,53 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from gpustack.schemas.login_captcha import LoginCaptchaNonce
+from gpustack.server import login_captcha_nonce_cleaner as cleaner_module
+from gpustack.server.login_captcha_nonce_cleaner import LoginCaptchaNonceCleaner
+
+
+def test_cleaner_rejects_invalid_interval():
+    with pytest.raises(ValueError, match="positive"):
+        LoginCaptchaNonceCleaner(interval=0)
+
+
+@pytest.mark.asyncio
+async def test_cleaner_deletes_only_expired_nonces(monkeypatch):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(LoginCaptchaNonce.__table__.create)
+
+    now = datetime.now(timezone.utc)
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add_all(
+            [
+                LoginCaptchaNonce(
+                    nonce_hash="a" * 64,
+                    expires_at=now - timedelta(seconds=1),
+                ),
+                LoginCaptchaNonce(
+                    nonce_hash="b" * 64,
+                    expires_at=now + timedelta(minutes=5),
+                ),
+            ]
+        )
+        await session.commit()
+
+    @asynccontextmanager
+    async def session_factory():
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            yield session
+
+    monkeypatch.setattr(cleaner_module, "async_session", session_factory)
+    try:
+        await LoginCaptchaNonceCleaner().cleanup_once()
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            rows = (await session.exec(select(LoginCaptchaNonce))).all()
+        assert [row.nonce_hash for row in rows] == ["b" * 64]
+    finally:
+        await engine.dispose()

--- a/uv.lock
+++ b/uv.lock
@@ -459,6 +459,18 @@ wheels = [
 ]
 
 [[package]]
+name = "captcha"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/65/8e186bb798f33ba390eab897c995b0fcee92bc030e0f40cb8ea01f34dd07/captcha-0.7.1.tar.gz", hash = "sha256:a1b462bcc633a64d8db5efa7754548a877c698d98f87716c620a707364cabd6b", size = 226561, upload-time = "2025-03-01T05:00:13.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/ff/3f0982ecd37c2d6a7266c22e7ea2e47d0773fe449984184c5316459d2776/captcha-0.7.1-py3-none-any.whl", hash = "sha256:8b73b5aba841ad1e5bdb856205bf5f09560b728ee890eb9dae42901219c8c599", size = 147606, upload-time = "2025-03-01T05:00:10.433Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -1127,6 +1139,7 @@ dependencies = [
     { name = "attrs" },
     { name = "blobfile" },
     { name = "cachetools" },
+    { name = "captcha" },
     { name = "certifi" },
     { name = "colorama" },
     { name = "cryptography" },
@@ -1217,6 +1230,7 @@ requires-dist = [
     { name = "attrs", specifier = ">=24.2.0" },
     { name = "blobfile", specifier = ">=3.0.0" },
     { name = "cachetools", specifier = ">=6.0.0" },
+    { name = "captcha", specifier = ">=0.7.1,<0.8.0" },
     { name = "certifi", specifier = ">=2024.0.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "cryptography", specifier = ">=43.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -459,6 +459,18 @@ wheels = [
 ]
 
 [[package]]
+name = "captcha"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/65/8e186bb798f33ba390eab897c995b0fcee92bc030e0f40cb8ea01f34dd07/captcha-0.7.1.tar.gz", hash = "sha256:a1b462bcc633a64d8db5efa7754548a877c698d98f87716c620a707364cabd6b", size = 226561, upload-time = "2025-03-01T05:00:13.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/ff/3f0982ecd37c2d6a7266c22e7ea2e47d0773fe449984184c5316459d2776/captcha-0.7.1-py3-none-any.whl", hash = "sha256:8b73b5aba841ad1e5bdb856205bf5f09560b728ee890eb9dae42901219c8c599", size = 147606, upload-time = "2025-03-01T05:00:10.433Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -1140,6 +1152,7 @@ dependencies = [
     { name = "attrs" },
     { name = "blobfile" },
     { name = "cachetools" },
+    { name = "captcha" },
     { name = "certifi" },
     { name = "colorama" },
     { name = "croniter" },
@@ -1231,6 +1244,7 @@ requires-dist = [
     { name = "attrs", specifier = ">=24.2.0" },
     { name = "blobfile", specifier = ">=3.0.0" },
     { name = "cachetools", specifier = ">=6.0.0" },
+    { name = "captcha", specifier = ">=0.7.1,<0.8.0" },
     { name = "certifi", specifier = ">=2024.0.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "croniter", specifier = ">=2.0.0,<3.0.0" },


### PR DESCRIPTION
## Summary

Add optional CAPTCHA protection for local username/password login. The feature is disabled by default and does not change SSO flows.

## What's included

- Add `enable_login_captcha` and validated `login_captcha_length` configuration, CLI flags, environment-variable support, and operator documentation.
- Serve short-lived image challenges and on-demand audio alternatives from the auth API, reusing generators per server thread to avoid repeated asset loading.
- Encrypt challenge contents with a domain-separated Fernet key derived from the shared JWT secret.
- Bind challenges to an HttpOnly, SameSite=Strict browser cookie and validate canonical browser origins against the trusted ASGI request origin or configured external URL while CAPTCHA is enabled.
- Add bounded per-process limits for challenge generation, audio generation, and local login attempts.
- Store consumed nonce hashes in a shared database table so a challenge cannot be replayed across server replicas.
- Disable ordinary user HTTP Basic password authentication while CAPTCHA is enabled; API keys, JWT sessions, Bearer tokens, and legacy `system/*` principals remain supported.
- Add focused route, token, configuration, CLI, Basic-auth, rate-limit, and replay tests.

## Security and compatibility

- The default remains `enable_login_captcha: false`; when disabled, the existing login behavior, including HTTP Basic and cross-site request handling, is preserved.
- CAPTCHA enforcement applies only to local password login. External authentication callbacks are unchanged.
- Challenges expire after five minutes and are consumed before answer comparison, so failed guesses cannot reuse the same token.
- Rate limiting is intentionally process-local. Multi-replica and Internet-facing deployments should still enforce a global limit at their trusted ingress.
- Enabling this option requires a UI version that supports `captcha_enabled`; API clients that currently use user/password Basic auth should migrate to API keys.

## Database schema change

Add `login_captcha_nonces` with a SHA-256 nonce-hash primary key and an indexed expiration timestamp. The uniqueness constraint provides atomic cross-replica replay protection; expired rows are removed every five minutes by a leader-only cleanup task, keeping DELETE work out of the login path.

## Testing

- `80 passed, 1 skipped` for the affected auth, CAPTCHA, config, and CLI test set.
- Repository-pinned Black, Flake8, YAML, debug-statements, and end-of-file hooks passed.
- Alembic reports one head: `a91c4f0e2d7b`.
- `git diff --check` passed.
- The full pytest collection is blocked on Windows by the repository's existing Unix-only `fcntl` import; Linux CI remains the source of truth for the complete suite.

## Frontend

Companion UI PR: https://github.com/gpustack/gpustack-ui/pull/1288