### PR TITLE
fix: preserve omitted runtime config fields

### DIFF
--- a/gpustack/cmd/reload_config.py
+++ b/gpustack/cmd/reload_config.py
@@ -106,44 +106,50 @@ def run(args):
         if handle_list_mode(args):
             return
 
-        cfg = parse_args_with_filter(args, {})
-        payload = {}
-        for field in WHITELIST_CONFIG_FIELDS:
-            if hasattr(cfg, field):
-                value = getattr(cfg, field)
-                if value is not None:
-                    payload[field] = value
+        config_data = get_filtered_config_data(args, {})
+        cfg = Config(**config_data)
+        payload = build_runtime_update_payload(cfg, config_data)
+        if not payload:
+            logger.info(
+                "No whitelisted configuration changes supplied; nothing to reload."
+            )
+            return
 
         setup_logging(cfg.debug)
         apply_runtime_updates(payload, args)
-        display_config_summary(cfg)
+        display_config_summary(payload)
 
     except Exception as e:
         logger.error(f"Failed to reload configuration: {e}")
         sys.exit(1)
 
 
-def display_config_summary(cfg):
+def build_runtime_update_payload(
+    cfg: Config, config_data: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Return the whitelisted fields explicitly supplied to reload-config."""
+    return {
+        field: getattr(cfg, field)
+        for field in WHITELIST_CONFIG_FIELDS.intersection(config_data)
+        if getattr(cfg, field) is not None
+    }
+
+
+def display_config_summary(payload: Dict[str, Any]):
     """Display a summary of the reloaded configuration - only show whitelisted fields."""
     logger.info("=== Configuration Reload Summary ===")
 
-    for field in WHITELIST_CONFIG_FIELDS:
-        if hasattr(cfg, field):
-            value = getattr(cfg, field)
-            if value is not None:
-                logger.info(f"- reload: {field} = {value}")
+    for field, value in payload.items():
+        logger.info(f"- reload: {field} = {value}")
     logger.info("Configuration successfully reloaded.")
 
     logger.info("=====================================")
 
 
-def parse_args_with_filter(args: argparse.Namespace, filtered_changes: Dict[str, Any]):
-    """
-    Parse arguments with filtered configuration changes.
-
-    This function reuses the logic from start.py but applies whitelist filtering.
-    """
-
+def get_filtered_config_data(
+    args: argparse.Namespace, filtered_changes: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Collect the whitelisted fields provided through reload-config inputs."""
     config_data = {}
 
     # Handle config file if provided
@@ -165,10 +171,7 @@ def parse_args_with_filter(args: argparse.Namespace, filtered_changes: Dict[str,
     for key, value in filtered_changes.items():
         config_data[key] = value
 
-    # Create config with filtered data - only use the filtered config data
-    # Don't call set_common_options/set_server_options/set_worker_options
-    # as they would re-apply all command line arguments including blocked ones
-    return Config(**config_data)
+    return config_data
 
 
 def resolve_scope_headers(args: argparse.Namespace) -> Dict[str, Dict[str, str]]:

--- a/tests/cmd/test_reload_config_auth.py
+++ b/tests/cmd/test_reload_config_auth.py
@@ -9,7 +9,13 @@ from gpustack.cmd.local_auth import (
     read_local_jwt_secret,
 )
 from gpustack.cmd import reload_config
-from gpustack.cmd.reload_config import apply_runtime_updates, resolve_scope_headers
+from gpustack.cmd.reload_config import (
+    apply_runtime_updates,
+    build_runtime_update_payload,
+    get_filtered_config_data,
+    resolve_scope_headers,
+)
+from gpustack.config.config import Config
 from gpustack.security import JWTManager
 
 
@@ -150,6 +156,43 @@ def test_apply_runtime_updates_still_fails_when_only_endpoint_is_unauthorized(
 
     with pytest.raises(Exception, match="HTTP 401"):
         apply_runtime_updates({"debug": True}, argparse.Namespace())
+
+
+def test_reload_config_payload_only_contains_explicit_fields(monkeypatch, tmp_path):
+    monkeypatch.setenv("GPUSTACK_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("GPUSTACK_DEBUG", "true")
+    args = argparse.Namespace(
+        file=None,
+        set=["system-default-container-registry=registry.example"],
+    )
+    config_data = get_filtered_config_data(args, {})
+    cfg = Config(**config_data)
+
+    assert cfg.debug is True
+    assert build_runtime_update_payload(cfg, config_data) == {
+        "system_default_container_registry": "registry.example"
+    }
+
+
+def test_reload_config_payload_keeps_explicit_false_boolean(monkeypatch, tmp_path):
+    monkeypatch.setenv("GPUSTACK_DATA_DIR", str(tmp_path))
+    args = argparse.Namespace(file=None, set=["debug=false"])
+    config_data = get_filtered_config_data(args, {})
+    cfg = Config(**config_data)
+
+    assert build_runtime_update_payload(cfg, config_data) == {"debug": False}
+
+
+def test_reload_config_skips_empty_runtime_update(monkeypatch, tmp_path):
+    monkeypatch.setenv("GPUSTACK_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(reload_config, "setup_logging", lambda debug: None)
+    monkeypatch.setattr(
+        reload_config,
+        "apply_runtime_updates",
+        lambda payload, args: pytest.fail("empty payload must not be sent"),
+    )
+
+    reload_config.run(argparse.Namespace(file=None, set=None, list=False))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Prevent `reload-config` from submitting whitelisted values that were not supplied through `--set` or `--file`.

## Root cause

`Config` supplies `debug=False` by default. The command serialized every non-null whitelisted field, so a registry-only update also disabled debug on both server and worker endpoints.

## Change

Build the update payload from the filtered input keys after validation. Explicit `debug=false` remains an update; defaults and `GPUSTACK_*` environment values do not become implicit runtime changes.

## Checks

- `git diff --check`
- `py_compile` for changed files
- `black --check` for changed files
- `flake8` for changed files
