### PR TITLE
feat(observability): grafana graphs with watt consumption

### DIFF
--- a/docker-compose/grafana/grafana_dashboards/gpustack-model.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-model.json
@@ -104,7 +104,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(gpustack:model_desired_instances{cluster_name=\"$cluster_name\", model_name=\"$model_name\"})",
@@ -180,7 +180,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(gpustack:model_running_instances{cluster_name=\"$cluster_name\",model_name=\"$model_name\"})",
@@ -271,7 +271,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(gpustack:model_desired_instances{cluster_name=\"$cluster_name\",model_name=\"$model_name\"}) - sum(gpustack:model_running_instances{cluster_name=\"$cluster_name\",model_name=\"$model_name\"})",
@@ -347,7 +347,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(gpustack:num_requests_running{cluster_name=\"$cluster_name\",model_name=\"$model_name\"})",
@@ -438,7 +438,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(gpustack:num_requests_waiting{cluster_name=\"$cluster_name\",model_name=\"$model_name\"})",
@@ -975,7 +975,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1084,7 +1084,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1100,7 +1100,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1117,7 +1117,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1134,7 +1134,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1151,7 +1151,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(gpustack:e2e_request_latency_seconds_sum{cluster_name=\"$cluster_name\",model_name=\"$model_name\", model_instance_name=~\"$model_instance_name\"}[$__rate_interval])\n/\nrate(gpustack:e2e_request_latency_seconds_count{cluster_name=\"$cluster_name\",model_name=\"$model_name\", model_instance_name=~\"$model_instance_name\"}[$__rate_interval])",
@@ -1241,7 +1241,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1363,7 +1363,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1379,7 +1379,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1396,7 +1396,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1504,7 +1504,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -1520,7 +1520,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -1629,7 +1629,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1646,7 +1646,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1662,7 +1662,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1679,7 +1679,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1696,7 +1696,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(gpustack:time_to_first_token_seconds_sum{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])\n/\nrate(gpustack:time_to_first_token_seconds_count{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])",
@@ -1801,7 +1801,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1817,7 +1817,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1834,7 +1834,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1851,7 +1851,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1868,7 +1868,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(gpustack:inter_token_latency_seconds_sum{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])\n/\nrate(gpustack:inter_token_latency_seconds_count{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])",
@@ -1973,7 +1973,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "gpustack:kv_cache_usage_ratio{cluster_name=\"$cluster_name\",model_name=~\"$model_name\",model_instance_name=~\"$model_instance_name\"}",
@@ -2076,7 +2076,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2180,7 +2180,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2272,7 +2272,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2381,7 +2381,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2397,7 +2397,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2414,7 +2414,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2431,7 +2431,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2448,7 +2448,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(gpustack:time_per_output_token_seconds_sum{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])\n/\nrate(gpustack:time_per_output_token_seconds_count{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])",
@@ -2552,7 +2552,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2660,7 +2660,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2676,7 +2676,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2692,7 +2692,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2709,7 +2709,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2818,7 +2818,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2835,7 +2835,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2851,7 +2851,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2868,7 +2868,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2885,7 +2885,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(gpustack:request_queue_time_seconds_sum{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])\n/\nrate(gpustack:request_queue_time_seconds_count{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])",
@@ -2990,7 +2990,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3007,7 +3007,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3023,7 +3023,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3040,7 +3040,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3057,7 +3057,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(gpustack:request_prefill_time_seconds_sum{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])\n/\nrate(gpustack:request_prefill_time_seconds_count{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])",
@@ -3162,7 +3162,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3178,7 +3178,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3195,7 +3195,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3212,7 +3212,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3229,7 +3229,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(gpustack:request_decode_time_seconds_sum{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])\n/\nrate(gpustack:request_decode_time_seconds_count{cluster_name=\"$cluster_name\",model_name=\"$model_name\",model_instance_name=~\"$model_instance_name\"}[$__rate_interval])",
@@ -3333,7 +3333,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -3349,7 +3349,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -3441,7 +3441,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3533,7 +3533,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3641,7 +3641,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -3657,7 +3657,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -3767,7 +3767,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -3783,7 +3783,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -3812,7 +3812,6 @@
         "name": "DS_PROMETHEUS",
         "type": "datasource",
         "label": "Datasource",
-        "datasource": "Prometheus",
         "hide": 0,
         "query": "prometheus",
         "current": {
@@ -3821,9 +3820,7 @@
         },
         "multi": false,
         "includeAll": false,
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false
+        "refresh": 1
       },
       {
         "current": {

--- a/docker-compose/grafana/grafana_dashboards/gpustack-model.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-model.json
@@ -44,7 +44,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -120,7 +120,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -196,7 +196,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -287,7 +287,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -363,7 +363,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -454,7 +454,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -521,7 +521,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -590,7 +590,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -674,7 +674,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -789,7 +789,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total request per minute.",
       "fieldConfig": {
@@ -888,7 +888,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of tokens generation per second for current model",
       "fieldConfig": {
@@ -996,7 +996,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "End to end request latency measured in seconds.",
       "fieldConfig": {
@@ -1275,7 +1275,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of requests in RUNNING, WAITING, and SWAPPED state",
       "fieldConfig": {
@@ -1417,7 +1417,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of tokens processed per second, combining prompt and generation tokens.",
       "fieldConfig": {
@@ -1541,7 +1541,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "P50, P90, P95, and P99 TTFT latency in seconds.",
       "fieldConfig": {
@@ -1713,7 +1713,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Inter token latency in seconds.\n\n**Supported backends:** vLLM, SGLang. MindIE does not expose this metric, so \"No data\" is expected when the runtime is MindIE (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -1885,7 +1885,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Percentage of used cache blocks by LLM Serving Runtime.",
       "fieldConfig": {
@@ -2092,7 +2092,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(gpustack:prefix_cache_hits_total{cluster_name=\"$cluster_name\",model_name=~\"$model_name\",model_instance_name=~\"$model_instance_name\"}[1m]) / rate(gpustack:prefix_cache_queries_total{cluster_name=\"$cluster_name\",model_name=~\"$model_name\",model_instance_name=~\"$model_instance_name\"}[1m])",
@@ -2109,7 +2109,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Heatmap of request prompt length\n\n**Supported backends:** vLLM, MindIE. SGLang does not expose this metric, so \"No data\" is expected when the runtime is SGLang (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -2201,7 +2201,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Heatmap of request generation length\n\n**Supported backends:** vLLM, MindIE. SGLang does not expose this metric, so \"No data\" is expected when the runtime is SGLang (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -2293,7 +2293,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Per output token latency in seconds.\n\n**Supported backends:** vLLM, MindIE. SGLang does not expose this metric, so \"No data\" is expected when the runtime is SGLang (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -2465,7 +2465,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of finished requests by their finish reason: either an EOS token was generated or the max sequence length was reached.\n\n**Supported backends:** vLLM, MindIE. SGLang does not expose this metric, so \"No data\" is expected when the runtime is SGLang (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -2573,7 +2573,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of prompt tokens and cached prompt tokens served per second.",
       "fieldConfig": {
@@ -2730,7 +2730,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Time spent waiting in the request queue.\n\n**Supported backends:** vLLM, SGLang. MindIE does not expose this metric, so \"No data\" is expected when the runtime is MindIE (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -2902,7 +2902,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Time spent in the prefill phase.\n\n**Supported backends:** vLLM only. Other runtimes do not expose this metric, so \"No data\" is expected for them (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -3074,7 +3074,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Time spent in the decode phase.\n\n**Supported backends:** vLLM only. Other runtimes do not expose this metric, so \"No data\" is expected for them (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -3370,7 +3370,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Heatmap of requested number of parallel completions per request.\n\n**Supported backends:** vLLM only. Other runtimes do not expose this metric, so \"No data\" is expected for them (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -3462,7 +3462,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Heatmap of requested max_tokens per request.\n\n**Supported backends:** vLLM only. Other runtimes do not expose this metric, so \"No data\" is expected for them (see Runtime in the Summary row).",
       "fieldConfig": {
@@ -3554,7 +3554,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of generation tokens processed per second.",
       "fieldConfig": {
@@ -3678,7 +3678,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Cumulative number of preemptions from the engine, shown as events per second.",
       "fieldConfig": {
@@ -3808,6 +3808,23 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "label": "Datasource",
+        "datasource": "Prometheus",
+        "hide": 0,
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "multi": false,
+        "includeAll": false,
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
       {
         "current": {
           "text": "",

--- a/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
@@ -78,7 +78,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 9,
+        "w": 8,
         "x": 0,
         "y": 0
       },
@@ -169,9 +169,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 4,
-        "x": 9,
-        "y": 0
+        "w": 6,
+        "x": 0,
+        "y": 4
       },
       "id": 89,
       "options": {
@@ -243,9 +243,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 4,
-        "x": 13,
-        "y": 0
+        "w": 6,
+        "x": 6,
+        "y": 4
       },
       "id": 90,
       "options": {
@@ -318,9 +318,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 4,
-        "x": 17,
-        "y": 0
+        "w": 6,
+        "x": 12,
+        "y": 4
       },
       "id": 82,
       "options": {
@@ -368,7 +368,7 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "max": 90,
+          "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -387,15 +387,15 @@
               }
             ]
           },
-          "unit": "watt"
+          "unit": "percent"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 3,
-        "x": 21,
-        "y": 0
+        "w": 6,
+        "x": 18,
+        "y": 4
       },
       "id": 96,
       "options": {
@@ -421,14 +421,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(gpustack:worker_node_gpu_power_used_watts{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
+          "expr": "100 * avg(gpustack:worker_node_gpu_power_used_watts{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}) / avg(gpustack:worker_node_gpu_power_limit_watts{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}) or avg(gpustack:worker_node_gpu_power_used_watts{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "description": "Average GPU power consumption in watts. Shows the current load on the power supply system.",
+      "description": "Average GPU power utilization as a percentage of the power limit. Falls back to average power in watts if limit data is unavailable.",
       "title": "Average GPU Power",
       "type": "gauge"
     },
@@ -468,9 +468,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 0,
-        "y": 4
+        "w": 5,
+        "x": 8,
+        "y": 0
       },
       "id": 95,
       "options": {
@@ -546,9 +546,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 3,
-        "y": 4
+        "w": 5,
+        "x": 13,
+        "y": 0
       },
       "id": 93,
       "options": {
@@ -622,9 +622,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 6,
-        "y": 4
+        "w": 6,
+        "x": 18,
+        "y": 0
       },
       "id": 94,
       "options": {
@@ -668,7 +668,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Detailed table of all GPUs: core utilization, VRAM usage, temperature, and power consumption for each accelerator.",
+      "description": "Detailed table of all GPUs: core utilization, VRAM usage, temperature, power consumption, and power limit for each accelerator.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -931,6 +931,26 @@
                 "value": 117
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Power Limit"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "watt"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.width",
+                "value": 117
+              }
+            ]
           }
         ]
       },
@@ -938,7 +958,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 12
       },
       "id": 66,
       "options": {
@@ -1007,6 +1027,21 @@
           "legendFormat": "__auto",
           "range": false,
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "gpustack:worker_node_gpu_power_limit_watts{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"} ",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "E"
         }
       ],
       "title": "GPUs",
@@ -1027,100 +1062,124 @@
               "__name__ 2": true,
               "__name__ 3": true,
               "__name__ 4": true,
+              "__name__ 5": true,
               "cluster_id 1": true,
               "cluster_id 2": true,
               "cluster_id 3": true,
               "cluster_id 4": true,
+              "cluster_id 5": true,
               "cluster_name 2": true,
               "cluster_name 3": true,
               "cluster_name 4": true,
+              "cluster_name 5": true,
               "exported_instance 1": true,
               "exported_instance 2": true,
               "exported_instance 3": true,
               "exported_instance 4": true,
+              "exported_instance 5": true,
               "gpu_chip_index 1": false,
               "gpu_chip_index 2": true,
               "gpu_chip_index 3": true,
               "gpu_chip_index 4": true,
+              "gpu_chip_index 5": true,
               "gpu_index 2": true,
               "gpu_index 3": true,
               "gpu_index 4": true,
+              "gpu_index 5": true,
               "gpu_name 2": true,
               "gpu_name 3": true,
               "gpu_name 4": true,
+              "gpu_name 5": true,
               "instance 1": true,
               "instance 2": true,
               "instance 3": true,
               "instance 4": true,
+              "instance 5": true,
               "job 1": true,
               "job 2": true,
               "job 3": true,
               "job 4": true,
+              "job 5": true,
               "worker_id 1": true,
               "worker_id 2": true,
               "worker_id 3": true,
               "worker_id 4": true,
+              "worker_id 5": true,
               "worker_name 2": true,
               "worker_name 3": true,
-              "worker_name 4": true
+              "worker_name 4": true,
+              "worker_name 5": true
             },
             "includeByName": {},
             "indexByName": {
-              "Time": 15,
+              "Time": 16,
               "Value #A": 13,
-              "Value #B": 29,
+              "Value #B": 30,
               "Value #C": 12,
               "Value #D": 14,
+              "Value #E": 15,
               "__name__ 1": 0,
-              "__name__ 2": 16,
-              "__name__ 3": 30,
-              "__name__ 4": 31,
+              "__name__ 2": 17,
+              "__name__ 3": 31,
+              "__name__ 4": 32,
+              "__name__ 5": 33,
               "cluster_id 1": 1,
-              "cluster_id 2": 17,
-              "cluster_id 3": 32,
-              "cluster_id 4": 33,
+              "cluster_id 2": 18,
+              "cluster_id 3": 34,
+              "cluster_id 4": 35,
+              "cluster_id 5": 36,
               "cluster_name 1": 2,
-              "cluster_name 2": 18,
-              "cluster_name 3": 34,
-              "cluster_name 4": 35,
+              "cluster_name 2": 19,
+              "cluster_name 3": 37,
+              "cluster_name 4": 38,
+              "cluster_name 5": 39,
               "exported_instance 1": 4,
-              "exported_instance 2": 19,
-              "exported_instance 3": 36,
-              "exported_instance 4": 37,
+              "exported_instance 2": 20,
+              "exported_instance 3": 40,
+              "exported_instance 4": 41,
+              "exported_instance 5": 42,
               "gpu_chip_index 1": 5,
-              "gpu_chip_index 2": 20,
-              "gpu_chip_index 3": 38,
-              "gpu_chip_index 4": 39,
+              "gpu_chip_index 2": 21,
+              "gpu_chip_index 3": 43,
+              "gpu_chip_index 4": 44,
+              "gpu_chip_index 5": 45,
               "gpu_index 1": 6,
-              "gpu_index 2": 21,
-              "gpu_index 3": 40,
-              "gpu_index 4": 41,
+              "gpu_index 2": 22,
+              "gpu_index 3": 46,
+              "gpu_index 4": 47,
+              "gpu_index 5": 48,
               "gpu_name 1": 7,
-              "gpu_name 2": 22,
-              "gpu_name 3": 42,
-              "gpu_name 4": 43,
+              "gpu_name 2": 23,
+              "gpu_name 3": 49,
+              "gpu_name 4": 50,
+              "gpu_name 5": 51,
               "instance 1": 8,
-              "instance 2": 23,
-              "instance 3": 44,
-              "instance 4": 45,
+              "instance 2": 24,
+              "instance 3": 52,
+              "instance 4": 53,
+              "instance 5": 54,
               "job 1": 9,
-              "job 2": 24,
-              "job 3": 46,
-              "job 4": 47,
+              "job 2": 25,
+              "job 3": 55,
+              "job 4": 56,
+              "job 5": 57,
               "worker_id 1": 10,
-              "worker_id 2": 25,
-              "worker_id 3": 48,
-              "worker_id 4": 49,
+              "worker_id 2": 26,
+              "worker_id 3": 58,
+              "worker_id 4": 59,
+              "worker_id 5": 60,
               "worker_name 1": 3,
-              "worker_name 2": 26,
-              "worker_name 3": 50,
-              "worker_name 4": 51
+              "worker_name 2": 27,
+              "worker_name 3": 61,
+              "worker_name 4": 62,
+              "worker_name 5": 63
             },
             "renameByName": {
               "Value #A": "GPU Utilization",
               "Value #B": "GPU VRAM Utilization",
               "Value #C": "Temperature",
               "Value #D": "Power",
+              "Value #E": "Power Limit",
               "cluster_name 1": "Cluster",
               "exported_instance 1": "",
               "gpu_chip_index 1": "Chip Index",
@@ -1200,7 +1259,7 @@
         "h": 13,
         "w": 6,
         "x": 0,
-        "y": 15
+        "y": 19
       },
       "id": 92,
       "options": {
@@ -1311,7 +1370,7 @@
         "h": 13,
         "w": 9,
         "x": 6,
-        "y": 15
+        "y": 19
       },
       "id": 48,
       "options": {
@@ -1422,7 +1481,7 @@
         "h": 13,
         "w": 9,
         "x": 15,
-        "y": 15
+        "y": 19
       },
       "id": 86,
       "options": {
@@ -1527,7 +1586,7 @@
         "h": 13,
         "w": 6,
         "x": 0,
-        "y": 28
+        "y": 32
       },
       "id": 91,
       "options": {
@@ -1636,7 +1695,7 @@
         "h": 13,
         "w": 9,
         "x": 6,
-        "y": 28
+        "y": 32
       },
       "id": 88,
       "options": {
@@ -1768,7 +1827,7 @@
         "h": 13,
         "w": 9,
         "x": 15,
-        "y": 28
+        "y": 32
       },
       "id": 87,
       "options": {
@@ -1874,9 +1933,9 @@
       },
       "gridPos": {
         "h": 14,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 54
+        "y": 45
       },
       "id": 97,
       "options": {
@@ -1952,7 +2011,7 @@
         "h": 14,
         "w": 12,
         "x": 0,
-        "y": 67
+        "y": 59
       },
       "id": 78,
       "options": {
@@ -2044,7 +2103,7 @@
         "h": 14,
         "w": 12,
         "x": 12,
-        "y": 67
+        "y": 59
       },
       "id": 79,
       "options": {
@@ -2104,7 +2163,6 @@
         "name": "DS_PROMETHEUS",
         "type": "datasource",
         "label": "Datasource",
-        "datasource": "Prometheus",
         "hide": 0,
         "query": "prometheus",
         "current": {
@@ -2113,9 +2171,7 @@
         },
         "multi": false,
         "includeAll": false,
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false
+        "refresh": 1
       },
       {
         "current": {

--- a/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -105,7 +105,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${idc}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "count(gpustack:worker_node_os_info{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
@@ -118,7 +118,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${idc}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "count(gpustack:worker_node_gpu_cores{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
@@ -128,14 +128,16 @@
           "refId": "A"
         }
       ],
+      "description": "Total number of workers and GPU accelerators in the cluster.",
       "title": "Summary",
       "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Average GPU core utilization across all accelerators in percent. Indicates how actively GPU compute resources are being used.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -167,7 +169,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 5,
+        "w": 4,
         "x": 9,
         "y": 0
       },
@@ -192,7 +194,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "avg(gpustack:worker_node_gpu_utilization_rate{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
@@ -208,7 +210,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -241,8 +243,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 5,
-        "x": 14,
+        "w": 4,
+        "x": 13,
         "y": 0
       },
       "id": 90,
@@ -266,7 +268,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "avg(gpustack:worker_node_gram_utilization_rate{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
@@ -276,13 +278,14 @@
           "refId": "A"
         }
       ],
+      "description": "Average VRAM utilization in percent, calculated as the ratio of used memory to total capacity.",
       "title": "Average VRAM Utilization",
       "type": "gauge"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -315,8 +318,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 5,
-        "x": 19,
+        "w": 4,
+        "x": 17,
         "y": 0
       },
       "id": 82,
@@ -340,7 +343,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "avg(gpustack:worker_node_gpu_temperature_celsius{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
@@ -350,13 +353,89 @@
           "refId": "A"
         }
       ],
+      "description": "Average GPU temperature in degrees Celsius. Helps monitor overheating and cooling efficiency.",
       "title": "Average GPU Temperature",
       "type": "gauge"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 90,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "#EAB839",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 21,
+        "y": 0
+      },
+      "id": 96,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg(gpustack:worker_node_gpu_power_used_watts{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "description": "Average GPU power consumption in watts. Shows the current load on the power supply system.",
+      "title": "Average GPU Power",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -416,7 +495,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(gpustack:worker_node_gram_total_bytes{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
@@ -426,14 +505,16 @@
           "refId": "A"
         }
       ],
+      "description": "Total VRAM capacity across all GPUs in the cluster.",
       "title": "VRAM Size",
       "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Total system RAM capacity across all workers.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -492,7 +573,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(gpustack:worker_node_memory_total_bytes{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
@@ -508,7 +589,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -568,7 +649,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(gpustack:worker_node_cpu_cores{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"})",
@@ -578,15 +659,16 @@
           "refId": "A"
         }
       ],
+      "description": "Total number of CPU cores across all workers.",
       "title": "CPU Cores",
       "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
-      "description": "",
+      "description": "Detailed table of all GPUs: core utilization, VRAM usage, temperature, and power consumption for each accelerator.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -829,6 +911,26 @@
                 "value": 117
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Power"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "watt"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.width",
+                "value": 117
+              }
+            ]
           }
         ]
       },
@@ -850,7 +952,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${idc}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -864,7 +966,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${idc}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -879,7 +981,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -890,6 +992,21 @@
           "legendFormat": "__auto",
           "range": false,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "gpustack:worker_node_gpu_power_used_watts{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"} ",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "D"
         }
       ],
       "title": "GPUs",
@@ -909,77 +1026,101 @@
               "__name__ 1": true,
               "__name__ 2": true,
               "__name__ 3": true,
+              "__name__ 4": true,
               "cluster_id 1": true,
               "cluster_id 2": true,
               "cluster_id 3": true,
+              "cluster_id 4": true,
               "cluster_name 2": true,
               "cluster_name 3": true,
+              "cluster_name 4": true,
               "exported_instance 1": true,
               "exported_instance 2": true,
               "exported_instance 3": true,
+              "exported_instance 4": true,
               "gpu_chip_index 1": false,
               "gpu_chip_index 2": true,
               "gpu_chip_index 3": true,
+              "gpu_chip_index 4": true,
               "gpu_index 2": true,
               "gpu_index 3": true,
+              "gpu_index 4": true,
               "gpu_name 2": true,
               "gpu_name 3": true,
+              "gpu_name 4": true,
               "instance 1": true,
               "instance 2": true,
               "instance 3": true,
+              "instance 4": true,
               "job 1": true,
               "job 2": true,
               "job 3": true,
+              "job 4": true,
               "worker_id 1": true,
               "worker_id 2": true,
               "worker_id 3": true,
+              "worker_id 4": true,
               "worker_name 2": true,
-              "worker_name 3": true
+              "worker_name 3": true,
+              "worker_name 4": true
             },
             "includeByName": {},
             "indexByName": {
               "Time": 15,
-              "Value #A": 12,
-              "Value #B": 27,
-              "Value #C": 11,
+              "Value #A": 13,
+              "Value #B": 29,
+              "Value #C": 12,
+              "Value #D": 14,
               "__name__ 1": 0,
               "__name__ 2": 16,
-              "__name__ 3": 28,
+              "__name__ 3": 30,
+              "__name__ 4": 31,
               "cluster_id 1": 1,
               "cluster_id 2": 17,
-              "cluster_id 3": 29,
+              "cluster_id 3": 32,
+              "cluster_id 4": 33,
               "cluster_name 1": 2,
               "cluster_name 2": 18,
-              "cluster_name 3": 30,
+              "cluster_name 3": 34,
+              "cluster_name 4": 35,
               "exported_instance 1": 4,
               "exported_instance 2": 19,
-              "exported_instance 3": 31,
+              "exported_instance 3": 36,
+              "exported_instance 4": 37,
               "gpu_chip_index 1": 5,
               "gpu_chip_index 2": 20,
-              "gpu_chip_index 3": 32,
+              "gpu_chip_index 3": 38,
+              "gpu_chip_index 4": 39,
               "gpu_index 1": 6,
               "gpu_index 2": 21,
-              "gpu_index 3": 33,
+              "gpu_index 3": 40,
+              "gpu_index 4": 41,
               "gpu_name 1": 7,
               "gpu_name 2": 22,
-              "gpu_name 3": 34,
+              "gpu_name 3": 42,
+              "gpu_name 4": 43,
               "instance 1": 8,
               "instance 2": 23,
-              "instance 3": 35,
+              "instance 3": 44,
+              "instance 4": 45,
               "job 1": 9,
               "job 2": 24,
-              "job 3": 36,
+              "job 3": 46,
+              "job 4": 47,
               "worker_id 1": 10,
               "worker_id 2": 25,
-              "worker_id 3": 37,
+              "worker_id 3": 48,
+              "worker_id 4": 49,
               "worker_name 1": 3,
               "worker_name 2": 26,
-              "worker_name 3": 38
+              "worker_name 3": 50,
+              "worker_name 4": 51
             },
             "renameByName": {
               "Value #A": "GPU Utilization",
               "Value #B": "GPU VRAM Utilization",
               "Value #C": "Temperature",
+              "Value #D": "Power",
               "cluster_name 1": "Cluster",
               "exported_instance 1": "",
               "gpu_chip_index 1": "Chip Index",
@@ -995,7 +1136,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1084,7 +1225,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "gpustack:worker_node_memory_used_bytes{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}",
@@ -1097,15 +1238,16 @@
           "refId": "A"
         }
       ],
+      "description": "System RAM usage on each worker in bytes.",
       "title": "System Memory Usage",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
-      "description": "",
+      "description": "GPU compute core utilization in percent. A value of 100 indicates full utilization.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1193,7 +1335,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${idc}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1211,9 +1353,9 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
-      "description": "",
+      "description": "Percentage of VRAM used relative to available capacity for each GPU.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1304,7 +1446,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${idc}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1322,7 +1464,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1410,7 +1552,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "gpustack:worker_node_cpu_utilization_rate{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}",
@@ -1421,14 +1563,16 @@
           "refId": "A"
         }
       ],
+      "description": "CPU utilization percentage on each worker.",
       "title": "CPU Utilization",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Total, used, and allocated VRAM for each GPU. Allocated memory is reserved by model instances.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1517,7 +1661,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "gpustack:worker_node_gram_total_bytes{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}",
@@ -1531,7 +1675,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "gpustack:worker_node_gram_used_bytes{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}",
@@ -1544,7 +1688,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "gpustack:worker_node_gram_allocated_bytes{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}",
@@ -1561,7 +1705,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1649,7 +1793,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "gpustack:worker_node_gpu_temperature_celsius{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}",
@@ -1661,14 +1805,123 @@
           "refId": "A"
         }
       ],
+      "description": "GPU accelerator temperature in degrees Celsius. High temperatures may lead to throttling.",
       "title": "GPU Temperature",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Current GPU power consumption in watts. Helps assess energy efficiency and power supply load.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "id": 97,
+      "options": {
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "gpustack:worker_node_gpu_power_used_watts{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{worker_name}} GPU{{gpu_index}} (chip {{gpu_chip_index}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Power Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Bar chart of GPU core utilization. Average value per GPU over the period.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1699,7 +1952,7 @@
         "h": 14,
         "w": 12,
         "x": 0,
-        "y": 41
+        "y": 67
       },
       "id": 78,
       "options": {
@@ -1734,7 +1987,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1751,7 +2004,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1791,7 +2044,7 @@
         "h": 14,
         "w": 12,
         "x": 12,
-        "y": 41
+        "y": 67
       },
       "id": 79,
       "options": {
@@ -1826,7 +2079,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${idc}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "avg by (cluster_name,worker_name, gpu_chip_index,gpu_index) (gpustack:worker_node_gram_utilization_rate{cluster_name=\"$cluster_name\",worker_name=~\"$worker_name\"}) ",
@@ -1836,6 +2089,7 @@
           "refId": "A"
         }
       ],
+      "description": "Bar chart of VRAM utilization. Average value per GPU over the period.",
       "title": "VRAM Utilization",
       "type": "bargauge"
     }
@@ -1848,12 +2102,28 @@
     "list": [
       {
         "current": {
+          "text": "${DS_PROMETHEUS}",
+          "value": "${DS_PROMETHEUS}"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "current": {
           "text": "",
           "value": ""
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "query_result(gpustack:cluster_info and on(cluster_id) gpustack:worker_info)",
         "includeAll": false,
@@ -1880,7 +2150,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "query_result(gpustack:worker_info{cluster_name=\"$cluster_name\"})",
         "includeAll": true,

--- a/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
@@ -2101,20 +2101,21 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "${DS_PROMETHEUS}",
-          "value": "${DS_PROMETHEUS}"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Datasource",
-        "multi": false,
         "name": "DS_PROMETHEUS",
-        "options": [],
+        "type": "datasource",
+        "label": "Datasource",
+        "datasource": "Prometheus",
+        "hide": 0,
         "query": "prometheus",
-        "queryValue": "",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "multi": false,
+        "includeAll": false,
         "refresh": 1,
-        "type": "datasource"
+        "regex": "",
+        "skipUrlSync": false
       },
       {
         "current": {

--- a/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-worker.json
@@ -2123,7 +2123,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "$DS_PROMETHEUS"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "query_result(gpustack:cluster_info and on(cluster_id) gpustack:worker_info)",
         "includeAll": false,

--- a/docker-compose/grafana/grafana_dashboards/higress-ai-loadbalance-dashboard.json
+++ b/docker-compose/grafana/grafana_dashboards/higress-ai-loadbalance-dashboard.json
@@ -29,7 +29,7 @@
       "panels": []
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "description": "Per-endpoint request rate. Lines that stay close together indicate balanced load; a persistent gap means one endpoint is taking more traffic.\n\nEndpoint is the upstream registry name: `model-<modelId>-<instanceId>` (a model instance) or `cluster-<clusterId>-worker-<workerId>` (a worker proxy); a trailing `-l<hash>` marks a LoRA adapter alias of the same instance. Look up the numeric IDs in the GPUStack UI to map them back to the model / instance / worker.",
       "fieldConfig": {
         "defaults": {
@@ -66,7 +66,7 @@
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
           "expr": "sum by (endpoint) (\n  label_replace(\n    rate(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__rate_interval]),\n    \"endpoint\", \"$1\", \"ai_cluster\", \"outbound\\\\|[0-9]+\\\\|\\\\|(.+)\\\\.static\"\n  )\n)",
           "legendFormat": "{{endpoint}}",
@@ -78,7 +78,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "description": "Share of total requests handled by each endpoint over the selected time range. The closer the slices are to equal, the more balanced the load.\n\nEndpoint is the upstream registry name: `model-<modelId>-<instanceId>` (a model instance) or `cluster-<clusterId>-worker-<workerId>` (a worker proxy); a trailing `-l<hash>` marks a LoRA adapter alias of the same instance. Look up the numeric IDs in the GPUStack UI to map them back to the model / instance / worker.",
       "fieldConfig": {
         "defaults": {
@@ -100,7 +100,7 @@
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
           "expr": "sum by (endpoint) (\n  label_replace(\n    increase(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__range]),\n    \"endpoint\", \"$1\", \"ai_cluster\", \"outbound\\\\|[0-9]+\\\\|\\\\|(.+)\\\\.static\"\n  )\n) > 0",
           "legendFormat": "{{endpoint}}",
@@ -113,7 +113,7 @@
       "type": "piechart"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "description": "Balance ratio = busiest endpoint rate / quietest endpoint rate. 1.0 = perfectly balanced. Higher values mean more skew. Green < 1.5, yellow < 3, red otherwise.",
       "fieldConfig": {
         "defaults": {
@@ -145,7 +145,7 @@
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
           "expr": "max(sum by (ai_cluster) (rate(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__rate_interval])))\n/\nclamp_min(min(sum by (ai_cluster) (rate(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__rate_interval]))), 0.0001)",
           "legendFormat": "balance ratio",
@@ -157,7 +157,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "description": "Number of upstream endpoints currently receiving traffic for the selected filters.",
       "fieldConfig": {
         "defaults": {
@@ -180,7 +180,7 @@
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
           "expr": "count(sum by (ai_cluster) (rate(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__rate_interval]) > 0))",
           "legendFormat": "active endpoints",
@@ -192,7 +192,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "description": "Current per-endpoint request rate as horizontal bars - a quick visual read of relative load.\n\nEndpoint is the upstream registry name: `model-<modelId>-<instanceId>` (a model instance) or `cluster-<clusterId>-worker-<workerId>` (a worker proxy); a trailing `-l<hash>` marks a LoRA adapter alias of the same instance. Look up the numeric IDs in the GPUStack UI to map them back to the model / instance / worker.",
       "fieldConfig": {
         "defaults": {
@@ -217,7 +217,7 @@
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
           "expr": "sum by (endpoint) (\n  label_replace(\n    rate(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__rate_interval]),\n    \"endpoint\", \"$1\", \"ai_cluster\", \"outbound\\\\|[0-9]+\\\\|\\\\|(.+)\\\\.static\"\n  )\n)",
           "legendFormat": "{{endpoint}}",
@@ -237,7 +237,7 @@
       "panels": []
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "description": "Average LLM duration per endpoint (llm_service_duration / llm_duration_count). Useful to confirm a balanced request count is not hiding uneven latency.\n\nEndpoint is the upstream registry name: `model-<modelId>-<instanceId>` (a model instance) or `cluster-<clusterId>-worker-<workerId>` (a worker proxy); a trailing `-l<hash>` marks a LoRA adapter alias of the same instance. Look up the numeric IDs in the GPUStack UI to map them back to the model / instance / worker.",
       "fieldConfig": {
         "defaults": {
@@ -274,7 +274,7 @@
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
           "expr": "sum by (endpoint) (\n  label_replace(\n    rate(route_upstream_model_consumer_metric_llm_service_duration{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__rate_interval]),\n    \"endpoint\", \"$1\", \"ai_cluster\", \"outbound\\\\|[0-9]+\\\\|\\\\|(.+)\\\\.static\"\n  )\n)\n/\nsum by (endpoint) (\n  label_replace(\n    rate(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__rate_interval]),\n    \"endpoint\", \"$1\", \"ai_cluster\", \"outbound\\\\|[0-9]+\\\\|\\\\|(.+)\\\\.static\"\n  )\n)",
           "legendFormat": "{{endpoint}}",
@@ -286,7 +286,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "description": "Per-endpoint totals over the selected range with each endpoint's share of total traffic.\n\nEndpoint is the upstream registry name: `model-<modelId>-<instanceId>` (a model instance) or `cluster-<clusterId>-worker-<workerId>` (a worker proxy); a trailing `-l<hash>` marks a LoRA adapter alias of the same instance. Look up the numeric IDs in the GPUStack UI to map them back to the model / instance / worker.",
       "fieldConfig": {
         "defaults": {
@@ -325,7 +325,7 @@
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
           "expr": "sum by (endpoint) (\n  label_replace(\n    increase(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__range]),\n    \"endpoint\", \"$1\", \"ai_cluster\", \"outbound\\\\|[0-9]+\\\\|\\\\|(.+)\\\\.static\"\n  )\n)",
           "format": "table",
@@ -334,7 +334,7 @@
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
           "expr": "100 * sum by (endpoint) (\n  label_replace(\n    increase(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__range]),\n    \"endpoint\", \"$1\", \"ai_cluster\", \"outbound\\\\|[0-9]+\\\\|\\\\|(.+)\\\\.static\"\n  )\n)\n/ ignoring(endpoint) group_left sum(\n  increase(route_upstream_model_consumer_metric_llm_duration_count{ai_route=~\"$ai_route\", ai_cluster=~\"$ai_cluster\", ai_model=~\"$ai_model\", ai_consumer=~\"$ai_consumer\"}[$__range])\n)",
           "format": "table",
@@ -371,8 +371,25 @@
   "templating": {
     "list": [
       {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "label": "Datasource",
+        "datasource": "Prometheus",
+        "hide": 0,
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "multi": false,
+        "includeAll": false,
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
+      {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
         "definition": "label_values(route_upstream_model_consumer_metric_llm_duration_count, ai_model)",
         "hide": 0,
         "includeAll": true,
@@ -392,7 +409,7 @@
       },
       {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
         "definition": "label_values(route_upstream_model_consumer_metric_llm_duration_count{ai_model=~\"$ai_model\"}, ai_route)",
         "hide": 0,
         "includeAll": true,
@@ -412,7 +429,7 @@
       },
       {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
         "definition": "label_values(route_upstream_model_consumer_metric_llm_duration_count{ai_model=~\"$ai_model\"}, ai_consumer)",
         "hide": 0,
         "includeAll": true,
@@ -432,7 +449,7 @@
       },
       {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
         "definition": "label_values(route_upstream_model_consumer_metric_llm_duration_count{ai_model=~\"$ai_model\", ai_route=~\"$ai_route\"}, ai_cluster)",
         "hide": 0,
         "includeAll": true,

--- a/docker-compose/grafana/grafana_dashboards/higress-ai-loadbalance-dashboard.json
+++ b/docker-compose/grafana/grafana_dashboards/higress-ai-loadbalance-dashboard.json
@@ -374,7 +374,6 @@
         "name": "DS_PROMETHEUS",
         "type": "datasource",
         "label": "Datasource",
-        "datasource": "Prometheus",
         "hide": 0,
         "query": "prometheus",
         "current": {
@@ -383,9 +382,7 @@
         },
         "multi": false,
         "includeAll": false,
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false
+        "refresh": 1
       },
       {
         "current": {},

--- a/docker-compose/grafana/grafana_dashboards/higress-dashboard.json
+++ b/docker-compose/grafana/grafana_dashboards/higress-dashboard.json
@@ -1828,7 +1828,6 @@
         "name": "DS_PROMETHEUS",
         "type": "datasource",
         "label": "Datasource",
-        "datasource": "Prometheus",
         "hide": 0,
         "query": "prometheus",
         "current": {
@@ -1837,9 +1836,7 @@
         },
         "multi": false,
         "includeAll": false,
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false
+        "refresh": 1
       },
       {
         "current": {},

--- a/docker-compose/grafana/grafana_dashboards/higress-dashboard.json
+++ b/docker-compose/grafana/grafana_dashboards/higress-dashboard.json
@@ -93,7 +93,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -157,7 +157,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "round(sum(irate(envoy_http_downstream_rq_total{higress=\"$gateway\"}[5m])), 0.001)",
           "format": "time_series",
@@ -172,7 +172,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -240,7 +240,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(irate(envoy_http_downstream_rq{higress=\"$gateway\", response_code_class!=\"5xx\"}[5m])) / sum(irate(envoy_http_downstream_rq_total{higress=\"$gateway\"}[5m]))",
           "format": "time_series",
@@ -258,7 +258,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -303,7 +303,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.50, sum(irate(envoy_http_downstream_rq_time_bucket{higress=\"$gateway\"}[1m])) by (le))",
           "format": "time_series",
@@ -315,7 +315,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.90, sum(irate(envoy_http_downstream_rq_time_bucket{higress=\"$gateway\"}[1m])) by (le))",
           "format": "time_series",
@@ -327,7 +327,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.99, sum(irate(envoy_http_downstream_rq_time_bucket{higress=\"$gateway\"}[1m])) by (le))",
           "format": "time_series",
@@ -339,7 +339,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(irate(envoy_http_downstream_rq_time_sum{higress=\"$gateway\"}[1m])) / sum(irate(envoy_http_downstream_rq_time_count{higress=\"$gateway\"}[1m]))",
@@ -385,7 +385,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -449,7 +449,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(irate(envoy_http_downstream_cx_rx_bytes_total{higress=\"$gateway\"}[1m]))",
           "format": "time_series",
@@ -465,7 +465,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -529,7 +529,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "round(sum(irate(envoy_cluster_upstream_rq_total{higress=\"$gateway\"}[5m])), 0.001)",
           "format": "time_series",
@@ -544,7 +544,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -612,7 +612,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(irate(envoy_cluster_upstream_rq{higress=\"$gateway\", response_code_class!=\"5xx\"}[5m])) / sum(irate(envoy_cluster_upstream_rq_total{higress=\"$gateway\"}[5m]))",
           "format": "time_series",
@@ -626,7 +626,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -731,7 +731,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.50, sum(irate(envoy_cluster_upstream_rq_time_bucket{higress=\"$gateway\"}[1m])) by (le))",
           "format": "time_series",
@@ -743,7 +743,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.90, sum(irate(envoy_cluster_upstream_rq_time_bucket{higress=\"$gateway\"}[1m])) by (le))",
           "format": "time_series",
@@ -755,7 +755,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.99, sum(irate(envoy_cluster_upstream_rq_time_bucket{higress=\"$gateway\"}[1m])) by (le))",
           "format": "time_series",
@@ -767,7 +767,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(irate(envoy_cluster_upstream_rq_time_sum{higress=\"$gateway\"}[1m])) / sum(irate(envoy_cluster_upstream_rq_time_count{higress=\"$gateway\"}[1m]))",
@@ -783,7 +783,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -847,7 +847,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(irate(envoy_http_downstream_cx_tx_bytes_total{higress=\"$gateway\"}[1m]))",
           "format": "time_series",
@@ -876,7 +876,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -954,7 +954,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -967,7 +967,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "avg(sum(istio_agent_go_memstats_alloc_bytes{higress=\"$gateway\"}) by (pod_name))",
@@ -987,7 +987,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -1028,7 +1028,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(irate(istio_agent_process_cpu_seconds_total{higress=\"$gateway\"}[1m]))",
           "format": "time_series",
@@ -1091,7 +1091,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Shows details about Envoy proxies in the mesh",
       "fill": 1,
@@ -1133,7 +1133,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(irate(envoy_cluster_upstream_cx_total{cluster_name=\"xds-grpc\"}[1m]))",
           "format": "time_series",
@@ -1145,7 +1145,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(irate(envoy_cluster_upstream_cx_connect_fail{cluster_name=\"xds-grpc\"}[1m]))",
           "format": "time_series",
@@ -1157,7 +1157,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(increase(envoy_server_hot_restart_epoch[1m]))",
           "format": "time_series",
@@ -1205,7 +1205,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -1246,7 +1246,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum(envoy_cluster_upstream_cx_active{cluster_name=\"xds-grpc\"})",
           "format": "time_series",
@@ -1295,7 +1295,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Shows the size of XDS requests and responses",
       "fill": 1,
@@ -1339,7 +1339,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "max(rate(envoy_cluster_upstream_cx_rx_bytes_total{cluster_name=\"xds-grpc\"}[1m]))",
           "format": "time_series",
@@ -1351,7 +1351,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "quantile(0.5, rate(envoy_cluster_upstream_cx_rx_bytes_total{cluster_name=\"xds-grpc\"}[1m]))",
           "format": "time_series",
@@ -1363,7 +1363,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "max(rate(envoy_cluster_upstream_cx_tx_bytes_total{cluster_name=\"xds-grpc\"}[1m]))",
           "format": "time_series",
@@ -1374,7 +1374,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "quantile(.5, rate(envoy_cluster_upstream_cx_tx_bytes_total{cluster_name=\"xds-grpc\"}[1m]))",
           "format": "time_series",
@@ -1431,7 +1431,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1481,7 +1481,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1528,7 +1528,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1578,7 +1578,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1626,7 +1626,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1676,7 +1676,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1723,7 +1723,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1773,7 +1773,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1825,10 +1825,27 @@
   "templating": {
     "list": [
       {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "label": "Datasource",
+        "datasource": "Prometheus",
+        "hide": 0,
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "multi": false,
+        "includeAll": false,
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
+      {
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(envoy_server_live, higress)",
         "hide": 2,

--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -176,6 +176,8 @@ These metrics are mapped from various runtime engines (vLLM, SGLang, MindIE) as 
 | gpustack:worker_node_gpu_cores                   | Gauge | Total GPU cores of the worker node.              |
 | gpustack:worker_node_gpu_utilization_rate        | Gauge | GPU utilization rate of the worker node.         |
 | gpustack:worker_node_gpu_temperature_celsius     | Gauge | GPU temperature in Celsius.                      |
+| gpustack:worker_node_gpu_power_limit_watts       | Gauge | GPU power management limit in watts.             |
+| gpustack:worker_node_gpu_power_used_watts        | Gauge | GPU power usage in watts.                        |
 | gpustack:worker_node_gram_total_bytes            | Gauge | Total GPU RAM in bytes.                          |
 | gpustack:worker_node_gram_allocated_bytes        | Gauge | Allocated GPU RAM in bytes.                      |
 | gpustack:worker_node_gram_used_bytes             | Gauge | Used GPU RAM in bytes.                           |

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -575,6 +575,8 @@ class Config(WorkerConfig, BaseSettings):
               device_index: 0              # optional
               device_chip_index: 0         # optional
               compute_capability: "9.0"    # optional
+              power: 300                   # optional, power limit in Watts
+              power_used: 150              # optional, current power in Watts
               memory:
                   total: 22906503168
                   is_unified_memory: true
@@ -607,6 +609,8 @@ class Config(WorkerConfig, BaseSettings):
             memory = gd.get("memory")
             network = gd.get("network")
             runtime_version = gd.get("runtime_version")
+            power = gd.get("power", None)
+            power_used = gd.get("power_used", None)
             type_ = gd.get("type") or manufacturer_to_backend(vendor)
 
             if not name:
@@ -677,6 +681,8 @@ class Config(WorkerConfig, BaseSettings):
                             mtu=network.get("mtu", None),
                         )
                     ),
+                    power=power,
+                    power_used=power_used,
                     type=type_,
                 )
             )

--- a/gpustack/detectors/runtime/runtime.py
+++ b/gpustack/detectors/runtime/runtime.py
@@ -55,6 +55,8 @@ class Runtime(GPUDetector):
                     utilization_rate=dev.memory_utilization,
                 ),
                 temperature=dev.temperature,
+                power=dev.power,
+                power_used=dev.power_used,
             )
             # Correct device_index if possible.
             if "card_id" in dev.appendix and dev.appendix["card_id"] is not None:

--- a/gpustack/schemas/workers.py
+++ b/gpustack/schemas/workers.py
@@ -151,6 +151,14 @@ class GPUDeviceStatus(GPUDeviceInfo):
     """
     Temperature of the GPU device in Celsius.
     """
+    power: Optional[float] = Field(default=None)
+    """
+    Power management limit of the GPU device in Watts.
+    """
+    power_used: Optional[float] = Field(default=None)
+    """
+    Current power consumption of the GPU device in Watts.
+    """
     network: Optional[GPUNetworkInfo] = Field(sa_column=Column(JSON), default=None)
     """
     Network information of the GPU device, mainly for Ascend devices.

--- a/gpustack/worker/exporter.py
+++ b/gpustack/worker/exporter.py
@@ -131,8 +131,8 @@ class MetricExporter(Collector):
             "GPU temperature in celsius of the worker node",
             labels=gpu_labels,
         )
-        gpu_power = GaugeMetricFamily(
-            metric_name("worker_node_gpu_power_watts"),
+        gpu_power_limit = GaugeMetricFamily(
+            metric_name("worker_node_gpu_power_limit_watts"),
             "GPU power management limit in watts of the worker node",
             labels=gpu_labels,
         )
@@ -294,7 +294,7 @@ class MetricExporter(Collector):
 
                 _add_metric(gpu_temperature, gpu_label_values, d.temperature)
 
-                _add_metric(gpu_power, gpu_label_values, d.power)
+                _add_metric(gpu_power_limit, gpu_label_values, d.power)
                 _add_metric(gpu_power_used, gpu_label_values, d.power_used)
 
                 if d.memory is not None:
@@ -352,7 +352,7 @@ class MetricExporter(Collector):
         yield gpu_cores
         yield gpu_utilization_rate
         yield gpu_temperature
-        yield gpu_power
+        yield gpu_power_limit
         yield gpu_power_used
         yield gram_total
         yield gram_allocated

--- a/gpustack/worker/exporter.py
+++ b/gpustack/worker/exporter.py
@@ -131,6 +131,16 @@ class MetricExporter(Collector):
             "GPU temperature in celsius of the worker node",
             labels=gpu_labels,
         )
+        gpu_power = GaugeMetricFamily(
+            metric_name("worker_node_gpu_power_watts"),
+            "GPU power management limit in watts of the worker node",
+            labels=gpu_labels,
+        )
+        gpu_power_used = GaugeMetricFamily(
+            metric_name("worker_node_gpu_power_used_watts"),
+            "GPU power usage in watts of the worker node",
+            labels=gpu_labels,
+        )
         gram_total = GaugeMetricFamily(
             metric_name("worker_node_gram_total_bytes"),
             "Total GPU RAM in bytes of the worker node",
@@ -284,6 +294,9 @@ class MetricExporter(Collector):
 
                 _add_metric(gpu_temperature, gpu_label_values, d.temperature)
 
+                _add_metric(gpu_power, gpu_label_values, d.power)
+                _add_metric(gpu_power_used, gpu_label_values, d.power_used)
+
                 if d.memory is not None:
                     _add_metric(gram_total, gpu_label_values, d.memory.total)
                     _add_metric(
@@ -339,6 +352,8 @@ class MetricExporter(Collector):
         yield gpu_cores
         yield gpu_utilization_rate
         yield gpu_temperature
+        yield gpu_power
+        yield gpu_power_used
         yield gram_total
         yield gram_allocated
         yield gram_used


### PR DESCRIPTION
Hi folks. Your gpustack-runtime [collects watt consumption](https://github.com/gpustack/runtime/blob/main/gpustack_runtime/detector/__types__.py#L218-L225), but default [grafana dashboard](https://github.com/gpustack/gpustack/blob/main/docker-compose/grafana/grafana_dashboards/gpustack-worker.json) doesn't display this data.

This PR solve this problem.

In this PR:

1. Improvements for worker metrics
2. Grafana graphs with watt consumption
3. Fix for dashboards - add datasource variable with metrics
