### PR TITLE
fix(worker): surface cluster-proxy stream failures instead of a truncated 200

### DIFF
--- a/gpustack/routes/worker/cluster_proxy.py
+++ b/gpustack/routes/worker/cluster_proxy.py
@@ -178,13 +178,7 @@ async def cluster_proxy(path: str, request: Request):
                 yield chunk
         except asyncio.CancelledError:
             raise
-        except Exception as e:
-            logger.warning(
-                "cluster-proxy stream interrupted for %s %s: %s",
-                request.method,
-                target_url,
-                e,
-            )
+        except Exception:
             # The status code and headers were already committed to the
             # caller from the upstream's initial response, so a mid-body
             # failure can no longer be turned into a non-200. Re-raise

--- a/gpustack/routes/worker/cluster_proxy.py
+++ b/gpustack/routes/worker/cluster_proxy.py
@@ -185,6 +185,14 @@ async def cluster_proxy(path: str, request: Request):
                 target_url,
                 e,
             )
+            # The status code and headers were already committed to the
+            # caller from the upstream's initial response, so a mid-body
+            # failure can no longer be turned into a non-200. Re-raise
+            # instead of returning normally: letting the generator complete
+            # cleanly here made StreamingResponse close out the body as if
+            # it had ended successfully, so the caller received a truncated
+            # payload under a 200 with no indication anything went wrong.
+            raise
         finally:
             resp.release()
 

--- a/tests/worker/test_cluster_proxy.py
+++ b/tests/worker/test_cluster_proxy.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 
 import pytest
 from aiohttp import web
+from aiohttp.client_exceptions import ClientPayloadError
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
@@ -156,10 +157,30 @@ async def test_cluster_proxy_surfaces_error_when_upstream_stream_fails_mid_read(
     signal "this body is incomplete" is to fail the ASGI response instead of
     letting the generator return normally. Before the fix, this raises nothing
     and the client observes a truncated body under a 200 with no indication
-    anything went wrong."""
+    anything went wrong.
+
+    A bare `pytest.raises(Exception)` is wide enough to pass on an unrelated
+    failure (e.g. the fake apiserver never starting), so this also pins the
+    concrete exception type and spies on the chunks streamer() actually
+    yielded, to prove the failure happens after the first chunk, i.e. mid-body
+    as the test claims, not before any byte streamed."""
     first_chunk = json.dumps({"items": ["ok"]}).encode() + b"\n"
+    yielded_chunks = []
+    real_streaming_response = cluster_proxy.StreamingResponse
+
+    def spying_streaming_response(content, *args, **kwargs):
+        async def spy():
+            async for chunk in content:
+                yielded_chunks.append(chunk)
+                yield chunk
+
+        return real_streaming_response(spy(), *args, **kwargs)
+
+    monkeypatch.setattr(cluster_proxy, "StreamingResponse", spying_streaming_response)
 
     async with _fake_apiserver_stream_then_fail(first_chunk) as base_url:
         async with _worker_client(monkeypatch, base_url) as client:
-            with pytest.raises(Exception):
+            with pytest.raises(ClientPayloadError):
                 await client.get("/cluster-proxy/api/v1/namespaces/kube-system/pods")
+
+    assert yielded_chunks == [first_chunk]

--- a/tests/worker/test_cluster_proxy.py
+++ b/tests/worker/test_cluster_proxy.py
@@ -110,3 +110,56 @@ async def test_cluster_proxy_uncompressed_passthrough(monkeypatch):
     assert resp.status_code == 200
     assert "content-encoding" not in {k.lower() for k in resp.headers}
     assert json.loads(resp.content) == json.loads(payload)
+
+
+@asynccontextmanager
+async def _fake_apiserver_stream_then_fail(first_chunk: bytes):
+    """A stand-in kube-apiserver that writes one chunk of a streamed response
+    (mimicking a `?watch=true` long-lived call) and then aborts the connection
+    mid-body, e.g. a network blip or the apiserver process dying. Never sends a
+    second chunk and never completes normally."""
+
+    async def handler(request):
+        resp = web.StreamResponse(
+            headers={"Content-Type": "application/json"},
+        )
+        await resp.prepare(request)
+        await resp.write(first_chunk)
+        # Simulate the transport failing mid-stream: abort the connection
+        # instead of returning normally, so nothing terminates the body
+        # cleanly. aiohttp's client (used by the proxy) sees this as a
+        # mid-read failure on resp.content.iter_any(), not a clean EOF.
+        request.transport.abort()
+        return resp
+
+    app = web.Application()
+    app.router.add_route("*", "/{path:.*}", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = runner.addresses[0][1]
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_cluster_proxy_surfaces_error_when_upstream_stream_fails_mid_read(
+    monkeypatch,
+):
+    """Regression for #5939: streamer() must not swallow a mid-body transport
+    failure into a clean-looking end of stream. The status code and headers
+    are already committed to the caller by the time the body starts (they were
+    set from the upstream's initial 200 response), so the only way left to
+    signal "this body is incomplete" is to fail the ASGI response instead of
+    letting the generator return normally. Before the fix, this raises nothing
+    and the client observes a truncated body under a 200 with no indication
+    anything went wrong."""
+    first_chunk = json.dumps({"items": ["ok"]}).encode() + b"\n"
+
+    async with _fake_apiserver_stream_then_fail(first_chunk) as base_url:
+        async with _worker_client(monkeypatch, base_url) as client:
+            with pytest.raises(Exception):
+                await client.get("/cluster-proxy/api/v1/namespaces/kube-system/pods")


### PR DESCRIPTION
## Root cause

`cluster_proxy()` (`gpustack/routes/worker/cluster_proxy.py`) forwards the upstream kube-apiserver response as a `StreamingResponse` whose `status_code` is fixed to `resp.status` before any body bytes are read. The body itself is streamed lazily from `streamer()`, which wraps `resp.content.iter_any()` in a `try/except Exception` that logs a warning and lets the generator return normally on any non-cancellation failure.

If the upstream connection fails partway through the body (network blip, apiserver restart, etc.), the caller has already been committed to a 200 with the upstream's headers. `streamer()` swallowing the exception then makes the ASGI response finish exactly as if the body had ended normally: the caller receives a truncated body under a 200, with nothing distinguishing it from a real, complete response.

## Fix

Re-raise after logging in the `except Exception` branch. Letting the exception propagate out of the generator fails the ASGI response instead of completing it cleanly, so the caller sees a connection failure/incomplete response rather than a truncated success. `resp.release()` still runs via the existing `finally`.

## Verification

Docker, `python:3.12-slim`, editable install of this repo at the branch tip.

- Added `test_cluster_proxy_surfaces_error_when_upstream_stream_fails_mid_read` to `tests/worker/test_cluster_proxy.py`: a fake apiserver writes one chunk of a streamed response then aborts the connection (`transport.abort()`), and asserts the client-visible call raises rather than returning a clean response.
- On `main` (`6bc353b2`): fails with `Failed: DID NOT RAISE Exception` (the client gets a normal 200 response with a truncated body; the log shows the swallowed `TransferEncodingError`).
- On this branch: passes.
- Full worker suite: `pytest tests/worker/` → 273 passed, 0 failed.
- `pre-commit run --files gpustack/routes/worker/cluster_proxy.py tests/worker/test_cluster_proxy.py` (flake8 7.0.0, black 24.4.2, matching `.pre-commit-config.yaml`) → clean.

Not verified: behavior against a real Kubernetes apiserver (the test drives the proxy's own aiohttp client against a local aiohttp server standing in for it, per the existing tests in this file) and the exact exception surfaced to a real downstream server-side caller of this proxy (only that the ASGI response fails rather than completing normally).

Fixes #5939
