### PR TITLE
fix(worker): stop pinning VLLM_PORT for cross-node vLLM MP

### DIFF
--- a/gpustack/worker/backends/vllm.py
+++ b/gpustack/worker/backends/vllm.py
@@ -479,10 +479,11 @@ class VLLMServer(InferenceServer):
             )
             if shape in ("dp_only", "nested") and ports:
                 env["VLLM_DP_MASTER_PORT"] = str(ports[-1])
-            # Pin vLLM's internal init port to a reserved one so get_open_port()
-            # can't grab a kernel-stealable ephemeral port (#5657). Needs the
-            # runner patch that makes get_open_port() honor VLLM_PORT.
-            if len(ports) > 3:
+            # Only dp_only needs a reserved start port for vLLM's TCPStore
+            # (#5657); with nnodes > 1 that port comes from --master-port, and a
+            # shared start port makes cross-node WorkerProcs racing for their
+            # XPUB socket collide (#6019).
+            if shape == "dp_only" and len(ports) > 3:
                 env["VLLM_PORT"] = str(ports[3])
         else:
             if ports:

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -1636,7 +1636,7 @@ class ServeManager:
             #   ports[0]: HTTP API (always)
             #   ports[1]: --data-parallel-rpc-port (DP coordinator ZMQ)
             #   ports[2]: --master-port (PyTorch distributed TCP store)
-            #   ports[3]: env VLLM_PORT
+            #   ports[3]: env VLLM_PORT (dp_only only; reserved but unused otherwise)
             #   ports[-1]: connecting port (= VLLM_DP_MASTER_PORT for dp_only/nested)
             # Ray path: only ports[1] (DP RPC), when user dp > 1.
             if mi.distributed_servers and mi.distributed_servers.subordinate_workers:

--- a/tests/worker/backends/test_multinode_topology.py
+++ b/tests/worker/backends/test_multinode_topology.py
@@ -7,6 +7,8 @@ Covers:
   (``dp_only`` / ``mp_only`` / ``nested``).
 - Heterogeneous worker groups (vLLM allows per-node DP-Local).
 - Failure paths: TP/PP that cannot fit, mismatched user-supplied DP, etc.
+- ``VLLM_PORT`` / ``VLLM_DP_MASTER_PORT`` injection per shape (Issues #5657,
+  #6019).
 """
 
 from unittest.mock import MagicMock
@@ -784,3 +786,65 @@ def test_create_candidate_skips_topology_check_for_single_worker():
     candidate, reason = _create_candidate(model, [_mock_worker("a", 8)])
     assert candidate is not None
     assert reason is None
+
+
+# ---------------------------------------------------------------------------
+# VLLM_PORT / VLLM_DP_MASTER_PORT injection per shape (#5657, #6019)
+# ---------------------------------------------------------------------------
+
+
+def _distributed_env(shape, executor_backend="mp", with_deployment_metadata=True):
+    """Drive _set_distributed_env with a stubbed topology shape.
+
+    The ports layout mirrors what _assign_ports hands a distributed mp
+    instance: [http, dp_rpc, master, VLLM_PORT, connecting].
+    """
+    server = object.__new__(VLLMServer)
+    server._model = MagicMock(
+        backend_parameters=["--distributed-executor-backend", executor_backend],
+        backend_version=None,
+    )
+    server._model_instance = MagicMock(ports=[40000, 40001, 40002, 40042, 40063])
+    server._worker = MagicMock(ip="10.0.0.1", ifname="eth0")
+    server._resolve_multinode_shape = MagicMock(return_value=shape)
+    server._get_selected_gpu_devices = MagicMock(return_value=[])
+
+    env = {}
+    if with_deployment_metadata:
+        server._set_distributed_env(env, MagicMock())
+    else:
+        server._set_distributed_env(env)
+    return env
+
+
+@pytest.mark.parametrize(
+    "shape, vllm_port, dp_master_port",
+    [
+        # dp_only leaves --nnodes unset, so vLLM derives its TCPStore port from
+        # get_next_dp_init_port() and needs a reserved start port (#5657).
+        ("dp_only", "40042", "40063"),
+        # nnodes > 1 shapes take --master-port instead, and every cross-node
+        # WorkerProc calls get_open_port() once for its XPUB socket — a shared
+        # start port makes them collide deterministically (#6019).
+        ("mp_only", None, None),
+        ("nested", None, "40063"),
+        # Topology inference failed: stay out of the way.
+        (None, None, None),
+    ],
+)
+def test_mp_port_injection_matrix(shape, vllm_port, dp_master_port):
+    env = _distributed_env(shape)
+    assert env.get("VLLM_PORT") == vllm_port
+    assert env.get("VLLM_DP_MASTER_PORT") == dp_master_port
+
+
+def test_mp_skips_injection_without_deployment_metadata():
+    env = _distributed_env(None, with_deployment_metadata=False)
+    assert "VLLM_PORT" not in env
+    assert "VLLM_DP_MASTER_PORT" not in env
+
+
+def test_ray_path_still_pins_vllm_port_to_connecting_port():
+    env = _distributed_env("dp_only", executor_backend="ray")
+    assert env["VLLM_PORT"] == "40063"
+    assert "VLLM_DP_MASTER_PORT" not in env


### PR DESCRIPTION
- inject VLLM_PORT only for the dp_only shape, where vLLM derives its TCPStore port from get_next_dp_init_port() and needs a reserved start port (#5657)
- mp_only and nested take --master-port instead, and every cross-node WorkerProc calls get_open_port() once for its XPUB socket, so a shared start port made them collide deterministically (#6019)