### PR TITLE
fix(usage): attribute no-org usage to the caller's personal domain

### DIFF
--- a/gpustack/server/metrics_collector.py
+++ b/gpustack/server/metrics_collector.py
@@ -19,7 +19,6 @@ from gpustack.schemas.models import Model, is_embedding_model, is_reranker_model
 from gpustack.schemas.principals import (
     Principal,
     PrincipalType,
-    platform_principal_id,
 )
 from gpustack.server.db import async_session
 from gpustack.utils.rollup_tz import resolve_rollup_tz
@@ -491,9 +490,16 @@ def _build_metric_snapshot(
                     "api_key_name": api_key.name,
                     "access_key": api_key.access_key,
                     "api_key_is_custom": api_key.is_custom,
-                    "consumer_principal_id": api_key.owner_principal_id,
                 }
             )
+            # A key with a non-NULL owner pins the consumer to that tenant
+            # (an Org, or a user's own personal principal). An admin
+            # "All"-mode key carries ``owner_principal_id = NULL``; leaving
+            # the field unset lets the no-Org fallback below attribute the
+            # usage to the caller's personal domain instead of writing a
+            # NULL row.
+            if api_key.owner_principal_id is not None:
+                snapshot["consumer_principal_id"] = api_key.owner_principal_id
         if model_route_id is not None:
             snapshot["model_route_id"] = model_route_id
             snapshot["model_route_name"] = model_route_name
@@ -527,35 +533,40 @@ def _build_metric_snapshot(
     snapshot.setdefault("provider_type", metric.provider_type)
     snapshot.setdefault("access_key", metric.access_key)
     snapshot.setdefault("api_key_is_custom", None)
-    # The api_key path above stamps ``consumer_principal_id`` from
-    # ``api_key.owner_principal_id`` whenever a key is present. For
-    # cookie-authed traffic (no api_key) the gateway plugin still
-    # provides the active tenant via the wire-format
-    # ``organization_id`` header — parse it back to int so the row
-    # carries its Org scope.
+    # For cookie-authed traffic (no api_key) the gateway plugin provides the
+    # active tenant via the wire-format ``organization_id`` header — parse it
+    # back to int so the row carries its Org scope.
     #
-    # ``organization_id`` must already reference a real principal by the time
-    # it reaches here (``model_usages.consumer_principal_id`` FKs ``principals``,
-    # and a dangling id would blow up the batch ``commit()``). The two producers
-    # guarantee that: the gateway path only ever hits this branch behind an
-    # api_key whose owner already set ``consumer_principal_id`` above, so the
-    # header is ignored there; the direct (cookie) path validates the header
-    # against ``get_tenant_context`` before stamping the metric (see
-    # ``_resolve_direct_consumer_org`` in ``api/middlewares.py``).
-    if "consumer_principal_id" not in snapshot and metric.organization_id:
+    # The raw header is client-controlled, so it must be validated before it
+    # becomes an attribution: a spoofed / stale id would silently mis-attribute
+    # usage to the wrong (or a non-existent) principal. This branch is therefore
+    # gated on ``api_key is None`` — only the direct (cookie) path validates the
+    # header against ``get_tenant_context`` before stamping the metric (see
+    # ``_resolve_direct_consumer_org`` in ``api/middlewares.py``). The gateway /
+    # api_key path never trusts the raw header: a NULL-owner key leaves
+    # ``consumer_principal_id`` unset (above) and falls through to the
+    # personal-domain fallback below rather than the unvalidated header.
+    if (
+        "consumer_principal_id" not in snapshot
+        and api_key is None
+        and metric.organization_id
+    ):
         try:
             snapshot["consumer_principal_id"] = int(metric.organization_id)
         except (TypeError, ValueError):
             pass
-    # Fallback for cookie-authed traffic with no Org header — the Enterprise
-    # UI sends ``X-Organization-Id`` (parsed above), but the OSS UI omits it
-    # since there's a single Org. Attribute to the caller's tenant the same
-    # way ownership is resolved everywhere else (``current_principal_id or
-    # platform_principal_id()``): a regular user consumes as themselves, a
-    # platform admin as the default/platform Org. This mirrors the read side
-    # (a regular user's self-scope filters ``consumer_principal_id ==
-    # user.id``) so the user sees their own usage, and keeps NULL off new
-    # rows. Enterprise is unaffected — ``organization_id`` is set there, so
+    # Fallback for no-Org traffic — attribute the usage to the caller's
+    # personal domain (their own USER-principal). This is the same rule for
+    # everyone, admin included: there is no active Org to bill, so consumption
+    # is personal. It covers
+    #   * OSS regular users (never in an Org; the OSS UI omits the header),
+    #   * cookie-authed Playground traffic with no Org header,
+    #   * admin / "All"-scope callers whose api_key has a NULL owner (the
+    #     api_key branch above intentionally leaves the field unset for them).
+    # Recording to the personal domain keeps NULL off new rows and mirrors the
+    # read side's self-scope filter (``consumer_principal_id == user.id OR IS
+    # NULL``) so the caller sees their own usage. Enterprise Org traffic is
+    # unaffected — either ``organization_id`` or the api_key owner is set, so
     # this branch never runs. SYSTEM callers (worker-proxied inference) are
     # left unattributed.
     if (
@@ -563,9 +574,7 @@ def _build_metric_snapshot(
         and user is not None
         and user.kind == PrincipalType.USER
     ):
-        snapshot["consumer_principal_id"] = (
-            platform_principal_id() if user.is_admin else user.id
-        )
+        snapshot["consumer_principal_id"] = user.id
     return snapshot
 
 

--- a/gpustack/utils/usage_snapshots.py
+++ b/gpustack/utils/usage_snapshots.py
@@ -147,9 +147,15 @@ def build_model_usage_snapshot(
                 "api_key_name": api_key.name,
                 "access_key": api_key.access_key,
                 "api_key_is_custom": api_key.is_custom,
-                "consumer_principal_id": api_key.owner_principal_id,
             }
         )
+        # A key with a non-NULL owner pins the consumer to that tenant (an
+        # Org, or a user's own personal principal). An admin "All"-mode key
+        # carries ``owner_principal_id = NULL`` — leave the field unset so the
+        # collector's no-Org fallback attributes the usage to the caller's
+        # personal domain rather than writing a NULL consumer row.
+        if api_key.owner_principal_id is not None:
+            snapshot["consumer_principal_id"] = api_key.owner_principal_id
     if model_route_id is not None:
         snapshot["model_route_id"] = model_route_id
         snapshot["model_route_name"] = model_route_name

--- a/tests/server/test_metrics_collector.py
+++ b/tests/server/test_metrics_collector.py
@@ -47,20 +47,57 @@ def _snapshot_for(user, *, organization_id=None):
     )
 
 
+def _snapshot_with_api_key(user, api_key, *, organization_id=None):
+    """Run ``_build_metric_snapshot`` for a model-less api_key metric.
+    Mirrors gateway traffic authenticated by an API key."""
+    metric = ModelUsageMetrics(
+        model="qwen3-0.6b",
+        user_id=getattr(user, "id", None),
+        access_key=api_key.access_key,
+        organization_id=organization_id,
+    )
+    user_by_id = {} if user is None else {user.id: user}
+    return _build_metric_snapshot(
+        metric,
+        {},  # model_by_id
+        {},  # provider_by_id
+        user_by_id,
+        {api_key.access_key: api_key},  # api_key_by_access_key
+        {},  # cluster_names_by_id
+        {},  # route_name_by_id
+        {},  # route_owner_by_id
+    )
+
+
+def _api_key(owner_principal_id, *, access_key="ak", id=3, is_custom=False):
+    return SimpleNamespace(
+        id=id,
+        name="key",
+        access_key=access_key,
+        is_custom=is_custom,
+        owner_principal_id=owner_principal_id,
+    )
+
+
 def test_consumer_fallback_regular_user_attributes_to_self():
     user = SimpleNamespace(id=5, name="carol", kind=PrincipalType.USER, is_admin=False)
     snapshot = _snapshot_for(user)
     assert snapshot["consumer_principal_id"] == 5
 
 
-def test_consumer_fallback_admin_attributes_to_platform_org():
-    user = SimpleNamespace(id=1, name="admin", kind=PrincipalType.USER, is_admin=True)
+def test_consumer_fallback_admin_attributes_to_self():
+    # No-Org admin (OSS admin / Enterprise "All" scope) with no api_key and no
+    # Org header attributes usage to their own personal domain — NOT the
+    # platform Org. Use an id distinct from ``platform_principal_id()`` so the
+    # assertion can't pass by coincidence.
+    user = SimpleNamespace(id=7, name="admin", kind=PrincipalType.USER, is_admin=True)
+    assert platform_principal_id() != 7
     snapshot = _snapshot_for(user)
-    assert snapshot["consumer_principal_id"] == platform_principal_id()
+    assert snapshot["consumer_principal_id"] == 7
 
 
 def test_consumer_org_header_wins_over_fallback():
-    # Enterprise path: organization_id present → fallback must not run.
+    # Enterprise cookie path: organization_id present → fallback must not run.
     user = SimpleNamespace(id=5, name="carol", kind=PrincipalType.USER, is_admin=False)
     snapshot = _snapshot_for(user, organization_id="42")
     assert snapshot["consumer_principal_id"] == 42
@@ -72,6 +109,37 @@ def test_consumer_fallback_skips_system_caller():
     )
     snapshot = _snapshot_for(user)
     assert "consumer_principal_id" not in snapshot
+
+
+def test_consumer_api_key_owner_pins_consumer():
+    # A key with a non-NULL owner pins the consumer to that tenant (an Org
+    # or a personal principal), regardless of who the calling user is.
+    user = SimpleNamespace(id=5, name="carol", kind=PrincipalType.USER, is_admin=False)
+    snapshot = _snapshot_with_api_key(user, _api_key(owner_principal_id=42))
+    assert snapshot["consumer_principal_id"] == 42
+
+
+def test_consumer_api_key_null_owner_attributes_to_self():
+    # An admin "All"-mode key has ``owner_principal_id = NULL``. The usage must
+    # fall through to the caller's personal domain instead of landing NULL,
+    # while the api_key metadata is still recorded.
+    user = SimpleNamespace(id=7, name="admin", kind=PrincipalType.USER, is_admin=True)
+    snapshot = _snapshot_with_api_key(user, _api_key(owner_principal_id=None))
+    assert snapshot["consumer_principal_id"] == 7
+    assert snapshot["api_key_id"] == 3
+    assert snapshot["access_key"] == "ak"
+
+
+def test_consumer_api_key_path_ignores_org_header():
+    # FK safety: the gateway / api_key path must never trust the raw
+    # X-Organization-Id header (unvalidated there). A NULL-owner key with a
+    # header present still attributes to the caller's personal domain, not the
+    # header value.
+    user = SimpleNamespace(id=7, name="admin", kind=PrincipalType.USER, is_admin=True)
+    snapshot = _snapshot_with_api_key(
+        user, _api_key(owner_principal_id=None), organization_id="999"
+    )
+    assert snapshot["consumer_principal_id"] == 7
 
 
 @pytest.fixture(autouse=True)

--- a/tests/utils/test_usage_snapshots.py
+++ b/tests/utils/test_usage_snapshots.py
@@ -53,6 +53,45 @@ def test_build_model_usage_snapshot_includes_user_and_api_key_fields():
     assert snapshot["api_key_is_custom"] is False
 
 
+def test_build_model_usage_snapshot_org_key_pins_consumer():
+    # A key with a non-NULL owner (an Org or a personal principal) pins the
+    # consumer principal.
+    model = new_model(1, "qwen3.5-9b", huggingface_repo_id="Qwen/Qwen3.5-9B")
+    api_key = ApiKey(
+        id=5,
+        name="test",
+        user_id=2,
+        access_key="abcd1234",
+        hashed_secret_key="secret",
+        owner_principal_id=42,
+    )
+
+    snapshot = build_model_usage_snapshot(model, api_key=api_key)
+
+    assert snapshot["consumer_principal_id"] == 42
+
+
+def test_build_model_usage_snapshot_null_owner_key_omits_consumer():
+    # An admin "All"-mode key has a NULL owner — the snapshot must NOT stamp
+    # a NULL consumer_principal_id. Leaving it unset lets the collector's
+    # no-Org fallback attribute the usage to the caller's personal domain.
+    model = new_model(1, "qwen3.5-9b", huggingface_repo_id="Qwen/Qwen3.5-9B")
+    api_key = ApiKey(
+        id=5,
+        name="test",
+        user_id=2,
+        access_key="abcd1234",
+        hashed_secret_key="secret",
+        owner_principal_id=None,
+    )
+
+    snapshot = build_model_usage_snapshot(model, api_key=api_key)
+
+    assert "consumer_principal_id" not in snapshot
+    # api_key metadata is still recorded even when the owner is NULL.
+    assert snapshot["api_key_id"] == 5
+
+
 def test_model_usage_is_fully_fk_less():
     # model_usages carries NO foreign keys — it is an attribution / audit table
     # (like model_usage_details / metered_usage) whose rows must outlive every


### PR DESCRIPTION
In the no-Org case (OSS regular users who belong to no Org; admin / Enterprise "All" scope with no pinned Org), usage attribution diverged:

  * admin cookie/Playground traffic fell back to the platform Org, while
  * a NULL-owner "All"-mode api_key short-circuited to a NULL consumer.

Both are inconsistent with the personal-domain rule regular users already follow, and the NULL rows violated the "keep NULL off new rows" intent.

Attribute all no-Org traffic to the caller's own USER-principal:

  * drop the is_admin special-case in the collector fallback so admin resolves to user.id like everyone else;
  * stop stamping consumer_principal_id when api_key.owner_principal_id is NULL (both the model and no-model snapshot paths), so the fallback can take over instead of writing NULL;
  * gate the org-header fallback on `api_key is None` to preserve the FK-safety invariant now that a NULL-owner key no longer pre-stamps the field (the gateway/api_key path must never trust the raw header).

Org-scoped traffic (api_key owner / validated X-Organization-Id) and SYSTEM callers are unaffected. Read side needs no change: self-scope already surfaces `consumer_principal_id == user.id OR IS NULL`, and the Organization dimension already renders USER-kind (personal) consumers.

Add tests covering admin -> self fallback, api_key NULL-owner -> self, api_key path ignoring the org header, and the snapshot builder omitting a NULL consumer while still recording api_key metadata.