### PR TITLE
fix(dashboards): only list clusters with workers in the cluster selector

### DIFF
--- a/docker-compose/grafana/grafana_dashboards/gpustack-model.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-model.json
@@ -3813,13 +3813,13 @@
           "text": "",
           "value": ""
         },
-        "definition": "query_result(gpustack:cluster_info)",
+        "definition": "query_result(gpustack:cluster_info and on(cluster_id) gpustack:worker_info)",
         "label": "Cluster",
         "name": "cluster_name",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "query_result(gpustack:cluster_info)",
+          "query": "query_result(gpustack:cluster_info and on(cluster_id) gpustack:worker_info)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
@@ -1855,14 +1855,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "query_result(gpustack:cluster_info)",
+        "definition": "query_result(gpustack:cluster_info and on(cluster_id) gpustack:worker_info)",
         "includeAll": false,
         "label": "Cluster",
         "name": "cluster_name",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "query_result(gpustack:cluster_info)",
+          "query": "query_result(gpustack:cluster_info and on(cluster_id) gpustack:worker_info)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
Filter the cluster selector to only show clusters that have at least one worker, so empty clusters with no data no longer appear. Applied to the model and worker dashboards.

Join cluster_info against worker_info on cluster_id so empty clusters (no workers, no data) are hidden from the dropdown.