### PR TITLE
feat(auth): add a fast digest for generated API key secrets

### DIFF
--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -11,7 +11,7 @@ from starlette.datastructures import Headers
 from gpustack.config.config import Config
 from gpustack.schemas.config import GatewayModeEnum
 from gpustack.server.db import async_session
-from typing import Annotated, Optional, Tuple, List, Dict
+from typing import Annotated, Optional, Set, Tuple, List, Dict
 from fastapi.security import (
     APIKeyCookie,
     APIKeyHeader,
@@ -21,6 +21,7 @@ from fastapi.security import (
     HTTPBearer,
 )
 from fastapi.security.utils import get_authorization_scheme_param
+from sqlalchemy import update
 from sqlmodel.ext.asyncio.session import AsyncSession
 from gpustack.api.exceptions import (
     ForbiddenException,
@@ -33,9 +34,13 @@ from gpustack.schemas.users import User
 from gpustack.schemas.principals import Principal, PrincipalType
 from gpustack.security import (
     JWTManager,
+    new_secret_key_digest,
+    secret_key_digest_usable,
     verify_hashed_secret,
+    verify_secret_key_digest,
     get_key_pair,
 )
+from gpustack.server.cache import delete_cache_by_key
 from gpustack.server.passwords import verify_password
 from gpustack.server.services import APIKeyService, UserService
 from gpustack.websocket_proxy.authenticator import (
@@ -329,6 +334,108 @@ def parse_hyphen_uuid(value: str) -> Optional[str]:
         return None
 
 
+_backfill_tasks: Set[asyncio.Task] = set()
+_backfill_in_flight: Set[int] = set()
+# Keys whose stored digest this build cannot parse. Warned about once per key per
+# process: the condition is per-request, and a polling worker would otherwise
+# flood the log with the same line.
+_warned_unusable_digest: Set[int] = set()
+
+
+def _schedule_secret_key_digest_backfill(api_key: ApiKey, secret_key: str) -> None:
+    """Write ``secret_key_digest`` for a key that has no usable one.
+
+    Off the request path on purpose: this is a pure optimization -- a key without
+    a digest keeps working through argon2 -- and the first wave after an upgrade
+    would otherwise put a DB write in front of a batch of authentications. For the
+    same reason nothing here may raise: the caller has already authenticated the
+    request, and turning that into a 500 over a missed optimization would be
+    absurd.
+
+    Each key converges after one successful verification, so this is a one-time
+    cost per key rather than anything the steady state pays.
+    """
+    try:
+        digest = new_secret_key_digest(
+            secret_key=secret_key,
+            is_custom=api_key.is_custom,
+            access_key=api_key.access_key,
+        )
+        if digest is None or api_key.id is None:
+            # Custom keys and the legacy cluster token stay on argon2 forever.
+            return
+        if api_key.id in _backfill_in_flight:
+            return
+        # Hold a reference: a bare create_task may be collected mid-flight.
+        task = asyncio.create_task(
+            _backfill_secret_key_digest(
+                api_key.id,
+                api_key.access_key,
+                digest,
+                expected_current=api_key.secret_key_digest,
+            )
+        )
+        # Marked in flight only once the task exists, and safe to do after
+        # ``create_task`` because the coroutine cannot run -- and so cannot reach
+        # its ``finally`` -- before this synchronous function yields.
+        _backfill_in_flight.add(api_key.id)
+        _backfill_tasks.add(task)
+        task.add_done_callback(_backfill_tasks.discard)
+    except Exception:
+        logger.exception(
+            f"Failed to schedule secret key digest backfill for {api_key.id}"
+        )
+
+
+async def _backfill_secret_key_digest(
+    api_key_id: int,
+    access_key: str,
+    digest: str,
+    expected_current: Optional[str] = None,
+) -> None:
+    """Store ``digest`` for ``api_key_id``, unless the row moved under us.
+
+    The update is a compare-and-set against the value the caller read, so
+    concurrent authentications of the same key collapse into one effective write,
+    and a value another process wrote in the meantime is never clobbered.
+    ``expected_current`` is NULL for a key that predates the column and the old
+    string when replacing one this build cannot parse -- an unusable value is
+    worth nothing, so leaving it in place would pin the key to argon2 forever.
+
+    ``updated_at`` is assigned its own value on purpose: the column carries
+    ``onupdate``, which fires on a bulk UPDATE too, and naming it in the SET
+    clause is what suppresses that. Otherwise the first wave after an upgrade
+    would restamp every API key -- a user-visible change, and one the API sorts
+    on -- for a derived column the user never set.
+    """
+    try:
+        async with async_session() as session:
+            guard = (
+                ApiKey.secret_key_digest.is_(None)
+                if expected_current is None
+                else ApiKey.secret_key_digest == expected_current
+            )
+            await session.execute(
+                update(ApiKey)
+                .where(ApiKey.id == api_key_id, guard)
+                .values(secret_key_digest=digest, updated_at=ApiKey.updated_at)
+            )
+            await session.commit()
+            # ``APIKeyService.get_by_access_key`` is cached, so without this the
+            # next requests would keep re-verifying through argon2 until the entry
+            # expired, and keep rescheduling this backfill.
+            await delete_cache_by_key(
+                APIKeyService(session).get_by_access_key, access_key
+            )
+    except Exception:
+        # Purely an optimization: the key keeps verifying through argon2, and the
+        # next request retries. Keep the traceback -- a failure here is either a
+        # DB problem or a bug, and both need the stack to diagnose.
+        logger.exception(f"Failed to backfill secret key digest for {api_key_id}")
+    finally:
+        _backfill_in_flight.discard(api_key_id)
+
+
 async def get_user_from_api_token(
     session: AsyncSession, token: str
 ) -> Tuple[Optional[Principal], Optional[ApiKey]]:
@@ -364,12 +471,33 @@ async def get_user_from_api_token(
         # rollback() is safe -- this lookup is read-only.
         await session.rollback()
 
-        # argon2 verification is synchronous and CPU-bound; run it off the
-        # event loop so concurrent requests keep flowing instead of serializing
-        # behind each hash.
-        verified = await asyncio.to_thread(
-            verify_hashed_secret, api_key.hashed_secret_key, secret_key
-        )
+        if secret_key_digest_usable(api_key.secret_key_digest):
+            # A few microseconds, and cheap enough to stay on the event loop.
+            # Only secrets this server generated ever get a digest, so a fast
+            # hash here is not a downgrade -- see security.new_secret_key_digest.
+            verified = verify_secret_key_digest(api_key.secret_key_digest, secret_key)
+        else:
+            # No digest, or one this build cannot check. argon2 is the permanent
+            # fallback verifier, so a malformed or unknown-algorithm value costs
+            # this request the slow path instead of locking a valid key out.
+            if api_key.secret_key_digest and api_key.id not in _warned_unusable_digest:
+                _warned_unusable_digest.add(api_key.id)
+                logger.warning(
+                    f"API key {api_key.id} has an unusable secret_key_digest; "
+                    "verifying via argon2 and replacing the value. The column held "
+                    "something this version cannot parse."
+                )
+            # argon2 verification is synchronous and CPU-bound; run it off the
+            # event loop so concurrent requests keep flowing instead of
+            # serializing behind each hash.
+            verified = await asyncio.to_thread(
+                verify_hashed_secret, api_key.hashed_secret_key, secret_key
+            )
+            if verified:
+                # The plaintext is in hand exactly here, and only here, for a key
+                # that predates the digest column. Fill it in so the next request
+                # takes the fast path.
+                _schedule_secret_key_digest_backfill(api_key, secret_key)
         if verified:
             user: Optional[User] = await UserService(session).get_by_id(
                 user_id=api_key.user_id,

--- a/gpustack/migrations/versions/2026_07_15_1600-367a3982fcde_v2_3_0_database_changes.py
+++ b/gpustack/migrations/versions/2026_07_15_1600-367a3982fcde_v2_3_0_database_changes.py
@@ -13,7 +13,15 @@ Bundles the pre-release schema changes for v2.3.0:
    list of ``start_cron`` + ``duration_seconds`` + ``replicas`` window rules);
    NULL means no schedule is configured.
 
-3. Cleanup of SYSTEM principals (and their registration API keys) leaked by
+3. ``api_keys.secret_key_digest``: a cheap second verifier
+   (``sha256$<salt>$<hash>``) for the secrets GPUStack generates itself, so
+   authentication no longer has to pay argon2 on the request path. Nullable and
+   additive — ``hashed_secret_key`` keeps its argon2 value for every key, so an
+   older version pointed at the same database still verifies everything. Existing
+   rows stay NULL: the plaintext is returned to the caller once at creation and
+   never stored, so it can only be filled in on a later successful verification.
+
+4. Cleanup of SYSTEM principals (and their registration API keys) leaked by
    cluster / worker deletes — data only, no schema change. See
    :func:`_cleanup_orphan_system_principals`.
 
@@ -77,12 +85,22 @@ def upgrade() -> None:
     with op.batch_alter_table('models', schema=None) as batch_op:
         batch_op.add_column(sa.Column('scaling_schedule', sa.JSON(), nullable=True))
 
+    with op.batch_alter_table('api_keys', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'secret_key_digest', sqlmodel.sql.sqltypes.AutoString(), nullable=True
+            )
+        )
+
     _cleanup_orphan_system_principals()
 
 
 def downgrade() -> None:
     # The orphan principal cleanup is data-only — the deleted rows (and their
     # credentials) can't be reconstructed, so there is nothing to undo for it.
+    with op.batch_alter_table('api_keys', schema=None) as batch_op:
+        batch_op.drop_column('secret_key_digest')
+
     with op.batch_alter_table('models', schema=None) as batch_op:
         batch_op.drop_column('scaling_schedule')
 

--- a/gpustack/routes/api_keys.py
+++ b/gpustack/routes/api_keys.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-import secrets
 from typing import Optional
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
@@ -12,7 +11,14 @@ from gpustack.api.exceptions import (
     InvalidException,
     NotFoundException,
 )
-from gpustack.security import API_KEY_PREFIX, get_secret_hash, get_key_pair
+from gpustack.security import (
+    API_KEY_PREFIX,
+    generate_access_key,
+    generate_secret_key,
+    get_secret_hash,
+    get_key_pair,
+    new_secret_key_digest,
+)
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 from gpustack.schemas.api_keys import (
@@ -184,7 +190,7 @@ async def create_api_key(
         )
 
     if key_in.custom is None:
-        access_key, secret_key = secrets.token_hex(8), secrets.token_hex(16)
+        access_key, secret_key = generate_access_key(), generate_secret_key()
     else:
         access_key, secret_key = get_key_pair(key_in.custom)
         existing_key = await ApiKey.one_by_field(
@@ -214,6 +220,13 @@ async def create_api_key(
             owner_principal_id=target_org_id,
             access_key=access_key,
             hashed_secret_key=get_secret_hash(secret_key),
+            # None for a custom key: the function refuses a secret it did not
+            # generate, so the fast digest can never cover a user-chosen one.
+            secret_key_digest=new_secret_key_digest(
+                secret_key=secret_key,
+                is_custom=key_in.custom is not None,
+                access_key=access_key,
+            ),
             expires_at=expires_at,
             allowed_model_names=key_in.allowed_model_names,
             is_custom=key_in.custom is not None,

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -64,7 +64,13 @@ from gpustack.schemas.principals import (
 )
 from gpustack.schemas.users import system_name_prefix
 from gpustack.schemas.api_keys import ApiKey
-from gpustack.security import get_secret_hash, API_KEY_PREFIX
+from gpustack.security import (
+    generate_access_key,
+    generate_secret_key,
+    get_secret_hash,
+    new_secret_key_digest,
+    API_KEY_PREFIX,
+)
 from gpustack.gpu_instances.cluster_apis_util import (
     principal_namespace_identifier,
     get_namespace_name,
@@ -496,8 +502,8 @@ async def create_cluster(
     )
     auto_default = has_existing_in_org is None
 
-    access_key = secrets.token_hex(8)
-    secret_key = secrets.token_hex(16)
+    access_key = generate_access_key()
+    secret_key = generate_secret_key()
     target_state = ClusterStateEnum.READY
     state_message = None
     if input.provider not in [ClusterProvider.Kubernetes, ClusterProvider.Docker]:
@@ -522,6 +528,9 @@ async def create_cluster(
         name=f'{system_name_prefix}-{to_create_cluster.hashed_suffix}',
         access_key=access_key,
         hashed_secret_key=get_secret_hash(secret_key),
+        secret_key_digest=new_secret_key_digest(
+            secret_key=secret_key, is_custom=False, access_key=access_key
+        ),
     )
     try:
         # create cluster

--- a/gpustack/routes/workers.py
+++ b/gpustack/routes/workers.py
@@ -63,7 +63,13 @@ from gpustack.schemas.config import (
     SensitivePredefinedConfig,
     PredefinedConfigNoDefaults,
 )
-from gpustack.security import get_secret_hash, API_KEY_PREFIX
+from gpustack.security import (
+    generate_access_key,
+    generate_secret_key,
+    get_secret_hash,
+    new_secret_key_digest,
+    API_KEY_PREFIX,
+)
 from gpustack.server.services import WorkerService
 from gpustack.cloud_providers.common import key_bytes_to_openssh_pem
 from gpustack.utils.grafana import resolve_grafana_base_url
@@ -646,8 +652,8 @@ async def create_worker(user: CurrentUserDep, worker_in: WorkerCreate):
             worker_config = _build_worker_config_dict(cluster)
 
             hashed_suffix = secrets.token_hex(6)
-            access_key = secrets.token_hex(8)
-            secret_key = secrets.token_hex(16)
+            access_key = generate_access_key()
+            secret_key = generate_secret_key()
             new_token = f"{API_KEY_PREFIX}_{access_key}_{secret_key}"
 
             new_worker = update_worker_data(
@@ -678,6 +684,9 @@ async def create_worker(user: CurrentUserDep, worker_in: WorkerCreate):
                     name=f'{system_name_prefix}-{hashed_suffix}',
                     access_key=access_key,
                     hashed_secret_key=get_secret_hash(secret_key),
+                    secret_key_digest=new_secret_key_digest(
+                        secret_key=secret_key, is_custom=False, access_key=access_key
+                    ),
                 )
                 if existing_api_key is None
                 else None

--- a/gpustack/schemas/api_keys.py
+++ b/gpustack/schemas/api_keys.py
@@ -56,6 +56,24 @@ class ApiKey(ApiKeyBase, BaseModelMixin, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     access_key: str = Field(unique=True, index=True)
     hashed_secret_key: str = Field(unique=True)
+    # Second verifier for the *same* plaintext, ``sha256$<salt>$<hash>``, issued
+    # only for secrets this server generated (see
+    # ``security.secret_key_digest_eligible``). Both columns are permanent and
+    # neither is legacy: this one is the hot-path verifier, ``hashed_secret_key``
+    # keeps its argon2 value forever as the fallback — which is also what lets an
+    # older version verify every key after a downgrade.
+    #
+    # HARD CONSTRAINT: the two columns must always derive from one plaintext.
+    # Authentication treats a digest mismatch as an authoritative rejection and
+    # does *not* retry against argon2, so anything that writes one column must
+    # write both, or set this one back to NULL. Today every writer is a creation
+    # path and there is no rotation path; a future rotation feature — or a manual
+    # DB fix — that touches ``hashed_secret_key`` alone would lock the key out.
+    #
+    # Populated at creation for eligible keys. NULL means either a row that
+    # predates the column, which the first successful argon2 verification
+    # backfills, or a key that is not eligible for a digest at all.
+    secret_key_digest: Optional[str] = Field(default=None, nullable=True)
     user_id: int = Field(foreign_key='principals.id', nullable=False)
     # ``owner_principal_id`` is the tenant the key acts as. Nullable
     # because an admin-created "All" mode key (no Org context) must

--- a/gpustack/security.py
+++ b/gpustack/security.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 import string
 from datetime import datetime, timedelta, timezone
@@ -13,7 +14,35 @@ ph = PasswordHasher()
 
 API_KEY_PREFIX = "gpustack"
 
+# Number of random bytes behind a secret this server generates itself. 16 bytes
+# of CSPRNG output (32 hex characters) is what makes the fast digest below sound:
+# there is no dictionary to try, so a work factor buys nothing.
+GENERATED_SECRET_KEY_BYTES = 16
+GENERATED_ACCESS_KEY_BYTES = 8
 
+# ``secret_key_digest`` value format, self-describing like argon2's own: the
+# algorithm name is the prefix, the salt is inlined. Changing construction means
+# changing the prefix, so the stored string always says how to verify it.
+SECRET_KEY_DIGEST_ALGORITHM = "sha256"
+_DIGEST_SALT_BYTES = 16
+_GENERATED_SECRET_KEY_RE = re.compile(f"^[0-9a-f]{{{GENERATED_SECRET_KEY_BYTES * 2}}}$")
+
+
+def _as_text(value: Union[str, bytes]) -> str:
+    return value.decode() if isinstance(value, bytes) else value
+
+
+def _as_bytes(value: Union[str, bytes]) -> bytes:
+    return value if isinstance(value, bytes) else value.encode()
+
+
+# argon2 is deliberately expensive and the credentials left on this path -- custom
+# keys and the legacy cluster token -- have no digest to fall back on, so the memo
+# is what keeps a frequently polling worker off a ~30 ms verify per request.
+# ``lru_cache`` is thread-safe and shared across the ``asyncio.to_thread`` workers
+# that call this, at the cost of holding the plaintext as part of the key. That
+# residency is bounded to the credentials above: anything carrying a
+# ``secret_key_digest`` never reaches here (see get_user_from_api_token).
 @lru_cache(maxsize=2048)
 def verify_hashed_secret(hashed: Union[str, bytes], plain: Union[str, bytes]) -> bool:
     try:
@@ -24,6 +53,113 @@ def verify_hashed_secret(hashed: Union[str, bytes], plain: Union[str, bytes]) ->
 
 def get_secret_hash(plain: Union[str, bytes]):
     return ph.hash(plain)
+
+
+def generate_access_key() -> str:
+    return secrets.token_hex(GENERATED_ACCESS_KEY_BYTES)
+
+
+def generate_secret_key() -> str:
+    return secrets.token_hex(GENERATED_SECRET_KEY_BYTES)
+
+
+def secret_key_digest_eligible(
+    *, secret_key: Union[str, bytes], is_custom: bool, access_key: str
+) -> bool:
+    """Whether ``secret_key`` may be stored under the fast digest.
+
+    Only secrets this server generated qualify. Getting this wrong stores a
+    low-entropy secret behind a fast hash, which is a real vulnerability rather
+    than a lost optimization, so all three conditions are required and the
+    decision lives here instead of at the call sites:
+
+    * ``is_custom`` — a user-supplied secret is excluded by the flag that records
+      it. ``ApiKeyCreate.custom`` has no entropy requirement at all, so
+      ``custom: "123456"`` is a key that can exist.
+    * ``access_key`` non-empty — excludes the legacy cluster token, whose row
+      stores the deployment-provided ``config.token`` under an empty access key
+      and never goes through the custom flag.
+    * shape — exactly the hex output of :func:`generate_secret_key`.
+
+    None of the three suffices alone: a custom key may well be a 32-character hex
+    string (an md5 of a dictionary word is one), and the ``config.token`` path
+    never sets ``is_custom``.
+    """
+    if is_custom:
+        return False
+    if not access_key:
+        return False
+    return bool(_GENERATED_SECRET_KEY_RE.match(_as_text(secret_key)))
+
+
+def new_secret_key_digest(
+    *, secret_key: Union[str, bytes], is_custom: bool, access_key: str
+) -> Optional[str]:
+    """A fresh ``sha256$<salt>$<hash>`` digest, or None if not eligible.
+
+    The salt blocks precomputation and keeps two keys that happen to share a
+    secret from producing the same digest.
+    """
+    if not secret_key_digest_eligible(
+        secret_key=secret_key, is_custom=is_custom, access_key=access_key
+    ):
+        return None
+    salt = secrets.token_hex(_DIGEST_SALT_BYTES)
+    return f"{SECRET_KEY_DIGEST_ALGORITHM}${salt}${_digest_hash(salt, secret_key)}"
+
+
+def secret_key_digest_usable(digest: Optional[str]) -> bool:
+    """Whether a stored digest is one this build can check.
+
+    Callers must consult this before treating a False from
+    :func:`verify_secret_key_digest` as a rejection. A missing, malformed or
+    unknown-algorithm value says nothing about the secret, and the argon2 hash --
+    which every key keeps permanently -- stays authoritative in that case.
+    Rejecting on an unusable digest would lock out a valid key on bad column
+    data, and would also make introducing a new digest algorithm a breaking
+    change for anything an older server reads.
+    """
+    return _parse_secret_key_digest(digest) is not None
+
+
+def verify_secret_key_digest(
+    digest: Optional[str], secret_key: Union[str, bytes]
+) -> bool:
+    """Constant-time check of a plaintext against a stored digest.
+
+    True only on a match. False covers both a real mismatch and a value this
+    build cannot check, so it is not on its own grounds for rejection -- see
+    :func:`secret_key_digest_usable`.
+    """
+    parsed = _parse_secret_key_digest(digest)
+    if parsed is None:
+        return False
+    salt, expected = parsed
+    return secrets.compare_digest(_digest_hash(salt, secret_key), expected)
+
+
+def _parse_secret_key_digest(digest: Optional[str]) -> Optional[Tuple[str, str]]:
+    """Split a stored value into (salt, hash), or None if unusable.
+
+    Single source of the value's layout: nothing outside this module needs to
+    know that it is ``<algorithm>$<salt>$<hash>``, or which algorithm names this
+    build understands.
+    """
+    if not digest:
+        return None
+    parts = digest.split("$")
+    if len(parts) != 3:
+        return None
+    algorithm, salt, expected = parts
+    if algorithm != SECRET_KEY_DIGEST_ALGORITHM or not salt or not expected:
+        return None
+    return salt, expected
+
+
+def _digest_hash(salt: str, secret_key: Union[str, bytes]) -> str:
+    # The salt is fixed-length and comes from the entry being checked, so the
+    # trailing secret is the only variable and no separator is needed.
+    return hashlib.sha256(_as_bytes(salt) + _as_bytes(secret_key)).hexdigest()
 
 
 def generate_secure_password(length=12):
@@ -63,9 +199,13 @@ def get_key_pair(key: str) -> Tuple[str, str]:
 
     Scenarios:
     1. Standard format key: "gpustack_{access_key}_{secret_key}"
-       - access_key: 8 characters (hex string, e.g. "3192253c")
-       - secret_key: 16 characters (hex string, e.g. "c11c75ed6334ea9505da4ad9")
+       - access_key: 8 random bytes, i.e. 16 hex characters (e.g. "3192253c1f4a9b7e")
+       - secret_key: 16 random bytes, i.e. 32 hex characters
+         (e.g. "c11c75ed6334ea9505da4ad9c11c75ed")
        - Used for normal API authentication via /v2/* routes
+       - The counts are byte counts doubled -- see GENERATED_ACCESS_KEY_BYTES /
+         GENERATED_SECRET_KEY_BYTES, which ``secret_key_digest_eligible`` keys
+         its shape test on
 
     2. Legacy UUID format key: standard UUID format with dashes
        - Example: access_key: "3192253c-c11c-75ed-6334-ea9505da4ad9", the secret_key can be any string

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -37,8 +37,11 @@ from gpustack.schemas.clusters import Cluster, ClusterProvider, ClusterStateEnum
 from gpustack.schemas.model_routes import ModelRoute, ModelRouteTarget
 from gpustack.schemas.model_provider import ModelProvider
 from gpustack.security import (
+    generate_access_key,
+    generate_secret_key,
     generate_secure_password,
     get_secret_hash,
+    new_secret_key_digest,
     API_KEY_PREFIX,
 )
 from gpustack.server.app import create_app
@@ -887,6 +890,13 @@ class Server:
                 name="Legacy Cluster Token",
                 access_key="",
                 hashed_secret_key=get_secret_hash(self._config.token),
+                # Always None here, and deliberately routed through the same
+                # guard rather than simply omitted: the deployment supplies
+                # ``config.token``, so its entropy is not ours to assume and it
+                # must keep verifying through argon2.
+                secret_key_digest=new_secret_key_digest(
+                    secret_key=self._config.token, is_custom=False, access_key=""
+                ),
                 user_id=default_cluster_principal.id,
                 user=default_cluster_principal,
             )
@@ -934,12 +944,17 @@ class Server:
                     )
                     worker.system_principal_id = worker_principal.id
                     await worker.save(session=session, auto_commit=False)
-                    access_key = secrets.token_hex(8)
-                    secret_key = secrets.token_hex(16)
+                    access_key = generate_access_key()
+                    secret_key = generate_secret_key()
                     to_create_apikey = ApiKey(
                         name=worker_principal.name,
                         access_key=access_key,
                         hashed_secret_key=get_secret_hash(secret_key),
+                        secret_key_digest=new_secret_key_digest(
+                            secret_key=secret_key,
+                            is_custom=False,
+                            access_key=access_key,
+                        ),
                         user=worker_principal,
                         user_id=worker_principal.id,
                     )
@@ -975,12 +990,15 @@ class Server:
         token = cluster.registration_token
         if not token:
             try:
-                access_key = secrets.token_hex(8)
-                secret_key = secrets.token_hex(16)
+                access_key = generate_access_key()
+                secret_key = generate_secret_key()
                 new_key = ApiKey(
                     name="Default Cluster Token",
                     access_key=access_key,
                     hashed_secret_key=get_secret_hash(secret_key),
+                    secret_key_digest=new_secret_key_digest(
+                        secret_key=secret_key, is_custom=False, access_key=access_key
+                    ),
                     user_id=cluster_principal.id,
                     user=cluster_principal,
                 )

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import ssl
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
@@ -111,7 +112,10 @@ async def test_authenticate_request_reuses_provided_session(monkeypatch):
 
 def _api_token_double(**overrides):
     fields = {
+        "id": 11,
         "hashed_secret_key": "stored-hash",
+        "secret_key_digest": None,
+        "is_custom": False,
         "expires_at": None,
         "user_id": 7,
         "access_key": "abcd1234",
@@ -210,6 +214,496 @@ async def test_get_user_from_api_token_rollback_before_verify_via_thread(monkeyp
     assert api_key is valid
     assert events == ["rollback", "verify"]  # connection released before argon2
     assert used_thread["n"] == 1  # argon2 ran via asyncio.to_thread
+
+
+@pytest.mark.asyncio
+async def test_get_user_from_api_token_prefers_the_digest(monkeypatch):
+    """A key that has a digest must not touch argon2 at all — that is the whole
+    point of the column — and must not need a worker thread either.
+    """
+    import gpustack.api.auth as auth_module
+    from gpustack.api.auth import get_user_from_api_token
+    from gpustack.security import generate_access_key, new_secret_key_digest
+
+    access_key = generate_access_key()
+    secret_key = "c11c75ed6334ea9505da4ad9c11c75ed"
+    key = _api_token_double(
+        access_key=access_key,
+        secret_key_digest=new_secret_key_digest(
+            secret_key=secret_key, is_custom=False, access_key=access_key
+        ),
+    )
+    expected_user = type("User", (), {"is_active": True, "id": 7})()
+
+    async def fake_get_by_access_key(self, candidate):
+        return key
+
+    async def fake_get_by_id(self, user_id):
+        return expected_user
+
+    def fail_verify(hashed, secret):  # pragma: no cover - must never run
+        raise AssertionError("argon2 must not run for a key that has a digest")
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr("gpustack.api.auth.UserService.get_by_id", fake_get_by_id)
+    monkeypatch.setattr("gpustack.api.auth.verify_hashed_secret", fail_verify)
+
+    thread_calls = {"n": 0}
+
+    async def spy_to_thread(fn, *args, **kwargs):  # pragma: no cover
+        thread_calls["n"] += 1
+        raise AssertionError("no thread offload needed for a fast hash")
+
+    monkeypatch.setattr(auth_module.asyncio, "to_thread", spy_to_thread)
+
+    user, api_key = await get_user_from_api_token(
+        _RollbackRecordingSession([]), f"gpustack_{access_key}_{secret_key}"
+    )
+
+    assert user is expected_user
+    assert api_key is key
+    assert thread_calls["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_digest_mismatch_is_rejected_without_falling_back_to_argon2(monkeypatch):
+    """Both columns derive from the same plaintext, so a digest mismatch means the
+    secret is simply wrong — falling back to argon2 would only pay 30 ms to reach
+    the same answer.
+    """
+    from gpustack.api.auth import get_user_from_api_token
+    from gpustack.security import generate_access_key, new_secret_key_digest
+
+    access_key = generate_access_key()
+    key = _api_token_double(
+        access_key=access_key,
+        secret_key_digest=new_secret_key_digest(
+            secret_key="c11c75ed6334ea9505da4ad9c11c75ed",
+            is_custom=False,
+            access_key=access_key,
+        ),
+    )
+
+    async def fake_get_by_access_key(self, candidate):
+        return key
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr(
+        "gpustack.api.auth.verify_hashed_secret",
+        lambda hashed, secret: (_ for _ in ()).throw(
+            AssertionError("no argon2 fallback on digest mismatch")
+        ),
+    )
+
+    user, api_key = await get_user_from_api_token(
+        _RollbackRecordingSession([]),
+        f"gpustack_{access_key}_ffffffffffffffffffffffffffffffff",
+    )
+
+    assert user is None and api_key is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stored_digest",
+    [
+        "garbage",
+        "sha256$truncated",
+        "sha256$deadbeef$",
+        "blake3$deadbeef$abc",  # e.g. written by a newer server
+    ],
+)
+async def test_unusable_digest_falls_back_to_argon2(monkeypatch, stored_digest):
+    """A digest this build cannot check says nothing about the secret. argon2 is
+    the permanent fallback verifier, so bad column data must cost the slow path
+    rather than lock a valid key out.
+    """
+    from gpustack.api.auth import get_user_from_api_token
+    from gpustack.security import generate_access_key
+
+    access_key = generate_access_key()
+    key = _api_token_double(access_key=access_key, secret_key_digest=stored_digest)
+    expected_user = type("User", (), {"is_active": True, "id": 7})()
+
+    async def fake_get_by_access_key(self, candidate):
+        return key
+
+    async def fake_get_by_id(self, user_id):
+        return expected_user
+
+    argon2_calls = {"n": 0}
+
+    def fake_verify(hashed, secret):
+        argon2_calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr("gpustack.api.auth.UserService.get_by_id", fake_get_by_id)
+    monkeypatch.setattr("gpustack.api.auth.verify_hashed_secret", fake_verify)
+    # An unusable digest is non-NULL, so the ``WHERE secret_key_digest IS NULL``
+    # backfill would not repair it -- assert we do not silently rewrite it either.
+    scheduled = {"n": 0}
+    monkeypatch.setattr(
+        "gpustack.api.auth._schedule_secret_key_digest_backfill",
+        lambda api_key, secret: scheduled.__setitem__("n", scheduled["n"] + 1),
+    )
+
+    user, api_key = await get_user_from_api_token(
+        _RollbackRecordingSession([]),
+        f"gpustack_{access_key}_c11c75ed6334ea9505da4ad9c11c75ed",
+    )
+
+    assert user is expected_user
+    assert api_key is key
+    assert argon2_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_successful_argon2_verify_backfills_the_digest(monkeypatch):
+    """A key created before the column converges on first use, and the write stays
+    off the request path.
+    """
+    import gpustack.api.auth as auth_module
+    from gpustack.api.auth import get_user_from_api_token
+    from gpustack.security import generate_access_key
+
+    access_key = generate_access_key()
+    secret_key = "c11c75ed6334ea9505da4ad9c11c75ed"
+    key = _api_token_double(access_key=access_key, secret_key_digest=None)
+
+    async def fake_get_by_access_key(self, candidate):
+        return key
+
+    async def fake_get_by_id(self, user_id):
+        return type("User", (), {"is_active": True, "id": 7})()
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr("gpustack.api.auth.UserService.get_by_id", fake_get_by_id)
+    monkeypatch.setattr(
+        "gpustack.api.auth.verify_hashed_secret", lambda hashed, secret: True
+    )
+
+    written = []
+
+    async def fake_backfill(api_key_id, key_access_key, digest, expected_current=None):
+        written.append((api_key_id, key_access_key, digest, expected_current))
+        auth_module._backfill_in_flight.discard(api_key_id)
+
+    monkeypatch.setattr(auth_module, "_backfill_secret_key_digest", fake_backfill)
+    auth_module._backfill_in_flight.clear()
+
+    user, _ = await get_user_from_api_token(
+        _RollbackRecordingSession([]), f"gpustack_{access_key}_{secret_key}"
+    )
+    await asyncio.sleep(0)  # let the background task run
+
+    assert user is not None
+    assert len(written) == 1
+    written_id, written_access_key, written_digest, expected_current = written[0]
+    assert (written_id, written_access_key) == (11, access_key)
+    # NULL guard: this row predates the column, so the write must not clobber a
+    # value another process may have set in the meantime.
+    assert expected_current is None
+    from gpustack.security import verify_secret_key_digest
+
+    assert verify_secret_key_digest(written_digest, secret_key)
+
+
+@pytest.mark.asyncio
+async def test_custom_key_is_never_backfilled(monkeypatch):
+    """Custom keys stay on argon2 permanently — a fast hash over a user-chosen
+    secret is the one outcome this design must not produce.
+    """
+    import gpustack.api.auth as auth_module
+    from gpustack.api.auth import get_user_from_api_token
+
+    key = _api_token_double(
+        is_custom=True,
+        secret_key_digest=None,
+        access_key="0123456789abcdef0123456789abcdef",
+    )
+
+    async def fake_get_by_access_key(self, candidate):
+        return key
+
+    async def fake_get_by_id(self, user_id):
+        return type("User", (), {"is_active": True, "id": 7})()
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr("gpustack.api.auth.UserService.get_by_id", fake_get_by_id)
+    monkeypatch.setattr(
+        "gpustack.api.auth.verify_hashed_secret", lambda hashed, secret: True
+    )
+
+    scheduled = []
+    monkeypatch.setattr(
+        auth_module,
+        "_backfill_secret_key_digest",
+        lambda *args: scheduled.append(args),
+    )
+    auth_module._backfill_in_flight.clear()
+
+    user, _ = await get_user_from_api_token(
+        _RollbackRecordingSession([]), "a-user-chosen-custom-key"
+    )
+    await asyncio.sleep(0)
+
+    assert user is not None
+    assert scheduled == []
+
+
+def test_concurrent_verifications_schedule_one_backfill(monkeypatch):
+    """The first wave after an upgrade hits the same keys repeatedly; only one
+    write should be in flight per key.
+    """
+    import gpustack.api.auth as auth_module
+    from gpustack.security import generate_access_key
+
+    access_key = generate_access_key()
+    key = _api_token_double(access_key=access_key, secret_key_digest=None)
+
+    created = []
+
+    class _FakeTask:
+        def add_done_callback(self, _cb):
+            pass
+
+    def fake_create_task(coro):
+        coro.close()  # nothing awaits it here; this test only counts schedulings
+        created.append(coro)
+        return _FakeTask()
+
+    monkeypatch.setattr(auth_module.asyncio, "create_task", fake_create_task)
+    auth_module._backfill_in_flight.clear()
+
+    auth_module._schedule_secret_key_digest_backfill(
+        key, "c11c75ed6334ea9505da4ad9c11c75ed"
+    )
+    auth_module._schedule_secret_key_digest_backfill(
+        key, "c11c75ed6334ea9505da4ad9c11c75ed"
+    )
+
+    assert len(created) == 1
+    auth_module._backfill_in_flight.clear()
+    auth_module._backfill_tasks.clear()
+
+
+def _mock_backfill_session(execute=None):
+    """An ``async_session()`` stand-in whose ``execute`` is awaitable."""
+    session = MagicMock()
+    session.execute = execute or AsyncMock()
+    session.commit = AsyncMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm, session
+
+
+def _compiled(stmt) -> str:
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+
+@pytest.mark.asyncio
+async def test_backfill_writes_only_the_digest_column(monkeypatch):
+    """The argon2 hash must survive untouched — it is what an older version falls
+    back to after a downgrade, and the two columns must keep describing the same
+    plaintext. ``updated_at`` must not move either: it carries ``onupdate``, which
+    fires on bulk UPDATEs, and the API sorts on it.
+    """
+    import gpustack.api.auth as auth_module
+
+    cm, session = _mock_backfill_session()
+    monkeypatch.setattr(auth_module, "async_session", lambda: cm)
+    monkeypatch.setattr(auth_module, "delete_cache_by_key", AsyncMock())
+    auth_module._backfill_in_flight.add(11)
+
+    await auth_module._backfill_secret_key_digest(11, "abcd1234", "sha256$aa$bb")
+
+    sql = _compiled(session.execute.await_args.args[0])
+    assert "secret_key_digest='sha256$aa$bb'" in sql
+    assert "hashed_secret_key" not in sql
+    assert "api_keys.id = 11" in sql
+    # Self-assignment, which is what keeps ``onupdate`` from restamping the row.
+    assert "updated_at=api_keys.updated_at" in sql
+    session.commit.assert_awaited_once()
+    assert 11 not in auth_module._backfill_in_flight
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected_current, guard",
+    [
+        (None, "api_keys.secret_key_digest IS NULL"),
+        ("garbage", "api_keys.secret_key_digest = 'garbage'"),
+    ],
+)
+async def test_backfill_is_a_compare_and_set(monkeypatch, expected_current, guard):
+    """Concurrent authentications of one key collapse into a single effective
+    write, and a value another process wrote meanwhile is never clobbered.
+    """
+    import gpustack.api.auth as auth_module
+
+    cm, session = _mock_backfill_session()
+    monkeypatch.setattr(auth_module, "async_session", lambda: cm)
+    monkeypatch.setattr(auth_module, "delete_cache_by_key", AsyncMock())
+
+    await auth_module._backfill_secret_key_digest(
+        11, "abcd1234", "sha256$aa$bb", expected_current=expected_current
+    )
+
+    assert guard in _compiled(session.execute.await_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_backfill_invalidates_the_key_the_read_path_reads(monkeypatch):
+    """The one assertion that keeps the backfill from becoming a silent no-op.
+
+    ``locked_cached`` stores under ``build_cache_key(unbound_f, *args[1:])`` while
+    the invalidation passes a *bound* method. The two only agree because
+    ``build_cache_key`` skips its self-stripping branch for bound methods — if
+    that ever changes, every request keeps paying argon2 and rescheduling this
+    backfill, with correct behaviour and no warning anywhere.
+    """
+    import gpustack.api.auth as auth_module
+    from gpustack.server.cache import build_cache_key
+    from gpustack.server.services import APIKeyService
+
+    cm, _ = _mock_backfill_session()
+    monkeypatch.setattr(auth_module, "async_session", lambda: cm)
+
+    invalidated = []
+
+    async def fake_delete(func, *args, **kwargs):
+        invalidated.append(build_cache_key(func, *args, **kwargs))
+
+    monkeypatch.setattr(auth_module, "delete_cache_by_key", fake_delete)
+
+    await auth_module._backfill_secret_key_digest(11, "abcd1234", "sha256$aa$bb")
+
+    # What ``locked_cached.decorator`` would have stored the row under.
+    read_path_key = build_cache_key(APIKeyService.get_by_access_key, "abcd1234")
+    assert invalidated == [read_path_key]
+
+
+@pytest.mark.asyncio
+async def test_backfill_failure_is_swallowed_and_releases_the_marker(monkeypatch):
+    """A failed optimization must not surface anywhere, and must not cost the key
+    its next attempt.
+    """
+    import gpustack.api.auth as auth_module
+
+    cm, _ = _mock_backfill_session(execute=AsyncMock(side_effect=RuntimeError("no db")))
+    monkeypatch.setattr(auth_module, "async_session", lambda: cm)
+    monkeypatch.setattr(auth_module, "delete_cache_by_key", AsyncMock())
+    auth_module._backfill_in_flight.add(11)
+
+    await auth_module._backfill_secret_key_digest(11, "abcd1234", "sha256$aa$bb")
+
+    assert 11 not in auth_module._backfill_in_flight
+
+
+@pytest.mark.asyncio
+async def test_scheduling_failure_never_reaches_the_caller(monkeypatch):
+    """``get_user_from_api_token`` wraps its body in a try that raises 500, so a
+    throw from scheduling would turn an already-authenticated request into an
+    error over a missed optimization.
+    """
+    import gpustack.api.auth as auth_module
+    from gpustack.security import generate_access_key
+
+    key = _api_token_double(access_key=generate_access_key(), secret_key_digest=None)
+
+    def boom(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(auth_module, "new_secret_key_digest", boom)
+    auth_module._backfill_in_flight.clear()
+
+    auth_module._schedule_secret_key_digest_backfill(
+        key, "c11c75ed6334ea9505da4ad9c11c75ed"
+    )
+
+    assert auth_module._backfill_in_flight == set()
+
+
+@pytest.mark.asyncio
+async def test_failed_create_task_does_not_strand_the_marker(monkeypatch):
+    """A stranded id would cost that key its backfill for the process's lifetime,
+    since nothing else ever clears the set.
+    """
+    import gpustack.api.auth as auth_module
+    from gpustack.security import generate_access_key
+
+    key = _api_token_double(access_key=generate_access_key(), secret_key_digest=None)
+
+    def failing_create_task(coro):
+        coro.close()
+        raise RuntimeError("no loop")
+
+    monkeypatch.setattr(auth_module.asyncio, "create_task", failing_create_task)
+    auth_module._backfill_in_flight.clear()
+
+    auth_module._schedule_secret_key_digest_backfill(
+        key, "c11c75ed6334ea9505da4ad9c11c75ed"
+    )
+
+    assert auth_module._backfill_in_flight == set()
+
+
+@pytest.mark.asyncio
+async def test_unusable_digest_warns_once_per_key(monkeypatch, caplog):
+    """A polling worker key would otherwise repeat the same warning every request
+    until the value is repaired.
+    """
+    import logging
+
+    import gpustack.api.auth as auth_module
+    from gpustack.api.auth import get_user_from_api_token
+    from gpustack.security import generate_access_key
+
+    access_key = generate_access_key()
+    key = _api_token_double(access_key=access_key, secret_key_digest="garbage")
+
+    async def fake_get_by_access_key(self, candidate):
+        return key
+
+    async def fake_get_by_id(self, user_id):
+        return type("User", (), {"is_active": True, "id": 7})()
+
+    monkeypatch.setattr(
+        "gpustack.api.auth.APIKeyService.get_by_access_key", fake_get_by_access_key
+    )
+    monkeypatch.setattr("gpustack.api.auth.UserService.get_by_id", fake_get_by_id)
+    monkeypatch.setattr(
+        "gpustack.api.auth.verify_hashed_secret", lambda hashed, secret: True
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "_schedule_secret_key_digest_backfill",
+        lambda api_key, secret: None,
+    )
+    auth_module._warned_unusable_digest.clear()
+
+    with caplog.at_level(logging.WARNING, logger="gpustack.api.auth"):
+        for _ in range(3):
+            await get_user_from_api_token(
+                _RollbackRecordingSession([]),
+                f"gpustack_{access_key}_c11c75ed6334ea9505da4ad9c11c75ed",
+            )
+
+    warnings = [r for r in caplog.records if "unusable secret_key_digest" in r.message]
+    assert len(warnings) == 1
+    auth_module._warned_unusable_digest.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,231 @@
+import hashlib
+
+import pytest
+
+from gpustack import security
+from gpustack.security import (
+    GENERATED_SECRET_KEY_BYTES,
+    SECRET_KEY_DIGEST_ALGORITHM,
+    generate_access_key,
+    generate_secret_key,
+    new_secret_key_digest,
+    secret_key_digest_eligible,
+    secret_key_digest_usable,
+    verify_hashed_secret,
+    verify_secret_key_digest,
+)
+
+
+def test_generated_secret_key_shape():
+    assert len(generate_secret_key()) == GENERATED_SECRET_KEY_BYTES * 2
+    assert len(generate_access_key()) == 16
+
+
+def test_digest_round_trip():
+    secret = generate_secret_key()
+    access_key = generate_access_key()
+    digest = new_secret_key_digest(
+        secret_key=secret, is_custom=False, access_key=access_key
+    )
+
+    algorithm, salt, _ = digest.split("$")
+    assert algorithm == SECRET_KEY_DIGEST_ALGORITHM
+    assert salt  # inlined so the stored value is self-describing
+    assert verify_secret_key_digest(digest, secret)
+    assert not verify_secret_key_digest(digest, generate_secret_key())
+
+
+def test_both_verifiers_accept_the_same_plaintext():
+    """The unit-level half of the downgrade guarantee: a key carrying a digest
+    still verifies through argon2 alone, which is all an older version has.
+
+    The end-to-end version — create on this version, let the backfill run, then
+    start an older one against the same database — needs two builds and stays a
+    manual check.
+    """
+    secret = generate_secret_key()
+    hashed = security.get_secret_hash(secret)
+    digest = new_secret_key_digest(
+        secret_key=secret, is_custom=False, access_key=generate_access_key()
+    )
+
+    assert verify_secret_key_digest(digest, secret)
+    assert verify_hashed_secret(hashed, secret)  # the only path an old build has
+
+
+def test_digest_is_salted_per_key():
+    """Two keys that happen to share a secret must not share a digest."""
+    secret = generate_secret_key()
+    first = new_secret_key_digest(
+        secret_key=secret, is_custom=False, access_key=generate_access_key()
+    )
+    second = new_secret_key_digest(
+        secret_key=secret, is_custom=False, access_key=generate_access_key()
+    )
+
+    assert first != second
+    assert verify_secret_key_digest(first, secret)
+    assert verify_secret_key_digest(second, secret)
+
+
+@pytest.mark.parametrize(
+    "digest",
+    [
+        None,
+        "",
+        "sha256$onlytwo",
+        "sha256$$abc",
+        "sha256$deadbeef$",
+        "$argon2id$v=19$m=65536,t=3,p=4$c2FsdA$aGFzaA",
+        "blake2b$deadbeef$abc",
+    ],
+)
+def test_malformed_or_unknown_digest_never_verifies(digest):
+    """Anything unparseable must not pass and must not raise."""
+    assert not verify_secret_key_digest(digest, generate_secret_key())
+
+
+@pytest.mark.parametrize(
+    "digest",
+    [
+        None,
+        "",
+        "sha256$onlytwo",
+        "sha256$$abc",
+        "sha256$deadbeef$",
+        "$argon2id$v=19$m=65536,t=3,p=4$c2FsdA$aGFzaA",
+        "blake2b$deadbeef$abc",
+    ],
+)
+def test_unusable_digest_is_reported_as_such(digest):
+    """A value this build cannot check says nothing about the secret, so it must
+    be distinguishable from a genuine mismatch -- otherwise bad column data would
+    lock out a key whose argon2 hash is still perfectly good.
+    """
+    assert not secret_key_digest_usable(digest)
+
+
+def test_a_real_digest_is_usable_whether_or_not_it_matches():
+    digest = new_secret_key_digest(
+        secret_key=generate_secret_key(),
+        is_custom=False,
+        access_key=generate_access_key(),
+    )
+    assert secret_key_digest_usable(digest)
+    # Usable but not matching: an authoritative rejection, unlike the cases above.
+    assert not verify_secret_key_digest(digest, generate_secret_key())
+
+
+# --- Eligibility: getting this wrong stores a weak secret behind a fast hash ---
+
+
+def test_custom_key_never_gets_a_digest():
+    """``ApiKeyCreate.custom`` has no entropy requirement, so ``custom: "123456"``
+    is a key that can exist.
+    """
+    assert (
+        new_secret_key_digest(
+            secret_key="123456", is_custom=True, access_key=generate_access_key()
+        )
+        is None
+    )
+
+
+def test_custom_key_shaped_like_a_generated_one_is_still_refused():
+    """The shape test alone is not enough: an md5 of a dictionary word is exactly
+    32 lowercase hex characters, and brute-forcing it is trivial.
+    """
+    md5_of_weak_word = hashlib.md5(b"123456").hexdigest()
+    assert len(md5_of_weak_word) == GENERATED_SECRET_KEY_BYTES * 2
+    assert (
+        new_secret_key_digest(
+            secret_key=md5_of_weak_word,
+            is_custom=True,
+            access_key=generate_access_key(),
+        )
+        is None
+    )
+
+
+def test_deployment_token_never_gets_a_digest():
+    """The legacy cluster token stores the deployment-provided ``config.token``
+    under an empty access key, and never goes through the custom flag — so the
+    empty access key is the only thing standing between it and a fast hash.
+    """
+    assert (
+        new_secret_key_digest(
+            secret_key=generate_secret_key(), is_custom=False, access_key=""
+        )
+        is None
+    )
+    assert (
+        new_secret_key_digest(
+            secret_key="a-deployment-chosen-token", is_custom=False, access_key=""
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "secret_key",
+    [
+        "",
+        "short",
+        "gpustack_3192253c1f4a9b7e_c11c75ed6334ea9505da4ad9",
+        "3192253c1f4a9b7e-c11c75ed6334ea95",  # right length, not hex
+        "C11C75ED6334EA9505DA4AD9C11C75ED",  # uppercase hex is not our output
+        "c11c75ed6334ea9505da4ad9c11c75e",  # one char short
+        "c11c75ed6334ea9505da4ad9c11c75ed9",  # one char long
+    ],
+)
+def test_secret_not_shaped_like_our_output_is_refused(secret_key):
+    assert not secret_key_digest_eligible(
+        secret_key=secret_key, is_custom=False, access_key=generate_access_key()
+    )
+
+
+def test_generated_secret_is_eligible():
+    assert secret_key_digest_eligible(
+        secret_key=generate_secret_key(),
+        is_custom=False,
+        access_key=generate_access_key(),
+    )
+
+
+# --- The argon2 fallback path keeps its memo ---
+
+
+def test_repeated_argon2_verify_is_served_from_the_memo():
+    """Custom keys and the legacy cluster token have no digest, so this path
+    stays hot for them and a second verify must not recompute argon2.
+    """
+    secret = "a-custom-secret-that-stays-on-argon2"
+    hashed = security.get_secret_hash(secret)
+    verify_hashed_secret.cache_clear()
+
+    assert verify_hashed_secret(hashed, secret)
+    before = verify_hashed_secret.cache_info().hits
+    assert verify_hashed_secret(hashed, secret)
+    assert verify_hashed_secret.cache_info().hits == before + 1
+    assert not verify_hashed_secret(hashed, "wrong-secret")
+
+
+def test_verify_memo_is_bounded(monkeypatch):
+    # A rejected argon2 verify costs as much as an accepted one, so stub the
+    # hasher: this test is about the bound, not about argon2. ``PasswordHasher``
+    # uses slots, so replace the instance rather than its method.
+    class _StubHasher:
+        def verify(self, hashed, plain):
+            return False
+
+    monkeypatch.setattr(security, "ph", _StubHasher())
+    verify_hashed_secret.cache_clear()
+    try:
+        maxsize = verify_hashed_secret.cache_info().maxsize
+        for index in range(maxsize + 5):
+            verify_hashed_secret("stored-hash", f"secret-{index}")
+        assert verify_hashed_secret.cache_info().currsize <= maxsize
+    finally:
+        # The memo is process-wide; leaving thousands of stubbed entries behind
+        # would follow later tests around.
+        verify_hashed_secret.cache_clear()


### PR DESCRIPTION
Refer to issue:
- #5991

argon2id over a 128-bit CSPRNG secret buys no security and costs ~30 ms per verification, which is what forces authentication to happen where the CPU budget is. Store a second verifier for the same plaintext — `sha256$<salt>$<hash>` in a new nullable `api_keys.secret_key_digest` — and prefer it on the request path.

- Eligibility is decided inside `security.new_secret_key_digest`, not by callers: a secret qualifies only if it is not custom, its key has a non-empty access key, and it has the exact shape of `generate_secret_key()` output. None of the three suffices alone — a custom key may well be 32 hex characters.
- argon2 remains the permanent fallback verifier, so custom keys, the legacy cluster token and user passwords are untouched, and an older version pointed at the same database still verifies every key.
- A digest this build cannot check (malformed, or a future algorithm) falls back to argon2 rather than rejecting, so bad column data costs the slow path instead of locking a valid key out. A genuine mismatch is still an immediate rejection.
- Rows predating the column are backfilled on their first successful argon2 verify, off the request path and once per key.
- The argon2 memo is unchanged. Only credentials without a digest reach it, so plaintext residency is bounded to custom keys and the legacy cluster token.
