### PR TITLE
fix(openai): return 503 instead of 404 when a model has no reachable instance

### DIFF
--- a/gpustack/routes/openai.py
+++ b/gpustack/routes/openai.py
@@ -212,8 +212,18 @@ async def proxy_request_by_model(
             await model_route_service.resolve_route_targets(model_name)
         )
         if not route_targets:
-            raise NotFoundException(
-                message="Model not found or no running instances available",
+            # resolve_route_targets filters on TargetStateEnum.ACTIVE, so an
+            # empty result means either no such route or every target sitting
+            # UNAVAILABLE while ready_replicas is 0 (any worker that misses
+            # /healthz does that to every model on it). 404 would tell the
+            # caller a deployed model is gone and not to retry, so split them.
+            if await model_route_service.get_by_name(model_name) is None:
+                raise NotFoundException(
+                    message="Model not found",
+                    is_openai_exception=True,
+                )
+            raise ServiceUnavailableException(
+                message="No running instances available",
                 is_openai_exception=True,
             )
         request.state.stream = stream

--- a/tests/routes/test_openai_route_resolution.py
+++ b/tests/routes/test_openai_route_resolution.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gpustack.api.exceptions import NotFoundException, ServiceUnavailableException
+from gpustack.routes import openai as openai_route
+from tests.utils.mock import mock_async_session
+
+
+def _stub_resolution(monkeypatch, *, route):
+    """Wire proxy_request_by_model up to the point of route resolution.
+
+    ``resolve_route_targets`` always comes back empty here (the branch under
+    test), and ``get_by_name`` returns ``route``, which is what decides whether
+    the caller sees 404 or 503.
+    """
+    monkeypatch.setattr(openai_route, "async_session", lambda: mock_async_session())
+    monkeypatch.setattr(
+        openai_route,
+        "parse_request_body",
+        AsyncMock(return_value=("qwen3", False, {"model": "qwen3"}, None)),
+    )
+    monkeypatch.setattr(
+        openai_route.UserService,
+        "model_allowed_for_user",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        openai_route.ModelRouteService,
+        "resolve_route_targets",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        openai_route.ModelRouteService,
+        "get_by_name",
+        AsyncMock(return_value=route),
+    )
+
+
+def _request():
+    request = MagicMock()
+    request.url.path = "/v1-openai/chat/completions"
+    return request
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_name_is_not_found(monkeypatch):
+    """No route by that name really is a 404."""
+    _stub_resolution(monkeypatch, route=None)
+
+    with pytest.raises(NotFoundException) as exc:
+        await openai_route.proxy_request_by_model(
+            request=_request(), user=SimpleNamespace(id=1)
+        )
+
+    assert exc.value.status_code == 404
+    assert exc.value.message == "Model not found"
+
+
+@pytest.mark.asyncio
+async def test_deployed_model_with_no_active_target_is_unavailable(monkeypatch):
+    """A route whose targets have all gone UNAVAILABLE must not read as a
+    missing model.
+
+    ``ready_replicas`` drops to 0 for every model on a worker as soon as that
+    worker misses /healthz, which flips each target to UNAVAILABLE and empties
+    ``resolve_route_targets``. Returning 404 there tells the client a deployed
+    model no longer exists and that retrying is pointless. It has to be 503.
+    """
+    _stub_resolution(monkeypatch, route=SimpleNamespace(id=7, name="qwen3"))
+
+    with pytest.raises(ServiceUnavailableException) as exc:
+        await openai_route.proxy_request_by_model(
+            request=_request(), user=SimpleNamespace(id=1)
+        )
+
+    assert exc.value.status_code == 503
+    assert exc.value.message == "No running instances available"


### PR DESCRIPTION
Refs #6030. That issue lists four changes and this PR is the first one, the status code. The rest are separate.

## Problem

When a worker stops answering `/healthz` for 20 seconds, every model on that worker starts returning 404 Not Found. GPUStack tells customers the model does not exist. It does exist, it is deployed, and it usually comes back a few minutes later.

404 is the wrong answer. It tells a client to give up. A 503 tells it to retry.

The cause is that one branch has to answer for two different situations. `resolve_route_targets` only returns targets whose state is `ACTIVE`:

```python
target_fields = {
    "route_name": raw_name,
    "state": TargetStateEnum.ACTIVE,
    "deleted_at": None,
}
```

So an empty result means one of two things:

1. No route by that name. The model really is unknown.
2. The route is there, but every target is `UNAVAILABLE`.

Case 2 happens on its own, with nobody changing anything. `sync_ready_replicas` counts only instances in `RUNNING`:

```python
for _, instance in enumerate(instances):
    if instance.state == ModelInstanceStateEnum.RUNNING:
        ready_replicas += 1
```

When a worker misses `/healthz`, `WorkerController` flips every instance on it to `UNREACHABLE`. So `ready_replicas` drops to 0, `notify_model_route_target` fires, and `_sync_state` sets the target to `UNAVAILABLE`:

```python
target_state = (
    TargetStateEnum.ACTIVE
    if model.ready_replicas > 0
    else TargetStateEnum.UNAVAILABLE
)
```

Both cases then landed on the same 404:

```python
if not route_targets:
    raise NotFoundException(
        message="Model not found or no running instances available",
        is_openai_exception=True,
    )
```

The old message named both cases because the code could not tell them apart.

There is already a right answer for case 2, in `get_running_instance`:

```python
raise ServiceUnavailableException(
    message="No running instances available",
    is_openai_exception=True,
)
```

The code never gets there. The 404 at `openai.py:215` fires before `get_running_instance` is called at `:244`. That 503 is what #4103 was closed on, so that fix does not apply when the cause is a target going `UNAVAILABLE`.

## Change

Look the route up before picking the error. `ModelRouteService.get_by_name` already exists, handles the `<owner-name>/<route>` prefix the same way `resolve_route_targets` does, and is `@locked_cached`. It runs only on this error path, so the normal path is untouched.

- No route by that name: still 404, message narrowed to `Model not found`.
- Route exists, no `ACTIVE` target: now 503 `No running instances available`, the same message the code below already uses.

Splitting the old combined message means each case says one thing.

A route that exists with no targets at all also gets the 503. That reads as right to me, since the route is there and has no capacity now. Happy to make that a 404 instead if you prefer.

## Test

`tests/routes/test_openai_route_resolution.py`, two cases: an unknown name gives 404, and a route whose targets have all gone `UNAVAILABLE` gives 503. Both assert the numeric status code, since the status code is the whole point.

Both fail on `main` at `openai.py:215`. `tests/routes tests/api tests/server` gives 589 passed, 2 skipped. `pre-commit run` is clean on both files.
