### PR TITLE
feat(exporter): Expose model category label in gpustack:model_info metric  #5940

### DIFF
--- a/docs/user-guide/observability.md
+++ b/docs/user-guide/observability.md
@@ -190,7 +190,7 @@ These metrics are mapped from various runtime engines (vLLM, SGLang, MindIE) as 
 | ------------------------------------------- | ----- | ------------------------------------------------------------- |
 | gpustack:cluster                            | Info  | Cluster information (ID, name, provider).                     |
 | gpustack:cluster_status                     | Gauge | Cluster status (with state label).                            |
-| gpustack:model                              | Info  | Model information (ID, name, runtime, source).                |
+| gpustack:model                              | Info  | Model information (ID, name, runtime, source, category).      |
 | gpustack:model_desired_instances            | Gauge | Desired number of model instances.                            |
 | gpustack:model_running_instances            | Gauge | Number of running model instances.                            |
 | gpustack:model_instance_status              | Gauge | Status of each model instance (with state label).             |

--- a/gpustack/exporter/exporter.py
+++ b/gpustack/exporter/exporter.py
@@ -194,11 +194,11 @@ class MetricExporter(Collector):
                     model.name,
                 ]
 
-                category = CategoryEnum.UNKNOWN.value
-                if model.categories:
-                    category = getattr(
-                        model.categories[0], "value", model.categories[0]
-                    )
+                category = (
+                    model.categories[0]
+                    if model.categories
+                    else CategoryEnum.UNKNOWN.value
+                )
 
                 model_info.add_metric(
                     model_labels

--- a/gpustack/exporter/exporter.py
+++ b/gpustack/exporter/exporter.py
@@ -194,6 +194,11 @@ class MetricExporter(Collector):
                     model.name,
                 ]
 
+                # NOTE: Model.categories is a list, but Prometheus labels are
+                # scalar. GPUStack currently treats the first entry as the
+                # primary category for metrics, so secondary categories are not
+                # exposed in gpustack:model_info. This keeps one model_info
+                # series per model for model_id joins.
                 category = (
                     model.categories[0]
                     if model.categories

--- a/gpustack/exporter/exporter.py
+++ b/gpustack/exporter/exporter.py
@@ -12,7 +12,7 @@ from gpustack.exporter.bus_metrics import BusMetricsCollector
 from gpustack.logging import setup_logging
 from gpustack.schemas.config import ModelInstanceProxyModeEnum
 from gpustack.schemas.clusters import Cluster
-from gpustack.schemas.models import Model
+from gpustack.schemas.models import CategoryEnum, Model
 from gpustack.schemas.workers import Worker, WorkerStateEnum
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep
@@ -194,9 +194,21 @@ class MetricExporter(Collector):
                     model.name,
                 ]
 
+                category = CategoryEnum.UNKNOWN.value
+                if model.categories:
+                    category = getattr(
+                        model.categories[0], "value", model.categories[0]
+                    )
+
                 model_info.add_metric(
                     model_labels
-                    + ["runtime", "runtime_version", "source", "source_key"],
+                    + [
+                        "runtime",
+                        "runtime_version",
+                        "source",
+                        "source_key",
+                        "category",
+                    ],
                     {
                         "cluster_id": str(cluster.id),
                         "cluster_name": cluster.name,
@@ -206,6 +218,7 @@ class MetricExporter(Collector):
                         "runtime_version": model.backend_version or "unknown",
                         "source": model.source,
                         "source_key": model.model_source_key,
+                        "category": category,
                     },
                 )
 

--- a/tests/exporter/test_exporter.py
+++ b/tests/exporter/test_exporter.py
@@ -25,6 +25,17 @@ def _sample_labels(metrics, metric_name):
     raise AssertionError(f"Metric {metric_name} not found")
 
 
+def _cluster_with_model(model):
+    return SimpleNamespace(
+        id=1,
+        name="default",
+        provider="docker",
+        state="ready",
+        cluster_workers=[],
+        cluster_models=[model],
+    )
+
+
 @pytest.mark.asyncio
 async def test_model_instance_restart_metrics_are_collected():
     exporter = MetricExporter(SimpleNamespace(metrics_port=10161))
@@ -45,6 +56,7 @@ async def test_model_instance_restart_metrics_are_collected():
         backend_version="0.8.0",
         source="huggingface",
         model_source_key="Qwen/Qwen2.5-0.5B-Instruct",
+        categories=[],
         replicas=1,
         ready_replicas=1,
         instances=[instance],
@@ -75,6 +87,68 @@ async def test_model_instance_restart_metrics_are_collected():
         "model_name": "qwen",
         "model_instance_name": "qwen-1",
     }
+
+
+@pytest.mark.asyncio
+async def test_model_info_metric_includes_category_label():
+    exporter = MetricExporter(SimpleNamespace(metrics_port=10161))
+    model = SimpleNamespace(
+        id=10,
+        name="embedding",
+        backend="vllm",
+        backend_version="0.8.0",
+        source="huggingface",
+        model_source_key="BAAI/bge-m3",
+        categories=["embedding"],
+        replicas=1,
+        ready_replicas=1,
+        instances=[],
+    )
+
+    with patch(
+        "gpustack.exporter.exporter.Cluster.all",
+        return_value=[_cluster_with_model(model)],
+    ):
+        metrics = await exporter._collect_metrics(session=SimpleNamespace())
+
+    assert _sample_labels(metrics, "gpustack:model") == {
+        "cluster_id": "1",
+        "cluster_name": "default",
+        "model_id": "10",
+        "model_name": "embedding",
+        "runtime": "vllm",
+        "runtime_version": "0.8.0",
+        "source": "huggingface",
+        "source_key": "BAAI/bge-m3",
+        "category": "embedding",
+    }
+
+
+@pytest.mark.asyncio
+async def test_model_info_metric_uses_unknown_for_uncategorized_models():
+    exporter = MetricExporter(SimpleNamespace(metrics_port=10161))
+    model = SimpleNamespace(
+        id=10,
+        name="qwen",
+        backend="vllm",
+        backend_version=None,
+        source="huggingface",
+        model_source_key="Qwen/Qwen2.5-0.5B-Instruct",
+        categories=[],
+        replicas=1,
+        ready_replicas=1,
+        instances=[],
+    )
+
+    with patch(
+        "gpustack.exporter.exporter.Cluster.all",
+        return_value=[_cluster_with_model(model)],
+    ):
+        metrics = await exporter._collect_metrics(session=SimpleNamespace())
+
+    labels = _sample_labels(metrics, "gpustack:model")
+    assert labels["category"] == "unknown"
+    assert labels["runtime_version"] == "unknown"
 
 
 class _NoopSession:


### PR DESCRIPTION
#5940

Hello, this is my first PR to GPUSTack.  
For issue #5940, my understanding is that we just need to add a `category` attribute to the `model_info` metric in the exporter. I tested it on the metrics endpoint at port 10161 and it works fine.  
I'm not sure if my understanding is correct, and I would really appreciate it if the GPUSTack team could review this for me. Thank you very much!

**Test Result**
```text
# TYPE gpustack:model_info gauge
gpustack:model_info{category="llm",cluster_id="1",cluster_name="RTX4060",model_id="1",model_name="Qwen3.5-0.8B",runtime="vLLM-custom",runtime_version="0.26",source="local_path",source_key="/root/.cache/modelscope/models/Qwen--Qwen3.5-0.8B/snapshots/master"} 1.0
```