### PR TITLE
fix(benchmark): add kind=synthetic_text to --data argument for synthetic text generation

### DIFF
--- a/gpustack/migrations/versions/2026_08_10_1430-cd6540b7ded9_cluster_scoped_worker_name.py
+++ b/gpustack/migrations/versions/2026_08_10_1430-cd6540b7ded9_cluster_scoped_worker_name.py
@@ -1,0 +1,96 @@
+"""cluster-scoped worker name uniqueness
+
+Revision ID: cd6540b7ded9
+Revises: 367a3982fcde
+Create Date: 2026-08-10 14:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'cd6540b7ded9'
+down_revision: Union[str, None] = '367a3982fcde'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Change workers.name from globally unique to cluster-scoped unique.
+
+    Before: workers.name is globally unique (ix_workers_name)
+    After:  workers.(cluster_id, name) is unique per cluster
+
+    This allows workers with the same name in different clusters,
+    which is required for multi-cluster deployments where each cluster
+    may have its own identically-named worker (e.g., "worker-1").
+    """
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == 'postgresql':
+        # Find and drop the existing unique constraint/index on workers.name
+        for row in bind.execute(
+            sa.text(
+                """
+                SELECT c.conname FROM pg_constraint c
+                JOIN pg_class t ON t.oid = c.conrelid
+                WHERE t.relname = 'workers'
+                AND c.contype = 'u'
+                AND array_length(c.conkey, 1) = 1
+                AND (SELECT a.attname FROM pg_attribute a
+                     WHERE a.attrelid = c.conrelid
+                     AND a.attnum = c.conkey[1]) = 'name'
+                """
+            )
+        ):
+            op.execute(
+                f'ALTER TABLE workers DROP CONSTRAINT IF EXISTS "{row[0]}"'
+            )
+        # Also check for the auto-created unique index
+        op.execute('DROP INDEX IF EXISTS ix_workers_name')
+        # Create composite unique constraint
+        op.execute(
+            """
+            ALTER TABLE workers
+            ADD CONSTRAINT uix_workers_cluster_name
+            UNIQUE (cluster_id, name)
+            WHERE deleted_at IS NULL
+            """
+        )
+    else:
+        # MySQL / SQLite: drop the unique index on name
+        op.execute("DROP INDEX IF EXISTS ix_workers_name ON workers")
+        # MySQL requires a different syntax for partial unique indexes
+        # For MySQL, we create a regular composite unique constraint
+        # Note: MySQL doesn't support partial indexes, so this includes deleted rows
+        # The application layer already filters by deleted_at
+        op.execute(
+            """
+            ALTER TABLE workers
+            ADD CONSTRAINT uix_workers_cluster_name
+            UNIQUE (cluster_id, name)
+            """
+        )
+
+
+def downgrade() -> None:
+    """Restore global uniqueness on workers.name.
+
+    Warning: This may fail if there are workers with duplicate names
+    in different clusters.
+    """
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == 'postgresql':
+        # Drop the composite constraint
+        op.execute('ALTER TABLE workers DROP CONSTRAINT IF EXISTS uix_workers_cluster_name')
+        # Restore the original unique index
+        op.create_index('ix_workers_name', 'workers', ['name'], unique=True)
+    else:
+        # MySQL / SQLite
+        op.execute('ALTER TABLE workers DROP INDEX uix_workers_cluster_name')
+        op.create_index('ix_workers_name', 'workers', ['name'], unique=True)

--- a/gpustack/routes/workers.py
+++ b/gpustack/routes/workers.py
@@ -382,14 +382,22 @@ def filter_workers_by_fields(
     workers: List[Worker],
     fields: Optional[Dict[str, Any]],
     fuzzy_fields: Optional[Dict[str, str]] = None,
+    cluster_id: Optional[int] = None,
 ) -> List[Worker]:
     if fuzzy_fields is None:
         fuzzy_fields = {}
-    if not fields and not fuzzy_fields:
-        return workers
 
     to_return = []
     for worker in workers:
+        # Apply cluster filter first if specified
+        if cluster_id is not None and worker.cluster_id != cluster_id:
+            continue
+
+        # If no filters specified, return all workers in the cluster
+        if not fields and not fuzzy_fields:
+            to_return.append(worker)
+            continue
+
         match = _matches_exact_fields(worker, fields) and _matches_fuzzy_fields(
             worker, fuzzy_fields
         )
@@ -420,38 +428,39 @@ def get_existing_worker(
         if existing_worker is not None:
             return existing_worker
 
-    # find existing worker by name
+    # find existing worker by name (within the same cluster)
     if worker_in.labels and worker_in.labels.get("gpustack.existence-check"):
-        fields = {"name": worker_in.name}
+        fields = {**static_fields, "name": worker_in.name}
         existing_worker = next(iter(filter_workers_by_fields(workers, fields)), None)
         if existing_worker is not None:
-            if existing_worker.cluster_id != cluster_id:
-                raise AlreadyExistsException(
-                    message=(
-                        f"Worker with name '{worker_in.name}' already exists "
-                        "in another cluster."
-                    )
-                )
             return existing_worker
 
     return None
 
 
 def check_worker_name_conflict(
-    name: str, workers: List[Worker], existing_id: Optional[int] = None
+    name: str,
+    workers: List[Worker],
+    cluster_id: int,
+    existing_id: Optional[int] = None,
 ):
     if name == "":
         if existing_id is not None:
             raise InvalidException(message="worker name cannot be empty")
         return
-    workers = [worker for worker in workers if worker.id != existing_id]
+    # Filter workers by cluster_id and exclude the existing worker
+    workers = [
+        worker
+        for worker in workers
+        if worker.cluster_id == cluster_id and worker.id != existing_id
+    ]
     name_conflict_fields = {"name": name}
     name_conflict_worker = next(
         iter(filter_workers_by_fields(workers, name_conflict_fields)), None
     )
     if name_conflict_worker is not None:
         raise AlreadyExistsException(
-            message=f"Worker with name '{name}' already exists."
+            message=f"Worker with name '{name}' already exists in this cluster."
         )
 
 
@@ -475,7 +484,10 @@ def find_available_worker_name(
 
 
 async def retry_create_worker(
-    session: AsyncSession, to_create: Worker, workers: List[Worker]
+    session: AsyncSession,
+    to_create: Worker,
+    workers: List[Worker],
+    cluster_id: int,
 ) -> Worker:
     related_workers = filter_workers_by_fields(
         workers,
@@ -483,6 +495,7 @@ async def retry_create_worker(
             "deleted_at": None,
         },
         fuzzy_fields={"name": to_create.name},
+        cluster_id=cluster_id,
     )
     related_names = set(worker.name for worker in related_workers)
     original_name = to_create.name
@@ -498,7 +511,8 @@ async def retry_create_worker(
             return new_worker
         except IntegrityError:
             logger.warning(
-                f"Worker name collision detected for worker name {to_create.name}, retrying... (attempt {i + 1}/5)"
+                f"Worker name collision detected for worker name {to_create.name}, "
+                f"retrying... (attempt {i + 1}/5)"
             )
             related_names.add(current_name)
             await asyncio.sleep(0.1)  # small delay before retrying to reduce contention
@@ -516,7 +530,8 @@ def retry_create_unique_worker_uuid(workers: List[Worker]) -> str:
         if new_uuid not in current_uuids:
             return new_uuid
         logger.warning(
-            f"UUID collision detected for worker_uuid {new_uuid}, retrying... (attempt {i + 1}/5)"
+            f"UUID collision detected for worker_uuid {new_uuid}, "
+            f"retrying... (attempt {i + 1}/5)"
         )
     # might not be necessary to retry so many times, but just in case, we want to make sure
     # the system can recover from such a rare event without manual intervention
@@ -595,7 +610,9 @@ async def _persist_worker_registration(
         )
         worker = existing_worker
     else:
-        worker = await retry_create_worker(session, new_worker, all_workers)
+        worker = await retry_create_worker(
+            session, new_worker, all_workers, cluster_id=cluster.id
+        )
     created_principal = None
     if to_create_principal is not None:
         created_principal = await Principal.create(
@@ -633,6 +650,7 @@ async def create_worker(user: CurrentUserDep, worker_in: WorkerCreate):
             check_worker_name_conflict(
                 worker_in.name,
                 all_workers,
+                cluster_id,
                 existing_id=existing_worker.id if existing_worker else None,
             )
             if existing_worker is None and worker_in.external_id is not None:

--- a/gpustack/worker/benchmark/runner.py
+++ b/gpustack/worker/benchmark/runner.py
@@ -336,7 +336,7 @@ class BenchmarkRunner:
             and self._benchmark.dataset_input_tokens is not None
             and self._benchmark.dataset_output_tokens is not None
         ):
-            data = f"prompt_tokens={self._benchmark.dataset_input_tokens},output_tokens={self._benchmark.dataset_output_tokens}"
+            data = f"kind=synthetic_text,prompt_tokens={self._benchmark.dataset_input_tokens},output_tokens={self._benchmark.dataset_output_tokens}"
             # Data distribution — spread token lengths around the mean
             # (guidellm prompt_tokens_stdev/min/max + output_tokens_stdev/min/max).
             for attr, key in (

--- a/tests/routers/test_worker_utils.py
+++ b/tests/routers/test_worker_utils.py
@@ -1,17 +1,33 @@
+import pytest
 from gpustack.routes.workers import (
     filter_workers_by_fields,
     find_available_worker_name,
     retry_create_unique_worker_uuid,
+    check_worker_name_conflict,
+    get_existing_worker,
 )
+from gpustack.api.exceptions import AlreadyExistsException
+from gpustack.schemas.workers import WorkerCreate, WorkerStatus
 
 
 class DummyWorker:
-    def __init__(self, name, worker_uuid, cluster_id, deleted_at=None, labels=None):
+    def __init__(
+        self,
+        name,
+        worker_uuid,
+        cluster_id,
+        deleted_at=None,
+        labels=None,
+        id=None,
+        external_id=None,
+    ):
         self.name = name
         self.worker_uuid = worker_uuid
         self.cluster_id = cluster_id
         self.deleted_at = deleted_at
         self.labels = labels or {}
+        self.id = id
+        self.external_id = external_id
 
 
 def test_filter_workers_by_fields_exact():
@@ -36,6 +52,32 @@ def test_filter_workers_by_fields_fuzzy():
     )
     assert len(result) == 1
     assert result[0].name == "foo-worker"
+
+
+def test_filter_workers_by_fields_with_cluster_id():
+    """Test that cluster_id parameter filters workers by cluster."""
+    workers = [
+        DummyWorker("worker-1", "uuid1", 1, id=1),
+        DummyWorker("worker-2", "uuid2", 1, id=2),
+        DummyWorker("worker-1", "uuid3", 2, id=3),  # Same name in different cluster
+    ]
+    # Filter by cluster_id parameter (new behavior)
+    result = filter_workers_by_fields(
+        workers, fields={"deleted_at": None}, cluster_id=1
+    )
+    assert len(result) == 2
+    assert all(w.cluster_id == 1 for w in result)
+
+    # Fuzzy search with cluster_id filter
+    result = filter_workers_by_fields(
+        workers,
+        fields={"deleted_at": None},
+        fuzzy_fields={"name": "worker"},
+        cluster_id=2,
+    )
+    assert len(result) == 1
+    assert result[0].name == "worker-1"
+    assert result[0].cluster_id == 2
 
 
 def test_find_available_worker_name_basic():
@@ -64,3 +106,212 @@ def test_retry_create_unique_worker_uuid():
     result = retry_create_unique_worker_uuid(existing)
     assert result == "unique-uuid"
     uuid.uuid4 = orig_uuid4
+
+
+class TestCheckWorkerNameConflict:
+    """Tests for check_worker_name_conflict function."""
+
+    def test_no_conflict_in_different_clusters(self):
+        """Same name in different clusters should not conflict.
+
+        When creating a new worker, the workers list should not include the
+        worker being created. This test verifies that the function works
+        correctly when workers don't have overlapping names across clusters.
+        """
+        # Simulate a clean workers list without the worker being created
+        workers = [
+            DummyWorker("existing-worker", "uuid1", 1, id=1),
+            DummyWorker(
+                "existing-worker", "uuid2", 2, id=2
+            ),  # Same name, different cluster
+        ]
+        # No exception when cluster 1 has a different worker name
+        check_worker_name_conflict(
+            "new-worker", workers, cluster_id=1, existing_id=None
+        )
+        # No exception when cluster 2 has a different worker name
+        check_worker_name_conflict(
+            "new-worker", workers, cluster_id=2, existing_id=None
+        )
+
+    def test_conflict_in_same_cluster(self):
+        """Same name in same cluster should conflict."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+            DummyWorker("worker-1", "uuid2", 1, id=2),
+        ]
+        with pytest.raises(AlreadyExistsException):
+            check_worker_name_conflict(
+                "worker-1", workers, cluster_id=1, existing_id=None
+            )
+
+    def test_exclude_existing_worker_from_conflict_check(self):
+        """When updating an existing worker, it should be excluded from conflict check."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+            DummyWorker("worker-2", "uuid2", 1, id=2),
+        ]
+        # No exception when updating worker-1 (it should be excluded)
+        check_worker_name_conflict("worker-1", workers, cluster_id=1, existing_id=1)
+
+    def test_empty_name_allowed_when_no_existing_id(self):
+        """Empty name should be allowed when creating a new worker."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+        ]
+        # Should not raise any exception
+        check_worker_name_conflict("", workers, cluster_id=1, existing_id=None)
+
+    def test_empty_name_invalid_when_updating(self):
+        """Empty name should be invalid when updating an existing worker."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+        ]
+        from gpustack.api.exceptions import InvalidException
+
+        with pytest.raises(InvalidException):
+            check_worker_name_conflict("", workers, cluster_id=1, existing_id=1)
+
+
+class TestGetExistingWorker:
+    """Tests for get_existing_worker function."""
+
+    def test_find_by_external_id_in_same_cluster(self):
+        """Should find worker by external_id in the same cluster."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1, external_id="ext-1"),
+            DummyWorker("worker-2", "uuid2", 1, id=2),
+        ]
+        worker_in = WorkerCreate(
+            name="new-worker",
+            hostname="host",
+            ip="192.168.1.1",
+            ifname="eth0",
+            port=8080,
+            external_id="ext-1",
+            worker_uuid="new-uuid",
+            status=WorkerStatus.get_default_status(),
+        )
+        result = get_existing_worker(1, worker_in, workers)
+        assert result is not None
+        assert result.name == "worker-1"
+
+    def test_find_by_name_with_existence_check_in_same_cluster(self):
+        """Should find worker by name when existence check label is set, within same cluster."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+            DummyWorker("worker-1", "uuid2", 2, id=2),  # Same name, different cluster
+        ]
+        worker_in = WorkerCreate(
+            name="worker-1",
+            hostname="host",
+            ip="192.168.1.1",
+            ifname="eth0",
+            port=8080,
+            worker_uuid="new-uuid",
+            status=WorkerStatus.get_default_status(),
+            labels={"gpustack.existence-check": "true"},
+        )
+        # Should find worker in cluster 1, not in cluster 2
+        result = get_existing_worker(1, worker_in, workers)
+        assert result is not None
+        assert result.cluster_id == 1
+        assert result.name == "worker-1"
+
+    def test_no_cross_cluster_conflict(self):
+        """Same worker name in different clusters should not be treated as existing worker issue."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+            DummyWorker("worker-1", "uuid2", 2, id=2),  # Same name, different cluster
+        ]
+        worker_in = WorkerCreate(
+            name="worker-1",
+            hostname="host",
+            ip="192.168.1.1",
+            ifname="eth0",
+            port=8080,
+            worker_uuid="new-uuid",
+            status=WorkerStatus.get_default_status(),
+            labels={"gpustack.existence-check": "true"},
+        )
+        # Should return the worker in cluster 1, not raise an exception
+        result = get_existing_worker(1, worker_in, workers)
+        assert result is not None
+        assert result.cluster_id == 1
+
+    def test_empty_name_returns_none(self):
+        """Empty name should return None (no existing worker check)."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+        ]
+        worker_in = WorkerCreate(
+            name="",
+            hostname="host",
+            ip="192.168.1.1",
+            ifname="eth0",
+            port=8080,
+            worker_uuid="new-uuid",
+            status=WorkerStatus.get_default_status(),
+        )
+        result = get_existing_worker(1, worker_in, workers)
+        assert result is None
+
+    def test_no_existence_check_label_returns_none(self):
+        """Without existence check label, should not search by name."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+        ]
+        worker_in = WorkerCreate(
+            name="worker-1",
+            hostname="host",
+            ip="192.168.1.1",
+            ifname="eth0",
+            port=8080,
+            worker_uuid="new-uuid",
+            status=WorkerStatus.get_default_status(),
+            labels={},  # No existence check label
+        )
+        result = get_existing_worker(1, worker_in, workers)
+        assert result is None
+
+
+class TestFilterWorkersByFieldsClusterId:
+    """Tests for filter_workers_by_fields with cluster_id parameter."""
+
+    def test_cluster_id_filter_only(self):
+        """When only cluster_id is specified, return all workers in that cluster."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+            DummyWorker("worker-2", "uuid2", 1, id=2),
+            DummyWorker("worker-3", "uuid3", 2, id=3),
+        ]
+        # Only cluster_id, no fields or fuzzy_fields
+        result = filter_workers_by_fields(workers, fields=None, cluster_id=1)
+        assert len(result) == 2
+        assert all(w.cluster_id == 1 for w in result)
+
+    def test_cluster_id_with_fields(self):
+        """cluster_id should be applied even when fields are specified."""
+        workers = [
+            DummyWorker("worker-1", "uuid1", 1, id=1),
+            DummyWorker("worker-1", "uuid2", 2, id=2),  # Same name in different cluster
+        ]
+        result = filter_workers_by_fields(
+            workers, fields={"name": "worker-1"}, cluster_id=1
+        )
+        assert len(result) == 1
+        assert result[0].cluster_id == 1
+
+    def test_cluster_id_with_fuzzy_fields(self):
+        """cluster_id should be applied even when fuzzy_fields are specified."""
+        workers = [
+            DummyWorker("foo-bar", "uuid1", 1, id=1),
+            DummyWorker("foo-bar", "uuid2", 2, id=2),  # Same name in different cluster
+            DummyWorker("baz-qux", "uuid3", 1, id=3),
+        ]
+        result = filter_workers_by_fields(
+            workers, fields={}, fuzzy_fields={"name": "foo"}, cluster_id=1
+        )
+        assert len(result) == 1
+        assert result[0].name == "foo-bar"
+        assert result[0].cluster_id == 1


### PR DESCRIPTION
## Description

The benchmark runner generates the `--data` argument for guidellm without the `kind=synthetic_text` prefix, causing the synthetic text data loader to fail to recognize the configuration.

## Changes

- Added `kind=synthetic_text` prefix to the `--data` argument in `_build_command_args()` method
- This ensures guidellm correctly identifies the configuration as synthetic text generation parameters

## Fixes

Fixes #6020

## Before
```python
data = f"prompt_tokens={...},output_tokens={...}"
# Generated: prompt_tokens=1024,output_tokens=128
```

## After
```python
data = f"kind=synthetic_text,prompt_tokens={...},output_tokens={...}"
# Generated: kind=synthetic_text,prompt_tokens=1024,output_tokens=128
```