### PR TITLE
fix(observability): add db changes for new watt consumption

### DIFF
--- a/gpustack/schemas/gpu_devices.py
+++ b/gpustack/schemas/gpu_devices.py
@@ -33,6 +33,8 @@ class GPUDeviceListParams(ListParams):
         "worker_name",
         "vendor",
         "temperature",
+        "power",
+        "power_used",
         "core.utilization_rate",
         "memory.utilization_rate",
         "created_at",

--- a/gpustack/schemas/stmt.py
+++ b/gpustack/schemas/stmt.py
@@ -64,8 +64,8 @@ SELECT
     JSON_EXTRACT(gpu_device, '$.core') AS `core`,
     JSON_EXTRACT(gpu_device, '$.memory') AS `memory`,
     CAST(COALESCE(JSON_VALUE(gpu_device, '$.temperature'), '0') AS DECIMAL(10, 2)) AS `temperature`,
-    CAST(COALESCE(JSON_VALUE(gpu_device, '$.power'), '0') AS DECIMAL(10, 2)) AS `power`,
-    CAST(COALESCE(JSON_VALUE(gpu_device, '$.power_used'), '0') AS DECIMAL(10, 2)) AS `power_used`,
+    CAST(JSON_VALUE(gpu_device, '$.power') AS DECIMAL(10, 2)) AS power,
+    CAST(JSON_VALUE(gpu_device, '$.power_used') AS DECIMAL(10, 2)) AS power_used,
     JSON_EXTRACT(gpu_device, '$.network') AS `network`
 FROM
     workers w,

--- a/gpustack/schemas/stmt.py
+++ b/gpustack/schemas/stmt.py
@@ -26,6 +26,8 @@ SELECT
     json_extract(value, '$.core') AS 'core',
     json_extract(value, '$.memory') AS 'memory',
     json_extract(value, '$.temperature') AS 'temperature',
+    json_extract(value, '$.power') AS 'power',
+    json_extract(value, '$.power_used') AS 'power_used',
     json_extract(value, '$.network') AS 'network'
 FROM
     workers w,
@@ -62,6 +64,8 @@ SELECT
     JSON_EXTRACT(gpu_device, '$.core') AS `core`,
     JSON_EXTRACT(gpu_device, '$.memory') AS `memory`,
     CAST(COALESCE(JSON_VALUE(gpu_device, '$.temperature'), '0') AS DECIMAL(10, 2)) AS `temperature`,
+    CAST(COALESCE(JSON_VALUE(gpu_device, '$.power'), '0') AS DECIMAL(10, 2)) AS `power`,
+    CAST(COALESCE(JSON_VALUE(gpu_device, '$.power_used'), '0') AS DECIMAL(10, 2)) AS `power_used`,
     JSON_EXTRACT(gpu_device, '$.network') AS `network`
 FROM
     workers w,
@@ -101,6 +105,8 @@ SELECT
     (gpu_device::json->>'core')::JSONB AS "core",
     (gpu_device::json->>'memory')::JSONB AS "memory",
     (gpu_device::json->>'temperature')::FLOAT AS "temperature",
+    (gpu_device::json->>'power')::FLOAT AS "power",
+    (gpu_device::json->>'power_used')::FLOAT AS "power_used",
     (gpu_device::json->>'network')::JSONB AS "network"
 FROM
     workers w,
@@ -138,6 +144,8 @@ SELECT
     (w.status::jsonb->'gpu_devices'->s.idx->'core')::JSONB AS "core",
     (w.status::jsonb->'gpu_devices'->s.idx->'memory')::JSONB AS "memory",
     (w.status::jsonb->'gpu_devices'->s.idx->>'temperature')::FLOAT AS "temperature",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'power')::FLOAT AS "power",
+    (w.status::jsonb->'gpu_devices'->s.idx->>'power_used')::FLOAT AS "power_used",
     (w.status::jsonb->'gpu_devices'->s.idx->'network')::JSONB AS "network"
 FROM
     workers w,


### PR DESCRIPTION
Hi folks. I have forget db migrations for PR https://github.com/gpustack/gpustack/pull/5955 . This PR needed for new metrics.

This change doesn't need alembic migration because backend [re-creates view on startup](https://github.com/gpustack/gpustack/blob/main/gpustack/server/init_db.py#L146).