### PR TITLE
fix(benchmark): never blame the user's range for the probe's own cap

### DIFF
--- a/gpustack/worker/benchmark/analysis.py
+++ b/gpustack/worker/benchmark/analysis.py
@@ -552,17 +552,28 @@ def _limit_warnings(
     one case: a run ended by `max_total_seconds` leaves exactly the same curve as
     one that stopped of its own accord, so the inference path below reported "raise
     the upper bound" for a run the CLOCK ended. Hence the facts.
+
+    A THIRD bound exists and is not the user's: the saturation probe's soft cap.
+    `not_saturated` must never be reported for it — its advice is "raise
+    upper_bound", and raising it changes nothing, because the probe re-derives the
+    cap from a fresh measurement on every run. Observed: a run configured 4..1024
+    stopped at 31 (cap = ceil(25.6 * 1.2)) and was told to raise the 1024.
     """
     bracket = (ramp or {}).get("bracket_reason")
     if bracket is not None:
         if bracket == RAMP_STOP_UPPER_BOUND and not overloaded_any:
+            if _stopped_on_the_probes_cap(benchmark, ramp):
+                return []
             return [{"code": "not_saturated", "params": {}}]
         if bracket in (RAMP_STOP_BUDGET_POINTS, RAMP_STOP_BUDGET_SECONDS):
             # `which` names the cap, so the message can point at the right knob.
             which = "seconds" if bracket == RAMP_STOP_BUDGET_SECONDS else "points"
             return [{"code": "budget_exhausted", "params": {"which": which}}]
-        # Any other reason (capacity_plateau, sla_failed, converged, ...) means the
-        # search ended because it had its answer: no limit to report.
+        # Any other reason means either the search had its answer
+        # (capacity_plateau, sla_failed, ...) or the limit was one the user cannot
+        # act on: `probe_bound` is the saturation probe's own soft cap, and raising
+        # upper_bound does not move a cap the probe re-derives from a fresh
+        # measurement on every run. Either way: no limit to report.
         return []
 
     # ── No facts (stage / legacy / pre-sidecar run): judge from the grid ──
@@ -579,6 +590,43 @@ def _limit_warnings(
     if max_points is not None and len(rate_points) >= max_points:
         return [{"code": "budget_exhausted", "params": {"which": "points"}}]
     return [{"code": "not_saturated", "params": {}}]
+
+
+def _stopped_on_the_probes_cap(benchmark, ramp: Optional[dict]) -> bool:
+    """Did the SOFT cap end this run, while reporting itself as `upper_bound`?
+
+    Runners that name the two bounds apart report `probe_bound` and never reach
+    this. For one that does not, the sidecar still carries enough to tell: the run
+    ended AT OR ABOVE the probe's cap, and that cap was below the range the user
+    asked for. Those two facts are jointly decisive, because the ramp only breaks
+    on a bound it has reached (`knob >= bound`, `bound = min(upper_bound, cap)`):
+
+      * the cap ended it  -> bound is the cap, so stopped_at >= probe_bound, and
+        the cap sits under the user's range.
+      * the range ended it -> bound is upper_bound, which means the cap was absent
+        or already at/above it, so `probe_bound < upper` is false.
+
+    `>=` rather than `==` because the run does not have to LAND on the cap. Points
+    are clamped to the bound at the end of an iteration, so the FIRST point is
+    never clamped: a range starting above the cap (lower_bound 32, cap 31) measures
+    32, stops, and reports 32. That is the one case the current runner can still
+    produce — it is exactly when the cap is allowed to end a search — so requiring
+    equality would miss it on every pre-`probe_bound` image.
+
+    Every one of the three facts is required: the cap (`probe_bound`), where the
+    run ended (`stopped_at`), and the range to compare the cap against
+    (`benchmark.upper_bound`, absent on runs that never had a search range). Any
+    of them missing and the verdict is left alone. That asymmetry is deliberate —
+    this only ever SUPPRESSES advice, so a false negative merely restores the old
+    (wrong) message, while a false positive would hide a real range limit.
+    """
+    facts = ramp or {}
+    probe_bound = facts.get("probe_bound")
+    stopped_at = facts.get("stopped_at")
+    upper = getattr(benchmark, "upper_bound", None)
+    if probe_bound is None or stopped_at is None or upper is None:
+        return False
+    return stopped_at >= probe_bound and probe_bound < upper
 
 
 def _plateaued_at_top(rate_points: list) -> bool:

--- a/tests/worker/test_benchmark_manager.py
+++ b/tests/worker/test_benchmark_manager.py
@@ -2056,3 +2056,77 @@ class TestOneMissingPercentileDoesNotCostThePoint:
         assert not [
             name for name, f in Percentiles.model_fields.items() if f.is_required()
         ]
+
+
+class TestTheProbesCapIsNotTheUsersRange:
+    """`not_saturated` says "raise upper_bound". Never say it about the soft cap.
+
+    The saturation probe derives its own cap from a fresh measurement on every
+    run, so raising the range cannot move it — the advice is not merely unhelpful,
+    it is unfollowable. Reproduces benchmark 40: configured 4..1024, probe read
+    25.6 rps, cap = ceil(25.6 * 1.2) = 31, ramp stopped there with the grid still
+    climbing (+63% throughput on the last step) and the page told the user to
+    raise the 1024.
+    """
+
+    BM40 = {
+        "version": 1,
+        "bracket_reason": "upper_bound",
+        "stop_reason": "upper_bound",
+        "stopped_at": 31,
+        "probe_ceiling": 25.6,
+        "probe_bound": 31,
+        "probe_relaxed": 0,
+    }
+
+    @staticmethod
+    def _points():
+        return [
+            _point(4, 4635.0, 0.4),
+            _point(8, 9220.0, 0.4),
+            _point(16, 18350.0, 0.5),
+            _point(31, 30022.0, 1.4),
+        ]
+
+    def _validity(self, ramp, upper_bound=1024):
+        return analysis.compute_validity(
+            SimpleNamespace(upper_bound=upper_bound, max_points=12),
+            self._points(),
+            {"recommended_rate": 31, "peak_rate": 31},
+            ramp,
+        )
+
+    def test_a_legacy_sidecar_that_calls_the_cap_upper_bound_is_seen_through(self):
+        # An older runner reports both bounds as `upper_bound`; the facts it does
+        # carry still tell them apart — it ended ON the cap, and the cap was below
+        # the range the user asked for.
+        assert self._validity(self.BM40)["warnings"] == []
+
+    def test_the_named_reason_needs_no_inference(self):
+        ramp = {**self.BM40, "bracket_reason": "probe_bound"}
+        assert self._validity(ramp)["warnings"] == []
+
+    def test_the_users_own_range_still_gets_the_advice(self):
+        # Same shape, but the run ended at the top of the range it was given:
+        # raising it is exactly the right thing to do.
+        ramp = {**self.BM40, "stopped_at": 1024, "probe_bound": 1024}
+        codes = [w["code"] for w in self._validity(ramp)["warnings"]]
+        assert codes == ["not_saturated"]
+
+    def test_a_cap_that_never_bound_anything_still_gets_the_advice(self):
+        # The probe read HIGH, so the ramp hit the user's range before the cap:
+        # stopped_at < probe_bound means the cap is not what ended this.
+        ramp = {**self.BM40, "stopped_at": 512, "probe_bound": 900}
+        codes = [w["code"] for w in self._validity(ramp, upper_bound=512)["warnings"]]
+        assert codes == ["not_saturated"]
+
+    def test_a_run_with_no_probe_is_unaffected(self):
+        # Concurrency axis: no probe, so no cap keys — the verdict must not change.
+        ramp = {
+            "version": 1,
+            "bracket_reason": "upper_bound",
+            "stop_reason": "upper_bound",
+            "stopped_at": 1024,
+        }
+        codes = [w["code"] for w in self._validity(ramp)["warnings"]]
+        assert codes == ["not_saturated"]


### PR DESCRIPTION
`not_saturated` means "the search range ended this run — raise upper_bound", and `_limit_warnings` emitted it for every `upper_bound` bracket the ramp reported. But the ramp has two ceilings: the range the user declared, and the soft cap the saturation probe derives for itself. Raising the range does nothing about the second one — the probe re-measures and re-derives its cap on every run — so the advice is not merely unhelpful, it cannot be followed.

Observed on a run configured 4..1024: the probe read 25.6 rps, capped the ramp at ceil(25.6 * 1.2) = 31, and the page told the user to raise the 1024.

benchmark-runner now names that stop `probe_bound`, which falls through to "no limit to report" here. Runs from an older image still report it as `upper_bound`, and for those the sidecar carries enough to tell the two apart anyway: the search ended exactly ON the probe's cap, and that cap sat below the range the user asked for. Both paths are covered, so the wrong advice stops without waiting for an image rebuild.

The check is deliberately conservative about missing facts — no probe, no cap, no change of verdict. It only ever suppresses advice, so a false negative merely restores today's behaviour while a false positive would hide a real range limit.