### PR TITLE
fix: package buildx precheck

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,30 @@ And check artifacts in `dist`.
 make test
 ```
 
+## Package
+
+Building the container image requires Docker with the [Buildx](https://docs.docker.com/build/install-buildx/) plugin:
+
+```bash
+make package
+```
+
+If `docker buildx version` fails, install the plugin with the package manager (`apt-get install docker-buildx-plugin` or `yum install docker-buildx-plugin`), or drop the release binary in place:
+
+```bash
+mkdir -p /usr/local/lib/docker/cli-plugins
+VER=$(curl -fsSL https://api.github.com/repos/docker/buildx/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+curl -fsSL "https://github.com/docker/buildx/releases/download/${VER}/buildx-${VER}.linux-${ARCH}" \
+  -o /usr/local/lib/docker/cli-plugins/docker-buildx
+chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
+docker buildx version
+```
+
+The unauthenticated GitHub API allows 60 requests per hour per IP. If it rate limits you, `VER` ends up empty and the download 404s — pick a version from the [releases page](https://github.com/docker/buildx/releases) and set it by hand.
+
+Install the plugin under `/usr/local/lib/docker/cli-plugins` rather than `~/.docker/cli-plugins` when packaging with `sudo`, otherwise the changed `HOME` hides it from the Docker CLI.
+
 ## Update Dependencies
 
 ```bash

--- a/hack/package.sh
+++ b/hack/package.sh
@@ -21,6 +21,13 @@ function pack() {
         exit 1
     fi
 
+    if ! docker buildx version &>/dev/null; then
+        gpustack::log::fatal "Docker Buildx plugin is not available." \
+            "Install it with the package manager, e.g. 'apt-get install docker-buildx-plugin' or 'yum install docker-buildx-plugin'," \
+            "or drop the release binary into '/usr/local/lib/docker/cli-plugins/docker-buildx' and make it executable." \
+            "See https://docs.docker.com/build/install-buildx/ for details."
+    fi
+
     if ! docker buildx inspect --builder "gpustack" &>/dev/null; then
         gpustack::log::info "Creating new buildx builder 'gpustack'"
         docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --uninstall qemu-*


### PR DESCRIPTION
Without the buildx plugin, the docker CLI parses `buildx create --name ...`
as root-command arguments and reports `unknown flag: --name` alongside the
generic docker usage, which points at the builder invocation instead of the
missing plugin. Probe `docker buildx version` up front and report the actual
cause with install hints.