### PR TITLE
fix(gpu-instances): stop retrying operator watches when the operator is absent

### DIFF
--- a/gpustack/gpu_instances/controllers.py
+++ b/gpustack/gpu_instances/controllers.py
@@ -273,7 +273,16 @@ class GPUInstanceController:
         so a worker-side change (phase drift, CR deleted out of band) flows back
         into the same work queue without a DB-triggered re-read. Runs leader-only
         because the whole controller is. The stream is reconnected on any error.
+
+        Without the operator there is no stream to consume at all, so the watcher
+        stops instead of reconnecting forever; upstream reconciles keep working.
         """
+        if not gateway_client.is_gateway_configured():
+            logger.info(
+                "Operator worker gateway is not configured; "
+                "GPU instance downstream watch is disabled."
+            )
+            return
         while True:
             try:
                 async for line in gateway_client.watch_instances():
@@ -1355,7 +1364,17 @@ class GPUInstanceTypeController:
         clusters) and feed the queue; reconnect on any error (mirrors
         :meth:`GPUInstanceController._watch_downstream`). The resync runs on every
         (re)connect so a fresh table is populated and a delete missed during the
-        previous gap is reconciled before the watch resumes."""
+        previous gap is reconciled before the watch resumes.
+
+        The operator watch is this controller's only source, so without the
+        operator there is nothing to project and the loop stops instead of
+        reconnecting forever."""
+        if not gateway_client.is_gateway_configured():
+            logger.info(
+                "Operator worker gateway is not configured; "
+                "GPU instance type projection is disabled."
+            )
+            return
         while True:
             try:
                 await self._resync()

--- a/gpustack/gpu_instances/gateway_client.py
+++ b/gpustack/gpu_instances/gateway_client.py
@@ -57,6 +57,19 @@ def set_gateway_unix_path(path: str) -> None:
     _unix_path = path
 
 
+def is_gateway_configured() -> bool:
+    """Whether the operator's worker gateway socket path is known.
+
+    ``False`` means the operator subprocess was never spawned (its binary is not
+    installed), so every call in this module would fail. The path is recorded
+    once at startup, before any consumer starts, so a ``False`` here is final
+    for the lifetime of the process and callers may opt out permanently rather
+    than retry. The truthiness test mirrors :func:`_session`, so the two agree
+    on what counts as configured.
+    """
+    return bool(_unix_path)
+
+
 def _ssl_context() -> ssl.SSLContext:
     ctx = ssl.create_default_context()
     ctx.check_hostname = False


### PR DESCRIPTION

The operator subprocess is skipped when its binary is not installed, so the worker gateway socket path is never recorded. Both gateway-backed watch loops then reconnected every 5s forever, logging a RuntimeError traceback each time.

Gate them on a new gateway_client.is_gateway_configured(): the path is set once at startup before any consumer starts, so an unconfigured gateway is final and the watchers opt out with a single info log instead of retrying. Upstream DB-driven reconciles and the PV/PVT finalizers are unaffected.

This avoids endless error logs in development environments without built operator.