### PR TITLE
fix(scheduler): account for externally used GPU memory when computing allocatable VRAM

### DIFF
--- a/gpustack/policies/utils.py
+++ b/gpustack/policies/utils.py
@@ -112,12 +112,18 @@ def get_worker_allocatable_resource(
                 or (gpu_type is not None and gpu.type != gpu_type)
             ):
                 continue
+            # Account for physical GPU memory already in use by processes that
+            # GPUStack does not manage (e.g. an independently launched container
+            # or a native CUDA process bound to this device). Workers report a
+            # live `used` value, whereas `MemoryInfo.allocated` is deprecated
+            # and never populated anymore, so the scheduler previously assumed
+            # every card with no known ModelInstance was fully available and
+            # could schedule onto a device that is actually saturated, causing
+            # the inference engine to OOM on startup.
+            physical_used = gpu.memory.used if gpu.memory.used is not None else 0
+            effective_used = max(allocated.vram.get(gpu_index, 0), physical_used)
             allocatable_vram = max(
-                (
-                    gpu.memory.total
-                    - allocated.vram.get(gpu_index, 0)
-                    - worker.system_reserved.vram
-                ),
+                (gpu.memory.total - effective_used - worker.system_reserved.vram),
                 0,
             )
             allocatable.vram[gpu_index] = allocatable_vram

--- a/tests/policies/utils/test_allocatable_physical_used.py
+++ b/tests/policies/utils/test_allocatable_physical_used.py
@@ -1,0 +1,68 @@
+from gpustack.policies.utils import get_worker_allocatable_resource
+from tests.fixtures.workers.fixtures import linux_nvidia_13_A100_80gx8
+from tests.utils.model import new_model_instance
+from gpustack.schemas.models import ComputedResourceClaim
+
+
+def _set_gpu_used(worker, index, used_bytes):
+    """Simulate external (non-GPUStack) processes occupying a device's VRAM."""
+    for gpu in worker.status.gpu_devices:
+        if gpu.index == index:
+            gpu.memory.used = used_bytes
+            if gpu.memory.total:
+                gpu.memory.utilization_rate = used_bytes / gpu.memory.total * 100
+            return
+
+
+def test_allocatable_accounts_for_physical_used_without_instances():
+    """Repro: with no GPUStack-managed instances, a GPU saturated by an
+    external process used to be reported as fully allocatable. The fix makes
+    the scheduler account for the physical `used` VRAM (i.e. does NOT ignore
+    it) so the saturated device is no longer considered available."""
+    worker = linux_nvidia_13_A100_80gx8()
+    total = worker.status.gpu_devices[0].memory.total
+
+    # GPU0 is ~fully used by an external process (e.g. independent container).
+    _set_gpu_used(worker, 0, total - 1 * 1024**3)
+
+    allocatable = get_worker_allocatable_resource([], worker)
+    gpu0_alloc = allocatable.vram.get(0, 0)
+    # We left exactly 1 GiB free on GPU0; anything above that means the
+    # external usage was ignored.
+    assert gpu0_alloc <= 1 * 1024**3, (
+        f"GPU0 has ~all VRAM consumed externally but reported "
+        f"{gpu0_alloc / 1024**3:.1f} GiB allocatable"
+    )
+
+
+def test_allocatable_free_gpu_keeps_full_capacity():
+    worker = linux_nvidia_13_A100_80gx8()
+    total = worker.status.gpu_devices[0].memory.total
+    allocatable = get_worker_allocatable_resource([], worker)
+    assert allocatable.vram.get(4, 0) >= total * 0.9
+
+
+def test_allocatable_uses_max_of_claimed_and_physical_used():
+    """An instance GPUStack already scheduled claims VRAM even before the
+    engine has actually allocated it (physical used may lag), while an
+    external process that holds more than the claim must still be respected."""
+    worker = linux_nvidia_13_A100_80gx8()
+    total = worker.status.gpu_devices[0].memory.total
+
+    # Physical externally-used is 60 GiB on GPU0...
+    _set_gpu_used(worker, 0, int(60 * 1024**3))
+    # ...while a GPUStack instance only claims 40 GiB on the same device.
+    mi = new_model_instance(
+        1,
+        name="test-instance",
+        model_id=1,
+        worker_id=worker.id,
+        gpu_indexes=[0],
+        computed_resource_claim=ComputedResourceClaim(
+            vram={0: int(40 * 1024**3)}, ram=0
+        ),
+    )
+
+    allocatable = get_worker_allocatable_resource([mi], worker)
+    # Should reflect the bigger of the two (physical 60 GiB), not double-count.
+    assert allocatable.vram.get(0, 0) == total - int(60 * 1024**3)


### PR DESCRIPTION
Closing this PR. After running the full unit-test suite it became clear this touches a widely-shared scheduler code path and semantic decision is best discussed as an issue first. The problem and an exploratory minimal patch are described in #6044.