### PR TITLE
fix(gpu-instances): add token authentication to JupyterLab instance templates

### DIFF
--- a/docs/user-guide/gpuservice-instance-templates.md
+++ b/docs/user-guide/gpuservice-instance-templates.md
@@ -37,6 +37,14 @@ A template lets you specify the following properties:
 
 After filling in the required fields, click `Save` to create the template.
 
+## Generated Value Placeholders
+
+When creating an instance, GPUStack resolves `{{generated_*}}` placeholders found in the startup command and in port access parameters, generating one value per instance and persisting it in the instance spec — so the value stays the same across instance stop/start. Currently supported:
+
+- `{{generated_token}}`: a random 32-character hex token. For example, the built-in JupyterLab templates use `--ServerApp.token={{generated_token}}` as the startup command and carry the same placeholder in the JUPYTER port's access parameters, so the web access link shown in the `Connect` column includes the token as a `?token=` query parameter for automatic login.
+
+Placeholders and port access parameters can be set through the API (`spec.command` and `spec.ports[].accessParams`); the template form does not expose them yet.
+
 ## Editing a Template
 
 Click `Edit` on a template card to open its configuration, make your changes, and click `Save`.

--- a/gpustack/assets/gpu-instance-templates.yaml
+++ b/gpustack/assets/gpu-instance-templates.yaml
@@ -176,14 +176,15 @@ items:
       command:
         - "jupyter"
         - "lab"
-        - "--ServerApp.token=''"
-        - "--ServerApp.password=''"
+        - "--ServerApp.token={{generated_token}}"
         - "--notebook-dir=/workspace"
         - "--allow-root"
       ports:
         - name: "JUPYTER"
           port: 8888
           protocol: "TCP"
+          accessParams:
+            token: "{{generated_token}}"
       resources:
         localStorage: "15Gi"
       volumeMount: "/workspace"
@@ -196,14 +197,15 @@ items:
       command:
         - "jupyter"
         - "lab"
-        - "--ServerApp.token=''"
-        - "--ServerApp.password=''"
+        - "--ServerApp.token={{generated_token}}"
         - "--notebook-dir=/workspace"
         - "--allow-root"
       ports:
         - name: "JUPYTER"
           port: 8888
           protocol: "TCP"
+          accessParams:
+            token: "{{generated_token}}"
       resources:
         localStorage: "15Gi"
       volumeMount: "/workspace"

--- a/gpustack/gpu_instances/placeholders.py
+++ b/gpustack/gpu_instances/placeholders.py
@@ -1,0 +1,53 @@
+"""Create-time ``{{generated_*}}`` placeholder substitution for GPU instance specs.
+
+Templates may carry placeholders (mustache-style, aligned with the
+inference-backend ``{{var_name}}`` convention) that the backend resolves once
+at create time; the concrete values are persisted in the spec. Unlike the
+inference backends — which store placeholders in the DB and resolve at launch
+time — GPU instances must resolve at create time: the UI reads generated
+values back (e.g. to build access links), and stop/start replays the stored
+spec, so regeneration on every apply would change the credential.
+"""
+
+import re
+from typing import Callable, Dict
+
+from gpustack.schemas.gpu_instances import GPUInstanceSpec
+from gpustack.security import generate_secret_key
+
+_PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
+
+# Placeholder name -> value provider. Providers are called lazily and at most
+# once per spec: every occurrence of the same placeholder resolves to the same
+# value. Unknown placeholders are left unchanged, mirroring the
+# inference-backend ``_resolve_env_vars`` semantics.
+_PLACEHOLDER_PROVIDERS: Dict[str, Callable[[], str]] = {
+    "generated_token": generate_secret_key,
+}
+
+
+def substitute_generated_placeholders(spec: GPUInstanceSpec) -> None:
+    """Resolve ``{{generated_*}}`` placeholders in ``spec`` in place.
+
+    Scans ``spec.command`` items and ``spec.ports[].access_params`` values. A
+    spec without placeholders is left semantically untouched.
+    """
+    values: Dict[str, str] = {}
+
+    def replace(match: re.Match) -> str:
+        name = match.group(1)
+        provider = _PLACEHOLDER_PROVIDERS.get(name)
+        if provider is None:
+            return match.group(0)
+        if name not in values:
+            values[name] = provider()
+        return values[name]
+
+    if spec.command:
+        spec.command = [_PLACEHOLDER_RE.sub(replace, item) for item in spec.command]
+    for port in spec.ports or []:
+        if port.access_params:
+            port.access_params = {
+                key: _PLACEHOLDER_RE.sub(replace, value)
+                for key, value in port.access_params.items()
+            }

--- a/gpustack/routes/gpu_instances.py
+++ b/gpustack/routes/gpu_instances.py
@@ -50,6 +50,7 @@ from gpustack.api.tenant import (
     validate_owner_principal,
 )
 from gpustack.gpu_instances import validate_k8s_object_name
+from gpustack.gpu_instances.placeholders import substitute_generated_placeholders
 from gpustack.routes.gpu_instance_persistent_volumes import resolve_pv_type_for_ctx
 from gpustack.schemas.clusters import Cluster
 
@@ -481,6 +482,10 @@ def _build_create_source(
     persistent_volume_id: Optional[int],
     type_snapshot: str,
 ) -> dict:
+    # Resolve {{generated_*}} placeholders before persisting: the stored spec
+    # must carry the concrete values so stop/start replays and UI access links
+    # see the same credential.
+    substitute_generated_placeholders(create_obj.spec)
     source: dict = create_obj.model_dump()
     source["creator_id"] = creator_id
     source["type_snapshot"] = type_snapshot
@@ -550,6 +555,9 @@ async def _build_update_source(
                 owner_principal_id=existing_obj.owner_principal_id,
                 volume=new_spec.volume,
             )
+        # Resolve {{generated_*}} placeholders in the accepted spec, same as at
+        # create: the stored spec must carry concrete values.
+        substitute_generated_placeholders(new_spec)
         source["spec"] = new_spec
         source["persistent_volume_id"] = persistent_volume_id
         # Re-stamp the type snapshot ONLY when the referenced type changed. An

--- a/gpustack/schemas/gpu_instances.py
+++ b/gpustack/schemas/gpu_instances.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, ClassVar, List, Literal
+from typing import Dict, Optional, ClassVar, List, Literal
 
 from pydantic import (
     ConfigDict,
@@ -47,6 +47,13 @@ class GPUInstancePort(BaseModel):
     name: Optional[str] = None
     """
     Name of the port mapping.
+    """
+
+    access_params: Optional[Dict[str, str]] = None
+    """
+    URL query parameters the UI appends to this port's web access link,
+    e.g. {"token": "..."} for JupyterLab. Server-side presentation metadata
+    only; stripped before submitting the worker CR.
     """
 
 
@@ -757,8 +764,13 @@ class GPUInstance(GPUInstanceBase, BaseModelMixin, table=True):
            provisioning and are not part of the CRD).
         3. ``sshPublicKeys`` (list) collapses into ``sshPublicKey`` (singular
            ``LocalObjectReference`` named after the instance).
+        4. ``ports[].accessParams`` is stripped — it is server-side
+           presentation metadata for the UI, not part of the operator CRD.
         """
         spec = self.spec.model_dump(by_alias=True, exclude_none=True)
+
+        for port in spec.get("ports") or []:
+            port.pop("accessParams", None)
 
         if self.display_name is not None:
             spec["displayName"] = self.display_name

--- a/tests/api/test_resource_scoping.py
+++ b/tests/api/test_resource_scoping.py
@@ -342,7 +342,7 @@ async def test_gpu_instance_create_allows_granted_cluster(monkeypatch):
         owner_principal_id=CALLER_PRINCIPAL,
         cluster_id=2,
         name="x",
-        spec=SimpleNamespace(type_=None),
+        spec=SimpleNamespace(type_=None, command=None, ports=None),
         model_dump=lambda: {"cluster_id": 2, "name": "x"},
     )
     ctx = _user_ctx()

--- a/tests/gpu_instances/test_convert_to_kuberes.py
+++ b/tests/gpu_instances/test_convert_to_kuberes.py
@@ -104,5 +104,38 @@ def test_convert_to_kuberes_minimal_instance():
     assert "sshPublicKeys" not in body["spec"]
 
 
+def test_convert_to_kuberes_strips_access_params():
+    # accessParams is server-side presentation metadata for the UI; the
+    # operator CRD must never see it.
+    spec = GPUInstanceSpec(
+        type_="gpu",
+        image="busybox",
+        ports=[
+            GPUInstancePort(
+                name="JUPYTER",
+                port=8888,
+                access_params={"token": "abc123"},
+            ),
+            GPUInstancePort(port=22),
+        ],
+    )
+    inst = _gi(spec=spec)
+
+    # Round-trip: the field is stored and serializes under its camelCase alias.
+    assert spec.ports[0].access_params == {"token": "abc123"}
+    dumped = spec.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["ports"][0]["accessParams"] == {"token": "abc123"}
+
+    body = inst.convert_to_kuberes()
+
+    ports = body["spec"]["ports"]
+    assert ports == [
+        {"name": "JUPYTER", "port": 8888, "protocol": "TCP"},
+        {"port": 22, "protocol": "TCP"},
+    ]
+    for port in ports:
+        assert "accessParams" not in port
+
+
 def test_kuberes_instance_id_label_key():
     assert KUBERES_INSTANCE_ID_LABEL == "gpustack.ai/instance-id"

--- a/tests/gpu_instances/test_placeholders.py
+++ b/tests/gpu_instances/test_placeholders.py
@@ -1,0 +1,94 @@
+"""Create-time ``{{generated_*}}`` placeholder substitution for GPU instance specs.
+
+Templates (e.g. the built-in JupyterLab ones) carry ``{{generated_token}}`` in
+``spec.command`` and ``spec.ports[].accessParams``; the backend resolves every
+occurrence to one per-instance value at create time and persists the concrete
+spec, so stop/start replays and UI link building always see the same token.
+"""
+
+import re
+
+from gpustack.gpu_instances.placeholders import substitute_generated_placeholders
+from gpustack.schemas.gpu_instances import (
+    GPUInstancePort,
+    GPUInstanceSpec,
+)
+
+_HEX_TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _spec() -> GPUInstanceSpec:
+    return GPUInstanceSpec(
+        type_="gpu",
+        image="jupyterlab",
+        command=[
+            "jupyter",
+            "lab",
+            "--ServerApp.token={{generated_token}}",
+            "--IdentityProvider.token={{generated_token}}",
+        ],
+        ports=[
+            GPUInstancePort(
+                name="JUPYTER",
+                port=8888,
+                access_params={"token": "{{generated_token}}", "fixed": "literal"},
+            ),
+            GPUInstancePort(name="SSH", port=22),
+        ],
+    )
+
+
+def test_all_occurrences_share_one_token():
+    spec = _spec()
+
+    substitute_generated_placeholders(spec)
+
+    token = spec.command[2].split("=", 1)[1]
+    assert _HEX_TOKEN_RE.match(token)
+    # Every occurrence — across command items and accessParams values — is the
+    # same per-instance value.
+    assert spec.command[3] == f"--IdentityProvider.token={token}"
+    assert spec.ports[0].access_params["token"] == token
+    # Non-placeholder values pass through untouched.
+    assert spec.ports[0].access_params["fixed"] == "literal"
+    assert spec.ports[1].access_params is None
+
+
+def test_no_placeholder_leaves_spec_byte_identical():
+    spec = GPUInstanceSpec(
+        type_="gpu",
+        image="busybox",
+        command=["sleep", "infinity"],
+        ports=[GPUInstancePort(port=8080)],
+    )
+    before = spec.model_dump(by_alias=True, exclude_none=True)
+
+    substitute_generated_placeholders(spec)
+
+    assert spec.model_dump(by_alias=True, exclude_none=True) == before
+
+
+def test_unknown_placeholder_left_unchanged():
+    # Mirrors the inference-backend _resolve_env_vars semantics: unknown names
+    # are not an error and stay as written.
+    spec = GPUInstanceSpec(
+        type_="gpu",
+        image="busybox",
+        command=["--token={{not_a_generated_value}}"],
+        ports=[GPUInstancePort(port=8888, access_params={"token": "{{other}}"})],
+    )
+
+    substitute_generated_placeholders(spec)
+
+    assert spec.command[0] == "--token={{not_a_generated_value}}"
+    assert spec.ports[0].access_params["token"] == "{{other}}"
+
+
+def test_distinct_specs_get_distinct_tokens():
+    spec_a = _spec()
+    spec_b = _spec()
+
+    substitute_generated_placeholders(spec_a)
+    substitute_generated_placeholders(spec_b)
+
+    assert spec_a.command[2] != spec_b.command[2]

--- a/tests/gpu_instances/test_templates.py
+++ b/tests/gpu_instances/test_templates.py
@@ -1,6 +1,7 @@
 import pytest
 
 from gpustack.gpu_instances import get_builtin_templates
+from gpustack.schemas.gpu_instance_templates import GPUInstanceSpecTemplate
 
 
 @pytest.mark.asyncio
@@ -11,3 +12,29 @@ async def test_get_builtin_templates():
     for template in templates:
         assert template.name is not None
         assert template.manufacturer is not None
+
+
+@pytest.mark.asyncio
+async def test_no_builtin_template_disables_auth():
+    # Regression guard for gpustack/gpustack#5757: a built-in template must
+    # never launch its service with authentication explicitly disabled.
+    templates = await get_builtin_templates()
+    for template in templates:
+        # Table-model init skips validation, so the YAML-loaded spec is a raw
+        # dict; validate it into the schema the DB column deserializes to.
+        spec = GPUInstanceSpecTemplate.model_validate(template.spec)
+        for item in spec.command or []:
+            assert "--ServerApp.token=''" not in item
+            assert "--ServerApp.password=''" not in item
+
+
+@pytest.mark.asyncio
+async def test_jupyter_templates_carry_generated_token():
+    templates = await get_builtin_templates()
+    jupyter = [t for t in templates if t.name.startswith("jupyter-lab-")]
+    assert len(jupyter) == 2
+    for template in jupyter:
+        spec = GPUInstanceSpecTemplate.model_validate(template.spec)
+        assert "--ServerApp.token={{generated_token}}" in spec.command
+        port = next(p for p in spec.ports if p.name == "JUPYTER")
+        assert port.access_params == {"token": "{{generated_token}}"}

--- a/tests/routes/test_gpu_instances.py
+++ b/tests/routes/test_gpu_instances.py
@@ -8,6 +8,7 @@ Exercised directly over a real in-memory sqlite DB with a fake ``ctx``.
 
 from datetime import datetime
 from types import SimpleNamespace
+import re
 
 import pytest
 import pytest_asyncio
@@ -22,6 +23,7 @@ from gpustack.schemas.gpu_instances import (
     GPUInstanceEphemeralVolume,
     GPUInstancePersistentVolumeReference,
     GPUInstancePhase,
+    GPUInstancePort,
     GPUInstancePublic,
     GPUInstanceSpec,
     GPUInstanceSSHPublicKeyReference,
@@ -238,6 +240,27 @@ async def test_spec_edit_stopped_swap_to_missing_pv_rejected(engine):
         await _build(engine, GPUInstanceUpdate(spec=_persistent_spec(name="nope")), row)
 
 
+@pytest.mark.asyncio
+async def test_update_stopped_resolves_generated_token(engine):
+    # A spec replacement may carry {{generated_token}} (e.g. re-applying a
+    # template); it must resolve to a concrete value just like at create.
+    await _seed(engine, phase=GPUInstancePhase.STOPPED)
+    row = await _row(engine)
+
+    new_spec = _ephemeral_spec()
+    new_spec.command = ["jupyter", "lab", "--ServerApp.token={{generated_token}}"]
+    new_spec.ports = [
+        GPUInstancePort(
+            name="JUPYTER", port=8888, access_params={"token": "{{generated_token}}"}
+        )
+    ]
+    source = await _build(engine, GPUInstanceUpdate(spec=new_spec), row)
+
+    token = source["spec"].command[2].split("=", 1)[1]
+    assert re.fullmatch(r"[0-9a-f]{32}", token)
+    assert source["spec"].ports[0].access_params["token"] == token
+
+
 # --- type_snapshot column -------------------------------------------------- #
 
 
@@ -305,6 +328,25 @@ def test_build_create_source_stamps_type_snapshot():
     source = routes._build_create_source(create_obj, 1, None, "sha1:stamped")
 
     assert source["type_snapshot"] == "sha1:stamped"
+
+
+def test_build_create_source_resolves_generated_token():
+    # The persisted spec carries the concrete token, so stop/start replays and
+    # the UI's accessParams link building always see the same value.
+    spec = _ephemeral_spec()
+    spec.command = ["jupyter", "lab", "--ServerApp.token={{generated_token}}"]
+    spec.ports = [
+        GPUInstancePort(
+            name="JUPYTER", port=8888, access_params={"token": "{{generated_token}}"}
+        )
+    ]
+    create_obj = GPUInstanceCreate(name="gi-1", spec=spec, cluster_id=2)
+
+    source = routes._build_create_source(create_obj, 1, None, "sha1:stamped")
+
+    token = source["spec"]["command"][2].split("=", 1)[1]
+    assert re.fullmatch(r"[0-9a-f]{32}", token)
+    assert source["spec"]["ports"][0]["access_params"]["token"] == token
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Address gpustack/gpustack#5757.

The built-in JupyterLab GPU-instance templates launched Jupyter with authentication explicitly disabled (`--ServerApp.token='' --ServerApp.password=''`). Since the operator exposes port 8888 as a NodePort, anyone who can reach a node IP gets a root JupyterLab.

This PR adds per-instance credential generation and secure-by-default templates:

- **`accessParams` on `GPUInstancePort`** — server-side URL query-parameter metadata for the UI (e.g. a Jupyter token). Round-trips the API/DB, stripped from the worker CR before submission (operator CRD compatibility).
- **`{{generated_token}}` placeholder** — resolved once at instance create time (and on spec replacement while Stopped), persisted into the spec, so stop/start replays and UI links always see the same token. Follows the inference-backend `{{var_name}}` convention; unknown placeholders pass through unchanged. Structured as a placeholder-name → provider map for future `{{generated_*}}` values.
- **Secured templates** — both JupyterLab templates now use `--ServerApp.token={{generated_token}}` and carry `accessParams.token` on the JUPYTER port, so the UI Connect link becomes `http://<ip>:<nodePort>?token=<token>` (Jupyter auto-login).

Token stays plaintext in the spec/DB, readable by anyone with instance read access — same exposure model as DAModel. Operator-level k8s Secret injection is noted as future hardening, out of scope.

## Test plan

- Unit: placeholder substitution (shared/distinct tokens, byte-identical passthrough, unknown placeholders), create+update route paths, `accessParams` CR-stripping golden test, template regression guards (no built-in may disable auth).
- E2E on a k3s cluster: created an instance from the secured JupyterLab template — no token lands on the Jupyter login page, `?token=` logs straight into JupyterLab, stop/start keeps the same token, and the API exposes the concrete token in `spec.command` and `spec.ports[].accessParams`.

## Related

- UI: gpustack/gpustack-ui#1326 (appends `accessParams` to Connect links, adds template YAML editor)
