### PR TITLE
fix(observability): add migrations for new watt consumption

### DIFF
--- a/gpustack/migrations/versions/2026_08_02_0950-27c7e92a41a2_add_power_fields_to_gpu_devices_view.py
+++ b/gpustack/migrations/versions/2026_08_02_0950-27c7e92a41a2_add_power_fields_to_gpu_devices_view.py
@@ -1,0 +1,65 @@
+"""add power fields to gpu_devices_view
+
+Revision ID: 27c7e92a41a2
+Revises: ddb9eb4a7eab
+Create Date: 2026-08-02 09:50:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from gpustack.migrations.utils import is_opengauss
+from gpustack.schemas.stmt import (
+    worker_after_drop_view_stmt_sqlite,
+    worker_after_drop_view_stmt_mysql,
+    worker_after_drop_view_stmt_postgres,
+    worker_after_create_view_stmt_sqlite,
+    worker_after_create_view_stmt_mysql,
+    worker_after_create_view_stmt_postgres,
+    worker_after_create_view_stmt_opengauss,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = '27c7e92a41a2'
+down_revision: Union[str, None] = 'ddb9eb4a7eab'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    dialect_name = op.get_bind().dialect.name
+
+    # Drop existing view
+    if dialect_name == 'mysql':
+        op.execute(worker_after_drop_view_stmt_mysql)
+    elif dialect_name == 'postgresql':
+        op.execute(worker_after_drop_view_stmt_postgres)
+    else:
+        op.execute(worker_after_drop_view_stmt_sqlite)
+
+    # Recreate view with new power fields
+    if dialect_name == 'mysql':
+        op.execute(worker_after_create_view_stmt_mysql)
+    elif dialect_name == 'postgresql':
+        if is_opengauss(conn):
+            op.execute(worker_after_create_view_stmt_opengauss)
+        else:
+            op.execute(worker_after_create_view_stmt_postgres)
+    else:
+        op.execute(worker_after_create_view_stmt_sqlite)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    dialect_name = op.get_bind().dialect.name
+
+    # Drop the view; it will be recreated with the old schema on next
+    # server start via the after_create event listener.
+    if dialect_name == 'mysql':
+        op.execute(worker_after_drop_view_stmt_mysql)
+    elif dialect_name == 'postgresql':
+        op.execute(worker_after_drop_view_stmt_postgres)
+    else:
+        op.execute(worker_after_drop_view_stmt_sqlite)

--- a/gpustack/schemas/gpu_devices.py
+++ b/gpustack/schemas/gpu_devices.py
@@ -33,6 +33,8 @@ class GPUDeviceListParams(ListParams):
         "worker_name",
         "vendor",
         "temperature",
+        "power",
+        "power_used",
         "core.utilization_rate",
         "memory.utilization_rate",
         "created_at",

--- a/gpustack/schemas/stmt.py
+++ b/gpustack/schemas/stmt.py
@@ -26,6 +26,8 @@ SELECT
     json_extract(value, '$.core') AS 'core',
     json_extract(value, '$.memory') AS 'memory',
     json_extract(value, '$.temperature') AS 'temperature',
+    json_extract(value, '$.power') AS 'power',
+    json_extract(value, '$.power_used') AS 'power_used',
     json_extract(value, '$.network') AS 'network'
 FROM
     workers w,
@@ -62,6 +64,8 @@ SELECT
     JSON_EXTRACT(gpu_device, '$.core') AS `core`,
     JSON_EXTRACT(gpu_device, '$.memory') AS `memory`,
     CAST(COALESCE(JSON_VALUE(gpu_device, '$.temperature'), '0') AS DECIMAL(10, 2)) AS `temperature`,
+    CAST(COALESCE(JSON_VALUE(gpu_device, '$.power'), '0') AS DECIMAL(10, 2)) AS `power`,
+    CAST(COALESCE(JSON_VALUE(gpu_device, '$.power_used'), '0') AS DECIMAL(10, 2)) AS `power_used`,
     JSON_EXTRACT(gpu_device, '$.network') AS `network`
 FROM
     workers w,
@@ -101,6 +105,8 @@ SELECT
     (gpu_device::json->>'core')::JSONB AS "core",
     (gpu_device::json->>'memory')::JSONB AS "memory",
     (gpu_device::json->>'temperature')::FLOAT AS "temperature",
+    (gpu_device::json->>'power')::FLOAT AS "power",
+    (gpu_device::json->>'power_used')::FLOAT AS "power_used",
     (gpu_device::json->>'network')::JSONB AS "network"
 FROM
     workers w,
@@ -138,6 +144,8 @@ SELECT
     (w.status::jsonb->'gpu_devices'->s.idx->'core')::JSONB AS "core",
     (w.status::jsonb->'gpu_devices'->s.idx->'memory')::JSONB AS "memory",
     (w.status::jsonb->'gpu_devices'->s.idx->>'temperature')::FLOAT AS "temperature",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'power')::FLOAT AS "power",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'power_used')::FLOAT AS "power_used",
     (w.status::jsonb->'gpu_devices'->s.idx->'network')::JSONB AS "network"
 FROM
     workers w,


### PR DESCRIPTION
Hi folks. I have forget db migrations for PR #5955 . This PR needed for new metrics. 