### PR TITLE
fix(scheduler): cancel losing worker broadcast tasks in read_local_path_file_from_workers

### DIFF
--- a/gpustack/scheduler/calculator.py
+++ b/gpustack/scheduler/calculator.py
@@ -959,11 +959,20 @@ async def read_local_path_file_from_workers(  # noqa: C901
         f"Broadcasting {file_path} read request to {len(filtered_workers)} filtered workers "
         f"(reduced from {len(workers)} total workers)"
     )
-    tasks = [try_read_from_worker(worker) for worker in filtered_workers]
-    for completed_task in asyncio.as_completed(tasks):
-        result = await completed_task
-        if result:
-            return result
+    tasks = [
+        asyncio.create_task(try_read_from_worker(worker)) for worker in filtered_workers
+    ]
+    try:
+        for completed_task in asyncio.as_completed(tasks):
+            result = await completed_task
+            if result:
+                return result
+    finally:
+        pending = [t for t in tasks if not t.done()]
+        for t in pending:
+            t.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
 
     error_items = list(worker_errors.items())
     shown_errors = ";\n".join(f"{name}: {err}" for name, err in error_items[:3])

--- a/tests/scheduler/test_calculator_worker_broadcast.py
+++ b/tests/scheduler/test_calculator_worker_broadcast.py
@@ -1,0 +1,59 @@
+"""read_local_path_file_from_workers must not leave broadcast tasks running
+after it has already returned a result to its caller."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gpustack.schemas.models import Model, SourceEnum
+from gpustack.scheduler.calculator import read_local_path_file_from_workers
+
+
+def make_local_path_model() -> Model:
+    return Model(
+        name="test-model",
+        replicas=1,
+        source=SourceEnum.LOCAL_PATH,
+        local_path="/mnt/models/foo",
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_local_path_file_from_workers_cancels_losers():
+    model = make_local_path_model()
+    workers = [SimpleNamespace(name=f"worker-{i}") for i in range(5)]
+
+    async def fake_read_model_config(self, worker, path):
+        if worker.name == "worker-0":
+            return {"ok": True}
+        await asyncio.sleep(2)
+        return {"ok": True}
+
+    before = asyncio.all_tasks()
+    with patch(
+        "gpustack.client.worker_filesystem_client.WorkerFilesystemClient.read_model_config",
+        new=fake_read_model_config,
+    ):
+        result = await read_local_path_file_from_workers(model, "config.json", workers)
+
+    spawned = asyncio.all_tasks() - before
+    assert result == {"ok": True}
+    assert all(t.done() for t in spawned)
+
+
+@pytest.mark.asyncio
+async def test_read_local_path_file_from_workers_reports_all_errors():
+    model = make_local_path_model()
+    workers = [SimpleNamespace(name=f"worker-{i}") for i in range(3)]
+
+    async def fake_read_model_config(self, worker, path):
+        raise RuntimeError(f"boom from {worker.name}")
+
+    with patch(
+        "gpustack.client.worker_filesystem_client.WorkerFilesystemClient.read_model_config",
+        new=fake_read_model_config,
+    ):
+        with pytest.raises(ValueError, match="Failed to read 'config.json'"):
+            await read_local_path_file_from_workers(model, "config.json", workers)


### PR DESCRIPTION
Refer to issue:
- #5935

## Root cause

`read_local_path_file_from_workers` broadcasts a filesystem read to every filtered worker and returns as soon as the first one succeeds:

```python
tasks = [try_read_from_worker(worker) for worker in filtered_workers]
for completed_task in asyncio.as_completed(tasks):
    result = await completed_task
    if result:
        return result
```

`asyncio.as_completed` schedules all tasks up front, but the loop only awaits the ones it iterates before returning. Every other in-flight `try_read_from_worker` task, and the `WorkerFilesystemClient` it opened (a `TCPConnector` plus two `aiohttp.ClientSession`s), keeps running in the background with nothing left to await or cancel it. With N workers this leaks up to N-1 sessions per call, each alive until its own HTTP request finishes or times out (up to 15s).

## Fix

Create the tasks explicitly and wrap the read loop in `try/finally`: on the winning result or once every worker has failed, cancel whatever is still pending and gather it before the function returns. This is the same shape on both exit paths, success and exhaustion, so no broadcast task can outlive the call.

## Scope

This closes the orphaned-task leak in the broadcast helper itself, which the issue's own investigation had not pinned down. It does not confirm this is the cause of the reported mass `NOT_READY` reschedule under load; that needs reproducing against a live multi-worker fleet, which I do not have. The regression test demonstrates the leak and the fix directly, independent of the reported symptom.

## Tests

`tests/scheduler/test_calculator_worker_broadcast.py`: one test drives the function with five fake workers (one fast success, four slow) and asserts no spawned task is still running once the call returns; fails on main (4 of 5 left running), passes with the fix. A second test checks the all-workers-fail path still raises with the per-worker error detail.

Full suite: 1748 passed, 12 skipped.
