### PR TITLE
fix: fork ai-proxy plugin to translation from anthropic to openai

### DIFF
--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -422,7 +422,7 @@ def model_pre_route_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         phase="AUTHN",
         priority=90,
         url=get_plugin_url_with_name_and_version(
-            name="gpustack-set-header-pre-route", version="1.0.0", cfg=cfg
+            name="gpustack-set-header-pre-route", version="1.0.1", cfg=cfg
         ),
     )
     return resource_name, expected_spec
@@ -433,7 +433,7 @@ def model_mapper_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         phase="AUTHN",
         priority=800,
         url=get_plugin_url_with_name_and_version(
-            name="gpustack-model-mapper", version="1.0.0", cfg=cfg
+            name="gpustack-model-mapper", version="1.0.1", cfg=cfg
         ),
         defaultConfigDisable=False,
         defaultConfig={"modelMapping": {}},
@@ -609,7 +609,7 @@ def generic_proxy_router_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         phase="AUTHN",
         priority=900,
         url=get_plugin_url_with_name_and_version(
-            name="gpustack-generic-proxy-router", version="1.0.0", cfg=cfg
+            name="gpustack-generic-proxy-router", version="1.0.1", cfg=cfg
         ),
     )
     return resource_name, expected_spec
@@ -636,7 +636,7 @@ def token_usage_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         phase="UNSPECIFIED_PHASE",
         priority=400,
         url=get_plugin_url_with_name_and_version(
-            name="gpustack-token-usage", version="1.1.0", cfg=cfg
+            name="gpustack-token-usage", version="1.1.1", cfg=cfg
         ),
     )
     return resource_name, expected_spec
@@ -653,7 +653,7 @@ def ai_proxy_plugin(cfg: Config) -> Tuple[str, WasmPluginSpec]:
         priority=100,
         phase="UNSPECIFIED_PHASE",
         url=get_plugin_url_with_name_and_version(
-            name="ai-proxy", version="2.0.0", cfg=cfg
+            name="gpustack-ai-proxy", version="2.0.0-patched", cfg=cfg
         ),
     )
     return resource_name, expected_spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "cachetools>=6.0.0",
     "gpustack-runner==0.1.27.post4",
     "gpustack-runtime==0.2.1",
-    "gpustack-higress-plugins==0.2.3.post5",
+    "gpustack-higress-plugins==0.3.0",
     "websockets==16.0",
     "py-radix>=1.1.0",
 ]

--- a/tests/gateway/test_gateway_plugins.py
+++ b/tests/gateway/test_gateway_plugins.py
@@ -69,11 +69,13 @@ class TestHigressPluginGetPath:
 
 class TestGetPluginUrlWithNameAndVersion:
     def test_known_plugin(self):
+        # Resolve from the manifest so version bumps don't break this test.
+        known = supported_plugins[0]
         cfg = make_cfg("http://127.0.0.1:8080")
-        url = get_plugin_url_with_name_and_version("ai-proxy", "2.0.0", cfg)
+        url = get_plugin_url_with_name_and_version(known.name, known.version, cfg)
         assert (
             url
-            == f"http://127.0.0.1:8080/{http_path_prefix}/ai-proxy/2.0.0/plugin.wasm"
+            == f"http://127.0.0.1:8080/{http_path_prefix}/{known.name}/{known.version}/plugin.wasm"
         )
 
     def test_unknown_plugin_raises(self):
@@ -82,7 +84,7 @@ class TestGetPluginUrlWithNameAndVersion:
 
     def test_wrong_version_raises(self):
         with pytest.raises(ValueError, match="not supported"):
-            get_plugin_url_with_name_and_version("ai-proxy", "9.9.9")
+            get_plugin_url_with_name_and_version(supported_plugins[0].name, "9.9.9")
 
 
 class TestSupportedPlugins:
@@ -97,7 +99,7 @@ class TestSupportedPlugins:
     def test_known_plugins_present(self):
         names = {p.name for p in supported_plugins}
         for expected in [
-            "ai-proxy",
+            "gpustack-ai-proxy",
             "ai-statistics",
             "ext-auth",
             "gpustack-generic-proxy-router",

--- a/uv.lock
+++ b/uv.lock
@@ -1223,7 +1223,7 @@ requires-dist = [
     { name = "dataclasses-json", specifier = ">=0.6.7" },
     { name = "fastapi", specifier = ">=0.115.0,<0.137.0" },
     { name = "fastapi-cdn-host", specifier = ">=0.8.0" },
-    { name = "gpustack-higress-plugins", specifier = "==0.2.3.post5" },
+    { name = "gpustack-higress-plugins", specifier = "==0.3.0" },
     { name = "gpustack-runner", specifier = "==0.1.27.post4" },
     { name = "gpustack-runtime", specifier = "==0.2.1" },
     { name = "hf-xet", specifier = ">=1.3.1,<2.0.0" },
@@ -1292,7 +1292,7 @@ dev = [
 
 [[package]]
 name = "gpustack-higress-plugins"
-version = "0.2.3.post5"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
@@ -1300,7 +1300,7 @@ dependencies = [
     { name = "uvicorn" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/4b/b5ae92fd1623fa689740dd345a10671052ba9e3414ed3f1acdd885f7bd31/gpustack_higress_plugins-0.2.3.post5-py3-none-any.whl", hash = "sha256:d455efaa16b57bd386ab4dc54a5dd64836339699dac57cbeb0e47f1f37449fa7", size = 16250928, upload-time = "2026-06-15T15:26:56.664Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a0/b44529543053167e97361bc23ed4ca3c30d41f384460c69acb1e420ed8c8/gpustack_higress_plugins-0.3.0-py3-none-any.whl", hash = "sha256:6f3192ed2ce091d0e7cea71578a0bfaab90fc993fbf111e95def6f202e392e76", size = 16431394, upload-time = "2026-07-27T16:55:15.584Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refer to issue:
- #5934 

Followings are the message of fix commit from gpustack-higress-plugins:

Vendored fork of higress ai-proxy at commit c8b82797c51a. Upstream stays the source of truth: every .go file keeps a header naming its upstream URL, so re-syncing is a plain diff against the fork commit.

The only functional change is mergeSystemMessages in provider/claude_to_openai.go. Claude clients (notably Claude Code) put a system-role message inside the messages array on top of Claude's top-level system field; upstream's converter keeps both, and a system message not at index 0 makes vLLM reject the request with "System message must be at the beginning." (gpustack/gpustack#5934). All system messages are now collapsed into a single leading one.

Also:
- pluginName is "gpustack-ai-proxy" so access logs distinguish this fork from a genuine upstream ai-proxy filter.
- VERSION 2.0.0-patched (upstream ships this code as OCI ai-proxy:2.0.0).
- Dropped upstream ai-proxy from remote_plugins.yaml — drop-in replacement, and shipping both would put two ~10 MiB wasm blobs in the wheel.
- Deleted option.yaml, Makefile, envoy.yaml and .gitignore: all hgctl-only, while this repo builds via extensions/Makefile.