### PR TITLE
fix(benchmark): add kind=synthetic_text to --data argument for synthetic text generation

### DIFF
--- a/gpustack/worker/benchmark/runner.py
+++ b/gpustack/worker/benchmark/runner.py
@@ -336,7 +336,7 @@ class BenchmarkRunner:
             and self._benchmark.dataset_input_tokens is not None
             and self._benchmark.dataset_output_tokens is not None
         ):
-            data = f"prompt_tokens={self._benchmark.dataset_input_tokens},output_tokens={self._benchmark.dataset_output_tokens}"
+            data = f"kind=synthetic_text,prompt_tokens={self._benchmark.dataset_input_tokens},output_tokens={self._benchmark.dataset_output_tokens}"
             # Data distribution — spread token lengths around the mean
             # (guidellm prompt_tokens_stdev/min/max + output_tokens_stdev/min/max).
             for attr, key in (


### PR DESCRIPTION
## Description

The benchmark runner generates the `--data` argument for guidellm without the `kind=synthetic_text` prefix, causing the synthetic text data loader to fail to recognize the configuration.

## Changes

- Added `kind=synthetic_text` prefix to the `--data` argument in `_build_command_args()` method
- This ensures guidellm correctly identifies the configuration as synthetic text generation parameters

## Fixes

Fixes #6020

## Before
```python
data = f"prompt_tokens={...},output_tokens={...}"
# Generated: prompt_tokens=1024,output_tokens=128
```

## After
```python
data = f"kind=synthetic_text,prompt_tokens={...},output_tokens={...}"
# Generated: kind=synthetic_text,prompt_tokens=1024,output_tokens=128
```