### PR TITLE
fix: gate SSO routes on the configured active provider

### DIFF
--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -11,7 +11,7 @@ import jwt
 from jwt.algorithms import RSAAlgorithm
 from gpustack.config.config import Config
 from typing import Annotated, Dict, List, Optional
-from fastapi import APIRouter, Form, Request, Response
+from fastapi import APIRouter, Depends, Form, Request, Response
 from gpustack.api.exceptions import (
     ConflictException,
     InvalidException,
@@ -434,6 +434,41 @@ def _saml_settings(config: Config, *, xml_bytes: Optional[bytes] = None) -> Dict
     }
 
 
+def _provider_gate(provider: AuthProviderEnum):
+    """Build a FastAPI dependency that rejects a request with 400 unless
+    ``provider`` is the active auth provider.
+
+    Attached at the sub-router level (see ``oidc_router`` / ``saml_router``
+    / ``cas_router``) so every current *and future* route under it is
+    gated without the handler having to remember — the check can't be
+    accidentally dropped when a new SSO route is added.
+
+    ``Config.init_auth`` resolves ``external_auth_type`` to at most one
+    provider (OIDC → SAML → CAS precedence), so gating each route group
+    on its own provider closes it on every other deployment. This
+    matters because the callbacks parse attacker-supplied IdP payloads
+    (a SAML ``SAMLResponse``, an OIDC token exchange, a CAS service
+    ticket) — leaving them live where the provider was never enabled is
+    needless attack surface.
+    """
+
+    def _dependency(request: Request) -> None:
+        config: Config = request.app.state.server_config
+        if config.external_auth_type != provider:
+            raise BadRequestException(message=f"{provider.value} is not configured")
+
+    return _dependency
+
+
+# One sub-router per external provider, each gated by ``_provider_gate``
+# so the whole provider's route group is closed unless that provider is
+# the configured active one. Included into ``router`` at the bottom of
+# the module.
+oidc_router = APIRouter(dependencies=[Depends(_provider_gate(AuthProviderEnum.OIDC))])
+saml_router = APIRouter(dependencies=[Depends(_provider_gate(AuthProviderEnum.SAML))])
+cas_router = APIRouter(dependencies=[Depends(_provider_gate(AuthProviderEnum.CAS))])
+
+
 async def init_saml_auth(request: Request):
     """
     Initialize SAML authentication configuration.
@@ -452,13 +487,13 @@ async def init_saml_auth(request: Request):
 # SAML login and callback endpoints
 
 
-@router.get("/saml/login")
+@saml_router.get("/saml/login")
 async def saml_login(request: Request):
     auth = await init_saml_auth(request)
     return RedirectResponse(url=auth.login())
 
 
-@router.api_route("/saml/callback", methods=["GET", "POST"])
+@saml_router.api_route("/saml/callback", methods=["GET", "POST"])
 @_sso_callback_errors_to_redirect
 async def saml_callback(request: Request, session: SessionDep):
     logger.debug("Invoke saml callback.")
@@ -635,7 +670,7 @@ async def saml_callback(request: Request, session: SessionDep):
     return response
 
 
-@router.api_route("/saml/logout/callback", methods=["GET", "POST"])
+@saml_router.api_route("/saml/logout/callback", methods=["GET", "POST"])
 async def saml_logout_callback(request: Request):
     try:
         auth = await init_saml_auth(request)
@@ -766,7 +801,7 @@ def _coerce_group_claim(raw) -> List[str]:
 # OIDC login and callback endpoints
 
 
-@router.get("/oidc/login")
+@oidc_router.get("/oidc/login")
 async def oidc_login(request: Request):
     config: Config = request.app.state.server_config
     authorization_endpoint = config.openid_configuration["authorization_endpoint"]
@@ -794,7 +829,7 @@ async def oidc_login(request: Request):
     return response
 
 
-@router.get("/oidc/callback")
+@oidc_router.get("/oidc/callback")
 @_sso_callback_errors_to_redirect
 async def oidc_callback(request: Request, session: SessionDep):
     logger.debug("Invoke oidc callback.")
@@ -1075,23 +1110,19 @@ async def validate_cas_ticket(
     return user_data
 
 
-@router.get("/cas/login")
+@cas_router.get("/cas/login")
 async def cas_login(request: Request):
     config: Config = request.app.state.server_config
-    if not config.cas_server_url:
-        raise BadRequestException(message="CAS is not configured")
     service = _cas_service_url(request, config)
     base = config.cas_server_url.rstrip("/")
     return RedirectResponse(url=f"{base}/login?service={quote(service, safe='')}")
 
 
-@router.get("/cas/callback")
+@cas_router.get("/cas/callback")
 @_sso_callback_errors_to_redirect
 async def cas_callback(request: Request, session: SessionDep):
     logger.debug("Invoke CAS callback.")
     config: Config = request.app.state.server_config
-    if not config.cas_server_url:
-        raise BadRequestException(message="CAS is not configured")
 
     ticket = request.query_params.get("ticket")
     if not ticket:
@@ -1374,3 +1405,11 @@ def remove_initial_password_file_if_exists(config: Config) -> None:
         initial_password_file.unlink(missing_ok=True)
     except OSError as e:
         logger.debug(f"Left initial password file in place: {e}")
+
+
+# Mount the per-provider sub-routers. Each carries a ``_provider_gate``
+# dependency, so their routes stay closed unless that provider is the
+# configured active one.
+router.include_router(oidc_router)
+router.include_router(saml_router)
+router.include_router(cas_router)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,17 +1,22 @@
 import ssl
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastapi import FastAPI
 from fastapi.security import HTTPAuthorizationCredentials
+from fastapi.testclient import TestClient
+from gpustack.api.exceptions import register_handlers
 from gpustack.api.auth import (
     GATEWAY_AUTH_TOKEN_HEADER,
     client_ip_getter,
     get_current_user,
     worker_auth,
 )
-from gpustack.api.exceptions import UnauthorizedException
+from gpustack.api.exceptions import BadRequestException, UnauthorizedException
 from gpustack.schemas.config import GatewayModeEnum
+from gpustack.schemas.users import AuthProviderEnum
 from gpustack.routes import auth as auth_route
 from gpustack.routes.auth import oidc_callback
 
@@ -543,6 +548,70 @@ def test_saml_settings_signature_floor():
     assert security.get("wantMessagesSigned") is False
 
 
+def test_provider_gate_allows_only_matching_active_provider():
+    """The SSO routes parse attacker-supplied IdP payloads, so each must
+    stay closed unless its provider is the configured active one.
+    ``external_auth_type`` resolves to at most one provider, so the gate
+    passes only for its own provider and rejects every other value
+    (including ``None``)."""
+    all_providers = (
+        AuthProviderEnum.OIDC,
+        AuthProviderEnum.SAML,
+        AuthProviderEnum.CAS,
+    )
+    for guarded in all_providers:
+        gate = auth_route._provider_gate(guarded)
+        request = MagicMock()
+        # The matching provider passes.
+        request.app.state.server_config.external_auth_type = guarded
+        assert gate(request) is None
+        # Every other provider (and the unconfigured None) is rejected.
+        for other in (None, *all_providers):
+            if other == guarded:
+                continue
+            request.app.state.server_config.external_auth_type = other
+            with pytest.raises(BadRequestException):
+                gate(request)
+
+
+def _sso_test_client(external_auth_type) -> TestClient:
+    """Mount the real auth router (prefix ``/auth``, matching production)
+    on a bare app so the sub-router ``dependencies`` and ``include_router``
+    wiring is exercised end-to-end over HTTP."""
+    app = FastAPI()
+    register_handlers(app)
+    app.include_router(auth_route.router, prefix="/auth")
+    app.state.server_config = SimpleNamespace(external_auth_type=external_auth_type)
+    return TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "login_path, provider",
+    [
+        ("/auth/oidc/login", AuthProviderEnum.OIDC),
+        ("/auth/saml/login", AuthProviderEnum.SAML),
+        ("/auth/cas/login", AuthProviderEnum.CAS),
+    ],
+)
+def test_sso_login_route_gated_by_active_provider(login_path, provider):
+    """Structural gating over real HTTP: each SSO route must return 400
+    when ``external_auth_type`` names a different provider (or nothing).
+    Asserting 400 rather than merely non-200 also catches a dropped
+    ``include_router`` — an unmounted route would surface as 404."""
+    for active in (
+        None,
+        AuthProviderEnum.OIDC,
+        AuthProviderEnum.SAML,
+        AuthProviderEnum.CAS,
+    ):
+        if active == provider:
+            continue
+        client = _sso_test_client(active)
+        resp = client.get(login_path, follow_redirects=False)
+        assert resp.status_code == 400, (login_path, active, resp.status_code)
+        assert "is not configured" in resp.json()["message"]
+
+
 def test_saml_unsigned_escape_hatch_detects_both_false():
     """The unsigned escape hatch flags only when *both*
     ``wantAssertionsSigned`` and ``wantMessagesSigned`` are the
@@ -742,6 +811,7 @@ def _saml_callback_request(saml_response_b64: str, **config_overrides) -> object
     request.query_params = {}
 
     cfg = request.app.state.server_config
+    cfg.external_auth_type = AuthProviderEnum.SAML
     cfg.saml_security = "{}"
     cfg.saml_sp_acs_url = "http://localhost:9000/auth/saml/callback"
     cfg.external_auth_name = None


### PR DESCRIPTION
The SAML and OIDC login/callback routes were always live: on a deployment that never enabled them they would still parse attacker-supplied IdP payloads (SAMLResponse bytes, OIDC token exchange), needlessly widening the attack surface. Only CAS guarded its routes, via an ad-hoc cas_server_url presence check.

Group each provider's routes under a sub-router carrying a _provider_gate dependency that rejects the request with 400 unless external_auth_type resolves to that provider. Applying the gate at the router level makes it structural — every current and future route in the group is covered without the handler having to remember — and unifies CAS onto the same, stricter check.