### PR TITLE
fix(worker): treat a blank backend version as Auto

### DIFF
--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -1092,7 +1092,10 @@ exec "$@"
 
         backend_variant = None
         service = self._model.backend.lower()
-        model_service_version = self._model.backend_version
+        # A blank backend version means "Auto", same as None. Legacy/migrated data
+        # and API clients can store "", which would otherwise be used as an exact
+        # version filter and match no runner at all.
+        model_service_version = self._model.backend_version or None
         service_version = model_service_version
 
         # Default variant for some backends.

--- a/tests/worker/backends/test_backend.py
+++ b/tests/worker/backends/test_backend.py
@@ -1108,6 +1108,54 @@ def test_resolve_image_fallback_matches_host_major(
     assert image_name == expected_image
 
 
+@pytest.mark.parametrize(
+    "backend_version, expected_service_version, expected_with_deprecated",
+    [
+        # Auto: no version filter, deprecated runners stay hidden.
+        (None, None, False),
+        # Blank version is stored by legacy/migrated data and API clients. It is
+        # shown as "Auto" in the UI and has to resolve like None, not like an
+        # exact version filter that matches no runner.
+        ("", None, False),
+        # An explicit version is still passed through verbatim.
+        ("0.10.2", "0.10.2", True),
+    ],
+)
+def test_resolve_image_treats_blank_backend_version_as_auto(
+    backend_version, expected_service_version, expected_with_deprecated, monkeypatch
+):
+    import gpustack.worker.backends.base as base_module
+
+    captured = {}
+
+    def fake_list_backend_runners(**kwargs):
+        captured.update(kwargs)
+        return [
+            types.SimpleNamespace(
+                versions=[
+                    _make_versioned_runner(
+                        "13.0", "gpustack/runner:cuda13.0-vllm0.10.2"
+                    )
+                ]
+            )
+        ]
+
+    monkeypatch.setattr(base_module, "list_backend_runners", fake_list_backend_runners)
+
+    server = VLLMServer.__new__(VLLMServer)
+    server._model = types.SimpleNamespace(
+        image_name=None, backend="vllm", backend_version=backend_version
+    )
+    server.inference_backend = None
+    server._get_device_info = lambda: ("cuda", "13.0", None)
+
+    image_name, _ = server._resolve_image()
+
+    assert image_name == "gpustack/runner:cuda13.0-vllm0.10.2"
+    assert captured["service_version"] == expected_service_version
+    assert captured["with_deprecated"] is expected_with_deprecated
+
+
 class _StubServer(InferenceServer):
     """Concrete InferenceServer so base methods can be exercised in isolation."""
 


### PR DESCRIPTION
Fixes #6014

## Problem

`InferenceServer._resolve_image()` passed `self._model.backend_version` straight into the runner query:

```python
model_service_version = self._model.backend_version
...
runners = list_backend_runners(
    ...,
    service_version=model_service_version,
    with_deprecated=model_service_version is not None,
)
```

The UI represents **Auto** as `null`, but legacy/migrated model data and API clients can store `""`. Every other consumer of `backend_version` treats a blank value as "not set" (`_update_model_backend_service_version()`, `_replace_command_param()`, `resolve_target_version()` all use `if not version` / `version or default`), but here `""` was used as an exact `service_version` filter — and `"" is not None` also flipped `with_deprecated` on. No runner matched, so provisioning stopped before the runner container was created:

```text
_resolve_image query: backend=cuda, backend_variant=None, service=vllm, service_version=, platform=linux/amd64, runtime_version=13.0
Error provisioning model instance: Failed to get vLLM backend image
```

## Change

Normalize the blank value to `None` so it resolves exactly the way Auto does. The image-resolution path above it (`inference_backend.get_image_name()` → `resolve_target_version()`) already collapses `""` to the default version, so this is the one remaining place where the distinction leaked through.

Once a runner is selected, the existing `_update_model_backend_service_version()` writes the resolved version back to the model, so affected deployments self-heal on the next start.

## Test

Added `test_resolve_image_treats_blank_backend_version_as_auto`, which captures the kwargs handed to `list_backend_runners` and asserts that `None` and `""` produce the same query (`service_version=None`, `with_deprecated=False`) while an explicit version is still passed through verbatim. It fails on `main` with `assert '' == None` and passes with this change.

`pytest tests/worker/` — 418 passed. `black` and `flake8` clean on both touched files.

I do not have a CUDA host with the affected data to reproduce the original provisioning failure end to end, so verification here is the unit test plus reading the surrounding call path; the reporter's logs in #6014 cover the runtime symptom.
