### PR TITLE
fix(gateway): delete provider McpBridge entries by exact name

### DIFF
--- a/gpustack/gateway/utils.py
+++ b/gpustack/gateway/utils.py
@@ -357,6 +357,10 @@ def provider_registry_name(id: int) -> str:
     return f"{provider_id_prefix}{id}"
 
 
+def provider_proxy_name(id: int) -> str:
+    return f"{provider_registry_name(id)}-proxy"
+
+
 def provider_registry(provider: ModelProvider) -> Optional[McpBridgeRegistry]:
     provider_url = provider.config.get_base_url()
     if provider_url is None:
@@ -398,7 +402,7 @@ def provider_proxy(provider: ModelProvider) -> Optional[McpBridgeProxy]:
     # timeout in seconds
     connection_timeout = provider.proxy_timeout or 5
     return McpBridgeProxy(
-        name=f"{provider_registry_name(provider.id)}-proxy",
+        name=provider_proxy_name(provider.id),
         serverAddress=proxy_url.hostname,
         serverPort=port,
         type=scheme.upper(),
@@ -457,17 +461,23 @@ def diff_registries(
     existing: List[McpBridgeRegistry],
     desired: List[McpBridgeRegistry],
     to_delete_prefix: Optional[str] = None,
+    to_delete_names: Optional[List[str]] = None,
 ) -> Tuple[bool, List[McpBridgeRegistry]]:
     desired_map = {
         reg.name: idx for idx, reg in enumerate(desired) if reg.name is not None
     }
+    to_delete_name_set = set(to_delete_names or [])
     total_list = []
     need_update = False
     for registry in existing:
-        if registry.name not in desired_map:
-            # delete registries that are not in the current list
-            if to_delete_prefix is not None and registry.name.startswith(
-                to_delete_prefix
+        name = registry.name
+        if name not in desired_map:
+            # delete registries that match the delete prefix or an exact name.
+            # ``name`` is Optional[str]; a nameless entry matches nothing and
+            # is kept as unrelated.
+            if name is not None and (
+                (to_delete_prefix is not None and name.startswith(to_delete_prefix))
+                or name in to_delete_name_set
             ):
                 need_update = True
             else:
@@ -475,7 +485,7 @@ def diff_registries(
                 total_list.append(registry)
         else:
             # update existing registries
-            idx = desired_map.pop(registry.name)
+            idx = desired_map.pop(name)
             if registry != desired[idx]:
                 need_update = True
                 registry = desired[idx]
@@ -493,23 +503,31 @@ def diff_proxies(
     existing: List[McpBridgeProxy],
     desired: List[McpBridgeProxy],
     to_delete_prefix: Optional[str] = None,
+    to_delete_names: Optional[List[str]] = None,
 ) -> Tuple[bool, List[McpBridgeProxy]]:
     desired_map = {
         reg.name: idx for idx, reg in enumerate(desired) if reg.name is not None
     }
+    to_delete_name_set = set(to_delete_names or [])
     total_list = []
     need_update = False
     for proxy in existing:
-        if proxy.name not in desired_map:
-            # delete registries that are not in the current list
-            if to_delete_prefix is not None and proxy.name.startswith(to_delete_prefix):
+        name = proxy.name
+        if name not in desired_map:
+            # delete proxies that match the delete prefix or an exact name.
+            # ``name`` is Optional[str]; a nameless entry matches nothing and
+            # is kept as unrelated.
+            if name is not None and (
+                (to_delete_prefix is not None and name.startswith(to_delete_prefix))
+                or name in to_delete_name_set
+            ):
                 need_update = True
             else:
                 # keep unrelated proxies
                 total_list.append(proxy)
         else:
             # update existing proxies
-            idx = desired_map.pop(proxy.name)
+            idx = desired_map.pop(name)
             if proxy != desired[idx]:
                 need_update = True
                 proxy = desired[idx]
@@ -530,8 +548,10 @@ async def ensure_mcp_bridge(
     mcp_bridge_name: str,
     desired_registries: List[McpBridgeRegistry],
     to_delete_prefix: Optional[str] = None,
+    to_delete_names: Optional[List[str]] = None,
     desired_proxies: List[McpBridgeProxy] = None,
     to_delete_proxies_prefix: Optional[str] = None,
+    to_delete_proxies_names: Optional[List[str]] = None,
 ):
     existing_bridge = None
     try:
@@ -559,6 +579,7 @@ async def ensure_mcp_bridge(
             existing=existing_bridge.spec.registries or [],
             desired=desired_registries,
             to_delete_prefix=to_delete_prefix,
+            to_delete_names=to_delete_names,
         )
         proxy_need_update = False
         proxy_list = existing_bridge.spec.proxies or []
@@ -567,6 +588,7 @@ async def ensure_mcp_bridge(
                 existing=existing_bridge.spec.proxies or [],
                 desired=desired_proxies,
                 to_delete_prefix=to_delete_proxies_prefix,
+                to_delete_names=to_delete_proxies_names,
             )
 
         if registry_need_update or proxy_need_update:

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -2805,8 +2805,11 @@ class ModelProviderController:
         registry_to_remove = (
             provider_registry is None or event.type == EventType.DELETED
         )
-        to_delete_prefix = (
-            f"{mcp_handler.provider_id_prefix}{model_provider.id}"
+        # Match by exact name (not prefix) so that deleting provider id "1" does
+        # not also drop other providers whose id shares that numeric prefix
+        # (e.g. "provider-10", "provider-11").
+        to_delete_names = (
+            [mcp_handler.provider_registry_name(model_provider.id)]
             if registry_to_remove
             else None
         )
@@ -2814,8 +2817,10 @@ class ModelProviderController:
 
         provider_proxy = mcp_handler.provider_proxy(model_provider)
         proxy_to_remove = provider_proxy is None or event.type == EventType.DELETED
-        to_delete_proxy_prefix = (
-            f"proxy-{model_provider.id}" if proxy_to_remove else None
+        to_delete_proxy_names = (
+            [mcp_handler.provider_proxy_name(model_provider.id)]
+            if proxy_to_remove
+            else None
         )
         desired_proxies = [] if proxy_to_remove else [provider_proxy]
 
@@ -2826,8 +2831,8 @@ class ModelProviderController:
                 mcp_bridge_name=mcp_handler.default_mcp_bridge_name,
                 desired_registries=desired_registries,
                 desired_proxies=desired_proxies,
-                to_delete_prefix=to_delete_prefix,
-                to_delete_proxies_prefix=to_delete_proxy_prefix,
+                to_delete_names=to_delete_names,
+                to_delete_proxies_names=to_delete_proxy_names,
             )
         except Exception as e:
             logger.error(

--- a/tests/gateway/test_gateway_utils.py
+++ b/tests/gateway/test_gateway_utils.py
@@ -8,6 +8,8 @@ from gpustack.api.exceptions import NotFoundException
 from gpustack.gateway.utils import (
     RoutePrefix,
     cleanup_generic_proxy_router_spec_diff,
+    diff_proxies,
+    diff_registries,
     generate_model_ingress,
     generic_proxy_router_diff_spec,
     get_instance_id_from_header,
@@ -25,7 +27,10 @@ from gpustack.schemas.model_provider import (
     OpenAIConfig,
     OllamaConfig,
 )
-from gpustack.gateway.client.networking_higress_io_v1_api import McpBridgeRegistry
+from gpustack.gateway.client.networking_higress_io_v1_api import (
+    McpBridgeProxy,
+    McpBridgeRegistry,
+)
 
 
 def test_flattened_prefixes():
@@ -519,3 +524,75 @@ def test_model_instances_registry_list_threads_suffix():
         f"model-5-1-{suffix}",
         f"model-5-2-{suffix}",
     ]
+
+
+def _reg(name: str) -> McpBridgeRegistry:
+    return McpBridgeRegistry(name=name, domain="127.0.0.1", type="dns", port=80)
+
+
+def test_diff_registries_prefix_deletes_matching_prefix():
+    existing = [_reg("provider-1"), _reg("provider-10"), _reg("model-5-1")]
+    need_update, result = diff_registries(
+        existing, desired=[], to_delete_prefix="provider-"
+    )
+    assert need_update is True
+    assert {r.name for r in result} == {"model-5-1"}
+
+
+def test_diff_registries_exact_name_avoids_prefix_collision():
+    # Deleting provider id "1" must NOT drop "provider-10"/"provider-11".
+    existing = [
+        _reg("provider-1"),
+        _reg("provider-10"),
+        _reg("provider-11"),
+        _reg("model-5-1"),
+    ]
+    need_update, result = diff_registries(
+        existing, desired=[], to_delete_names=["provider-1"]
+    )
+    assert need_update is True
+    assert {r.name for r in result} == {"provider-10", "provider-11", "model-5-1"}
+
+
+def test_diff_registries_no_delete_targets_keeps_all():
+    existing = [_reg("provider-1"), _reg("provider-10")]
+    need_update, result = diff_registries(existing, desired=[])
+    assert need_update is False
+    assert {r.name for r in result} == {"provider-1", "provider-10"}
+
+
+def test_diff_registries_nameless_entry_is_kept_not_crashed():
+    # name is Optional[str]; a nameless existing entry must not raise on the
+    # prefix check and should be preserved as unrelated.
+    nameless = McpBridgeRegistry(domain="127.0.0.1", type="dns", port=80)
+    existing = [nameless, _reg("provider-1")]
+    need_update, result = diff_registries(
+        existing, desired=[], to_delete_prefix="provider-"
+    )
+    assert need_update is True
+    assert result == [nameless]
+
+
+def _proxy(name: str) -> McpBridgeProxy:
+    return McpBridgeProxy(
+        name=name, serverAddress="127.0.0.1", serverPort=80, type="HTTP"
+    )
+
+
+def test_diff_proxies_exact_name_deletes_only_target():
+    existing = [_proxy("provider-1-proxy"), _proxy("provider-10-proxy")]
+    need_update, result = diff_proxies(
+        existing, desired=[], to_delete_names=["provider-1-proxy"]
+    )
+    assert need_update is True
+    assert {p.name for p in result} == {"provider-10-proxy"}
+
+
+def test_diff_proxies_nameless_entry_is_kept_not_crashed():
+    nameless = McpBridgeProxy(serverAddress="127.0.0.1", serverPort=80, type="HTTP")
+    existing = [nameless, _proxy("provider-1-proxy")]
+    need_update, result = diff_proxies(
+        existing, desired=[], to_delete_prefix="provider-"
+    )
+    assert need_update is True
+    assert result == [nameless]


### PR DESCRIPTION
Provider registries in the shared `default` McpBridge are named `provider-<id>` without a trailing separator, and deletion matched by prefix (`startswith("provider-<id>")`). Deleting provider id "1" therefore also dropped `provider-10`, `provider-11`, etc., breaking those providers' inference routes until the next periodic reconcile re-added them.

Add `to_delete_names` (and `to_delete_proxies_names`) to diff_registries / diff_proxies / ensure_mcp_bridge for exact-name deletion, and use it in ModelProviderController._ensure_provider_registry. This also fixes the orphaned proxy entry: the proxy is named `provider-<id>-proxy` but the old delete prefix `proxy-<id>` never matched it.

Refer to issue:
- #5927