### PR TITLE
fix(worker): clean up the download lock file on model file deletion

### DIFF
--- a/gpustack/worker/model_file_manager.py
+++ b/gpustack/worker/model_file_manager.py
@@ -163,6 +163,18 @@ class ModelFileManager:
         paths_to_delete = set()
 
         try:
+            if model_file.source in (SourceEnum.HUGGING_FACE, SourceEnum.MODEL_SCOPE):
+                # Every HF/ModelScope download takes out a coarse lock file up front
+                # (gpustack.utils.locks.HeartbeatSoftFileLock, keyed by get_lock_path())
+                # before any per-file work starts. It only self-removes on a clean
+                # __exit__, so deleting the model file mid/after a failed or
+                # in-progress download always leaves it behind unless we add it here;
+                # this is separate from HuggingFace's own per-file lock below, which
+                # already handles its own cleanup.
+                lock_path = get_lock_path(self._config.cache_dir, model_file)
+                if lock_path:
+                    paths_to_delete.add(lock_path)
+
             if model_file.source == SourceEnum.HUGGING_FACE:
                 if not model_file.huggingface_filename:
                     # The resolved_paths in vLLM model points to entire dir of cache, delete it directly

--- a/tests/worker/test_model_file_manager.py
+++ b/tests/worker/test_model_file_manager.py
@@ -1,0 +1,93 @@
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gpustack.schemas.model_files import ModelFile, ModelFileStateEnum
+from gpustack.schemas.models import SourceEnum
+from gpustack.worker.model_file_manager import ModelFileManager
+
+
+def _manager(cache_dir: str) -> ModelFileManager:
+    manager = ModelFileManager.__new__(ModelFileManager)
+    manager._config = SimpleNamespace(cache_dir=cache_dir)
+    return manager
+
+
+def _lock_path(cache_dir: str, source_dir: str, group_or_owner: str, name: str) -> str:
+    return os.path.join(cache_dir, source_dir, group_or_owner, f"{name}.lock")
+
+
+@pytest.mark.asyncio
+async def test_get_incomplete_model_files_modelscope_whole_repo_includes_lock_file(
+    tmp_path,
+):
+    # Mirrors the SourceEnum.MODEL_SCOPE / no model_scope_file_path path: a full
+    # repo download, deleted before it completed (issue #4018's exact shape).
+    cache_dir = str(tmp_path)
+    local_dir = os.path.join(cache_dir, "model_scope", "unsloth", "DeepSeek-R1-GGUF")
+    lock_path = _lock_path(cache_dir, "model_scope", "unsloth", "DeepSeek-R1-GGUF")
+    os.makedirs(local_dir, exist_ok=True)
+    Path(lock_path).touch()
+
+    model_file = ModelFile(
+        source=SourceEnum.MODEL_SCOPE,
+        model_scope_model_id="unsloth/DeepSeek-R1-GGUF",
+        resolved_paths=[local_dir],
+        state=ModelFileStateEnum.READY,
+    )
+
+    paths = await _manager(cache_dir)._get_incomplete_model_files(model_file)
+
+    assert lock_path in paths
+
+
+@pytest.mark.asyncio
+async def test_get_incomplete_model_files_modelscope_single_file_includes_lock_file(
+    tmp_path,
+):
+    # Mirrors the model_scope_file_path path: a single matched file inside the
+    # repo dir was downloading when the model file was deleted.
+    cache_dir = str(tmp_path)
+    local_dir = os.path.join(cache_dir, "model_scope", "unsloth", "DeepSeek-R1-GGUF")
+    lock_path = _lock_path(cache_dir, "model_scope", "unsloth", "DeepSeek-R1-GGUF")
+    os.makedirs(local_dir, exist_ok=True)
+    Path(lock_path).touch()
+
+    model_file = ModelFile(
+        source=SourceEnum.MODEL_SCOPE,
+        model_scope_model_id="unsloth/DeepSeek-R1-GGUF",
+        model_scope_file_path="model.gguf",
+        resolved_paths=[os.path.join(local_dir, "model.gguf")],
+        state=ModelFileStateEnum.READY,
+    )
+
+    paths = await _manager(cache_dir)._get_incomplete_model_files(model_file)
+
+    assert lock_path in paths
+
+
+@pytest.mark.asyncio
+async def test_get_incomplete_model_files_huggingface_whole_repo_includes_lock_file(
+    tmp_path,
+):
+    # Same coarse-lock leak on the HuggingFace side: downloaders.HfDownloader takes
+    # out the identical HeartbeatSoftFileLock (get_lock_path) before its own
+    # per-file lock/metadata cleanup (already handled below) ever runs.
+    cache_dir = str(tmp_path)
+    local_dir = os.path.join(cache_dir, "huggingface", "org", "repo")
+    lock_path = _lock_path(cache_dir, "huggingface", "org", "repo")
+    os.makedirs(local_dir, exist_ok=True)
+    Path(lock_path).touch()
+
+    model_file = ModelFile(
+        source=SourceEnum.HUGGING_FACE,
+        huggingface_repo_id="org/repo",
+        resolved_paths=[local_dir],
+        state=ModelFileStateEnum.READY,
+    )
+
+    paths = await _manager(cache_dir)._get_incomplete_model_files(model_file)
+
+    assert lock_path in paths


### PR DESCRIPTION
## Root cause

`HfDownloader.download` and `ModelScopeDownloader.download` (`gpustack/worker/downloaders.py`) both take out a coarse `HeartbeatSoftFileLock` up front, keyed by `gpustack.utils.locks.get_lock_path(cache_dir, model_file)`, before any per-file work starts. That lock file only self-removes on a clean `__exit__` (`HeartbeatSoftFileLock.__exit__` / `_release_os_lock`), so if the model file is deleted mid-download or after a failed download, the lock file is orphaned on disk.

`ModelFileManager._get_incomplete_model_files` (`gpustack/worker/model_file_manager.py`) is what computes the set of paths to remove on deletion, and it never included this lock file:
- The `SourceEnum.MODEL_SCOPE` branch didn't reference it at all, matching this issue's repro (`DeepSeek-R1-GGUF.lock` left behind after the model dir was deleted).
- The `SourceEnum.HUGGING_FACE` branch does add a `.lock` file to the deletion set, but that's `huggingface_hub`'s own separate per-file lock (from `get_local_download_paths`), not the coarse one above, so the same leak exists there too under the same conditions.

## Fix

Compute `get_lock_path(...)` once for both `HUGGING_FACE` and `MODEL_SCOPE` sources and add it to `paths_to_delete` before the existing source-specific cleanup runs, so it's covered regardless of which branch a given model uses.

## Verification

Docker, `python:3.11-slim`, editable install of this repo at the branch tip.

- Added `tests/worker/test_model_file_manager.py` with three cases: ModelScope whole-repo delete, ModelScope single-file delete, HuggingFace whole-repo delete. Each creates a real lock file on disk at the path the downloader actually uses and asserts `_get_incomplete_model_files` includes it.
- On `main` (`1b2e048c`), all three fail: the lock path is absent from the returned set.
- On this branch, all three pass.
- Full existing suite: `pytest tests/` → 1588 passed, 12 skipped, 0 failed (no regressions).
- `pre-commit run --files gpustack/worker/model_file_manager.py tests/worker/test_model_file_manager.py` (flake8 7.0.0, black 24.4.2, matching `.pre-commit-config.yaml`) → clean.

Not verified: behavior against a live ModelScope/HuggingFace download (the test constructs the lock file directly rather than running a real download), and the multi-file glob pattern case for ModelScope (`model_scope_file_path` matching more than one file) beyond the single-file case tested.

Fixes #4018
