### PR TITLE
fix(k8s): disable service-link env injection on server/worker pods

### DIFF
--- a/charts/gpustack-chart/templates/server-statefulset.yaml
+++ b/charts/gpustack-chart/templates/server-statefulset.yaml
@@ -29,6 +29,15 @@ spec:
         prometheus.io/port: "{{ .Values.server.metricsPort }}"
         prometheus.io/path: "/metrics"
     spec:
+      # Disable Kubernetes service-link env injection. Kubernetes injects a
+      # <SVCNAME>_PORT=tcp://... env var (name uppercased, '-' -> '_') for every
+      # Service in the namespace; a GPUSTACK_-prefixed name would collide with
+      # GPUStack's GPUSTACK_-prefixed config defaults and crash-loop prerun
+      # (e.g. a worker Service named gpustack-worker -> GPUSTACK_WORKER_PORT).
+      # GPUStack sets every env it needs explicitly and resolves peers via DNS,
+      # so it never relies on these link vars. KUBERNETES_SERVICE_HOST and
+      # KUBERNETES_SERVICE_PORT are exempt from this flag and keep working.
+      enableServiceLinks: false
       {{- with (include "image_pull_secrets" . | trim) }}
       {{- nindent 6 . }}
       {{- end }}

--- a/charts/gpustack-chart/templates/worker-daemonset.yaml
+++ b/charts/gpustack-chart/templates/worker-daemonset.yaml
@@ -62,6 +62,15 @@ spec:
         gpustack.io/runtime: {{ $w.name }}
         {{- end }}
     spec:
+      # Disable Kubernetes service-link env injection. Kubernetes injects a
+      # <SVCNAME>_PORT=tcp://... env var (name uppercased, '-' -> '_') for every
+      # Service in the namespace; a GPUSTACK_-prefixed name would collide with
+      # GPUStack's GPUSTACK_-prefixed config defaults and crash-loop prerun
+      # (e.g. a worker Service named gpustack-worker -> GPUSTACK_WORKER_PORT).
+      # GPUStack sets every env it needs explicitly and resolves peers via DNS,
+      # so it never relies on these link vars. KUBERNETES_SERVICE_HOST and
+      # KUBERNETES_SERVICE_PORT are exempt from this flag and keep working.
+      enableServiceLinks: false
       {{- with (include "image_pull_secrets" $ | trim) }}
       {{- nindent 6 . }}
       {{- end }}

--- a/gpustack/k8s/daemonset.jinja
+++ b/gpustack/k8s/daemonset.jinja
@@ -26,6 +26,13 @@ spec:
         gpustack.io/runtime: {{ worker.name }}
         {%- endif %}
     spec:
+      # Disable Kubernetes service-link env injection. The gpustack-worker
+      # Service would otherwise inject GPUSTACK_WORKER_PORT=tcp://... which
+      # collides with the GPUSTACK_-prefixed config defaults and crashes prerun.
+      # GPUStack sets every env it needs explicitly and resolves peers via DNS,
+      # so it never relies on these link vars. (KUBERNETES_SERVICE_HOST/_PORT are
+      # exempt from this flag and keep working.)
+      enableServiceLinks: false
       containers:
         - env:
             - name: GPUSTACK_SERVER_URL


### PR DESCRIPTION
A Service named gpustack-worker makes Kubernetes inject GPUSTACK_WORKER_PORT=tcp://... into same-namespace pods, which collides with GPUSTACK_-prefixed config defaults and crash-loops prerun. Set enableServiceLinks: false on the server StatefulSet, the chart worker DaemonSet, and the imported-cluster worker DaemonSet. GPUStack sets all env explicitly and resolves peers via DNS; KUBERNETES_SERVICE_HOST/_PORT are exempt from this flag and keep working.

Refer to issue:
- https://github.com/gpustack/gpustack/issues/5891#issuecomment-5015650894