### PR TITLE
feat(catalog): tokenized, separator-insensitive model set search

### DIFF
--- a/gpustack/routes/draft_models.py
+++ b/gpustack/routes/draft_models.py
@@ -8,6 +8,7 @@ from gpustack.server.catalog import (
     get_catalog_draft_models,
 )
 from gpustack.server.deps import ListParamsDep
+from gpustack.utils.search import rank_matches
 
 router = APIRouter()
 
@@ -20,8 +21,10 @@ async def get_draft_models(
     draft_models: List[DraftModel] = Depends(get_catalog_draft_models),
 ):
     if search:
-        search = search.strip().lower()
-        draft_models = [model for model in draft_models if search in model.name.lower()]
+        # Same catalog, same directory page in the UI as /model-sets, so the
+        # same matching: `qwen3 235b eagle3` finds the model whose name is
+        # spelled Qwen3-235B-A22B-EAGLE3.
+        draft_models = rank_matches(draft_models, search, key=lambda model: model.name)
 
     if algorithm:
         draft_models = [

--- a/gpustack/routes/model_sets.py
+++ b/gpustack/routes/model_sets.py
@@ -15,6 +15,7 @@ from gpustack.server.catalog import (
     get_model_set_specs,
 )
 from gpustack.server.deps import ListParamsDep, SessionDep
+from gpustack.utils.search import rank_matches
 from gpustack.worker.backends.base import get_ascend_cann_variant
 
 router = APIRouter()
@@ -28,9 +29,11 @@ async def get_model_sets(
     model_sets: List[ModelSet] = Depends(get_model_sets),
 ):
     if search:
-        model_sets = [
-            model for model in model_sets if search.lower() in model.name.lower()
-        ]
+        # Matching ignores separators, which admits loose matches; ranking by
+        # relevance is what keeps the model the user typed above them, since
+        # the curated (order, release_date) sequence knows nothing about the
+        # query.
+        model_sets = rank_matches(model_sets, search, key=lambda model: model.name)
 
     if categories:
         model_sets = [

--- a/gpustack/utils/search.py
+++ b/gpustack/utils/search.py
@@ -1,0 +1,200 @@
+"""Tolerant keyword matching for in-memory catalog search.
+
+Model names are dense in separators and digits, and users type them
+inconsistently: with spaces, with dashes, with underscores, with the size
+first. So the query is split on whitespace and both sides are squashed to
+alphanumerics, and a candidate matches when every token appears in it. Token
+order is therefore irrelevant, and everything that scores a match is
+order-insensitive too.
+
+Squashing separators away makes short numeric tokens promiscuous -- a `35`
+typed as `3.5` also occurs inside a `235B` -- so matches are scored and ranked
+rather than merely filtered, and anything far below the best match is dropped.
+Scoring rewards matches that land on the candidate's own unit boundaries, where
+a unit ends at a separator *or* at a letter/digit transition. The second kind
+matters because version numbers sit there: in a name like ``foo3.5-2b`` the
+units are ``foo|3|5|2|b``, so a ``3.5`` lines up even though nothing separates
+the ``3`` from the ``5`` once squashed.
+
+No edit-distance fuzziness, deliberately. Model names differ from their
+siblings by a single character, so typo tolerance would make neighbouring
+releases and sizes match each other -- worse than not matching at all.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence, Set, Tuple, TypeVar
+
+T = TypeVar("T")
+
+# Whole-candidate scores, awarded on top of the per-token scores below.
+_EXACT = 40
+"""The tokens account for the whole candidate."""
+_CONTIGUOUS = 25
+"""The tokens sit next to each other in the candidate, ignoring separators."""
+_PREFIX = 15
+"""...starting at its very beginning."""
+
+# Per-token scores. Only the best occurrence of each token is scored. Every
+# candidate in a result set matches every token, so the token count is
+# constant and these sums stay comparable.
+_ALIGNED = 10
+"""The token spans whole units."""
+_START_ALIGNED = 6
+"""The token starts on a unit boundary."""
+_END_ALIGNED = 3
+"""The token ends on a unit boundary."""
+_UNALIGNED = 1
+"""The token appears mid-unit."""
+
+_RELEVANCE_FLOOR = 0.4
+"""On a multi-token query, drop candidates below this fraction of the best.
+
+Ranking alone fixes what the first page shows; it leaves the result count and
+every later page full of incidental matches. The bound is relative because
+scores are only comparable within one query -- more tokens means a higher
+ceiling, so no absolute cut-off transfers between queries.
+
+It applies only to multi-token queries because that is where the noise comes
+from: separators are dropped, so combining tokens starts matching across parts
+of a name that have nothing to do with each other. A single token is an
+ordinary contains-search, and its scores span a narrow range -- a genuine
+mid-unit hit (a model whose family name embeds the query, say) sits at 30% of
+an exact one and has to survive.
+"""
+
+
+def _squash(text: str) -> str:
+    """Lowercase and drop everything that is not alphanumeric."""
+    return "".join(ch for ch in text.casefold() if ch.isalnum())
+
+
+def _normalize(text: str) -> Tuple[str, Set[int]]:
+    """Squash `text` and locate its unit boundaries.
+
+    Returns the squashed text and the offsets into it at which a unit starts.
+    A unit ends at a separator or at a letter/digit transition.
+    """
+    squashed: List[str] = []
+    starts: Set[int] = set()
+    previous: Optional[str] = None  # None also means "a separator preceded this"
+    for ch in text.casefold():
+        if not ch.isalnum():
+            previous = None
+            continue
+        if previous is None or ch.isdigit() != previous.isdigit():
+            starts.add(len(squashed))
+        squashed.append(ch)
+        previous = ch
+    return "".join(squashed), starts
+
+
+@dataclass(frozen=True)
+class _SearchQuery:
+    """A parsed search query, scored against one candidate at a time."""
+
+    tokens: Tuple[str, ...]
+    """Squashed query tokens. Every one must match for a candidate to match."""
+
+    def score(self, text: str) -> Optional[int]:
+        """Score `text` against this query, or None if it does not match.
+
+        Higher is better. Scores are only comparable within one query.
+        """
+        squashed, starts = _normalize(text)
+        # A unit ends where the next one starts, or at the end of the text.
+        ends = starts | {len(squashed)}
+
+        total = 0
+        placements = []
+        for token in self.tokens:
+            match = self._best_token_match(token, squashed, starts, ends)
+            if match is None:
+                return None
+            score, position = match
+            total += score
+            placements.append((position, token))
+
+        # Judged in the order the tokens occur in the candidate rather than the
+        # order they were typed, so that two spellings of the same intent score
+        # alike.
+        placements.sort()
+        run = "".join(token for _, token in placements)
+        if run in squashed:
+            # Adjacency is a claim about how the tokens sit relative to each
+            # other, so it earns nothing when there is only one -- a lone token
+            # is trivially contiguous, and paying for that would flatten the
+            # gap between a real match and an incidental one.
+            if len(self.tokens) > 1:
+                total += _CONTIGUOUS
+            if squashed.startswith(run):
+                total += _PREFIX
+            if squashed == run:
+                total += _EXACT
+
+        return total
+
+    @staticmethod
+    def _best_token_match(
+        token: str, squashed: str, starts: Set[int], ends: Set[int]
+    ) -> Optional[Tuple[int, int]]:
+        """The best-aligned occurrence of `token` as (score, position)."""
+        best = None
+        position = squashed.find(token)
+        while position != -1:
+            end = position + len(token)
+            if position in starts:
+                score = _ALIGNED if end in ends else _START_ALIGNED
+            else:
+                score = _END_ALIGNED if end in ends else _UNALIGNED
+
+            if best is None or score > best[0]:
+                best = (score, position)
+            if score == _ALIGNED:
+                break
+
+            position = squashed.find(token, position + 1)
+
+        return best
+
+
+def _compile_search_query(search: Optional[str]) -> Optional[_SearchQuery]:
+    """Parse a raw search string, or return None if it carries no keywords.
+
+    None means "no filtering": this is what makes a blank or punctuation-only
+    query behave like no query at all, including one that is nothing but
+    leading or trailing spaces.
+    """
+    if not search:
+        return None
+
+    tokens = tuple(token for token in map(_squash, search.split()) if token)
+    if not tokens:
+        return None
+
+    return _SearchQuery(tokens=tokens)
+
+
+def rank_matches(
+    items: Sequence[T], search: Optional[str], key: Callable[[T], str]
+) -> List[T]:
+    """Keep the items relevant to `search`, best match first.
+
+    Ties keep the caller's ordering, so a broad query leaves a curated
+    sequence intact instead of reshuffling it by score noise.
+    """
+    query = _compile_search_query(search)
+    if query is None:
+        return list(items)
+
+    scored = []
+    for item in items:
+        score = query.score(key(item))
+        if score is not None:
+            scored.append((score, item))
+
+    if scored and len(query.tokens) > 1:
+        floor = max(score for score, _ in scored) * _RELEVANCE_FLOOR
+        scored = [pair for pair in scored if pair[0] >= floor]
+
+    scored.sort(key=lambda pair: -pair[0])
+    return [item for _, item in scored]

--- a/tests/routers/test_model_sets.py
+++ b/tests/routers/test_model_sets.py
@@ -1,7 +1,14 @@
 import pytest
-from gpustack.routes.model_sets import filter_specs_by_gpu
+from gpustack.routes.draft_models import get_draft_models
+from gpustack.routes.model_sets import filter_specs_by_gpu, get_model_sets
+from gpustack.schemas.common import ListParams
 from gpustack.schemas.gpu_devices import GPUDevice
-from gpustack.schemas.model_sets import GPUFilters, ModelSpec
+from gpustack.schemas.model_sets import (
+    DraftModel,
+    GPUFilters,
+    ModelSetPublic,
+    ModelSpec,
+)
 from gpustack.schemas.models import SourceEnum
 
 
@@ -174,3 +181,138 @@ def test_filter_specs_by_gpu(
     except AssertionError as e:
         print(f"Test case '{case_name}' failed.")
         raise e
+
+
+# --- GET /model-sets and GET /draft-models: search, filters, pagination -------
+# Both handlers hold the catalog in memory and receive it as a dependency, so
+# they can be driven directly without a database.
+
+CATALOG = [
+    ModelSetPublic(id=1, name="Qwen3-235B-A22B-Instruct-2507", categories=["llm"]),
+    ModelSetPublic(id=2, name="Qwen3.5-0.8B", categories=["llm"]),
+    ModelSetPublic(id=3, name="Qwen3.5-9B", categories=["llm"]),
+    ModelSetPublic(id=4, name="Qwen3.5-27B", categories=["llm"]),
+    ModelSetPublic(id=5, name="Qwen3-Embedding-8B", categories=["embedding"]),
+    ModelSetPublic(id=6, name="FLUX.2-klein-9B", categories=["image"]),
+]
+
+
+def params(page=1, perPage=100):
+    return ListParams(page=page, perPage=perPage, watch=False, sort_by=None)
+
+
+async def call(**kwargs):
+    kwargs.setdefault("params", params())
+    kwargs.setdefault("model_sets", CATALOG)
+    # Both are declared with FastAPI defaults, which are marker objects rather
+    # than None when the handler is called directly.
+    kwargs.setdefault("search", None)
+    kwargs.setdefault("categories", None)
+    return await get_model_sets(**kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "search",
+    ["qwen3.5 9b", "9b qwen3.5", "qwen3.5_9b", "qwen 3.5 9b", "  QWEN3.5-9B  "],
+)
+async def test_search_finds_the_model_however_it_is_typed(search):
+    result = await call(search=search)
+    assert [item.name for item in result.items] == ["Qwen3.5-9B"]
+    assert result.pagination.total == 1
+
+
+@pytest.mark.asyncio
+async def test_search_ranks_and_excludes_incidental_matches():
+    result = await call(search="qwen 3.5")
+    names = [item.name for item in result.items]
+    # `35` also sits inside `235B`, and the total is what feeds pagination, so
+    # it has to count only the relevant ones.
+    assert names == ["Qwen3.5-0.8B", "Qwen3.5-9B", "Qwen3.5-27B"]
+    assert result.pagination.total == 3
+
+
+@pytest.mark.asyncio
+async def test_blank_search_returns_the_whole_catalog():
+    # Whitespace-only input reaches the route as a truthy string; it has to
+    # behave as no query rather than matching nothing.
+    for search in ["   ", "\t", None]:
+        result = await call(search=search)
+        assert result.pagination.total == len(CATALOG)
+
+
+@pytest.mark.asyncio
+async def test_search_combines_with_categories():
+    result = await call(search="9b", categories=["image"])
+    assert [item.name for item in result.items] == ["FLUX.2-klein-9B"]
+    assert result.pagination.total == 1
+
+
+@pytest.mark.asyncio
+async def test_search_survives_pagination():
+    first = await call(search="qwen 3.5", params=params(page=1, perPage=2))
+    second = await call(search="qwen 3.5", params=params(page=2, perPage=2))
+
+    assert [item.name for item in first.items] == ["Qwen3.5-0.8B", "Qwen3.5-9B"]
+    assert [item.name for item in second.items] == ["Qwen3.5-27B"]
+    assert first.pagination.total == second.pagination.total == 3
+    assert first.pagination.totalPage == 2
+
+
+@pytest.mark.asyncio
+async def test_search_with_no_match_is_empty():
+    result = await call(search="nonexistent-model")
+    assert result.items == []
+    assert result.pagination.total == 0
+
+
+# --- /draft-models: same catalog, same matching --------------------------------
+
+
+def draft(name, repo):
+    return DraftModel(
+        name=name,
+        algorithm="eagle3",
+        source="huggingface",
+        huggingface_repo_id=repo,
+    )
+
+
+DRAFT_MODELS = [
+    draft("Qwen3-8B-EAGLE3", "Tengyunw/qwen3_8b_eagle3"),
+    draft("Qwen3-30B-A3B-EAGLE3", "Tengyunw/qwen3_30b_moe_eagle3"),
+    draft("Qwen3-235B-A22B-EAGLE3", "lmsys/Qwen3-235B-A22B-EAGLE3"),
+    draft("gpt-oss-120b-EAGLE3", "lmsys/EAGLE3-gpt-oss-120b-bf16"),
+]
+
+
+async def call_drafts(**kwargs):
+    kwargs.setdefault("params", params())
+    kwargs.setdefault("draft_models", DRAFT_MODELS)
+    kwargs.setdefault("search", None)
+    kwargs.setdefault("algorithm", None)
+    return await get_draft_models(**kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "search",
+    ["qwen3 235b eagle3", "eagle3 qwen3-235b", "qwen3_235b_a22b", "  QWEN3 235B  "],
+)
+async def test_draft_model_search_matches_like_model_sets(search):
+    result = await call_drafts(search=search)
+    assert [item.name for item in result.items] == ["Qwen3-235B-A22B-EAGLE3"]
+
+
+@pytest.mark.asyncio
+async def test_draft_model_blank_search_returns_everything():
+    result = await call_drafts(search="   ")
+    assert result.pagination.total == len(DRAFT_MODELS)
+
+
+@pytest.mark.asyncio
+async def test_draft_model_search_combines_with_algorithm():
+    result = await call_drafts(search="gpt oss", algorithm="eagle3")
+    assert [item.name for item in result.items] == ["gpt-oss-120b-EAGLE3"]
+    result = await call_drafts(search="gpt oss", algorithm="medusa")
+    assert result.items == []

--- a/tests/utils/test_search.py
+++ b/tests/utils/test_search.py
@@ -1,0 +1,142 @@
+import pytest
+
+from gpustack.utils.search import rank_matches
+
+# A slice of real catalog names, in catalog order, so ranking assertions
+# reflect what the /model-sets endpoint actually has to sort through.
+CATALOG = [
+    "Qwen3-0.6B",
+    "Qwen3-8B",
+    "Qwen3-14B",
+    "Qwen3-32B",
+    "Qwen3-30B-A3B-Instruct-2507",
+    "Qwen3-235B-A22B-Instruct-2507",
+    "Qwen3.6-35B-A3B",
+    "Qwen3.5-0.8B",
+    "Qwen3.5-9B",
+    "Qwen3.5-27B",
+    "Qwen3.5-397B-A17B",
+    "GLM-4.6",
+    "GLM-4.7",
+    "gpt-oss-20b",
+    "gpt-oss-120b",
+    "Deepseek-V3.2",
+    "Deepseek-V3.2-Speciale",
+    "MiniMax-M2.5",
+    "FLUX.2-klein-9B",
+]
+
+
+def search(query, catalog=CATALOG):
+    return rank_matches(catalog, query, key=lambda name: name)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # Every spelling a user might reach for to mean one specific model.
+        "qwen3.5    ",
+        "   qwen3.5",
+        "qwen3.5 9b",
+        "qwen 3.5 9b",
+        "9b qwen3.5",
+        "qwen3.5-9b",
+        "qwen3.5_9b",
+        "qwen3.5   9b",
+        "QWEN3.5 9B",
+    ],
+)
+def test_separator_and_order_insensitive(query):
+    assert "Qwen3.5-9B" in search(query)
+
+
+def test_exact_name_ranks_first():
+    # `9b` alone also matches FLUX.2-klein-9B, and `qwen3.5` alone matches the
+    # whole Qwen3.5 family; together they must put the exact model on top.
+    assert search("qwen3.5 9b")[0] == "Qwen3.5-9B"
+    assert search("9b qwen3.5")[0] == "Qwen3.5-9B"
+    assert search("Qwen3.5-9B")[0] == "Qwen3.5-9B"
+
+
+def test_typing_order_does_not_change_the_result():
+    # The decoy holds both tokens but with something between them, so it has to
+    # rank below the name where they are adjacent -- whichever order they were
+    # typed in. It is listed first, so falling back to catalog order on a score
+    # tie would put it on top.
+    catalog = ["Foo3.5-VL-9B-Instruct", "Foo3.5-9B"]
+    assert search("foo3.5 9b", catalog) == search("9b foo3.5", catalog)
+    assert search("9b foo3.5", catalog)[0] == "Foo3.5-9B"
+
+
+def test_contiguous_match_outranks_scattered_tokens():
+    # Ignoring separators, `35` also appears inside `Qwen3-235B-A22B`, which is
+    # the kind of incidental match the relevance floor is there to remove.
+    results = search("qwen 3.5")
+    assert results[:3] == ["Qwen3.5-0.8B", "Qwen3.5-9B", "Qwen3.5-27B"]
+    assert "Qwen3-235B-A22B-Instruct-2507" not in results
+
+
+def test_ties_keep_catalog_order():
+    # Nothing distinguishes these beyond the curated order they came in.
+    assert search("gpt oss") == ["gpt-oss-20b", "gpt-oss-120b"]
+    assert search("qwen3")[:4] == [
+        "Qwen3-0.6B",
+        "Qwen3-8B",
+        "Qwen3-14B",
+        "Qwen3-32B",
+    ]
+
+
+def test_unit_match_outranks_mid_unit_match():
+    # `20b` is a whole unit of gpt-oss-20b but only part of `120b`, far enough
+    # below to be dropped rather than merely ranked lower.
+    assert search("gpt oss 20b") == ["gpt-oss-20b"]
+    # `9b` is a whole unit of both, so neither is promoted over the other.
+    assert search("9b") == ["Qwen3.5-9B", "FLUX.2-klein-9B"]
+
+
+def test_version_aligns_across_a_letter_digit_transition():
+    # `Qwen3.5` has no separator between `3` and `5` once squashed, yet `3.5`
+    # must still align there and outrank the `35` buried inside `235B`.
+    results = search("3.5")
+    assert results.index("Qwen3.5-9B") < results.index("Qwen3-235B-A22B-Instruct-2507")
+    # `M2.5` does not contain a `3.5` at all, however it is squashed.
+    assert "MiniMax-M2.5" not in results
+
+
+def test_relevance_floor_drops_incidental_matches():
+    # Combining tokens is what starts matching across unrelated parts of a
+    # name, so the count -- not just the first page -- has to shed those.
+    assert "Qwen3-235B-A22B-Instruct-2507" not in search("qwen 3.5")
+    assert search("gpt oss 20b") == ["gpt-oss-20b"]
+
+
+def test_single_token_search_keeps_partial_matches():
+    # A lone token is an ordinary contains-search: a model whose family name
+    # embeds the query is a real hit, even though the query lands mid-unit
+    # there, so the floor must not reach it.
+    catalog = ["DeepSeek-OCR", "PaddleOCR-VL-1.5", "LightOnOCR-2-1B"]
+    assert search("ocr", catalog) == catalog
+
+
+def test_dotted_version_is_not_a_wildcard():
+    assert search("glm 4.6") == ["GLM-4.6"]
+    assert search("deepseek v3.2") == ["Deepseek-V3.2", "Deepseek-V3.2-Speciale"]
+
+
+def test_every_token_must_match():
+    assert search("qwen3.5 405b") == []
+    assert search("qwen3.5 glm") == []
+
+
+def test_blank_query_does_not_filter():
+    # A user who typed only spaces should see the full catalog, not nothing.
+    for query in [None, "", "   ", "\t\n", "---", "  _.-  "]:
+        assert search(query) == CATALOG
+
+
+def test_unmatchable_query_returns_nothing():
+    # Non-alphanumeric scripts survive tokenization, so they filter normally
+    # instead of degrading into an empty (match-everything) query.
+    assert search("通义千问") == []
+    assert search("nonexistent-model") == []


### PR DESCRIPTION
## Issue

#5810

## Problem

Catalog search was a plain substring match with no normalization:

```python
model_sets = [model for model in model_sets if search.lower() in model.name.lower()]
```

Every example in the issue returns zero results against the built-in catalog, including `"qwen3.5    "` (trailing spaces) and `"qwen 3.5"`.

## Approach

`gpustack/utils/search.py`, a pure function with no new dependencies. `rank_matches` is the only public name.

- The query is split on whitespace; each token and each candidate is squashed to alphanumerics. A candidate matches when **every** token appears in it, which makes token order irrelevant.
- Squashing separators makes short numeric tokens promiscuous — a `35` typed as `3.5` also occurs inside a `235B` — so matches are scored and ranked, and incidental ones are dropped outright.
- Scoring rewards matches landing on the candidate's own unit boundaries, where a unit ends at a separator **or at a letter/digit transition**. The second kind is what lets `3.5` align inside a name like `foo3.5-2b` (units `foo|3|5|2|b`), which has no separator between the `3` and the `5` once squashed, while demoting a `35` buried mid-unit.
- Everything that scores a match is order-insensitive, including the adjacency bonus: tokens are ordered by **where they matched in the candidate**, not by how they were typed, before checking whether they sit contiguously. Otherwise `qwen3.5 9b` and `9b qwen3.5` differ by 80 points on the same target.
- Adjacency earns nothing on a single-token query — one token is trivially contiguous, and paying for it flattens the gap between a real match and an incidental one.
- Ties keep the caller's ordering, so a broad query leaves the catalog's curated `(order, release_date)` sequence intact instead of reshuffling it by score noise.

Applied to `/model-sets` and `/draft-models`, the two in-memory catalog list endpoints.

No edit-distance fuzziness on purpose: model names differ from their siblings by a single character, so typo tolerance would make neighbouring releases and sizes match each other — worse than not matching at all. Every example in the issue is a separator/tokenization problem, not a typo.

The catalog is 123 entries filtered in memory per request, so there is no index or performance concern.

### Relevance floor

Ranking alone fixes what the first page shows; it leaves the result count — which feeds pagination — and every later page full of incidental matches. So on a **multi-token** query, candidates scoring below 40% of the best match are dropped.

It is scoped to multi-token queries because that is where the noise comes from: combining tokens with separators removed starts matching across parts of a name that have nothing to do with each other. Measured on the real catalog:

| query | tokens | best | next scores |
|---|---|---|---|
| `qwen 3.5` | 2 | 60 | 13 (21%) — `Qwen3-235B-A22B-…` |
| `gpt oss 20b` | 3 | 110 | 23 (21%) — `gpt-oss-120b` |
| `ocr` | 1 | 10 | 3 (30%) — `PaddleOCR-VL-1.5`, `LightOnOCR-2-1B` |

A single token is an ordinary contains-search and its scores span a narrow range: those `ocr` matches at 30% are genuinely relevant models, so a uniform 40% cut would drop them. A uniform 25% would fit this catalog, but only inside a 3-point band between 22% and 30% — tuned to the current data rather than to a reason.

### Not in scope

The ~20 DB-backed `search` endpoints use SQL `LIKE` with database-side pagination and support `sort_by`. Adopting this would mean pushing a normalized expression into SQL per dialect and deciding how relevance interacts with an explicit sort — a separate change.

## Results

Measured against the full built-in catalog:

| search | before | after |
|---|---|---|
| `"qwen3.5    "` | 0 | 8, the whole Qwen3.5 family |
| `"qwen3.5 9b"` | 0 | `Qwen3.5-9B` |
| `"qwen 3.5"` | 0 | 8, all Qwen3.5 |
| `"9b qwen3.5"` | 0 | `Qwen3.5-9B` |
| `"qwen3.5_9b"` | 0 | `Qwen3.5-9B` |
| `"gpt oss 20b"` | 0 | `gpt-oss-20b` |
| `"ocr"` | 3 | 3 |
| `"   "` (spaces only) | 0 | 123, i.e. no filtering |

One accepted trade-off: a bare `3.5` keeps 15 matches, since a single token gets no floor and the query is genuinely ambiguous — the Qwen3.5 family ranks above the incidental `235B` hits rather than excluding them.

## Tests

`tests/utils/test_search.py` (21 cases) covers the issue's original spellings, ranking, the letter/digit boundary, the floor, single-token recall, blank and punctuation-only queries, and a non-Latin query (which correctly returns nothing rather than degrading into a match-everything query).

The typing-order test uses a fixture holding a decoy that contains both tokens non-adjacently, so it fails under order-sensitive scoring instead of passing vacuously.

`tests/routes/test_model_sets.py` (16 cases) drives both handlers directly — no database needed, since the catalog arrives as a dependency — covering search × category/algorithm × pagination, the result `total`, and the one user-visible behaviour change: a whitespace-only query now returns the full catalog instead of nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
