### PR TITLE
fix(model_route): Fix provider model name validation error #5969

### DIFF
--- a/gpustack/schemas/model_routes.py
+++ b/gpustack/schemas/model_routes.py
@@ -165,11 +165,6 @@ class ModelRouteTargetUpdate(SQLModel):
             return v
         if not isinstance(v, str):
             raise ValueError("overridden_model_name must be a string")
-        if not re.match(name_pattern, v):
-            raise ValueError(
-                "overridden_model_name must start with a letter and contain only "
-                "letters, numbers, hyphens, underscores, dots, or colons"
-            )
         return v
 
     @model_validator(mode="after")
@@ -185,18 +180,25 @@ class ModelRouteTargetUpdate(SQLModel):
             raise ValueError(
                 "overridden_model_name must be provided when provider_id is set."
             )
+        if self.provider_id is not None and not self.overridden_model_name.strip():
+            raise ValueError(
+                "overridden_model_name must not be empty or blank when provider_id is set."
+            )
         # Local-model targets only accept overridden_model_name shaped like
         # "<base_model_name>:<lora_name>". The full base-prefix check lives in
         # the service layer (lora_route_name_for); schema only enforces shape.
-        if (
-            self.model_id is not None
-            and self.overridden_model_name is not None
-            and ":" not in self.overridden_model_name
-        ):
-            raise ValueError(
-                "overridden_model_name for a local-model target must be of the "
-                "form '<base_model_name>:<lora_name>'."
-            )
+        if self.model_id is not None and self.overridden_model_name is not None:
+            if not re.match(name_pattern, self.overridden_model_name):
+                raise ValueError(
+                    "overridden_model_name for a local-model target must start "
+                    "with a letter and contain only letters, numbers, hyphens, "
+                    "underscores, dots, or colons"
+                )
+            if ":" not in self.overridden_model_name:
+                raise ValueError(
+                    "overridden_model_name for a local-model target must be of the "
+                    "form '<base_model_name>:<lora_name>'."
+                )
         return self
 
 

--- a/tests/routes/test_model_routes.py
+++ b/tests/routes/test_model_routes.py
@@ -311,6 +311,25 @@ def test_model_route_create_rejects_slashed_name():
         ModelRouteCreate(name="org1/qwen3-0.6b", targets=[])
 
 
+def test_provider_target_accepts_slashed_model_name():
+    target = ModelRouteTargetUpdateItem(
+        provider_id=10,
+        overridden_model_name="kimi/kimi-k3",
+        weight=1,
+    )
+
+    assert target.overridden_model_name == "kimi/kimi-k3"
+
+
+def test_local_model_target_rejects_slashed_overridden_model_name():
+    with pytest.raises(ValueError, match="local-model target must start"):
+        ModelRouteTargetUpdateItem(
+            model_id=5,
+            overridden_model_name="base/lora",
+            weight=1,
+        )
+
+
 def test_model_route_public_accepts_enriched_slashed_name():
     """Regression: the My Models response serializes through
     ``ModelRoutePublic``; once ``_apply_effective_name_to_my_models``


### PR DESCRIPTION
#5969 
This was already repaired in PR https://github.com/gpustack/gpustack/pull/5969

My thought is to remove the regex validation on the provider model target, because we cannot predict what format the upstream model name will come in — for example, it might contain an extra slash (/). Or should we instead apply a more lenient regex validation to the provider model target?