### PR TITLE
fix: stale model instance cache

### DIFF
--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -111,6 +111,16 @@ MODEL_INSTANCE_RESCHEDULE_GRACE_PERIOD = int(
 MODEL_INSTANCE_HEALTH_CHECK_INTERVAL = int(
     os.getenv("GPUSTACK_MODEL_INSTANCE_HEALTH_CHECK_INTERVAL", 3)
 )
+# Period, in seconds, for forcing an authoritative (uncached) DB reconciliation
+# of locally-tracked model instances in the worker state sync. 0 disables it,
+# leaving the sync purely cache-backed. It exists only as a backstop for a
+# watch cache that silently diverged from DB truth without a reconnect (e.g. a
+# coordinator dropping a DELETED on a live stream); enabling it reintroduces one
+# uncached full SELECT per worker per period, so keep it well above the health
+# check interval when set.
+MODEL_INSTANCE_STATE_RECONCILE_INTERVAL = int(
+    os.getenv("GPUSTACK_MODEL_INSTANCE_STATE_RECONCILE_INTERVAL", 0)
+)
 DISABLE_OS_FILELOCK = os.getenv("GPUSTACK_DISABLE_OS_FILELOCK", "false").lower() in [
     "true",
     "1",

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -948,6 +948,12 @@ class ModelInstanceService:
                 ids.add(m.model_id)
             await self.session.commit()
 
+            # delete(auto_commit=False) returns before invalidating cached_all,
+            # so the batch commit must do it. Otherwise subscribe()'s replay
+            # snapshot keeps serving the deleted rows and watch reconnects
+            # resurrect them as ghost CREATED events.
+            await ModelInstance._invalidate_cached_all()
+
             for id in ids:
                 await delete_cache_by_key(self.get_running_instances, id)
             await invalidate_workers_allocated(model_instances)
@@ -964,6 +970,9 @@ class ModelInstanceService:
         model_instances: List[ModelInstance],
         source: Union[dict, SQLModel, None] = None,
     ):
+        if not model_instances:
+            return []
+
         names = [mi.name for mi in model_instances]
         ids = set()
         try:
@@ -971,6 +980,12 @@ class ModelInstanceService:
                 await m.update(self.session, source, auto_commit=False)
                 ids.add(m.model_id)
             await self.session.commit()
+
+            # Per-instance update() invalidates cached_all at flush time, i.e.
+            # before this manual commit — a concurrent read in that window could
+            # repopulate it with pre-commit state. Invalidate again after commit
+            # so the replay snapshot reflects the committed rows.
+            await ModelInstance._invalidate_cached_all()
 
             for id in ids:
                 await delete_cache_by_key(self.get_running_instances, id)

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -176,6 +176,11 @@ class ServeManager:
         # Track last health check time per model instance
         self._last_health_check_time: Dict[int, float] = {}
 
+        # Timestamp of the last authoritative (uncached) DB reconciliation in
+        # the state sync, for the optional periodic backstop. Starts "now" so
+        # the first forced reconciliation is one full period in, not immediate.
+        self._last_state_reconcile_time: float = time.time()
+
         os.makedirs(self._serve_log_dir, exist_ok=True)
 
     def record_successful_inference(self, instance_id: int):
@@ -268,18 +273,41 @@ class ServeManager:
             if mi.get_deployment_metadata(self._worker_id) is not None
         }
 
+        # Optional periodic reconciliation against DB truth even when the cache
+        # reports nothing reapable. The cache and local serving state are both
+        # fed by the same awatch stream, so a ghost re-seeded into the cache
+        # sits in both and `local - cache` never flags it; an independent DB
+        # read is the only thing that catches that. Disabled by default (the
+        # server-side cached_all fix plus reconnect-driven reaping cover the
+        # realistic cases); opt in via the
+        # GPUSTACK_MODEL_INSTANCE_STATE_RECONCILE_INTERVAL env var when a
+        # coordinator may drop DELETEDs on a live stream.
+        reconcile_interval = envs.MODEL_INSTANCE_STATE_RECONCILE_INTERVAL
+        now = time.time()
+        force_authoritative = (
+            reconcile_interval > 0
+            and now - self._last_state_reconcile_time >= reconcile_interval
+        )
+
         # Reaping tears down live workloads, so it must act on an authoritative
         # snapshot. The cache is not one at every instant: awatch clears it and
         # flips _watch_started before the replay snapshot arrives, so a read
         # during a reconnect window can see an empty-but-"authoritative" cache
-        # and surface healthy instances as stale. So confirm any reap candidates
+        # and surface healthy instances as stale. So confirm reap candidates
         # against a fresh, unpaginated, uncached fetch — this only touches the
-        # DB when something actually looks reapable.
-        if reap_ids:
+        # DB when something looks reapable or on the periodic reconciliation.
+        if reap_ids or force_authoritative:
             response = self._clientset.model_instances.list(
                 params={"page": -1},
                 use_cache=False,
             )
+            # Any successful authoritative fetch counts as a reconciliation —
+            # whether triggered by the timer or by a reap candidate — so reset
+            # the timer here (list() raises on API failure, so a failed fetch
+            # doesn't advance it and the next tick retries). Skipped when the
+            # backstop is disabled to keep the timestamp meaningless-but-inert.
+            if reconcile_interval > 0:
+                self._last_state_reconcile_time = now
             all_items = response.items or []
             reap_ids = local_assigned_ids - {
                 mi.id

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -720,7 +720,23 @@ class ServeManager:
                 # Reset failure count on success.
                 self._inference_health_check_failures.pop(model_instance.id, None)
 
-    def _handle_model_instance_event(self, event: Event):  # noqa: C901
+    def _handle_model_instance_event(self, event: Event):
+        """Handle a model instance event without ever crashing the watch stream.
+
+        The awatch callback runs inline in the watch loop, so any exception
+        that escapes here tears the stream down and forces a full reconnect
+        plus cache reload. Swallow and log (with traceback) instead; the next
+        event or the periodic state sync recovers the instance.
+        """
+        try:
+            self._dispatch_model_instance_event(event)
+        except Exception:
+            logger.exception(
+                f"Failed to handle {event.type} event for model instance "
+                f"{getattr(event, 'id', None)}"
+            )
+
+    def _dispatch_model_instance_event(self, event: Event):  # noqa: C901
         """
         Handle model instance events.
 
@@ -804,8 +820,15 @@ class ServeManager:
                     return
 
         if event.type == EventType.DELETED:
-            self._stop_model_instance(mi, delete_logs=True)
-            logger.trace(f"DELETED event: stopped deleted model instance {mi.name}.")
+            # Teardown is left to the periodic reap in sync_model_instances_state,
+            # which is the authoritative reconciler and must run anyway to catch
+            # DELETEDs missed during a watch disconnect. Tearing down here too
+            # would give a second concurrent caller racing the reap on
+            # delete_workload, so just let the reap reap it (within one tick).
+            logger.trace(
+                f"DELETED event for model instance {mi.name}; "
+                "teardown deferred to reap."
+            )
             return
 
         if event.type == EventType.UPDATED:

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -219,9 +219,10 @@ def test_cleanup_old_logs_restart_zero_purges_all(tmp_path: Path):
     assert remaining == [f"{other}.0.log", f"model_file_{mid}.download.log"]
 
 
-def test_delete_event_purges_logs_but_restart_keeps_them(tmp_path: Path):
-    """DELETED removes the instance's serve logs so a reused id can't inherit them;
-    a restart (default stop) keeps them for the log viewer."""
+def test_permanent_teardown_purges_logs_but_restart_keeps_them(tmp_path: Path):
+    """A permanent teardown (delete_logs=True, used by the reap) removes the
+    instance's serve logs so a reused id can't inherit them; a restart (default
+    stop) keeps them for the log viewer."""
     serve_dir = tmp_path / "serve"
     serve_dir.mkdir(parents=True)
     log = serve_dir / "1.container.ray-head.0.log"
@@ -232,9 +233,6 @@ def test_delete_event_purges_logs_but_restart_keeps_them(tmp_path: Path):
     model_instance = new_model_instance(
         1, "qwen3-0.6b", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
     )
-    # _handle_model_instance_event re-validates the payload; source/repo required.
-    model_instance.source = SourceEnum.HUGGING_FACE
-    model_instance.huggingface_repo_id = "Qwen/Qwen3-0.6B"
 
     with (
         patch("gpustack.worker.serve_manager.logger"),
@@ -242,12 +240,12 @@ def test_delete_event_purges_logs_but_restart_keeps_them(tmp_path: Path):
         patch.object(manager, "_stop_container_log_persistence"),
         patch.object(manager, "_is_provisioning", return_value=False),
     ):
+        # Restart-style stop keeps the logs.
         manager._stop_model_instance(model_instance)
         assert log.exists()
 
-        manager._handle_model_instance_event(
-            Event(type=EventType.DELETED, data=model_instance)
-        )
+        # Permanent teardown removes them.
+        manager._stop_model_instance(model_instance, delete_logs=True)
         assert not log.exists()
 
 
@@ -405,6 +403,48 @@ def test_ghost_in_cache_reaped_when_backstop_interval_elapsed():
     confirm_call = clientset.model_instances.list.call_args_list[1]
     assert confirm_call.kwargs.get("params") == {"page": -1}
     assert confirm_call.kwargs.get("use_cache") is False
+
+
+def test_delete_event_defers_teardown_to_reap():
+    """The DELETED handler no longer tears down directly; teardown is left to the
+    periodic reap so there is a single teardown path (no reap-vs-event race)."""
+    manager, _ = _build_serve_manager(worker_id=1)
+    mi = new_model_instance(
+        4, "qwen3-0.6b-kqkco", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    mi.source = SourceEnum.HUGGING_FACE
+    mi.huggingface_repo_id = "Qwen/Qwen3-0.6B"
+    manager._model_instance_by_instance_id[mi.id] = mi
+
+    with (
+        patch("gpustack.worker.serve_manager.logger"),
+        patch.object(manager, "_stop_model_instance") as stop_model_instance,
+    ):
+        manager._handle_model_instance_event(Event(type=EventType.DELETED, data=mi))
+
+    stop_model_instance.assert_not_called()
+
+
+def test_updated_event_error_does_not_crash_watch():
+    """A failure on any event path (not just DELETED) must be swallowed so it
+    never escapes the awatch callback. Here an UPDATED->restart raises."""
+    manager, _ = _build_serve_manager(worker_id=1)
+    mi = new_model_instance(
+        5, "qwen3-0.6b", 1, worker_id=1, state=ModelInstanceStateEnum.SCHEDULED
+    )
+    mi.source = SourceEnum.HUGGING_FACE
+    mi.huggingface_repo_id = "Qwen/Qwen3-0.6B"
+
+    with (
+        patch("gpustack.worker.serve_manager.logger"),
+        patch.object(
+            manager,
+            "_restart_model_instance",
+            side_effect=RuntimeError("start failed"),
+        ),
+    ):
+        # Must not raise.
+        manager._handle_model_instance_event(Event(type=EventType.UPDATED, data=mi))
 
 
 def test_persist_container_logs_reconnects_and_dedupes(tmp_path: Path):

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -339,6 +339,74 @@ def test_reap_confirmation_reaps_when_missing_from_authoritative_fetch():
     assert clientset.model_instances.list.call_count == 2
 
 
+def test_ghost_in_cache_not_reconciled_when_backstop_disabled():
+    """With the periodic reconciliation disabled (default), an instance present
+    in both local state and the watch cache but gone from DB is not a
+    `local - cache` reap candidate, so the sync trusts the cache and takes no
+    DB round trip."""
+    manager, clientset = _build_serve_manager(worker_id=1)
+    ghost = new_model_instance(
+        1, "qwen3-0.6b", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    manager._model_instance_by_instance_id[ghost.id] = ghost
+    clientset.model_instances.list.return_value = SimpleNamespace(items=[ghost])
+
+    with (
+        patch("gpustack.worker.serve_manager.logger"),
+        patch(
+            "gpustack.worker.serve_manager.envs.MODEL_INSTANCE_STATE_RECONCILE_INTERVAL",
+            0,
+        ),
+        patch.object(manager, "_stop_model_instance") as stop_model_instance,
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            return_value=SimpleNamespace(state=WorkloadStatusStateEnum.INITIALIZING),
+        ),
+    ):
+        manager.sync_model_instances_state()
+
+    stop_model_instance.assert_not_called()
+    # Cache read only; no authoritative DB fetch when the backstop is off.
+    assert clientset.model_instances.list.call_count == 1
+
+
+def test_ghost_in_cache_reaped_when_backstop_interval_elapsed():
+    """When the reconciliation backstop is enabled and its interval has elapsed,
+    the forced authoritative DB read reaps a ghost living in both local state
+    and the cache — the case `local - cache` can never flag on its own."""
+    manager, clientset = _build_serve_manager(worker_id=1)
+    ghost = new_model_instance(
+        1, "qwen3-0.6b", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    manager._model_instance_by_instance_id[ghost.id] = ghost
+    # Last reconciliation is far enough in the past to be due.
+    manager._last_state_reconcile_time = 0
+    # Cache still lists the ghost; the authoritative DB fetch does not.
+    clientset.model_instances.list.side_effect = [
+        SimpleNamespace(items=[ghost]),
+        SimpleNamespace(items=[]),
+    ]
+
+    with (
+        patch("gpustack.worker.serve_manager.logger"),
+        patch(
+            "gpustack.worker.serve_manager.envs.MODEL_INSTANCE_STATE_RECONCILE_INTERVAL",
+            60,
+        ),
+        patch.object(manager, "_stop_model_instance") as stop_model_instance,
+        patch.object(manager, "_is_provisioning", return_value=False),
+    ):
+        manager.sync_model_instances_state()
+
+    stop_model_instance.assert_called_once_with(ghost, delete_logs=True)
+    # Cache read plus the forced authoritative fetch.
+    assert clientset.model_instances.list.call_count == 2
+    confirm_call = clientset.model_instances.list.call_args_list[1]
+    assert confirm_call.kwargs.get("params") == {"page": -1}
+    assert confirm_call.kwargs.get("use_cache") is False
+
+
 def test_persist_container_logs_reconnects_and_dedupes(tmp_path: Path):
     """On stream EOF while the workload is still running, reconnect and resume
     by skipping already-written history (anchor), appending only new lines."""


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5919

1. Stopping deployments calls batch delete api but server cache is not invalidated as expected in this case
2. Now we have two stop_model_instance paths in serve manager and it causes race condition complexity. Keep only the neccessary one.
3. Add optional periodic DB reconciliation of instance state. This is a backstop in case any inconsistent cache degration happens, there's possible solution other than restarting workers