### PR TITLE
feat(gateway): key ai-proxy providers by deployment

### DIFF
--- a/gpustack/gateway/ai_proxy_types.py
+++ b/gpustack/gateway/ai_proxy_types.py
@@ -51,9 +51,11 @@ class FailoverConfig(EnableState):
 
 class AIProxyDefaultConfig(CustomConfig):
     id: str
-    apiTokens: List[str] = Field(
-        default_factory=list,
-    )
+    # Optional (rather than an empty-list default) so that ``exclude_none`` is
+    # enough to omit it: a provider with no static credential must not emit
+    # ``apiTokens: []``, or ai-proxy stops falling back to the inbound
+    # ``Authorization`` header.
+    apiTokens: Optional[List[str]] = None
     failover: FailoverConfig = Field(default_factory=FailoverConfig)
     retryOnFailure: EnableState = Field(default_factory=EnableState)
     type: ModelProviderTypeEnum

--- a/gpustack/gateway/utils.py
+++ b/gpustack/gateway/utils.py
@@ -4,10 +4,11 @@ import logging
 import copy
 import math
 from urllib.parse import urlparse
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from functools import partial
 from typing import (
     List,
+    Iterable,
     Optional,
     Tuple,
     Union,
@@ -42,6 +43,7 @@ from gpustack.gateway.client.networking_istio_io_v1alpha3_api import (
     get_ingress_fallback_envoyfilter,
 )
 from gpustack.schemas.models import (
+    Model,
     ModelInstance,
     ModelInstancePublic,
 )
@@ -73,6 +75,21 @@ model_ingress_prefix = "ai-route-model-"
 model_route_ingress_prefix = "ai-route-route-"
 provider_id_prefix = "provider-"
 model_id_prefix = "model-"
+# AI proxy provider id prefix for self-hosted deployments. One provider per
+# Model (deployment), shared by every ModelRoute pointing at it. Supersedes the
+# per-route ``ai-route-route-<route_id>`` ids, which a route retires itself when
+# it reconciles (see ``legacy_model_route_provider_id``).
+model_ai_proxy_provider_prefix = "gpustack-model-"
+# Legacy per-route provider ids happen to reuse the route ingress prefix — alias
+# it so call sites read as provider ids rather than as ingress names.
+legacy_model_route_provider_prefix = model_route_ingress_prefix
+# Provider ids the reconciler may garbage collect once no match rule references
+# them: the per-deployment ids it owns, plus the legacy per-route ids those
+# supersede.
+_collectable_provider_prefixes = (
+    model_ai_proxy_provider_prefix,
+    legacy_model_route_provider_prefix,
+)
 
 router_header_key = "X-GPUStack-Model-Instance"
 gpustack_original_path_header = "x-gpustack-original-path"
@@ -81,6 +98,33 @@ gpustack_fallback_path_header = "x-gpustack-fallback-path"
 # Type alias for destination tuples
 # Each tuple contains (weight: int, model_name: str, registry: McpBridgeRegistry)
 DestinationTupleList = List[Tuple[int, str, McpBridgeRegistry]]
+
+
+@dataclass
+class ModelAIProxyGroup:
+    """AI proxy grouping for one deployment (Model) inside a single route.
+
+    The upstream services of a deployment are its model instances' registries
+    (plus the LoRA aliases of those instances), or the remote cluster gateway
+    registry when the deployment lives in another cluster. They all accept the
+    same credential — the registration token of the deployment's cluster — so
+    one provider per Model is both necessary and sufficient, and it is shared by
+    every route pointing at that Model.
+
+    ``service_names`` and ``fallback_service_names`` are kept apart because the
+    main and the fallback ingress each get their own match rule.
+    ``fallback_service_names`` is a subset: a fallback target also serves the
+    main ingress (see the FIXME in ``sync_gateway``), so the fallback rule
+    covers fewer services, never other ones.
+    """
+
+    model_id: int
+    api_tokens: List[str] = dataclass_field(default_factory=list)
+    service_names: Set[str] = dataclass_field(default_factory=set)
+    fallback_service_names: Set[str] = dataclass_field(default_factory=set)
+
+    def provider_id(self) -> str:
+        return model_ai_proxy_provider_id(self.model_id)
 
 
 @dataclass
@@ -203,8 +247,21 @@ def model_mcp_bridge_name(cluster_id: int) -> str:
     return cluster_mcp_bridge_name(cluster_id)
 
 
-def model_route_cleanup_prefix(model_route_id: int) -> str:
-    return f"{model_route_ingress_prefix}{model_route_id}"
+def model_ai_proxy_provider_id(model_id: int) -> str:
+    """AI proxy provider id for a self-hosted deployment (Model)."""
+    return f"{model_ai_proxy_provider_prefix}{model_id}"
+
+
+def legacy_model_route_provider_id(model_route_id: int) -> str:
+    """AI proxy provider id written by versions that keyed providers per route.
+
+    Superseded by ``model_ai_proxy_provider_id``. A route drops its own legacy
+    entry when it reconciles — the legacy rule carries the same ingress the
+    reconcile owns, and the provider is then garbage collected as unreferenced —
+    so migration happens in one CR write per route, never leaving a route
+    without a provider.
+    """
+    return f"{legacy_model_route_provider_prefix}{model_route_id}"
 
 
 def model_route_ingress_name(model_route_id: int) -> str:
@@ -216,6 +273,23 @@ def fallback_ingress_name(name: str) -> str:
     if len(split_name) == 1:
         return f"{name}.fallback"
     return f"{split_name[0]}.fallback.{split_name[1]}"
+
+
+def route_ingress_names_for_plugins(
+    model_route_id: int, resource_namespace: str, gateway_namespace: str
+) -> Tuple[str, str]:
+    """The (main, fallback) ingress names as WasmPlugin match rules store them.
+
+    Higress qualifies an ingress reference with ``<namespace>/`` when the ingress
+    lives outside the gateway's own namespace. The route reconciler and the
+    startup pruner must spell the names identically or they will not match.
+    """
+    prefix = "" if resource_namespace == gateway_namespace else f"{resource_namespace}/"
+    ingress_name = model_route_ingress_name(model_route_id)
+    return (
+        f"{prefix}{ingress_name}",
+        f"{prefix}{fallback_ingress_name(ingress_name)}",
+    )
 
 
 def model_ingress_name(model_id: int) -> str:
@@ -1284,74 +1358,204 @@ async def ensure_fallback_filter(
             )
 
 
-def ai_proxy_openai_provider_config(id: str) -> Dict[str, Any]:
+def ai_proxy_openai_provider_config(
+    id: str, api_tokens: Optional[List[str]] = None
+) -> Dict[str, Any]:
+    """Build an openai-type provider entry for a self-hosted upstream.
+
+    ``api_tokens`` makes ai-proxy hold the upstream credential statically:
+    ``apiTokens`` has the highest priority in its openai provider, so the
+    credential no longer has to be injected per request by ``/token-auth``.
+    Left empty, ai-proxy falls back to reading the inbound ``Authorization``
+    header, which is the pre-existing behavior.
+    """
     return ai_proxy_types.AIProxyDefaultConfig(
         type=ModelProviderTypeEnum.OPENAI,
         id=id,
+        apiTokens=api_tokens or None,
         failover=ai_proxy_types.FailoverConfig(enabled=False),
         retryOnFailure=ai_proxy_types.EnableState(enabled=False),
+        # ``exclude_unset`` keeps the nested configs down to the flags set here,
+        # matching the entries already in the CR; ``apiTokens`` is omitted by
+        # ``exclude_none`` alone.
     ).model_dump(exclude_none=True, exclude_unset=True)
+
+
+def model_ai_proxy_plugin_spec(
+    groups: Iterable[ModelAIProxyGroup],
+    main_ingress: str,
+    fallback_ingress: str,
+) -> Tuple[List[Dict[str, Any]], List[WasmPluginMatchRule]]:
+    """Build the providers and match rules of one route, grouped by deployment.
+
+    ``main_ingress`` / ``fallback_ingress`` must already carry the namespace
+    prefix Higress expects for cross-namespace routes.
+
+    A rule is keyed by (ingress, services) so two routes pointing at the same
+    Model each get their own rule while sharing one provider entry. Service
+    lists are sorted so an unchanged deployment produces a byte-identical CR and
+    the reconciler's diff stays quiet.
+    """
+    providers: List[Dict[str, Any]] = []
+    match_rules: List[WasmPluginMatchRule] = []
+    for group in sorted(groups, key=lambda g: g.model_id):
+        if not group.service_names and not group.fallback_service_names:
+            continue
+        provider_id = group.provider_id()
+        providers.append(
+            ai_proxy_openai_provider_config(provider_id, api_tokens=group.api_tokens)
+        )
+        for ingress, service_names in (
+            (main_ingress, group.service_names),
+            (fallback_ingress, group.fallback_service_names),
+        ):
+            if not service_names:
+                continue
+            match_rules.append(
+                WasmPluginMatchRule(
+                    config={"activeProviderId": provider_id},
+                    configDisable=False,
+                    service=sorted(service_names),
+                    ingress=[ingress],
+                )
+            )
+    return providers, match_rules
 
 
 def compare_and_append_default_proxy_config(
     existing_providers: List[Dict[str, Any]],
     expected_providers: List[Dict[str, Any]],
     operating_id_prefix: Optional[str] = None,
+    referenced_ids: Optional[Set[str]] = None,
 ) -> List[Dict[str, Any]]:
+    """Merge ``expected_providers`` into the existing list.
+
+    An existing entry is dropped when it is owned by this reconcile
+    (``operating_id_prefix``), when it is superseded by an expected entry with
+    the same id, or — for the ids under ``_collectable_provider_prefixes`` — when
+    ``referenced_ids`` says no remaining match rule points at it. That last rule
+    garbage collects a deployment's provider once the last route stops targeting
+    it, without any one route having to know about the others, and it retires a
+    legacy per-route provider in the same write that replaces its rule.
+    """
+    expected_ids = {
+        provider.get('id') for provider in expected_providers if provider.get('id')
+    }
     to_keep_config = []
     for provider in existing_providers:
         provider_id: Optional[str] = provider.get('id', None)
-        if (
-            provider_id is None
-            or operating_id_prefix is None
-            or not provider_id.startswith(operating_id_prefix)
-        ):
+        if provider_id is None:
             to_keep_config.append(provider)
             continue
+        if operating_id_prefix is not None and provider_id.startswith(
+            operating_id_prefix
+        ):
+            continue
+        if provider_id in expected_ids:
+            continue
+        if (
+            referenced_ids is not None
+            and provider_id.startswith(_collectable_provider_prefixes)
+            and provider_id not in referenced_ids
+        ):
+            continue
+        to_keep_config.append(provider)
     return_providers = expected_providers.copy()
     return_providers.extend(to_keep_config)
     return_providers.sort(key=lambda p: p.get("id", ""))
     return return_providers
 
 
+def _match_rule_provider_id(rule: WasmPluginMatchRule) -> Optional[str]:
+    # ``config`` is Optional on the CR model, so a hand-edited ``config: null``
+    # would otherwise raise on attribute access.
+    return (rule.config or {}).get("activeProviderId", None)
+
+
+def _match_rule_sort_key(rule: WasmPluginMatchRule) -> Tuple[str, str, str]:
+    return (
+        _match_rule_provider_id(rule) or "",
+        ",".join(rule.ingress or []),
+        ",".join(rule.service or []),
+    )
+
+
 def compare_and_append_proxy_match_rules(
     existing_rules: List[WasmPluginMatchRule],
     expected_rules: List[WasmPluginMatchRule],
     operating_id_prefix: Optional[str] = None,
+    owned_ingresses: Optional[Set[str]] = None,
 ) -> List[WasmPluginMatchRule]:
+    """Merge ``expected_rules`` into the existing list.
+
+    Ownership can be expressed two ways: by provider id prefix (external model
+    providers, whose rules match on service only) or by ingress
+    (``owned_ingresses``, one route's ingress plus its fallback ingress). The
+    latter is required now that provider ids are per deployment: dropping rules
+    by id prefix would delete the rules other routes hold for the same
+    deployment.
+    """
     to_keep_config = []
+    owned = owned_ingresses or set()
     for rule in existing_rules:
-        provider_id: Optional[str] = rule.config.get('activeProviderId', None)
+        provider_id: Optional[str] = _match_rule_provider_id(rule)
         if (
-            provider_id is None
-            or operating_id_prefix is None
-            or not provider_id.startswith(operating_id_prefix)
+            provider_id is not None
+            and operating_id_prefix is not None
+            and provider_id.startswith(operating_id_prefix)
         ):
-            to_keep_config.append(rule)
             continue
+        if owned and owned.intersection(rule.ingress or []):
+            continue
+        to_keep_config.append(rule)
 
     return_rules = expected_rules.copy()
     return_rules.extend(to_keep_config)
-    return_rules.sort(key=lambda r: (r.config.get("activeProviderId", None) or ""))
+    return_rules.sort(key=_match_rule_sort_key)
     return return_rules
 
 
 async def cleanup_ai_proxy_config(
     providers: List[ModelProvider],
+    models: List[Model],
     routes: List[ModelRoute],
+    expected_ingresses: Set[str],
     k8s_config: k8s_client.Configuration,
     namespace: str,
 ):
-    prefixes_to_keep = {model_route_cleanup_prefix(route.id) for route in routes}
-    prefixes_to_keep.update(
-        {provider_registry_name(provider.id) for provider in providers}
-    )
+    """Prune the ai-proxy CR at startup, before the controllers replay routes.
 
-    def should_keep(provider_id: str) -> bool:
-        for prefix in prefixes_to_keep:
-            if provider_id.startswith(prefix):
-                return True
-        return False
+    Kept: one entry per live external provider, one per live deployment, and the
+    legacy per-route entry of every live route. Legacy entries are deliberately
+    *not* pruned here: each route retires its own when it reconciles, in the same
+    write that adds the deployment entry replacing it, so no route is ever left
+    without a provider. Pruning them here would open a window between this pass
+    and the route replay — which only starts after leader election.
+
+    Dropped: everything else, i.e. entries whose route, deployment or provider no
+    longer exists — the case this pass exists for, since nothing will reconcile
+    them.
+
+    Rules are filtered on both axes. Provider retention alone is not enough now
+    that provider ids are per deployment: a route deleted while the server was
+    down leaves a rule that still references a live deployment provider, and no
+    reconcile will ever revisit it. ``expected_ingresses`` therefore carries the
+    namespace-prefixed ingress names (main and fallback) of every live route, in
+    the same form the rules store. Rules with no ingress at all belong to external
+    providers, which match on service, and are judged by provider id only.
+    """
+    ids_to_keep = {model_ai_proxy_provider_id(model.id) for model in models}
+    ids_to_keep.update({provider_registry_name(provider.id) for provider in providers})
+    ids_to_keep.update({legacy_model_route_provider_id(route.id) for route in routes})
+
+    def should_keep_rule(
+        rule: WasmPluginMatchRule, kept_provider_ids: Set[str]
+    ) -> bool:
+        if _match_rule_provider_id(rule) not in kept_provider_ids:
+            return False
+        if not rule.ingress:
+            return True
+        return any(ingress in expected_ingresses for ingress in rule.ingress)
 
     try:
         extensions_api = ExtensionsHigressIoV1Api(k8s_client.ApiClient(k8s_config))
@@ -1360,19 +1564,26 @@ async def cleanup_ai_proxy_config(
             name=gpustack_ai_proxy_name,
         )
         existing_plugin = WasmPlugin.model_validate(ai_proxy_data)
-        current_providers = existing_plugin.spec.defaultConfig.get("providers", [])
+        default_config = existing_plugin.spec.defaultConfig or {}
+        current_providers = default_config.get("providers", [])
         filtered_providers = [
-            p for p in current_providers if p.get("id") and should_keep(p.get("id"))
+            p for p in current_providers if p.get("id") and p.get("id") in ids_to_keep
         ]
-        existing_plugin.spec.defaultConfig["providers"] = filtered_providers
+        default_config["providers"] = filtered_providers
+        existing_plugin.spec.defaultConfig = default_config
         filtered_provider_ids = {
             p.get("id") for p in filtered_providers if p.get("id") is not None
         }
-        filtered_rules = [
-            r
-            for r in existing_plugin.spec.matchRules or []
-            if r.config.get("activeProviderId") in filtered_provider_ids
-        ]
+        filtered_rules = []
+        for rule in existing_plugin.spec.matchRules or []:
+            if should_keep_rule(rule, filtered_provider_ids):
+                filtered_rules.append(rule)
+            else:
+                logger.info(
+                    f"Removing ai proxy rule with provider "
+                    f"{_match_rule_provider_id(rule)} and ingress {rule.ingress} "
+                    "as its route, deployment or provider no longer exists."
+                )
         existing_plugin.spec.matchRules = filtered_rules
         await extensions_api.edit_wasmplugin(
             namespace=namespace,
@@ -1518,19 +1729,31 @@ def ai_proxy_diff_spec(
     expected_providers: List[Dict[str, Any]],
     expected_match_rules: List[WasmPluginMatchRule],
     operating_id_prefix: Optional[str] = None,
+    owned_ingresses: Optional[Set[str]] = None,
 ) -> WasmPluginSpec:
     if current_spec is None:
         return current_spec
+    if current_spec.defaultConfig is None:
+        current_spec.defaultConfig = {}
+    match_rules = compare_and_append_proxy_match_rules(
+        existing_rules=current_spec.matchRules or [],
+        expected_rules=expected_match_rules,
+        operating_id_prefix=operating_id_prefix,
+        owned_ingresses=owned_ingresses,
+    )
+    # Providers are merged against the *resulting* rules so a deployment
+    # provider disappears together with the last rule referencing it.
     current_spec.defaultConfig["providers"] = compare_and_append_default_proxy_config(
         existing_providers=current_spec.defaultConfig.get("providers", []),
         expected_providers=expected_providers,
         operating_id_prefix=operating_id_prefix,
+        referenced_ids={
+            provider_id
+            for provider_id in map(_match_rule_provider_id, match_rules)
+            if provider_id
+        },
     )
-    current_spec.matchRules = compare_and_append_proxy_match_rules(
-        existing_rules=current_spec.matchRules or [],
-        expected_rules=expected_match_rules,
-        operating_id_prefix=operating_id_prefix,
-    )
+    current_spec.matchRules = match_rules
     return current_spec
 
 

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -944,57 +944,30 @@ async def ensure_route_ai_proxy_config(
     cfg: Config,
     model_route_id: int,
     extensions_api: ExtensionsHigressIoV1Api,
-    route_destinations: mcp_handler.DestinationTupleList,
-    fallback_destinations: mcp_handler.DestinationTupleList,
+    model_groups: List[mcp_handler.ModelAIProxyGroup],
 ):
-    service_namespace_prefix = cfg.get_namespace() + "/"
-    if cfg.get_namespace() == cfg.gateway_namespace:
-        service_namespace_prefix = ""
-    operating_id = mcp_handler.model_route_cleanup_prefix(model_route_id)
-    ingress_name = mcp_handler.model_route_ingress_name(model_route_id)
-    fallback_ingress_name = mcp_handler.fallback_ingress_name(ingress_name)
-    expected_providers = []
-    expected_match_rules = []
-    # cross provider needs to configure ai_proxy
-    unique_registry_services: Set[str] = set(
-        registry.get_service_name()
-        for _, _, registry in route_destinations
-        if (not registry.name.startswith(mcp_handler.provider_id_prefix))
-    )
-    unique_fallback_registry_services: Set[str] = set(
-        registry.get_service_name()
-        for _, _, registry in fallback_destinations
-        if (not registry.name.startswith(mcp_handler.provider_id_prefix))
-    )
+    """Reconcile this route's slice of the ai-proxy CR, grouped by deployment.
 
-    if len(unique_registry_services) + len(unique_fallback_registry_services) > 0:
-        expected_providers.append(
-            mcp_handler.ai_proxy_openai_provider_config(operating_id)
-        )
+    Provider entries are keyed by Model, so a Model targeted by several routes
+    has exactly one of them and route-level changes never rewrite it. Ownership
+    of the *rules* is therefore expressed by ingress rather than by provider id
+    — see ``compare_and_append_proxy_match_rules``.
 
-    if len(unique_registry_services) > 0:
-        expected_match_rules.append(
-            WasmPluginMatchRule(
-                config={
-                    "activeProviderId": operating_id,
-                },
-                configDisable=False,
-                service=list(unique_registry_services),
-                ingress=[f"{service_namespace_prefix}{ingress_name}"],
-            )
+    External model providers are not handled here: ``ModelProviderController``
+    owns their ``provider-<id>`` entries, whose rules match on service only.
+    """
+    prefixed_ingress_name, prefixed_fallback_ingress_name = (
+        mcp_handler.route_ingress_names_for_plugins(
+            model_route_id=model_route_id,
+            resource_namespace=cfg.get_namespace(),
+            gateway_namespace=cfg.gateway_namespace,
         )
-    # same logic for fallback
-    if len(unique_fallback_registry_services) > 0:
-        expected_match_rules.append(
-            WasmPluginMatchRule(
-                config={
-                    "activeProviderId": operating_id,
-                },
-                configDisable=False,
-                service=list(unique_fallback_registry_services),
-                ingress=[f"{service_namespace_prefix}{fallback_ingress_name}"],
-            )
-        )
+    )
+    expected_providers, expected_match_rules = mcp_handler.model_ai_proxy_plugin_spec(
+        groups=model_groups,
+        main_ingress=prefixed_ingress_name,
+        fallback_ingress=prefixed_fallback_ingress_name,
+    )
 
     await mcp_handler.ensure_wasm_plugin(
         api=extensions_api,
@@ -1004,7 +977,10 @@ async def ensure_route_ai_proxy_config(
             mcp_handler.ai_proxy_diff_spec,
             expected_providers=expected_providers,
             expected_match_rules=expected_match_rules,
-            operating_id_prefix=operating_id,
+            owned_ingresses={
+                prefixed_ingress_name,
+                prefixed_fallback_ingress_name,
+            },
         ),
     )
 
@@ -1034,11 +1010,12 @@ async def sync_gateway(
     )
     destinations = []
     fallback_destinations = []
+    model_groups: List[mcp_handler.ModelAIProxyGroup] = []
     if not model_route_from_db:
         event_type = EventType.DELETED
     if event.type != EventType.DELETED:
-        destinations, fallback_destinations = await calculate_destinations(
-            session, model_route
+        destinations, fallback_destinations, model_groups = (
+            await calculate_destinations(session, model_route)
         )
     # Effective model name = `<owner-name>/<route.name>` for non-platform
     # Orgs (so two Orgs can use the same `route.name` without colliding
@@ -1115,8 +1092,7 @@ async def sync_gateway(
         cfg=cfg,
         model_route_id=model_route.id,
         extensions_api=extensions_api,
-        route_destinations=destinations,
-        fallback_destinations=fallback_destinations,
+        model_groups=model_groups,
     )
 
 
@@ -1142,19 +1118,32 @@ def flatten_destinations(
 async def calculate_destinations(
     session: AsyncSession,
     model_route: ModelRoute,
-) -> Tuple[mcp_handler.DestinationTupleList, mcp_handler.DestinationTupleList]:
+) -> Tuple[
+    mcp_handler.DestinationTupleList,
+    mcp_handler.DestinationTupleList,
+    List[mcp_handler.ModelAIProxyGroup],
+]:
     """
-    return persentage Tuple for each registry with model name and the fallback registry
+    Return the percentage tuple for each registry with model name and the
+    fallback registry, plus the route's self-hosted destinations grouped by
+    deployment (Model) for the ai-proxy provider config. External provider
+    targets are excluded from the groups — they carry their own credentials and
+    their own provider entry.
     """
     weight_to_count: List[Tuple[int, int, mcp_handler.DestinationTupleList]] = []
     fallback_weight_to_count: List[
         Tuple[int, int, mcp_handler.DestinationTupleList]
     ] = []
+    model_groups: Dict[int, mcp_handler.ModelAIProxyGroup] = {}
+    # Routes commonly fan out to several deployments of one cluster; cache the
+    # token per cluster so the group build stays at one query per cluster.
+    cluster_api_tokens: Dict[Optional[int], List[str]] = {}
     targets = await ModelRouteTarget.all_by_field(session, "route_id", model_route.id)
     for target in targets:
         if target.state != TargetStateEnum.ACTIVE:
             continue
         to_extend: mcp_handler.DestinationTupleList = []
+        model: Optional[Model] = None
         if target.model_id is not None:
             model = await Model.one_by_id(session, target.model_id)
             if model is None:
@@ -1171,15 +1160,25 @@ async def calculate_destinations(
         if to_extend is None or len(to_extend) == 0:
             # no valid destination found
             continue
-        count = sum([count for count, _, _ in to_extend])
-        weight_to_count.append((target.weight, count, to_extend))
-        if (
+        is_fallback_target = (
             target.fallback_status_codes is not None
             and len(target.fallback_status_codes) > 0
-        ):
+        )
+        if model is not None:
+            await accumulate_model_ai_proxy_group(
+                session=session,
+                model_groups=model_groups,
+                cluster_api_tokens=cluster_api_tokens,
+                model=model,
+                destinations=to_extend,
+                is_fallback_target=is_fallback_target,
+            )
+        count = sum([count for count, _, _ in to_extend])
+        weight_to_count.append((target.weight, count, to_extend))
+        if is_fallback_target:
             fallback_weight_to_count.append((target.weight, count, to_extend))
     if len(weight_to_count) == 0:
-        return [], []
+        return [], [], []
 
     flatten_registry_list = flatten_destinations(weight_to_count)
     fallback_registry_list = []
@@ -1189,7 +1188,60 @@ async def calculate_destinations(
             fallback_weight_to_count, max_weight=1
         )
 
-    return flatten_registry_list, fallback_registry_list
+    return flatten_registry_list, fallback_registry_list, list(model_groups.values())
+
+
+async def accumulate_model_ai_proxy_group(
+    session: AsyncSession,
+    model_groups: Dict[int, mcp_handler.ModelAIProxyGroup],
+    cluster_api_tokens: Dict[Optional[int], List[str]],
+    model: Model,
+    destinations: mcp_handler.DestinationTupleList,
+    is_fallback_target: bool,
+):
+    """Fold one route target's upstream services into its deployment's group.
+
+    A Model can appear under several targets of the same route (e.g. one target
+    per LoRA, each aliasing the same instances), so services accumulate instead
+    of overwriting. The credential is the deployment's cluster registration
+    token: it is the only existing credential every worker of that cluster
+    accepts, and ai-proxy holds one ``apiTokens`` list per provider while the
+    backend worker is picked independently by Envoy.
+
+    ``cluster_api_tokens`` is the caller's per-reconcile cache, so a route with
+    many deployments in one cluster resolves the token once.
+    """
+    group = model_groups.get(model.id)
+    if group is None:
+        if model.cluster_id not in cluster_api_tokens:
+            cluster_api_tokens[model.cluster_id] = await cluster_registration_tokens(
+                session, model.cluster_id
+            )
+        group = mcp_handler.ModelAIProxyGroup(
+            model_id=model.id,
+            api_tokens=cluster_api_tokens[model.cluster_id],
+        )
+        model_groups[model.id] = group
+    service_names = {registry.get_service_name() for _, _, registry in destinations}
+    group.service_names.update(service_names)
+    if is_fallback_target:
+        group.fallback_service_names.update(service_names)
+
+
+async def cluster_registration_tokens(
+    session: AsyncSession, cluster_id: Optional[int]
+) -> List[str]:
+    """The cluster's registration token as an ai-proxy ``apiTokens`` list.
+
+    Empty when the cluster or its token is missing, which leaves ai-proxy on its
+    pre-existing behavior of reading the inbound ``Authorization`` header.
+    """
+    if cluster_id is None:
+        return []
+    cluster = await Cluster.one_by_id(session, cluster_id)
+    if cluster is None or not cluster.registration_token:
+        return []
+    return [cluster.registration_token]
 
 
 async def provider_destinations(

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -98,6 +98,7 @@ from gpustack.gateway.utils import (
     model_route_ingress_prefix,
     model_route_ingress_name,
     fallback_ingress_name,
+    route_ingress_names_for_plugins,
     cleanup_ingresses,
     cleanup_model_mapper,
     cleanup_fallback_filters,
@@ -1016,6 +1017,10 @@ class Server:
             session=session,
             fields={"deleted_at": None},
         )
+        models = await Model.all_by_fields(
+            session=session,
+            fields={"deleted_at": None},
+        )
         model_instances = await ModelInstance.all_by_fields(
             session=session,
             fields={"deleted_at": None},
@@ -1065,10 +1070,25 @@ class Server:
             reason="orphaned",
             k8s_config=k8s_config,
         )
+        # Both ingress names of every live route, spelled as the plugin's match
+        # rules store them, so rules left behind by a route deleted while the
+        # server was down are pruned even when the deployment they point at is
+        # still alive.
+        expected_plugin_ingresses = {
+            name
+            for model_route in model_routes
+            for name in route_ingress_names_for_plugins(
+                model_route_id=model_route.id,
+                resource_namespace=self.config.get_namespace(),
+                gateway_namespace=self.config.gateway_namespace,
+            )
+        }
         await cleanup_ai_proxy_config(
             namespace=self.config.gateway_namespace,
             providers=providers,
+            models=models,
             routes=model_routes,
+            expected_ingresses=expected_plugin_ingresses,
             k8s_config=k8s_config,
         )
         await cleanup_generic_proxy_router(

--- a/tests/gateway/test_ai_proxy_model_grouping.py
+++ b/tests/gateway/test_ai_proxy_model_grouping.py
@@ -1,0 +1,529 @@
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gpustack.gateway.client.extensions_higress_io_v1_api import (
+    WasmPluginMatchRule,
+    WasmPluginSpec,
+)
+from gpustack.gateway.utils import (
+    ModelAIProxyGroup,
+    ai_proxy_diff_spec,
+    ai_proxy_openai_provider_config,
+    cleanup_ai_proxy_config,
+    model_ai_proxy_plugin_spec,
+    model_ai_proxy_provider_id,
+    provider_id_prefix,
+    route_ingress_names_for_plugins,
+)
+from gpustack.schemas.model_provider import ModelProvider
+from gpustack.schemas.model_routes import ModelRoute
+from gpustack.schemas.models import Model
+
+ROUTE_A = "default/ai-route-route-1.internal"
+ROUTE_A_FALLBACK = "default/ai-route-route-1.fallback.internal"
+ROUTE_B = "default/ai-route-route-2.internal"
+ROUTE_B_FALLBACK = "default/ai-route-route-2.fallback.internal"
+
+
+def _spec(
+    providers: Optional[List[Dict[str, Any]]] = None,
+    match_rules: Optional[List[WasmPluginMatchRule]] = None,
+) -> WasmPluginSpec:
+    return WasmPluginSpec(
+        defaultConfig={"providers": providers or []},
+        matchRules=match_rules or [],
+    )
+
+
+def _rule(provider_id: str, ingress: str, services: List[str]) -> WasmPluginMatchRule:
+    return WasmPluginMatchRule(
+        config={"activeProviderId": provider_id},
+        configDisable=False,
+        service=services,
+        ingress=[ingress],
+    )
+
+
+def _provider_ids(spec: WasmPluginSpec) -> List[str]:
+    return [p["id"] for p in spec.defaultConfig["providers"]]
+
+
+def _rule_keys(spec: WasmPluginSpec) -> List[tuple]:
+    return [
+        (
+            (r.config or {}).get("activeProviderId"),
+            tuple(r.ingress or []),
+            tuple(r.service or []),
+        )
+        for r in spec.matchRules or []
+    ]
+
+
+def test_provider_id_is_per_deployment():
+    assert model_ai_proxy_provider_id(7) == "gpustack-model-7"
+
+
+def test_api_tokens_only_present_when_supplied():
+    with_token = ai_proxy_openai_provider_config("gpustack-model-7", ["gpustack_ak_sk"])
+    assert with_token["apiTokens"] == ["gpustack_ak_sk"]
+    # Absent rather than empty: an empty list would be a CR change with no
+    # meaning, and ai-proxy's fallback to the inbound header is what we want.
+    assert "apiTokens" not in ai_proxy_openai_provider_config("gpustack-model-7")
+
+
+def test_plugin_spec_groups_by_deployment():
+    groups = [
+        ModelAIProxyGroup(
+            model_id=9,
+            api_tokens=["token-cluster-2"],
+            service_names={"model-9-2.static", "model-9-1.static"},
+        ),
+        ModelAIProxyGroup(
+            model_id=5,
+            api_tokens=["token-cluster-1"],
+            service_names={"model-5-1.static"},
+            fallback_service_names={"model-5-1.static"},
+        ),
+    ]
+
+    providers, rules = model_ai_proxy_plugin_spec(groups, ROUTE_A, ROUTE_A_FALLBACK)
+
+    # One provider per deployment, each holding its own cluster's token.
+    assert [p["id"] for p in providers] == ["gpustack-model-5", "gpustack-model-9"]
+    assert providers[0]["apiTokens"] == ["token-cluster-1"]
+    assert providers[1]["apiTokens"] == ["token-cluster-2"]
+    # A fallback target gets a second rule on the fallback ingress; services are
+    # sorted so an unchanged deployment yields a byte-identical CR.
+    assert [(r.config["activeProviderId"], r.ingress, r.service) for r in rules] == [
+        ("gpustack-model-5", [ROUTE_A], ["model-5-1.static"]),
+        ("gpustack-model-5", [ROUTE_A_FALLBACK], ["model-5-1.static"]),
+        (
+            "gpustack-model-9",
+            [ROUTE_A],
+            ["model-9-1.static", "model-9-2.static"],
+        ),
+    ]
+
+
+def test_plugin_spec_skips_deployment_without_services():
+    providers, rules = model_ai_proxy_plugin_spec(
+        [ModelAIProxyGroup(model_id=5, api_tokens=["t"])], ROUTE_A, ROUTE_A_FALLBACK
+    )
+    assert providers == []
+    assert rules == []
+
+
+def test_two_routes_share_one_deployment_provider():
+    """Reconciling one route must not disturb another route's rule for the same
+    deployment — the whole point of moving ownership from provider id to ingress.
+    """
+    live = _spec(
+        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["token"])],
+        match_rules=[_rule("gpustack-model-5", ROUTE_B, ["model-5-1.static"])],
+    )
+    providers, rules = model_ai_proxy_plugin_spec(
+        [
+            ModelAIProxyGroup(
+                model_id=5, api_tokens=["token"], service_names={"model-5-1.static"}
+            )
+        ],
+        ROUTE_A,
+        ROUTE_A_FALLBACK,
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=providers,
+        expected_match_rules=rules,
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert _provider_ids(result) == ["gpustack-model-5"], "provider must not duplicate"
+    assert _rule_keys(result) == [
+        ("gpustack-model-5", (ROUTE_A,), ("model-5-1.static",)),
+        ("gpustack-model-5", (ROUTE_B,), ("model-5-1.static",)),
+    ]
+
+
+def test_route_removal_keeps_provider_while_another_route_references_it():
+    live = _spec(
+        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["token"])],
+        match_rules=[
+            _rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"]),
+            _rule("gpustack-model-5", ROUTE_B, ["model-5-1.static"]),
+        ],
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=[],
+        expected_match_rules=[],
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert _rule_keys(result) == [
+        ("gpustack-model-5", (ROUTE_B,), ("model-5-1.static",))
+    ]
+    assert _provider_ids(result) == ["gpustack-model-5"]
+
+
+def test_last_route_removal_garbage_collects_the_provider():
+    live = _spec(
+        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["token"])],
+        match_rules=[_rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"])],
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=[],
+        expected_match_rules=[],
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert result.matchRules == []
+    assert _provider_ids(result) == []
+
+
+def test_fallback_ingress_rule_is_dropped_when_fallback_goes_away():
+    live = _spec(
+        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["token"])],
+        match_rules=[
+            _rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"]),
+            _rule("gpustack-model-5", ROUTE_A_FALLBACK, ["model-5-1.static"]),
+        ],
+    )
+    providers, rules = model_ai_proxy_plugin_spec(
+        [
+            ModelAIProxyGroup(
+                model_id=5, api_tokens=["token"], service_names={"model-5-1.static"}
+            )
+        ],
+        ROUTE_A,
+        ROUTE_A_FALLBACK,
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=providers,
+        expected_match_rules=rules,
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert _rule_keys(result) == [
+        ("gpustack-model-5", (ROUTE_A,), ("model-5-1.static",))
+    ]
+
+
+def test_token_change_updates_the_existing_provider_entry():
+    live = _spec(
+        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["old-token"])],
+        match_rules=[_rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"])],
+    )
+    providers, rules = model_ai_proxy_plugin_spec(
+        [
+            ModelAIProxyGroup(
+                model_id=5, api_tokens=["new-token"], service_names={"model-5-1.static"}
+            )
+        ],
+        ROUTE_A,
+        ROUTE_A_FALLBACK,
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=providers,
+        expected_match_rules=rules,
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert _provider_ids(result) == ["gpustack-model-5"]
+    assert result.defaultConfig["providers"][0]["apiTokens"] == ["new-token"]
+
+
+def test_external_provider_reconcile_leaves_deployment_entries_alone():
+    """``ModelProviderController`` owns ``provider-<id>`` entries and reconciles
+    them by id prefix; its rules match on service only, so they carry no ingress.
+    """
+    live = _spec(
+        providers=[
+            ai_proxy_openai_provider_config("gpustack-model-5", ["token"]),
+            {"id": "provider-3", "type": "openai", "apiTokens": ["stale"]},
+        ],
+        match_rules=[
+            _rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"]),
+            WasmPluginMatchRule(
+                config={"activeProviderId": "provider-3"},
+                configDisable=False,
+                service=["provider-3.dns"],
+            ),
+        ],
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=[
+            {"id": "provider-3", "type": "openai", "apiTokens": ["ok"]}
+        ],
+        expected_match_rules=[
+            WasmPluginMatchRule(
+                config={"activeProviderId": "provider-3"},
+                configDisable=False,
+                service=["provider-3.dns"],
+            )
+        ],
+        operating_id_prefix=provider_id_prefix,
+    )
+
+    assert _provider_ids(result) == ["gpustack-model-5", "provider-3"]
+    assert [p for p in result.defaultConfig["providers"] if p["id"] == "provider-3"][0][
+        "apiTokens"
+    ] == ["ok"]
+    assert _rule_keys(result) == [
+        ("gpustack-model-5", (ROUTE_A,), ("model-5-1.static",)),
+        ("provider-3", (), ("provider-3.dns",)),
+    ]
+
+
+def test_diff_is_idempotent():
+    groups = [
+        ModelAIProxyGroup(
+            model_id=5,
+            api_tokens=["token"],
+            service_names={"model-5-2.static", "model-5-1.static"},
+            fallback_service_names={"model-5-1.static"},
+        )
+    ]
+    providers, rules = model_ai_proxy_plugin_spec(groups, ROUTE_A, ROUTE_A_FALLBACK)
+
+    first = ai_proxy_diff_spec(
+        _spec(),
+        expected_providers=providers,
+        expected_match_rules=rules,
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+    providers, rules = model_ai_proxy_plugin_spec(groups, ROUTE_A, ROUTE_A_FALLBACK)
+    second = ai_proxy_diff_spec(
+        first,
+        expected_providers=providers,
+        expected_match_rules=rules,
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert second.model_dump(exclude_none=True) == first.model_dump(exclude_none=True)
+
+
+def test_diff_returns_none_when_plugin_absent():
+    assert (
+        ai_proxy_diff_spec(None, expected_providers=[], expected_match_rules=[]) is None
+    )
+
+
+def test_legacy_route_entry_migrates_in_one_write():
+    """A route retires its own legacy entry in the same write that adds the
+    deployment entry replacing it, so it is never left without a provider.
+    """
+    live = _spec(
+        providers=[{"id": "ai-route-route-1", "type": "openai"}],
+        match_rules=[
+            _rule("ai-route-route-1", ROUTE_A, ["model-5-1.static"]),
+            _rule("ai-route-route-1", ROUTE_A_FALLBACK, ["model-5-1.static"]),
+        ],
+    )
+    providers, rules = model_ai_proxy_plugin_spec(
+        [
+            ModelAIProxyGroup(
+                model_id=5,
+                api_tokens=["token"],
+                service_names={"model-5-1.static"},
+                fallback_service_names={"model-5-1.static"},
+            )
+        ],
+        ROUTE_A,
+        ROUTE_A_FALLBACK,
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=providers,
+        expected_match_rules=rules,
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert _provider_ids(result) == ["gpustack-model-5"]
+    # Sorted by (provider id, ingress, services), so the fallback ingress sorts
+    # ahead of the main one on the shared prefix.
+    assert _rule_keys(result) == [
+        ("gpustack-model-5", (ROUTE_A_FALLBACK,), ("model-5-1.static",)),
+        ("gpustack-model-5", (ROUTE_A,), ("model-5-1.static",)),
+    ]
+
+
+def test_another_routes_legacy_entry_is_left_alone():
+    """Ownership is by ingress, so reconciling one route must not retire the
+    legacy entry of a route that has not reconciled yet.
+    """
+    live = _spec(
+        providers=[{"id": "ai-route-route-2", "type": "openai"}],
+        match_rules=[_rule("ai-route-route-2", ROUTE_B, ["model-9-1.static"])],
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=[],
+        expected_match_rules=[],
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert _provider_ids(result) == ["ai-route-route-2"]
+    assert _rule_keys(result) == [
+        ("ai-route-route-2", (ROUTE_B,), ("model-9-1.static",))
+    ]
+
+
+@pytest.mark.asyncio
+async def test_startup_cleanup_drops_only_entries_nothing_will_reconcile():
+    """The startup pass keeps live providers, live deployments, and the legacy
+    entry of every live route — the last of those because the route retires it
+    itself moments later, and pruning it here would leave the route without a
+    provider until the replay reaches it. Only entries whose route, deployment or
+    provider is gone are dropped, since nothing will ever reconcile those.
+    """
+    live_plugin = {
+        "metadata": {"name": "gpustack-ai-proxy"},
+        "spec": {
+            "defaultConfig": {
+                "providers": [
+                    {"id": "ai-route-route-1", "type": "openai"},
+                    {"id": "ai-route-route-404", "type": "openai"},
+                    {"id": "gpustack-model-5", "type": "openai"},
+                    {"id": "gpustack-model-404", "type": "openai"},
+                    {"id": "provider-3", "type": "openai"},
+                    {"id": "provider-404", "type": "openai"},
+                ]
+            },
+            "matchRules": [
+                _rule("ai-route-route-1", ROUTE_A, ["model-5-1.static"]).model_dump(),
+                _rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"]).model_dump(),
+                _rule(
+                    "gpustack-model-404", ROUTE_B, ["model-404-1.static"]
+                ).model_dump(),
+            ],
+        },
+    }
+    api = MagicMock()
+    api.get_wasmplugin = AsyncMock(return_value=live_plugin)
+    api.edit_wasmplugin = AsyncMock()
+
+    with (
+        patch("gpustack.gateway.utils.ExtensionsHigressIoV1Api", return_value=api),
+        patch("gpustack.gateway.utils.k8s_client.ApiClient"),
+    ):
+        await cleanup_ai_proxy_config(
+            providers=[ModelProvider(id=3, name="p3")],
+            models=[Model(id=5, name="m5")],
+            routes=[ModelRoute(id=1, name="r1")],
+            expected_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+            k8s_config=MagicMock(),
+            namespace="higress-system",
+        )
+
+    body = api.edit_wasmplugin.await_args.kwargs["body"]
+    assert _provider_ids(body.spec) == [
+        "ai-route-route-1",
+        "gpustack-model-5",
+        "provider-3",
+    ]
+    assert _rule_keys(body.spec) == [
+        ("ai-route-route-1", (ROUTE_A,), ("model-5-1.static",)),
+        ("gpustack-model-5", (ROUTE_A,), ("model-5-1.static",)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_startup_cleanup_drops_rules_of_a_deleted_route():
+    """A route deleted while the server was down leaves a rule that still points
+    at a live deployment provider, and no reconcile will ever revisit it — so the
+    provider id alone cannot decide retention. Rules of external providers carry
+    no ingress and must survive.
+    """
+    live_plugin = {
+        "metadata": {"name": "gpustack-ai-proxy"},
+        "spec": {
+            "defaultConfig": {
+                "providers": [
+                    {"id": "gpustack-model-5", "type": "openai"},
+                    {"id": "provider-3", "type": "openai"},
+                ]
+            },
+            "matchRules": [
+                _rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"]).model_dump(),
+                # Same live deployment, but route 2 is gone.
+                _rule("gpustack-model-5", ROUTE_B, ["model-5-1.static"]).model_dump(),
+                WasmPluginMatchRule(
+                    config={"activeProviderId": "provider-3"},
+                    configDisable=False,
+                    service=["provider-3.dns"],
+                ).model_dump(),
+            ],
+        },
+    }
+    api = MagicMock()
+    api.get_wasmplugin = AsyncMock(return_value=live_plugin)
+    api.edit_wasmplugin = AsyncMock()
+
+    with (
+        patch("gpustack.gateway.utils.ExtensionsHigressIoV1Api", return_value=api),
+        patch("gpustack.gateway.utils.k8s_client.ApiClient"),
+    ):
+        await cleanup_ai_proxy_config(
+            providers=[ModelProvider(id=3, name="p3")],
+            models=[Model(id=5, name="m5")],
+            routes=[ModelRoute(id=1, name="r1")],
+            expected_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+            k8s_config=MagicMock(),
+            namespace="higress-system",
+        )
+
+    body = api.edit_wasmplugin.await_args.kwargs["body"]
+    assert _rule_keys(body.spec) == [
+        ("gpustack-model-5", (ROUTE_A,), ("model-5-1.static",)),
+        ("provider-3", (), ("provider-3.dns",)),
+    ]
+    assert _provider_ids(body.spec) == ["gpustack-model-5", "provider-3"]
+
+
+def test_ingress_names_for_plugins_qualify_across_namespaces():
+    assert route_ingress_names_for_plugins(42, "default", "higress-system") == (
+        "default/ai-route-route-42.internal",
+        "default/ai-route-route-42.fallback.internal",
+    )
+    # Same namespace needs no qualifier.
+    assert route_ingress_names_for_plugins(42, "gpustack", "gpustack") == (
+        "ai-route-route-42.internal",
+        "ai-route-route-42.fallback.internal",
+    )
+
+
+def test_none_config_and_default_config_are_tolerated():
+    """``config`` and ``defaultConfig`` are Optional on the CR models, so a
+    hand-edited ``null`` must not crash the reconcile.
+    """
+    live = WasmPluginSpec(
+        defaultConfig=None,
+        matchRules=[WasmPluginMatchRule(config=None, ingress=[ROUTE_B])],
+    )
+
+    result = ai_proxy_diff_spec(
+        live,
+        expected_providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["t"])],
+        expected_match_rules=[_rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"])],
+        owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
+    )
+
+    assert _provider_ids(result) == ["gpustack-model-5"]
+    assert _rule_keys(result) == [
+        (None, (ROUTE_B,), ()),
+        ("gpustack-model-5", (ROUTE_A,), ("model-5-1.static",)),
+    ]

--- a/tests/server/test_route_ai_proxy_grouping.py
+++ b/tests/server/test_route_ai_proxy_grouping.py
@@ -1,0 +1,178 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gpustack.gateway.utils import lora_registry_name_suffix
+from gpustack.schemas.clusters import Cluster
+from gpustack.schemas.model_routes import ModelRoute, ModelRouteTarget, TargetStateEnum
+from gpustack.schemas.models import ModelInstanceStateEnum
+from gpustack.server.controllers import (
+    accumulate_model_ai_proxy_group,
+    calculate_destinations,
+)
+from tests.utils.model import new_model, new_model_instance
+
+CLUSTER_ID = 3
+MODEL_ID = 5
+
+
+def _cluster(id: int = CLUSTER_ID, token: str = "cluster-token") -> Cluster:
+    # ``system_principal_id`` stays None so ``get_cluster_registry`` returns
+    # None and destinations are built from the deployment's own instances.
+    return Cluster(id=id, name=f"cluster-{id}", registration_token=token)
+
+
+def _running_instance(id: int, model_id: int = MODEL_ID):
+    instance = new_model_instance(
+        id,
+        f"instance-{id}",
+        model_id,
+        worker_id=id,
+        state=ModelInstanceStateEnum.RUNNING,
+    )
+    instance.worker_ip = f"10.0.0.{id}"
+    instance.port = 8000
+    return instance
+
+
+def _target(id: int, overridden_model_name=None, weight: int = 1):
+    return ModelRouteTarget(
+        id=id,
+        route_id=1,
+        model_id=MODEL_ID,
+        overridden_model_name=overridden_model_name,
+        weight=weight,
+        state=TargetStateEnum.ACTIVE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lora_targets_of_one_deployment_fold_into_a_single_group():
+    """Several LoRA targets on one deployment share a single provider.
+
+    Each LoRA target aliases the same instances under its own service name
+    (see ``lora_registry_name_suffix``), so the group has to accumulate the
+    services of every target instead of overwriting them — otherwise only the
+    last adapter's rule would carry the deployment's token.
+    """
+    model = new_model(MODEL_ID, "base", huggingface_repo_id="repo/base")
+    model.cluster_id = CLUSTER_ID
+    instances = [_running_instance(1), _running_instance(2)]
+    targets = [
+        _target(1),
+        _target(2, overridden_model_name="base:adapter-a"),
+        _target(3, overridden_model_name="base:adapter-b"),
+    ]
+
+    with (
+        patch(
+            "gpustack.server.controllers.ModelRouteTarget.all_by_field",
+            AsyncMock(return_value=targets),
+        ),
+        patch(
+            "gpustack.server.controllers.Model.one_by_id",
+            AsyncMock(return_value=model),
+        ),
+        patch(
+            "gpustack.server.controllers.Cluster.one_by_id",
+            AsyncMock(return_value=_cluster()),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstance.all_by_field",
+            AsyncMock(return_value=instances),
+        ),
+        patch(
+            "gpustack.server.controllers.Worker.all_by_fields",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        _, _, groups = await calculate_destinations(
+            session=None, model_route=ModelRoute(id=1, name="base")
+        )
+
+    assert len(groups) == 1
+    group = groups[0]
+    assert group.provider_id() == "gpustack-model-5"
+    assert group.api_tokens == ["cluster-token"]
+    suffix_a = lora_registry_name_suffix("base:adapter-a")
+    suffix_b = lora_registry_name_suffix("base:adapter-b")
+    assert group.service_names == {
+        "model-5-1.static",
+        "model-5-2.static",
+        f"model-5-1-{suffix_a}.static",
+        f"model-5-2-{suffix_a}.static",
+        f"model-5-1-{suffix_b}.static",
+        f"model-5-2-{suffix_b}.static",
+    }
+    # No target declares fallback status codes, so the fallback ingress gets no
+    # rule at all.
+    assert group.fallback_service_names == set()
+
+
+@pytest.mark.asyncio
+async def test_fallback_target_services_land_on_both_ingresses():
+    model = new_model(MODEL_ID, "base", huggingface_repo_id="repo/base")
+    model.cluster_id = CLUSTER_ID
+    fallback_target = _target(2, overridden_model_name="base:adapter-a")
+    fallback_target.fallback_status_codes = ["5xx"]
+
+    with (
+        patch(
+            "gpustack.server.controllers.ModelRouteTarget.all_by_field",
+            AsyncMock(return_value=[_target(1), fallback_target]),
+        ),
+        patch(
+            "gpustack.server.controllers.Model.one_by_id",
+            AsyncMock(return_value=model),
+        ),
+        patch(
+            "gpustack.server.controllers.Cluster.one_by_id",
+            AsyncMock(return_value=_cluster()),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstance.all_by_field",
+            AsyncMock(return_value=[_running_instance(1)]),
+        ),
+        patch(
+            "gpustack.server.controllers.Worker.all_by_fields",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        _, _, groups = await calculate_destinations(
+            session=None, model_route=ModelRoute(id=1, name="base")
+        )
+
+    (group,) = groups
+    suffix_a = lora_registry_name_suffix("base:adapter-a")
+    assert group.service_names == {
+        "model-5-1.static",
+        f"model-5-1-{suffix_a}.static",
+    }
+    # Only the fallback target's alias is on the fallback ingress; it is a
+    # subset of the main ingress' services.
+    assert group.fallback_service_names == {f"model-5-1-{suffix_a}.static"}
+    assert group.fallback_service_names < group.service_names
+
+
+@pytest.mark.asyncio
+async def test_cluster_token_is_resolved_once_per_cluster():
+    """Deployments of one cluster share the reconcile's token lookup."""
+    one_by_id = AsyncMock(return_value=_cluster())
+    model_groups = {}
+    cluster_api_tokens = {}
+
+    with patch("gpustack.server.controllers.Cluster.one_by_id", one_by_id):
+        for model_id in (MODEL_ID, MODEL_ID + 1):
+            model = new_model(model_id, f"m-{model_id}", huggingface_repo_id="repo/m")
+            model.cluster_id = CLUSTER_ID
+            await accumulate_model_ai_proxy_group(
+                session=None,
+                model_groups=model_groups,
+                cluster_api_tokens=cluster_api_tokens,
+                model=model,
+                destinations=[],
+                is_fallback_target=False,
+            )
+
+    assert one_by_id.await_count == 1
+    assert {group.api_tokens[0] for group in model_groups.values()} == {"cluster-token"}


### PR DESCRIPTION
Refer to issue:
- #5991 

- One `gpustack-model-<model_id>` provider per deployment, shared by every route targeting it, replacing the per-route `ai-route-route-<route_id>` providers.
- `apiTokens` holds the deployment's cluster registration token, so the upstream credential is static instead of injected per request.
- Match-rule ownership keys on ingress rather than provider-id prefix, since ids are no longer route-unique. A route therefore retires its own legacy entry in the same write that adds its replacement, and the startup pass only drops entries whose route, deployment or provider no longer exists.