### PR TITLE
fix(worker): keep the first-failure serve log across a crash loop

### DIFF
--- a/docs/cli-reference/start.md
+++ b/docs/cli-reference/start.md
@@ -140,6 +140,7 @@ gpustack start [OPTIONS]
 | `--benchmark-image-repo` value           | `gpustack/benchmark-runner`            | Override the default benchmark image repo for the GPUStack benchmark container.                                                                                                              |
 | `--benchmark-dir` value                  | `<data-dir>/benchmarks`                | Directory to store benchmark results.                                                                                                                                                        |
 | `--benchmark-max-duration-seconds` value | (empty)                                | Max duration for a benchmark before timeout. Disabled when empty.                                                                                                                            |
+| `--serve-log-retention-count` value      | `2`                                    | Number of restart generations of model instance logs kept on the worker, counting back from the current restart. The log from restart 0 is always kept in addition.                           |
 
 ### Available Environment Variables
 
@@ -219,6 +220,7 @@ worker_port: 10150
 service_port_range: 40000-40063
 ray_port_range: 41000-41999
 log_dir: /path/to/log_dir
+serve_log_retention_count: 2
 system_reserved:
   ram: 2
   vram: 1

--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -608,6 +608,12 @@ def start_cmd_options(parser_server: argparse.ArgumentParser):
         default=get_gpustack_env("BENCHMARK_MAX_DURATION_SECONDS"),
     )
     worker_group.add_argument(
+        "--serve-log-retention-count",
+        type=int,
+        help="Number of restart generations of model instance logs kept on the worker, counting back from the current restart. The log from restart 0 is always kept in addition, so a crash loop cannot destroy the first-failure log. The default is 2.",
+        default=get_gpustack_env("SERVE_LOG_RETENTION_COUNT"),
+    )
+    worker_group.add_argument(
         "--disable-worker-metrics",
         action=OptionalBoolAction,
         help="Disable worker metrics.",
@@ -895,6 +901,7 @@ def set_worker_options(args, config_data: dict):
         "service_port_range",
         "ray_port_range",
         "benchmark_max_duration_seconds",
+        "serve_log_retention_count",
         "log_dir",
         "benchmark_dir",
         "system_reserved",

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -111,6 +111,7 @@ class Config(WorkerConfig, BaseSettings):
         bin_dir: Directory to store additional binaries, e.g., versioned backend executables.
         benchmark_dir: Directory to store benchmark results.
         benchmark_max_duration_seconds: Max duration for a benchmark before timeout. Disabled when unset.
+        serve_log_retention_count: Number of restart generations of model instance logs kept on the worker, counting back from the current restart. The log from restart 0 is always kept in addition. Default is 2.
         pipx_path: Path to the pipx executable, used to install versioned backends.
         system_reserved: Reserved system resources.
         tools_download_base_url: Base URL to download dependency tools.

--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from typing import List, Optional, Tuple
 import aiohttp
-from fastapi import APIRouter, Request, status, HTTPException
+from fastapi import APIRouter, Query, Request, status, HTTPException
 from fastapi.responses import PlainTextResponse, StreamingResponse, RedirectResponse
 from urllib.parse import urlencode
 
@@ -279,6 +279,11 @@ async def get_serving_logs(  # noqa: C901
             "model_instance_name": model_instance.name,
             "previous": log_options.previous,
         }
+        # Omitted rather than sent as None: _convert_params only normalises
+        # bools, so a None would reach yarl and raise. Leaving it out also keeps
+        # the request byte-identical to today's for callers that don't ask.
+        if log_options.restart_count is not None:
+            params["restart_count"] = log_options.restart_count
         if container_name:
             params["container_name"] = container_name
         if (
@@ -365,8 +370,12 @@ async def fetch_serve_log_options_from_worker(
     request: Request,
     worker: Worker,
     model_instance_id: int,
+    all_restarts: bool = False,
 ) -> ServeLogOptionsResponse:
     timeout = aiohttp.ClientTimeout(total=envs.PROXY_TIMEOUT, sock_connect=5)
+    # Only sent when asked for, so the request to an older worker (which would
+    # ignore the param anyway) stays exactly as it is today.
+    params = {"all_restarts": True} if all_restarts else None
     try:
         resp, body = await request_to_worker(
             worker=worker,
@@ -374,6 +383,7 @@ async def fetch_serve_log_options_from_worker(
             path=f"serveLogOptions/{model_instance_id}",
             proxy_client=request.app.state.http_client,
             no_proxy_client=request.app.state.http_client_no_proxy,
+            params=params,
             timeout=timeout,
         )
     except Exception as e:
@@ -400,6 +410,14 @@ async def get_model_instance_log_options(
     session: SessionDep,
     ctx: TenantContextDep,
     id: int,
+    all_restarts: bool = Query(
+        default=False,
+        description=(
+            "List every retained log session per worker, not just the two a "
+            "'previous' request can address. Read those extras with the "
+            "'restart_count' query parameter on the logs endpoint."
+        ),
+    ),
 ):
     """Return per-worker restart_count values that exist on disk for this model instance."""
     model_instance = await fetch_model_instance(session, ctx, id)
@@ -421,7 +439,7 @@ async def get_model_instance_log_options(
             display_name = worker.name or ""
         try:
             payload = await fetch_serve_log_options_from_worker(
-                request, worker, model_instance.id
+                request, worker, model_instance.id, all_restarts
             )
             return ModelInstanceLogWorkerOption(
                 worker_id=wid,

--- a/gpustack/routes/worker/logs.py
+++ b/gpustack/routes/worker/logs.py
@@ -137,9 +137,17 @@ async def get_all_log_files(
 
 
 async def resolve_restart_count(
-    log_dir: Path, model_instance_id: int, previous: bool
+    log_dir: Path,
+    model_instance_id: int,
+    previous: bool,
+    restart_count: Optional[int] = None,
 ) -> Optional[int]:
-    """Resolve ``previous`` flag to an actual restart_count from disk files.
+    """Resolve the requested log set to an actual restart_count from disk files.
+
+    An explicit ``restart_count`` wins when that log set is on disk: the worker
+    retains more than two restarts, and ``previous`` can only name the second
+    newest. An unknown ``restart_count`` falls back to the boolean rather than
+    streaming nothing, so a stale UI list cannot produce an empty log view.
 
     Returns:
         The restart_count integer for the target log set, or ``None`` when
@@ -149,6 +157,8 @@ async def resolve_restart_count(
     if not files:
         return None
     counts = sorted(set(extract_restart_count(f.name) for f in files))
+    if restart_count is not None and restart_count in counts:
+        return restart_count
     if previous and len(counts) >= 2:
         return counts[-2]
     return counts[-1]
@@ -168,9 +178,11 @@ def restart_entries_from_main_log_files(
 ) -> List[ModelInstanceLogRestartEntry]:
     """Build restart entries from main log paths; one entry per restart_count.
 
-    Entries are ordered by restart_count descending (newest first).
-    The highest restart_count maps to ``previous=False`` (current);
-    the second highest maps to ``previous=True``.
+    Entries are ordered by restart_count descending (newest first). The highest
+    restart_count maps to ``previous=False`` (current) and every older one to
+    ``previous=True``, so with more than two retained sessions the flag no
+    longer identifies a single entry. Read ``restart_count`` to tell them apart;
+    the caller decides how many entries to expose.
 
     If multiple files share a restart_count, use the lexicographically smallest
     name as the representative path for stat.
@@ -198,7 +210,10 @@ def restart_entries_from_main_log_files(
         )
         entries.append(
             ModelInstanceLogRestartEntry(
-                previous=i > 0, started_at=started_at, containers=containers
+                previous=i > 0,
+                restart_count=rc,
+                started_at=started_at,
+                containers=containers,
             )
         )
     return entries
@@ -226,7 +241,9 @@ def restart_entries_from_sidecar_log_files(
         except OSError:
             started_at = None
         entries.append(
-            ModelInstanceLogRestartEntry(previous=i > 0, started_at=started_at)
+            ModelInstanceLogRestartEntry(
+                previous=i > 0, restart_count=rc, started_at=started_at
+            )
         )
     return entries
 
@@ -421,7 +438,7 @@ async def combined_log_generator(
     log_dir = Path(log_dir)
 
     restart_count = await resolve_restart_count(
-        log_dir, model_instance_id, options.previous
+        log_dir, model_instance_id, options.previous, options.restart_count
     )
 
     # When a specific sidecar container is requested, stream only its logs.
@@ -526,8 +543,25 @@ async def combined_log_generator(
 
 
 @router.get("/serveLogOptions/{id}", response_model=ServeLogOptionsResponse)
-async def get_serve_log_options(request: Request, id: int):
-    """List restart_count values for which main serve log files exist locally."""
+async def get_serve_log_options(
+    request: Request,
+    id: int,
+    all_restarts: bool = Query(
+        default=False,
+        description=(
+            "List every retained log session instead of only the two a "
+            "'previous' request can address. Callers that set this must read "
+            "logs with 'restart_count'; 'previous' cannot reach the extras."
+        ),
+    ),
+):
+    """List restart_count values for which main serve log files exist locally.
+
+    Capped to the two newest by default. The worker retains more than that (the
+    first-failure log is pinned and the window is configurable), but ``previous``
+    only addresses the two newest, so listing the rest unconditionally would
+    offer a client sessions it cannot fetch, and it would serve the wrong log.
+    """
     log_dir = request.app.state.config.log_dir
     serve_log_dir = Path(log_dir) / "serve"
     files = await get_all_log_files(serve_log_dir, id, container=False)
@@ -573,6 +607,11 @@ async def get_serve_log_options(request: Request, id: int):
     restarts = await asyncio.to_thread(
         restart_entries_from_main_log_files, files, container_names_by_restart
     )
+    if not all_restarts:
+        # Entries are newest-first, so this leaves exactly the current and
+        # previous sessions, which is what this endpoint returned before extra
+        # sessions were retained.
+        restarts = restarts[:2]
 
     return ServeLogOptionsResponse(restarts=restarts)
 

--- a/gpustack/schemas/config.py
+++ b/gpustack/schemas/config.py
@@ -72,8 +72,24 @@ class PredefinedConfig(SensitivePredefinedConfig):
     service_port_range: Optional[str] = "40000-40063"
     ray_port_range: Optional[str] = "41000-41999"
     benchmark_max_duration_seconds: Optional[int] = None
+    # How many restart generations of a model instance's serve logs the worker
+    # keeps, counting back from the current restart. The log from restart 0 is
+    # always kept on top of this window, so a crash loop cannot destroy the
+    # first-failure log (issue #6019).
+    serve_log_retention_count: int = 2
     system_reserved: Optional[dict] = None
     pipx_path: Optional[str] = None
+
+    @field_validator("serve_log_retention_count")
+    @classmethod
+    def _validate_serve_log_retention_count(cls, v):
+        # None only reaches here via PredefinedConfigNoDefaults, where an unset
+        # option means "inherit", not "keep zero generations".
+        if v is None:
+            return v
+        if v < 1:
+            raise ValueError(f"serve_log_retention_count must be at least 1, got {v!r}")
+        return v
 
     @field_validator("system_reserved", mode="before")
     @classmethod
@@ -110,6 +126,7 @@ class PredefinedConfigNoDefaults(PredefinedConfig):
     service_port_range: Optional[str] = None
     ray_port_range: Optional[str] = None
     benchmark_max_duration_seconds: Optional[int] = None
+    serve_log_retention_count: Optional[int] = None
     image_repo: Optional[str] = None
     benchmark_image_repo: Optional[str] = None
     gateway_mode: Optional[str] = None

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -904,6 +904,15 @@ class ModelInstanceLogRestartEntry(BaseModel):
     """One main serve log session on disk, with optional UX label time."""
 
     previous: bool = False
+    restart_count: Optional[int] = Field(
+        default=None,
+        description=(
+            "Restart count of this log set on disk. Pass it back as the "
+            "'restart_count' query parameter to read this specific session. "
+            "More than two sessions can be retained, and 'previous' only "
+            "reaches the second newest, so prefer this field when present."
+        ),
+    )
     started_at: Optional[datetime] = Field(
         default=None,
         description=(
@@ -960,7 +969,7 @@ class ServeLogOptionsResponse(BaseModel):
         # the second highest to previous=True.
         entries = []
         for i, c in enumerate(counts):
-            entries.append({"previous": i > 0, "started_at": None})
+            entries.append({"previous": i > 0, "restart_count": c, "started_at": None})
         return {**data, "restarts": entries}
 
 

--- a/gpustack/worker/logs.py
+++ b/gpustack/worker/logs.py
@@ -18,11 +18,19 @@ class LogOptions:
     follow: bool = False
     stop_event: Optional[asyncio.Event] = None
     previous: bool = False
+    # Address one specific retained restart. ``previous`` can only reach the two
+    # newest log sets, but the worker retains more than that (the first-failure
+    # log is pinned, and serve_log_retention_count may widen the window), so
+    # those are only reachable by naming the restart count. Takes precedence
+    # over ``previous`` when set; None keeps the old boolean behaviour.
+    restart_count: Optional[int] = None
 
     def url_encode(self):
         params = f"tail={self.tail}&follow={self.follow}"
         if self.previous:
             params += "&previous=true"
+        if self.restart_count is not None:
+            params += f"&restart_count={self.restart_count}"
         return params
 
 
@@ -33,14 +41,24 @@ default_follow = Query(default=False, description="Whether to follow the log out
 default_previous = Query(
     default=False, description="Whether to fetch logs from the previous restart"
 )
+default_restart_count = Query(
+    default=None,
+    description=(
+        "Fetch logs for this specific restart count, as listed by the "
+        "log-options endpoint. Takes precedence over 'previous'."
+    ),
+)
 
 
 def get_log_options(
     tail: int = default_tail,
     follow: bool = default_follow,
     previous: bool = default_previous,
+    restart_count: Optional[int] = default_restart_count,
 ) -> LogOptions:
-    return LogOptions(tail=tail, follow=follow, previous=previous)
+    return LogOptions(
+        tail=tail, follow=follow, previous=previous, restart_count=restart_count
+    )
 
 
 LogOptionsDep = Annotated[LogOptions, Depends(get_log_options)]

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -1374,16 +1374,29 @@ class ServeManager:
                     )
 
     def _cleanup_old_logs(self, model_instance_id: int, current_restart_count: int):
-        """Keep serve logs for restart_count in {R, R-1}.
+        """Keep the newest ``serve_log_retention_count`` restarts, plus restart 0.
 
         R==0 is a fresh lifecycle start, so all existing files are purged (any
         present belong to a previous owner of a reused id).
+
+        Restart 0 survives the whole lifecycle on top of that sliding window
+        because it holds the run that failed first, which is the log needed to
+        explain why the instance started restarting at all. A window alone
+        loses it after ``serve_log_retention_count`` restarts, so a crash loop
+        overwrites its own root cause (issue #6019).
         """
         if current_restart_count == 0:
             self._purge_instance_logs(model_instance_id)
             return
 
         try:
+            # Inside the try with the rest: a retention problem must never stop
+            # a model instance from starting, and this runs on the start path.
+            # The config validator already rejects anything below 1.
+            retention_count = self._config.serve_log_retention_count
+            oldest_in_window = max(0, current_restart_count - retention_count + 1)
+            keep = {0, *range(oldest_in_window, current_restart_count + 1)}
+
             log_dir = Path(self._serve_log_dir)
 
             # Separate main logs, container logs, and sidecar container logs
@@ -1407,13 +1420,9 @@ class ServeManager:
                 f for f in all_container_files if f not in default_container_logs
             ]
 
-            self._cleanup_log_type(all_main_logs, current_restart_count, "main")
-            self._cleanup_log_type(
-                default_container_logs, current_restart_count, "container"
-            )
-            self._cleanup_log_type(
-                sidecar_container_logs, current_restart_count, "sidecar_container"
-            )
+            self._cleanup_log_type(all_main_logs, keep, "main")
+            self._cleanup_log_type(default_container_logs, keep, "container")
+            self._cleanup_log_type(sidecar_container_logs, keep, "sidecar_container")
 
         except Exception as e:
             logger.error(f"Failed to cleanup old logs for {model_instance_id}: {e}")
@@ -1421,14 +1430,10 @@ class ServeManager:
     def _cleanup_log_type(
         self,
         log_files: List[Path],
-        current_restart_count: int,
+        keep: Set[int],
         log_type: str,
     ):
-        """Delete log files whose restart_count is not current or previous."""
-
-        keep = {current_restart_count}
-        if current_restart_count > 0:
-            keep.add(current_restart_count - 1)
+        """Delete log files whose restart_count is not in ``keep``."""
 
         def _extract_sidecar_restart_count(filename: str) -> int:
             """Extract restart count from {id}.container.{name}.{restart_count}.log"""

--- a/tests/schemas/test_model_instance_log_options.py
+++ b/tests/schemas/test_model_instance_log_options.py
@@ -1,0 +1,46 @@
+from gpustack.schemas.models import ServeLogOptionsResponse
+
+
+def test_legacy_restart_counts_become_addressable_entries():
+    """An old worker sends only restart_counts. Expanding them must fill in
+    restart_count, or the pinned first-failure log stays unreachable: `previous`
+    names just the second newest, and these lists are not contiguous."""
+    response = ServeLogOptionsResponse.model_validate({"restart_counts": [199, 0, 198]})
+
+    assert [(e.restart_count, e.previous) for e in response.restarts] == [
+        (199, False),
+        (198, True),
+        (0, True),
+    ]
+
+
+def test_legacy_restart_counts_skip_unparsable_values():
+    response = ServeLogOptionsResponse.model_validate(
+        {"restart_counts": [2, "nope", None, 1]}
+    )
+
+    assert [e.restart_count for e in response.restarts] == [2, 1]
+
+
+def test_restarts_from_a_current_worker_pass_through():
+    """`restarts` present means the worker already reports restart_count."""
+    response = ServeLogOptionsResponse.model_validate(
+        {
+            "restarts": [
+                {"previous": False, "restart_count": 7},
+                {"previous": True, "restart_count": 0},
+            ]
+        }
+    )
+
+    assert [(e.restart_count, e.previous) for e in response.restarts] == [
+        (7, False),
+        (0, True),
+    ]
+
+
+def test_missing_restart_counts_yields_no_entries():
+    assert ServeLogOptionsResponse.model_validate({}).restarts == []
+    assert (
+        ServeLogOptionsResponse.model_validate({"restart_counts": None}).restarts == []
+    )

--- a/tests/worker/test_logs.py
+++ b/tests/worker/test_logs.py
@@ -1,8 +1,20 @@
 import asyncio
+from types import SimpleNamespace
 from typing import List, Union
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from gpustack.worker.logs import LogOptions, log_generator
+
+# Importing gpustack.worker.logs above initialises gpustack.worker, which pulls
+# in gpustack.routes.worker.logs; importing the router before it would hit a
+# circular import.
+from gpustack.routes.worker.logs import (  # noqa: E402
+    resolve_restart_count,
+    restart_entries_from_main_log_files,
+    router as worker_logs_router,
+)
 
 
 @pytest.fixture
@@ -127,3 +139,163 @@ async def test_log_generator_tail_larger_than_large_file(large_log_file):
         [line async for line in log_generator(log_path, options)]
     )
     assert result == ["line" * 256 + "\n", "line" * 256 + "\n"]
+
+
+def test_log_options_url_encode_carries_restart_count():
+    """The server proxies to the worker through this encoding, so an addressed
+    restart must survive the hop; unset stays absent rather than 'None'."""
+    assert "restart_count" not in LogOptions(tail=5).url_encode()
+    assert "restart_count=0" in LogOptions(tail=5, restart_count=0).url_encode()
+    assert "restart_count=198" in LogOptions(restart_count=198).url_encode()
+
+
+@pytest.mark.asyncio
+async def test_resolve_restart_count_addresses_a_specific_restart(tmp_path):
+    """With the first-failure log pinned, on-disk counts are not contiguous.
+    'previous' can only name the second newest, so restart 0 is reachable only
+    by asking for it directly."""
+    mid = 2945
+    for rc in (0, 198, 199):
+        (tmp_path / f"{mid}.{rc}.log").write_text("x", encoding="utf-8")
+
+    async def resolve(previous=False, restart_count=None):
+        return await resolve_restart_count(tmp_path, mid, previous, restart_count)
+
+    assert await resolve() == 199
+    assert await resolve(previous=True) == 198
+    assert await resolve(restart_count=0) == 0
+    # An explicit restart_count wins over previous.
+    assert await resolve(previous=True, restart_count=0) == 0
+    # A count that is no longer on disk falls back instead of streaming nothing.
+    assert await resolve(restart_count=42) == 199
+    assert await resolve(previous=True, restart_count=42) == 198
+
+
+@pytest.mark.asyncio
+async def test_resolve_restart_count_without_files(tmp_path):
+    """No log files on disk yet resolves to None, even when one is addressed."""
+    assert await resolve_restart_count(tmp_path, 1, False) is None
+    assert await resolve_restart_count(tmp_path, 1, False, 0) is None
+
+
+def test_restart_entries_expose_their_restart_count(tmp_path):
+    """The log-options list must name each retained session so a client can
+    address the pinned first-failure log."""
+    mid = 42
+    files = [tmp_path / f"{mid}.{rc}.log" for rc in (0, 198, 199)]
+    for f in files:
+        f.write_text("x", encoding="utf-8")
+
+    entries = restart_entries_from_main_log_files(files)
+
+    assert [(e.restart_count, e.previous) for e in entries] == [
+        (199, False),
+        (198, True),
+        (0, True),
+    ]
+
+
+def _serve_log_client(tmp_path, model_instance_id: int, contents: dict) -> TestClient:
+    """A worker app over a serve log dir holding {restart_count: text}."""
+    serve_dir = tmp_path / "serve"
+    serve_dir.mkdir(parents=True, exist_ok=True)
+    for rc, text in contents.items():
+        (serve_dir / f"{model_instance_id}.{rc}.log").write_text(text, encoding="utf-8")
+
+    app = FastAPI()
+    app.include_router(worker_logs_router)
+    app.state.config = SimpleNamespace(log_dir=str(tmp_path))
+    return TestClient(app)
+
+
+def test_serve_log_options_lists_two_by_default(tmp_path):
+    """Retention keeps more than two sessions, but 'previous' addresses only the
+    two newest. Listing the extras unconditionally would offer an existing
+    client a session it fetches as the wrong log, so they stay opt-in."""
+    mid = 116
+    client = _serve_log_client(
+        tmp_path, mid, {0: "THE STALL\n", 198: "restart 198\n", 199: "restart 199\n"}
+    )
+
+    listed = client.get(f"/serveLogOptions/{mid}").json()["restarts"]
+    assert [(e["restart_count"], e["previous"]) for e in listed] == [
+        (199, False),
+        (198, True),
+    ]
+
+    everything = client.get(
+        f"/serveLogOptions/{mid}", params={"all_restarts": True}
+    ).json()["restarts"]
+    assert [(e["restart_count"], e["previous"]) for e in everything] == [
+        (199, False),
+        (198, True),
+        (0, True),
+    ]
+
+
+def test_every_listed_restart_is_fetchable_by_restart_count(tmp_path):
+    """Whatever all_restarts lists must be readable, and read back as itself."""
+    mid = 116
+    contents = {0: "THE STALL\n", 198: "restart 198\n", 199: "restart 199\n"}
+    client = _serve_log_client(tmp_path, mid, contents)
+
+    listed = client.get(
+        f"/serveLogOptions/{mid}", params={"all_restarts": True}
+    ).json()["restarts"]
+
+    for entry in listed:
+        rc = entry["restart_count"]
+        resp = client.get(f"/serveLogs/{mid}", params={"restart_count": rc})
+        assert resp.status_code == 200
+        assert resp.text.strip() == contents[rc].strip()
+
+
+def test_serve_logs_query_precedence(tmp_path):
+    """restart_count wins over previous; an unset one keeps today's behaviour;
+    a count no longer on disk falls back instead of returning an empty view."""
+    mid = 116
+    client = _serve_log_client(
+        tmp_path, mid, {0: "THE STALL\n", 198: "restart 198\n", 199: "restart 199\n"}
+    )
+
+    def body(**params):
+        return client.get(f"/serveLogs/{mid}", params=params).text.strip()
+
+    assert body() == "restart 199"
+    assert body(previous=True) == "restart 198"
+    assert body(restart_count=0) == "THE STALL"
+    assert body(restart_count=0, previous=True) == "THE STALL"
+    assert body(restart_count=9999) == "restart 199"
+    assert body(restart_count=9999, previous=True) == "restart 198"
+
+
+@pytest.mark.parametrize(
+    "on_disk",
+    [
+        [0],
+        [0, 1],
+        [0, 1, 2],
+        [0, 198, 199],
+        [0, 7, 8, 9, 10, 11],
+    ],
+)
+def test_default_listing_is_always_addressable_by_previous(tmp_path, on_disk):
+    """The invariant the two-entry cap exists to hold: every session listed by
+    default resolves, from its own 'previous' flag alone, to itself. Without the
+    cap a third entry is listed whose flag resolves to a different log, which is
+    a silently wrong log view rather than a missing one."""
+    mid = 116
+    contents = {rc: f"restart {rc}\n" for rc in on_disk}
+    client = _serve_log_client(tmp_path, mid, contents)
+
+    listed = client.get(f"/serveLogOptions/{mid}").json()["restarts"]
+    assert listed, "at least the current session must be listed"
+
+    for entry in listed:
+        by_flag = client.get(
+            f"/serveLogs/{mid}", params={"previous": entry["previous"]}
+        )
+        assert by_flag.text.strip() == contents[entry["restart_count"]].strip(), (
+            f"entry rc={entry['restart_count']} previous={entry['previous']} "
+            f"served the wrong log"
+        )

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -53,10 +53,12 @@ def _get_workload_sequence(states):
     return next_state
 
 
-def _build_serve_manager(worker_id: int = 1):
+def _build_serve_manager(worker_id: int = 1, serve_log_retention_count: int = 2):
     clientset = MagicMock()
     clientset.model_instances.list.return_value = SimpleNamespace(items=[])
-    cfg = SimpleNamespace(log_dir="/tmp")
+    cfg = SimpleNamespace(
+        log_dir="/tmp", serve_log_retention_count=serve_log_retention_count
+    )
     manager = ServeManager(lambda: worker_id, lambda: clientset, cfg)
     manager._inference_backend_manager = MagicMock()
     return manager, clientset
@@ -166,8 +168,9 @@ def test_restart_model_instance_preserves_transient_backoff_count():
     assert manager._restart_backoff_counts[model_instance.id] == 1
 
 
-def test_cleanup_old_logs_keeps_only_current_and_previous_restart(tmp_path: Path):
-    """Keep main/container logs for R and R-1; delete older restart_count files."""
+def test_cleanup_old_logs_keeps_retention_window_and_first_failure(tmp_path: Path):
+    """Keep main/container logs for R and R-1 (the default window) plus restart
+    0; delete restart counts that fall between them."""
     serve_dir = tmp_path / "serve"
     serve_dir.mkdir(parents=True)
     mid = 42
@@ -175,23 +178,84 @@ def test_cleanup_old_logs_keeps_only_current_and_previous_restart(tmp_path: Path
         f"{mid}.0.log",
         f"{mid}.1.log",
         f"{mid}.2.log",
+        f"{mid}.3.log",
         f"{mid}.container.0.log",
         f"{mid}.container.1.log",
         f"{mid}.container.2.log",
+        f"{mid}.container.3.log",
     ):
         (serve_dir / name).write_text("x", encoding="utf-8")
 
     manager, _clients = _build_serve_manager()
     manager._serve_log_dir = str(serve_dir)
 
-    manager._cleanup_old_logs(mid, 2)
+    manager._cleanup_old_logs(mid, 3)
+
+    # 1 is outside the window {2, 3} and is not the first-failure log.
+    remaining = sorted(p.name for p in serve_dir.iterdir())
+    assert remaining == [
+        f"{mid}.0.log",
+        f"{mid}.2.log",
+        f"{mid}.3.log",
+        f"{mid}.container.0.log",
+        f"{mid}.container.2.log",
+        f"{mid}.container.3.log",
+    ]
+
+
+def test_cleanup_old_logs_keeps_first_failure_through_a_crash_loop(tmp_path: Path):
+    """A long crash loop must not overwrite its own root cause. Restart counts
+    reach the hundreds in practice (issue #5858), and the log explaining why the
+    instance started restarting is restart 0."""
+    serve_dir = tmp_path / "serve"
+    serve_dir.mkdir(parents=True)
+    mid = 2945
+    for name in (
+        f"{mid}.0.log",
+        f"{mid}.197.log",
+        f"{mid}.198.log",
+        f"{mid}.199.log",
+        f"{mid}.container.0.log",
+        f"{mid}.container.199.log",
+    ):
+        (serve_dir / name).write_text("x", encoding="utf-8")
+
+    manager, _clients = _build_serve_manager()
+    manager._serve_log_dir = str(serve_dir)
+
+    manager._cleanup_old_logs(mid, 199)
 
     remaining = sorted(p.name for p in serve_dir.iterdir())
     assert remaining == [
-        f"{mid}.1.log",
+        f"{mid}.0.log",
+        f"{mid}.198.log",
+        f"{mid}.199.log",
+        f"{mid}.container.0.log",
+        f"{mid}.container.199.log",
+    ]
+
+
+def test_cleanup_old_logs_honours_configured_retention_count(tmp_path: Path):
+    """serve_log_retention_count widens the window; restart 0 stays pinned."""
+    serve_dir = tmp_path / "serve"
+    serve_dir.mkdir(parents=True)
+    mid = 42
+    for name in (f"{mid}.{rc}.log" for rc in range(6)):
+        (serve_dir / name).write_text("x", encoding="utf-8")
+
+    manager, _clients = _build_serve_manager(serve_log_retention_count=4)
+    manager._serve_log_dir = str(serve_dir)
+
+    manager._cleanup_old_logs(mid, 5)
+
+    # Window is {2, 3, 4, 5}; only restart 1 is neither in it nor the first.
+    remaining = sorted(p.name for p in serve_dir.iterdir())
+    assert remaining == [
+        f"{mid}.0.log",
         f"{mid}.2.log",
-        f"{mid}.container.1.log",
-        f"{mid}.container.2.log",
+        f"{mid}.3.log",
+        f"{mid}.4.log",
+        f"{mid}.5.log",
     ]
 
 
@@ -659,7 +723,7 @@ def _build_vgpu_manager(worker_id=1, device_index=1):
             gpu_devices=[SimpleNamespace(uuid="GPU-uuid-1", index=device_index)]
         )
     )
-    cfg = SimpleNamespace(log_dir="/tmp")
+    cfg = SimpleNamespace(log_dir="/tmp", serve_log_retention_count=2)
     manager = ServeManager(lambda: worker_id, lambda: clientset, cfg)
     manager._inference_backend_manager = MagicMock()
     return manager, clientset


### PR DESCRIPTION
Addresses the log retention half of #6019. Deliberately not a closing reference: the vLLM 0.25/0.26 `VLLM_PORT` ZMQ port race in that issue is untouched here, so #6019 should stay open after this merges.

When a model instance restarts, `_cleanup_old_logs` kept a sliding window of the two newest restart generations. Any instance that restarts more than twice therefore destroys the log of the run that failed first, which is the only record of why it started restarting. Restart counts reach the hundreds in practice (#5858 shows `2945.198.log` / `2945.199.log` on a live worker), so a crash loop reliably overwrites its own root cause and the failure GPUStack recovered from cannot be diagnosed afterwards. #6019 asks for exactly this: "Preserve first-failure logs for subordinate containers across restarts."

Fixing retention alone is not enough, because the read path could not reach a third session. `previous` resolves to `counts[-2]`, so a client that lists a pinned log and asks for it with the boolean receives a different log instead. That is a silently wrong log view, so the read path is extended first and the retention change builds on it.

### Changes

- `worker/serve_manager.py`: `_cleanup_log_type` keeps a configurable window of restart generations plus restart 0, pinned for the life of the instance. The window is computed inside the existing `try/except`, because this runs on the model instance start path and a retention problem must never stop an instance from starting.
- `schemas/config.py`, `config/config.py`, `cmd/start.py`, `docs/cli-reference/start.md`: new `--serve-log-retention-count` (env `GPUSTACK_SERVE_LOG_RETENTION_COUNT`, YAML `serve_log_retention_count`), default 2. Values below 1 are rejected at startup.
- `worker/logs.py`, `routes/worker/logs.py`: `restart_count` on the logs query, carried through `url_encode`. It wins over `previous`; an unknown value falls back to `previous` rather than streaming an empty view.
- `schemas/models.py`, `routes/worker/logs.py`: each log-options entry reports its `restart_count` so a client can discover a session before addressing it. The legacy `restart_counts` payload from older workers expands with it too.
- `routes/worker/logs.py`, `routes/model_instances.py`: the log-options listing stays capped at the two newest unless `all_restarts=true`.

### Design calls worth reviewing

**The default listing is capped on purpose.** Retention now keeps up to three sessions, but `previous` only names two. Listing the third unconditionally would offer clients a session they fetch as the wrong log, so extras are opt-in and the invariant holds that anything listed by default is reachable with `previous` alone. Existing clients see exactly what they see today. `tests/worker/test_logs.py::test_default_listing_is_always_addressable_by_previous` pins that invariant across several on-disk shapes.

**Consequence: the pinned log is not visible in the current UI.** The file survives and the API serves it, which is what makes an after-the-fact diagnosis possible at all, but surfacing it needs a picker in the web UI that reads `restart_count` and calls `log-options?all_restarts=true`. That is a separate frontend change and I am happy to follow it up if you want it in the same release.

**Restart 0 is the first log of the instance's life, not of the current failure streak.** For an instance that stalls and restarts once, they are the same log and the pin is exactly right. For one that has restarted a hundred times over months, restart 0 is old and probably unrelated to the current loop. Pinning the start of the current streak needs state the worker does not keep today, so this takes the cheap and bounded version: one extra main log and one extra container log per instance.

**Not addressed here:** the serve logs still have no size cap, so a single long-running instance's stdout grows without limit. That is the same class as #5774 and fits the existing `logrotate` precedent in `pack/rootfs/etc/logrotate.d/`. Happy to send it as a separate PR.
