### PR TITLE
fix(worker): preserve the reason a model instance first failed

### DIFF
--- a/gpustack/migrations/versions/2026_08_11_1000-9f4c1ab7d203_model_instance_first_failure.py
+++ b/gpustack/migrations/versions/2026_08_11_1000-9f4c1ab7d203_model_instance_first_failure.py
@@ -1,0 +1,63 @@
+"""Preserve the first failure reason on a model instance
+
+Adds ``model_instances.first_failure_message`` and
+``model_instances.first_failure_at``: the failure that started the current
+unhealthy streak, kept across the automatic restarts that clear
+``state_message``. Without them the recovery destroys the reason for the failure
+it recovered from, so a crash loop leaves only the latest secondary error behind
+(issue #6019).
+
+Both nullable and additive, and nothing reads them unless the worker writes
+them, so an older version pointed at the same database keeps working.
+
+The subordinate-worker equivalents need no schema change: they live inside the
+existing ``model_instances.distributed_servers`` JSON column.
+
+Revision ID: 9f4c1ab7d203
+Revises: 367a3982fcde
+Create Date: 2026-08-11 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from gpustack.schemas.common import UTCDateTime
+from gpustack.migrations.utils import column_exists
+
+# revision identifiers, used by Alembic.
+revision: str = '9f4c1ab7d203'
+down_revision: Union[str, None] = '367a3982fcde'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Guarded per column, matching the v2.3.0 bundle: a development database
+    that already carries one of these can migrate forward instead of rebuild."""
+    # The guard sits outside the batch context on purpose: SQLite batch mode
+    # rebuilds the table from the reflected definition, so reflecting from
+    # inside a live batch block is not the same question as asking first.
+    if not column_exists('model_instances', 'first_failure_message'):
+        with op.batch_alter_table('model_instances', schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column('first_failure_message', sa.Text(), nullable=True)
+            )
+
+    if not column_exists('model_instances', 'first_failure_at'):
+        with op.batch_alter_table('model_instances', schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column('first_failure_at', UTCDateTime(), nullable=True)
+            )
+
+
+def downgrade() -> None:
+    if column_exists('model_instances', 'first_failure_at'):
+        with op.batch_alter_table('model_instances', schema=None) as batch_op:
+            batch_op.drop_column('first_failure_at')
+
+    if column_exists('model_instances', 'first_failure_message'):
+        with op.batch_alter_table('model_instances', schema=None) as batch_op:
+            batch_op.drop_column('first_failure_message')

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -652,6 +652,16 @@ class ModelInstanceSubordinateWorker(BaseModel):
     state_message: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)
     )
+    # Same write-once-per-streak contract as ModelInstanceBase, for the
+    # subordinate's own failure. This is where a multi-node root cause lives:
+    # the main worker only ever reports a summary built from a subordinate's
+    # state_message, so once the restart clears that, the true first failure is
+    # gone and only cascading peer errors remain (issue #6019). Embedded in the
+    # distributed_servers JSON column, so no schema migration.
+    first_failure_message: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+    first_failure_at: Optional[datetime] = None
 
 
 class DistributedServerCoordinateModeEnum(Enum):
@@ -733,6 +743,18 @@ class ModelInstanceBase(SQLModel, ModelSource):
     state: ModelInstanceStateEnum = ModelInstanceStateEnum.PENDING
     state_message: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)
+    )
+    # The failure that started the current unhealthy streak. Restarting clears
+    # state_message, so without this the recovery destroys the reason for the
+    # failure it recovered from, and a crash loop leaves only the latest
+    # secondary error behind (issue #6019). Written once per streak and cleared
+    # when the instance reaches RUNNING again, so it describes the streak in
+    # progress rather than some unrelated failure months earlier.
+    first_failure_message: Optional[str] = Field(
+        default=None, sa_column=Column(Text, nullable=True)
+    )
+    first_failure_at: Optional[datetime] = Field(
+        sa_column=Column(UTCDateTime, nullable=True), default=None
     )
     computed_resource_claim: Optional[ComputedResourceClaim] = Field(
         sa_column=Column(pydantic_column_type(ComputedResourceClaim)), default=None

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -657,10 +657,10 @@ class ModelInstanceSubordinateWorker(BaseModel):
     # the main worker only ever reports a summary built from a subordinate's
     # state_message, so once the restart clears that, the true first failure is
     # gone and only cascading peer errors remain (issue #6019). Embedded in the
-    # distributed_servers JSON column, so no schema migration.
-    first_failure_message: Optional[str] = Field(
-        default=None, sa_column=Column(Text, nullable=True)
-    )
+    # distributed_servers JSON column, so no schema migration. Plain fields: this
+    # model is not a table, so an sa_column here would be inert decoration (the
+    # neighbouring state_message still carries one).
+    first_failure_message: Optional[str] = None
     first_failure_at: Optional[datetime] = None
 
 

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -554,12 +554,6 @@ class ServeManager:
                 else:
                     # For initialize later mode, the state is set to RUNNING directly,
                     # which means the subordinate worker doesn't need to wait for the main worker to be healthy.
-                    if (
-                        model_instance.distributed_servers.mode
-                        == DistributedServerCoordinateModeEnum.INITIALIZE_LATER
-                    ):
-                        continue
-                    # Otherwise, update subordinate worker state to RUNNING.
                     sw_pos = next(
                         (
                             i
@@ -570,14 +564,30 @@ class ServeManager:
                         ),
                     )
                     sw = model_instance.distributed_servers.subordinate_workers[sw_pos]
-                    if sw.state == ModelInstanceStateEnum.RUNNING:
-                        continue
-                    sw.state = ModelInstanceStateEnum.RUNNING
-                    sw.state_message = ""
-                    # Streak over for this subordinate; see the main worker's
-                    # RUNNING patch above.
+
+                    # Reaching here means the workload is healthy, so this
+                    # subordinate's unhealthy streak is over. Capturing the reason
+                    # is gated on neither the coordinate mode nor sw.state, so
+                    # clearing it must not be either: both early exits below would
+                    # otherwise strand a stale reason on a healthy subordinate for
+                    # the rest of the instance's life.
+                    had_failure = bool(sw.first_failure_message or sw.first_failure_at)
                     sw.first_failure_message = None
                     sw.first_failure_at = None
+
+                    # INITIALIZE_LATER marks the subordinate RUNNING at start, so
+                    # in that mode there is never a state transition to make here.
+                    already_running = (
+                        model_instance.distributed_servers.mode
+                        == DistributedServerCoordinateModeEnum.INITIALIZE_LATER
+                        or sw.state == ModelInstanceStateEnum.RUNNING
+                    )
+                    if already_running and not had_failure:
+                        continue
+                    if not already_running:
+                        # Otherwise, update subordinate worker state to RUNNING.
+                        sw.state = ModelInstanceStateEnum.RUNNING
+                        sw.state_message = ""
                     patch_dict = {
                         f"distributed_servers.subordinate_workers.{sw_pos}": sw,
                     }

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -472,6 +472,9 @@ class ServeManager:
                             ]
                             sw.state = ModelInstanceStateEnum.ERROR
                             sw.state_message = failure_message
+                            if not sw.first_failure_message:
+                                sw.first_failure_message = failure_message
+                                sw.first_failure_at = datetime.now(timezone.utc)
                             patch_dict = {
                                 f"distributed_servers.subordinate_workers.{sw_pos}": sw,
                             }
@@ -522,6 +525,12 @@ class ServeManager:
                         patch_dict = {
                             "state": ModelInstanceStateEnum.RUNNING,
                             "state_message": "",
+                            # The streak ended, so the captured reason no longer
+                            # describes anything in progress. Cleared alongside
+                            # the backoff count above for the same reason: a
+                            # later failure must report itself, not a stale one.
+                            "first_failure_message": None,
+                            "first_failure_at": None,
                         }
 
                         # Fetch model meta once running.
@@ -565,6 +574,10 @@ class ServeManager:
                         continue
                     sw.state = ModelInstanceStateEnum.RUNNING
                     sw.state_message = ""
+                    # Streak over for this subordinate; see the main worker's
+                    # RUNNING patch above.
+                    sw.first_failure_message = None
+                    sw.first_failure_at = None
                     patch_dict = {
                         f"distributed_servers.subordinate_workers.{sw_pos}": sw,
                     }
@@ -1822,13 +1835,23 @@ class ServeManager:
 
         with contextlib.suppress(NotFoundException):
             self._restart_backoff_counts[mi.id] = backoff_count + 1
-            self._update_model_instance(
-                mi.id,
-                restart_count=restart_count + 1,
-                last_restart_time=current_time,
-                state=ModelInstanceStateEnum.SCHEDULED,
-                state_message="",
-            )
+            patch = {
+                "restart_count": restart_count + 1,
+                "last_restart_time": current_time,
+                "state": ModelInstanceStateEnum.SCHEDULED,
+                "state_message": "",
+            }
+            # This is the one place the failure reason is destroyed, so it is
+            # the one place worth capturing it. Write-once per unhealthy streak:
+            # later restarts in the same crash loop carry secondary errors, and
+            # overwriting would lose the root cause the operator needs.
+            if mi.state_message and not mi.first_failure_message:
+                patch["first_failure_message"] = mi.state_message
+                # Observation time, not failure time: the failure happened
+                # somewhere between the previous health check and now, and this
+                # is the closest bound the restart path has.
+                patch["first_failure_at"] = current_time
+            self._update_model_instance(mi.id, **patch)
 
         # Pop from error model instances,
         # if failed to restart next time, it will be added again in watch_model_instance_events().

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -1097,3 +1097,90 @@ def test_subordinate_captures_and_keeps_its_first_failure():
     )
     assert subordinate.first_failure_message == root_cause
     assert subordinate.first_failure_at == first_seen_at
+
+
+def test_subordinate_first_failure_is_cleared_in_initialize_later_mode():
+    """INITIALIZE_LATER marks the subordinate RUNNING at start and returns early
+    from the state sync, but the capture runs in every mode. Without an equally
+    ungated clear, a recovered subordinate carries a stale reason for the rest of
+    the instance's life."""
+    manager, clientset = _build_serve_manager(worker_id=2)
+
+    model_instance = new_model_instance(
+        1, "initialize-later", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    subordinate = ModelInstanceSubordinateWorker(
+        worker_id=2,
+        worker_name="worker-2",
+        worker_ip="10.0.0.58",
+        state=ModelInstanceStateEnum.RUNNING,
+        first_failure_message="zmq.error.ZMQError: Address already in use",
+        first_failure_at=datetime.now(timezone.utc),
+    )
+    model_instance.distributed_servers = DistributedServers(
+        mode=DistributedServerCoordinateModeEnum.INITIALIZE_LATER,
+        subordinate_workers=[subordinate],
+    )
+    clientset.model_instances.list.return_value = SimpleNamespace(
+        items=[model_instance]
+    )
+
+    model = new_model(1, "test", 1, huggingface_repo_id="Qwen/Qwen2.5-0.5B-Instruct")
+    model.backend = BackendEnum.VLLM
+    model.backend_version = "0.8.0"
+
+    with (
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            return_value=SimpleNamespace(state=WorkloadStatusStateEnum.RUNNING),
+        ),
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch.object(manager, "_get_model", return_value=model),
+        patch.object(manager, "_update_model_instance") as update_model_instance,
+    ):
+        manager.sync_model_instances_state()
+
+    assert subordinate.first_failure_message is None
+    assert subordinate.first_failure_at is None
+    # The clear has to be persisted, not just applied to the in-memory copy.
+    update_model_instance.assert_called_once()
+
+
+def test_healthy_subordinate_without_a_captured_failure_is_not_patched():
+    """The clear must not turn every healthy sync into a write."""
+    manager, clientset = _build_serve_manager(worker_id=2)
+
+    model_instance = new_model_instance(
+        1, "steady", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    model_instance.distributed_servers = DistributedServers(
+        mode=DistributedServerCoordinateModeEnum.INITIALIZE_LATER,
+        subordinate_workers=[
+            ModelInstanceSubordinateWorker(
+                worker_id=2,
+                worker_name="worker-2",
+                worker_ip="10.0.0.58",
+                state=ModelInstanceStateEnum.RUNNING,
+            )
+        ],
+    )
+    clientset.model_instances.list.return_value = SimpleNamespace(
+        items=[model_instance]
+    )
+
+    model = new_model(1, "test", 1, huggingface_repo_id="Qwen/Qwen2.5-0.5B-Instruct")
+    model.backend = BackendEnum.VLLM
+    model.backend_version = "0.8.0"
+
+    with (
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            return_value=SimpleNamespace(state=WorkloadStatusStateEnum.RUNNING),
+        ),
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch.object(manager, "_get_model", return_value=model),
+        patch.object(manager, "_update_model_instance") as update_model_instance,
+    ):
+        manager.sync_model_instances_state()
+
+    update_model_instance.assert_not_called()

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -930,3 +930,170 @@ def test_sync_vgpu_allocation_steady_state_skips_worker_fetch():
         manager.sync_model_instances_state()
 
     clientset.workers.get.assert_not_called()
+
+
+def _restart_error_instance(manager, model_instance):
+    """Drive the error-restart path and return the patch it wrote."""
+    with (
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch.object(manager, "_update_model_instance") as update_model_instance,
+        patch("gpustack.worker.serve_manager.logger"),
+    ):
+        manager._restart_error_model_instance(model_instance)
+    return update_model_instance.call_args.kwargs
+
+
+def test_restart_captures_the_first_failure_reason():
+    """The restart clears state_message, so the reason for the failure it is
+    recovering from has to be captured here or it is gone (issue #6019)."""
+    manager, _ = _build_serve_manager()
+    model_instance = new_model_instance(
+        1, "stalled-instance", 1, worker_id=1, state=ModelInstanceStateEnum.ERROR
+    )
+    model_instance.state_message = "Inference server exited or unhealthy."
+
+    patch_kwargs = _restart_error_instance(manager, model_instance)
+
+    assert patch_kwargs["state_message"] == ""
+    assert (
+        patch_kwargs["first_failure_message"] == "Inference server exited or unhealthy."
+    )
+    assert patch_kwargs["first_failure_at"] is not None
+
+
+def test_restart_does_not_overwrite_an_earlier_first_failure():
+    """Write-once per streak: later restarts in a crash loop carry secondary
+    errors, and overwriting would replace the root cause with one of them."""
+    manager, _ = _build_serve_manager()
+    model_instance = new_model_instance(
+        1, "crash-looping", 1, worker_id=1, state=ModelInstanceStateEnum.ERROR
+    )
+    model_instance.restart_count = 42
+    model_instance.last_restart_time = datetime.now(timezone.utc)
+    model_instance.first_failure_message = "zmq.error.ZMQError: Address already in use"
+    model_instance.first_failure_at = datetime.now(timezone.utc)
+    model_instance.state_message = "Connection closed by peer"
+
+    patch_kwargs = _restart_error_instance(manager, model_instance)
+
+    assert "first_failure_message" not in patch_kwargs
+    assert "first_failure_at" not in patch_kwargs
+
+
+def test_restart_without_a_message_captures_nothing():
+    """Nothing to preserve means nothing is written, so an empty reason cannot
+    mask a real one captured later in the same streak."""
+    manager, _ = _build_serve_manager()
+    model_instance = new_model_instance(
+        1, "quiet-failure", 1, worker_id=1, state=ModelInstanceStateEnum.ERROR
+    )
+    model_instance.state_message = ""
+
+    patch_kwargs = _restart_error_instance(manager, model_instance)
+
+    assert "first_failure_message" not in patch_kwargs
+    assert "first_failure_at" not in patch_kwargs
+
+
+def test_recovery_clears_the_captured_first_failure():
+    """Reaching RUNNING ends the streak, so the captured reason stops describing
+    anything in progress and must not survive into a later, unrelated failure."""
+    manager, clientset = _build_serve_manager()
+
+    model_instance = new_model_instance(
+        1, "recovered", 1, worker_id=1, state=ModelInstanceStateEnum.STARTING
+    )
+    model_instance.worker_ip = "127.0.0.1"
+    model_instance.port = 8000
+    model_instance.first_failure_message = "Inference server exited or unhealthy."
+    model_instance.first_failure_at = datetime.now(timezone.utc)
+    clientset.model_instances.list.return_value = SimpleNamespace(
+        items=[model_instance]
+    )
+
+    model = new_model(1, "test", 1, huggingface_repo_id="Qwen/Qwen2.5-0.5B-Instruct")
+    model.backend = BackendEnum.VLLM
+    model.backend_version = "0.8.0"
+
+    with (
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            return_value=SimpleNamespace(state="running"),
+        ),
+        patch("gpustack.worker.serve_manager.is_ready", return_value=True),
+        patch(
+            "gpustack.worker.serve_manager.get_meta_from_running_instance",
+            return_value=None,
+        ),
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch.object(manager, "_get_model", return_value=model),
+        patch.object(manager, "_update_model_instance") as update_model_instance,
+    ):
+        manager.sync_model_instances_state()
+
+    patch_kwargs = update_model_instance.call_args.kwargs
+    assert patch_kwargs["state"] == ModelInstanceStateEnum.RUNNING
+    assert patch_kwargs["first_failure_message"] is None
+    assert patch_kwargs["first_failure_at"] is None
+
+
+def test_subordinate_captures_and_keeps_its_first_failure():
+    """A multi-node root cause lives on the subordinate: the main worker only
+    reports a summary built from sw.state_message, so once that is overwritten
+    by a later cascading error the true first failure is gone (issue #6019)."""
+    manager, clientset = _build_serve_manager(worker_id=2)
+
+    model_instance = new_model_instance(
+        1, "distributed", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    subordinate = ModelInstanceSubordinateWorker(
+        worker_id=2,
+        worker_name="worker-2",
+        worker_ip="10.0.0.58",
+        state=ModelInstanceStateEnum.RUNNING,
+    )
+    model_instance.distributed_servers = DistributedServers(
+        mode=DistributedServerCoordinateModeEnum.RUN_FIRST,
+        subordinate_workers=[subordinate],
+    )
+    clientset.model_instances.list.return_value = SimpleNamespace(
+        items=[model_instance]
+    )
+
+    model = new_model(1, "test", 1, huggingface_repo_id="Qwen/Qwen2.5-0.5B-Instruct")
+    model.backend = BackendEnum.VLLM
+    model.backend_version = "0.8.0"
+
+    def sync_with_workload_failure(message):
+        with (
+            patch(
+                "gpustack.worker.serve_manager.get_workload",
+                return_value=SimpleNamespace(
+                    state=WorkloadStatusStateEnum.FAILED, state_message=message
+                ),
+            ),
+            patch.object(manager, "_is_provisioning", return_value=False),
+            patch.object(manager, "_get_model", return_value=model),
+            patch.object(manager, "_update_model_instance"),
+        ):
+            manager.sync_model_instances_state()
+
+    root_cause = (
+        "zmq.error.ZMQError: Address already in use (addr='tcp://10.0.0.58:40043')"
+    )
+    sync_with_workload_failure(root_cause)
+
+    assert subordinate.first_failure_message == root_cause
+    first_seen_at = subordinate.first_failure_at
+    assert first_seen_at is not None
+
+    # A later cascading error overwrites the live message but must not touch the
+    # captured root cause: "Connection closed by peer" is the symptom, not why.
+    subordinate.state = ModelInstanceStateEnum.RUNNING
+    sync_with_workload_failure("RuntimeError: ... gloo ... Connection closed by peer")
+
+    assert subordinate.state_message == (
+        "RuntimeError: ... gloo ... Connection closed by peer"
+    )
+    assert subordinate.first_failure_message == root_cause
+    assert subordinate.first_failure_at == first_seen_at


### PR DESCRIPTION
Addresses the "expose first crash reason" half of #6019. Not a closing reference: the vLLM port race in that issue is untouched here.

When a model instance fails, GPUStack restarts it and sets `state_message` back to `""`. The reason it failed goes with it. The recovery erases the reason for the failure it was recovering from.

This bites hardest on multi-node, which is the case #6019 reports. The sequence there:

1. A subordinate worker cannot bind its port: `zmq.error.ZMQError: Address already in use (addr='tcp://10.0.0.58:40043')`. This is the root cause.
2. Its peers lose the connection and fail too: `RuntimeError: ... gloo ... Connection closed by peer`.
3. The restart clears that subordinate's `state_message`.
4. The main worker builds its own message out of a subordinate's `state_message`, so what an operator ends up looking at is the peer error.

The port collision is why it broke. The dropped connection is what happened afterwards. One or two restarts later, only the second one is still on screen. That is the "master side often only shows secondary distributed failures" complaint in the issue.

## What this changes

`first_failure_message` and `first_failure_at`, written in `_restart_error_model_instance`, which is the one place the reason gets cleared.

Written once per unhealthy streak. In a crash loop the later messages are follow-on errors, so overwriting would swap the root cause for a symptom.

Cleared when the instance reaches RUNNING again, right next to the existing `_restart_backoff_counts.pop()`. Without that, an instance that failed once in May and recovered fine would still be showing that May message beside an unrelated failure today.

The same two fields go on `ModelInstanceSubordinateWorker`, because that is where a multi-node root cause actually lives. They sit inside the existing `distributed_servers` JSON column, so only the two `model_instances` columns need a schema change.

## Migration

New revision `9f4c1ab7d203` on top of `367a3982fcde`, rather than folded into the `v2.3.0` bundle, so a database already stamped at `367a3982fcde` picks the columns up without a manual stamp-back. Happy to fold it in instead if you would rather keep the bundle.

Tested on PostgreSQL 17: upgrade, downgrade, re-upgrade, and the guarded case where the columns are already present but the database is stamped one revision back. `alembic revision --autogenerate` against the migrated database asks for no further changes to these columns.

## Not in this PR

`_get_main_worker_distributed_state` picks which failed subordinate to report by list order, not by which one failed first. It breaks out of the loop at the first subordinate in ERROR state. That is the other half of the same complaint in #6019, but it is a separate root cause from preserving the message, so it wants its own change. I can file it if useful.
