### PR TITLE
fix(users): accept '.' in passwords and close the update-path bypass

### DIFF
--- a/docs/user-guide/user-management.md
+++ b/docs/user-guide/user-management.md
@@ -16,6 +16,16 @@ In the default setup, this file is located at `/var/lib/gpustack/initial_admin_p
 
 You can set a custom password for the default admin by using the `--bootstrap-password` flag when starting `GPUStack`.
 
+## Password Requirements
+
+A password set through the UI or the API must contain at least one uppercase letter, one lowercase letter, one digit, and one of the following special characters:
+
+```
+! @ # $ % ^ & * _ + .
+```
+
+The UI additionally limits passwords to 6–64 characters.
+
 ## Create User
 
 1. Navigate to the `Users` page.

--- a/gpustack/schemas/users.py
+++ b/gpustack/schemas/users.py
@@ -48,6 +48,7 @@ from gpustack.schemas.principals import (  # noqa: F401  re-exports
     Principal,
     PrincipalType,
 )
+from gpustack.security import PASSWORD_SPECIAL_CHARACTERS
 
 # ``User`` aliases the unified :class:`Principal` so that code which
 # constructs / queries the user-shaped surface continues to work
@@ -74,9 +75,28 @@ def _validate_password(value: str) -> str:
         raise ValueError('Password must contain at least one lowercase letter')
     if not re.search(r'[0-9]', value):
         raise ValueError('Password must contain at least one digit')
-    if not re.search(r'[!@#$%^&*_+]', value):
-        raise ValueError('Password must contain at least one special character')
+    # Membership test rather than a regex character class: the set contains
+    # ``^`` and ``.``, which change meaning inside ``[...]`` depending on
+    # position, so building the class from the constant would be a silent
+    # footgun the next time a character is added.
+    if not any(char in PASSWORD_SPECIAL_CHARACTERS for char in value):
+        raise ValueError(
+            'Password must contain at least one special character '
+            f'({" ".join(PASSWORD_SPECIAL_CHARACTERS)})'
+        )
     return value
+
+
+def _validate_optional_password(value: Optional[str]) -> Optional[str]:
+    """Validate a password field that doubles as "don't touch the password".
+
+    The write paths key off ``if user_in.password``, so an empty string means
+    the caller is not setting a password -- it has to collapse to ``None``
+    rather than be measured against a policy meant for real passwords.
+    """
+    if not value:
+        return None
+    return _validate_password(value)
 
 
 class UserBase(SQLModel):
@@ -128,13 +148,21 @@ class UserCreate(UserBase):
 
     @field_validator('password')
     def validate_password(cls, value):
-        if value is None:
-            return value
-        return _validate_password(value)
+        return _validate_optional_password(value)
 
 
 class UserUpdate(UserBase):
     password: Optional[str] = None
+
+    # ``update_user`` feeds this straight into ``set_password``, exactly as
+    # ``create_user`` does, so it has to carry the same policy: without the
+    # validator here an admin could set a password through
+    # ``PUT /users/{id}`` that ``POST /users`` would refuse, and ``/login``
+    # would honour it.
+    @field_validator('password')
+    def validate_password(cls, value):
+        return _validate_optional_password(value)
+
     # Overrides ``UserBase.source`` on two axes.
     #
     # Default ``None`` (vs. ``UserBase``'s ``"Local"``): an omitted
@@ -173,9 +201,7 @@ class UserSelfUpdate(SQLModel):
 
     @field_validator('password')
     def validate_password(cls, value):
-        if value is None:
-            return value
-        return _validate_password(value)
+        return _validate_optional_password(value)
 
 
 class UpdatePassword(SQLModel):

--- a/gpustack/security.py
+++ b/gpustack/security.py
@@ -27,6 +27,23 @@ SECRET_KEY_DIGEST_ALGORITHM = "sha256"
 _DIGEST_SALT_BYTES = 16
 _GENERATED_SECRET_KEY_RE = re.compile(f"^[0-9a-f]{{{GENERATED_SECRET_KEY_BYTES * 2}}}$")
 
+# The characters that count as "special" for the password policy. The set is
+# the one the UI's client-side check offers, so a password its form accepts is
+# a password this API accepts:
+#
+#   /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*_+.])[a-zA-Z\d!@#$%^&*_+.]{6,64}$/
+#
+# The length bound and the allowlist of permitted characters in that regex are
+# the UI's own. A client may be stricter than the server; the server is the
+# authority, and NIST SP 800-63B argues against capping length or restricting
+# the alphabet there.
+#
+# Both the validator and ``generate_secure_password`` read this, and they have
+# to agree: ``gpustack reset-admin-password`` submits a generated password
+# through the regular UserUpdate path, so anything the generator can emit that
+# the validator would reject turns that command into a 422.
+PASSWORD_SPECIAL_CHARACTERS = "!@#$%^&*_+."
+
 
 def _as_text(value: Union[str, bytes]) -> str:
     return value.decode() if isinstance(value, bytes) else value
@@ -166,7 +183,7 @@ def generate_secure_password(length=12):
     if length < 8:
         raise ValueError("Password length should be at least 8 characters")
 
-    special_characters = "!@#$%^&*_+"
+    special_characters = PASSWORD_SPECIAL_CHARACTERS
     characters = string.ascii_letters + string.digits + special_characters
     while True:
         password = ''.join(secrets.choice(characters) for i in range(length))

--- a/tests/schemas/test_password_policy.py
+++ b/tests/schemas/test_password_policy.py
@@ -1,0 +1,180 @@
+"""Password policy on the user DTOs.
+
+The policy has to stay in step with the check the UI runs client-side. Anything
+the UI accepts and the server refuses reaches the user as a 422 on a password
+the form told them was fine.
+"""
+
+import inspect
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import gpustack.schemas.users as users_schemas
+from gpustack.schemas.users import (
+    UpdatePassword,
+    UserCreate,
+    UserSelfUpdate,
+    UserUpdate,
+)
+from gpustack.security import (
+    PASSWORD_SPECIAL_CHARACTERS,
+    generate_secure_password,
+)
+
+PASSWORD_FIELD_NAMES = {"password", "new_password"}
+
+# A value that trips the first rule in the policy, whatever else changes.
+VIOLATING_PASSWORD = "a"
+
+# DTOs whose password field doubles as "leave the password alone".
+OPTIONAL_PASSWORD_DTOS = [UserCreate, UserUpdate, UserSelfUpdate]
+
+
+def create_with(password):
+    return UserCreate(username="alice", password=password)
+
+
+def build(dto, **kwargs):
+    """Construct ``dto`` with only the fields it actually declares.
+
+    ``UserSelfUpdate`` has no ``username``, and pydantic drops unknown keys
+    silently, so passing one everywhere would quietly test something else.
+    """
+    accepted = {key: value for key, value in kwargs.items() if key in dto.model_fields}
+    return dto(**accepted)
+
+
+@pytest.mark.parametrize("special", list(PASSWORD_SPECIAL_CHARACTERS))
+def test_accepts_every_special_character_the_ui_offers(special):
+    # Pins the set to what the UI's regex offers, character by character.
+    password = f"Aa1x{special}y"
+    assert create_with(password).password == password
+
+
+def test_length_is_not_part_of_the_policy():
+    # The server is the authority and does not cap length; the UI's own 6-64
+    # bound is a client-side courtesy. NIST SP 800-63B asks for at least 64
+    # characters to be accepted, and argon2 hashes the whole string -- there is
+    # no bcrypt-style truncation to defend against.
+    short = "Aa1!"
+    long = "Aa1!" + "a" * 200
+    assert create_with(short).password == short
+    assert create_with(long).password == long
+
+
+@pytest.mark.parametrize(
+    "password, expected",
+    [
+        ("passw0rd.", "uppercase"),
+        ("PASSW0RD.", "lowercase"),
+        ("Password.", "digit"),
+        ("Passw0rdx", "special character"),
+        # Outside the set the UI accepts, so it stays rejected on purpose --
+        # accepting it here would just move the mismatch to the other side.
+        ("Passw0rd-", "special character"),
+    ],
+)
+def test_rejects(password, expected):
+    with pytest.raises(ValidationError, match=expected):
+        create_with(password)
+
+
+def test_error_message_names_the_accepted_characters():
+    # "must contain at least one special character" reads as a lie to someone
+    # whose password does contain one, just not from this set — so the message
+    # has to spell the set out.
+    with pytest.raises(ValidationError) as excinfo:
+        create_with("Passw0rdx")
+    for special in PASSWORD_SPECIAL_CHARACTERS:
+        assert special in str(excinfo.value)
+
+
+@pytest.mark.parametrize("dto", OPTIONAL_PASSWORD_DTOS)
+def test_optional_password_dtos_enforce_the_policy(dto):
+    # All three reach `set_password`, so the policy has to hold on every one:
+    # a route that skips it becomes a way to set a password the create route
+    # would refuse.
+    with pytest.raises(ValidationError, match="uppercase"):
+        build(dto, username="alice", password=VIOLATING_PASSWORD)
+
+
+@pytest.mark.parametrize("dto", OPTIONAL_PASSWORD_DTOS)
+@pytest.mark.parametrize("absent", [None, ""])
+def test_absent_password_leaves_the_password_alone(dto, absent):
+    # The write paths act on `if user_in.password`, so an empty string has to
+    # arrive as None rather than as a policy violation.
+    assert build(dto, username="alice", password=absent).password is None
+
+
+def test_update_password_enforces_the_policy():
+    with pytest.raises(ValidationError, match="uppercase"):
+        UpdatePassword(current_password="whatever", new_password=VIOLATING_PASSWORD)
+
+
+def test_update_password_rejects_an_empty_new_password():
+    # `new_password` is required and names the thing being set, so blank is a
+    # violation here rather than "no change".
+    with pytest.raises(ValidationError, match="uppercase"):
+        UpdatePassword(current_password="whatever", new_password="")
+
+
+def _password_dtos():
+    for name, cls in vars(users_schemas).items():
+        if not (inspect.isclass(cls) and issubclass(cls, BaseModel)):
+            continue
+        fields = set(getattr(cls, "model_fields", {})) & PASSWORD_FIELD_NAMES
+        if fields:
+            yield name, cls, sorted(fields)
+
+
+def test_every_password_field_on_the_api_surface_is_validated():
+    """Any DTO carrying a password on the API surface must enforce the policy.
+
+    Asserted behaviourally rather than by looking for a validator: a validator
+    that accepts everything would satisfy the declaration and nothing else.
+
+    The check covers construction, which is where request bodies are parsed.
+    Assigning to the attribute afterwards does not run validators -- e.g.
+    ``cmd/reset_admin_password.py`` sets ``user_update.password`` on an already
+    built model -- so a client can skip the policy locally and the server-side
+    parse of the request body is what actually holds the line.
+    """
+    unguarded = {}
+    for name, cls, fields in _password_dtos():
+        for field in fields:
+            kwargs = {
+                other: "x"
+                for other, spec in cls.model_fields.items()
+                if spec.is_required() and other not in PASSWORD_FIELD_NAMES
+            }
+            kwargs[field] = VIOLATING_PASSWORD
+            try:
+                cls(**kwargs)
+            except ValidationError:
+                continue
+            unguarded.setdefault(name, []).append(field)
+
+    assert (
+        not unguarded
+    ), f"password fields that accept {VIOLATING_PASSWORD!r}: {unguarded}"
+
+
+def test_the_guard_above_covers_the_known_dtos():
+    # Guards the guard: a rename that makes _password_dtos() yield nothing
+    # would leave the scan vacuously green.
+    assert {name for name, _, _ in _password_dtos()} == {
+        "UserCreate",
+        "UserUpdate",
+        "UserSelfUpdate",
+        "UpdatePassword",
+    }
+
+
+def test_generated_passwords_satisfy_the_policy():
+    # `gpustack reset-admin-password` submits a generated password through
+    # UserUpdate, so a generator that drifts from the validator turns that
+    # command into a 422.
+    for _ in range(50):
+        password = generate_secure_password()
+        assert create_with(password).password == password


### PR DESCRIPTION
## Issue

#5952

## Problem

The password policy's "special character" check is a hardcoded allowlist that omits `.`:

```python
if not re.search(r'[!@#$%^&*_+]', value):
    raise ValueError('Password must contain at least one special character')
```

The UI's client-side check **already accepts** `.`:

```js
/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*_+.])[a-zA-Z\d!@#$%^&*_+.]{6,64}$/
```

So the UI lets `Passw0rd.` through and the API rejects it with a 422 — which matches the "UI verification failed" report on the issue. The fix belongs on the server side.

One further problem surfaced while reproducing it: **`UserUpdate` declared `password` with no validator at all**, while `UserCreate` / `UserSelfUpdate` / `UpdatePassword` all have one. `update_user` feeds `user_in.password` straight into `set_password`, so an admin could set a one-character password through `PUT /users/{id}` and `/login` honoured it:

```
PUT /v2/users/5 {"password":"a"}   -> 200
POST /auth/login  u_bang / a       -> 200
```

It also made the reported symptom inconsistent: the same `Passw0rd.` was rejected on create and accepted on update.

## Changes

- `PASSWORD_SPECIAL_CHARACTERS` in `gpustack/security.py`, holding the set the UI's regex offers. `generate_secure_password` now reads it instead of carrying its own copy — a generated password the validator rejects would break `gpustack reset-admin-password`, which submits one through `UserUpdate`.
- `_validate_password` checks the special character by set membership (the set contains `^` and `.`, whose meaning inside a regex `[...]` depends on position) and names the accepted characters in the error message, since "must contain at least one special character" reads as a lie to someone who typed `Passw0rd.`.
- `UserUpdate` gets the missing validator.
- `_validate_optional_password` collapses `""` to `None` on the three DTOs whose password field is optional. The write paths act on `if user_in.password`, so an empty string has always meant "leave the password alone"; adding a validator without this would turn that into a 422. `UpdatePassword.new_password` is required and stays strict, so a blank new password is still rejected there.

**No length rule.** The server does not bound password length, and this PR does not add one:

- It is unrelated to what the issue reports and would ride along as a separate policy change.
- An upper bound would contradict this PR's own reasoning below for not narrowing the character set — NIST SP 800-63B asks for at least 64 characters to be accepted and against a low cap, for the same reason it asks against a restricted alphabet.
- There is no algorithmic motive: hashing is argon2 (`ph = PasswordHasher()`), so there is no bcrypt-style 72-byte truncation to defend against.
- A minimum would not buy policy consistency either, because the bootstrap path calls `set_password` directly (`server/server.py`) without going through any DTO. `--bootstrap-password 123456` is accepted today, and the documented example in `docs/cli-reference/start.md` (`bootstrap_password: your_admin_password`) does not even satisfy the character rules that predate this PR. Covering bootstrap too would break existing deployments on startup and needs its own evaluation.

Also deliberately **not** narrowing the server to the UI's character allowlist. The server accepts e.g. `Passw0rd-!`, which the UI rejects; matching that would tighten what the API accepts today and break existing callers. The UI being *stricter* than the server is harmless — the reverse is what produced this bug.

## Docs

`docs/user-guide/user-management.md` gains a "Password Requirements" section listing the accepted special characters. The issue was a user hitting an undocumented rule.

## Tests

`tests/schemas/test_password_policy.py`, 32 cases. Worth calling out:

- A guard that walks every DTO in `gpustack.schemas.users` with a `password` / `new_password` field and asserts each one **rejects a violating value**, so a future DTO can't repeat the `UserUpdate` omission. Asserted behaviourally rather than by looking for a validator declaration, since a validator that accepts everything would satisfy the declaration and nothing else. Removing the `UserUpdate` validator locally fails it with `password fields that accept 'a': {'UserUpdate': ['password']}`. A companion test pins the set of scanned DTOs so a rename can't leave the scan vacuously green.
- `""` and `None` both arriving as `None` on every optional-password DTO.
- `generate_secure_password()` output always passing the validator, pinning the generator to the policy.
- The scan builds each DTO with only the fields it declares — `UserSelfUpdate` has no `username`, and pydantic drops unknown keys silently.

Verified against a running server:

| `POST /v2/users` password | before | after |
|---|---|---|
| `Passw0rd.` | 422 | **200** |
| `Aa1!` (4 chars) | 200 | 200 |
| 65 chars | 200 | 200 |
| `Passw0rd-` | 422 | 422 |
| `""` | 422 charset | 422 "Password is required for Local users." |

| `PUT /v2/users/{id}` | before | after |
|---|---|---|
| password `"a"` | 200, login worked | **422**, login 401 |
| password `Passw0rd.` | 200 | 200 |
| password `""` + `full_name` change | 200, password untouched | 200, password untouched |
| password omitted | 200 | 200 |

`gpustack reset-admin-password` still works end to end (the path most at risk from adding the validator) — it mints a fresh password, and logging in with it succeeds. `tests/schemas`, `tests/api`, `tests/server`, `tests/routes` each pass in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
