### PR TITLE
Align with gpustack-runtime v0.2.3: Event read RBAC and the container exit code

### DIFF
--- a/charts/gpustack-chart/templates/worker-rbac.yaml
+++ b/charts/gpustack-chart/templates/worker-rbac.yaml
@@ -99,11 +99,17 @@ rules:
       - get
       - list
       - watch
+  # The read is what turns a bare "ImagePullBackOff" into the registry error
+  # behind it: gpustack-runtime reads the workload Pod's Events to explain why
+  # the pull fails, and reports it on the workload's state message,
+  # see gpustack/gpustack#5869.
   - apiGroups:
       - ""
-    resources: 
+    resources:
       - "events"
-    verbs: 
+    verbs:
+      - "get"
+      - "list"
       - "create"
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -72,6 +72,9 @@ logger = logging.getLogger(__name__)
 # Inference health check error message
 _INFERENCE_HEALTH_CHECK_FAILED_MESSAGE = "Inference health check failed."
 
+# Last-resort message for a workload that stopped serving without saying why.
+_WORKLOAD_FAILED_MESSAGE = "Inference server exited or unhealthy."
+
 # One health-check cycle (+2s margin) to let a container return after a stream
 # EOF; beyond that gpustack marks it ERROR and takes over recovery.
 LOG_RECONNECT_GRACE_SECONDS = envs.MODEL_INSTANCE_HEALTH_CHECK_INTERVAL + 2
@@ -128,6 +131,54 @@ def _parse_allocated_accelerators(annotations: Optional[Dict[str, str]]) -> List
                 if isinstance(accelerator, dict) and accelerator.get("id"):
                     accelerators.append(accelerator)
     return accelerators
+
+
+def _describe_workload_failure(workload) -> str:
+    """
+    Explain why a workload stopped serving, for the instance's state message.
+
+    The workload's `state_message` is the most specific text the runtime has --
+    a Pod's admission rejection, or an image-pull reason plus the registry error
+    behind it (gpustack/gpustack#5869) -- but it never carries an exit code, and
+    a container that merely crashed leaves it empty on Kubernetes. The
+    per-container `exits` carry both, so take the reason from there when there
+    is no message, and append the exit code either way
+    (gpustack/gpustack#4217).
+
+    Args:
+        workload: The runtime WorkloadStatus, None if the workload is gone.
+
+    Returns:
+        The failure message to surface on the model instance.
+    """
+    if not workload:
+        return _WORKLOAD_FAILED_MESSAGE
+
+    message = getattr(workload, "state_message", "") or ""
+    # A container blocked from starting reports no exit code, and its reason is
+    # already what the state message is built from, so it adds nothing here.
+    exits = [
+        exit_
+        for exit_ in (getattr(workload, "exits", None) or [])
+        if exit_.exit_code is not None
+    ]
+    if not exits:
+        return message or _WORKLOAD_FAILED_MESSAGE
+
+    if not message:
+        # Deduplicated but order-preserving: sidecars usually die of one cause.
+        message = ", ".join(
+            dict.fromkeys(exit_.reason for exit_ in exits if exit_.reason)
+        )
+    codes = ", ".join(
+        (
+            f"{exit_.name} exit code {exit_.exit_code}"
+            if len(exits) > 1
+            else f"exit code {exit_.exit_code}"
+        )
+        for exit_ in exits
+    )
+    return f"{message or _WORKLOAD_FAILED_MESSAGE} ({codes})"
 
 
 class ServeManager:
@@ -444,11 +495,10 @@ class ServeManager:
             ]:
                 # Only if not in ERROR state yet.
                 if model_instance.state != ModelInstanceStateEnum.ERROR:
-                    # Surface the workload's status message (e.g. a
-                    # device-plugin admission rejection) when available.
-                    failure_message = (
-                        workload and getattr(workload, "state_message", "")
-                    ) or "Inference server exited or unhealthy."
+                    # Surface the workload's own diagnosis (e.g. a device-plugin
+                    # admission rejection, an image-pull failure, an exit code)
+                    # when available.
+                    failure_message = _describe_workload_failure(workload)
                     with contextlib.suppress(NotFoundException):
                         # Get patch dict for main worker.
                         if is_main_worker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "msgpack>=1.1.2",
     "cachetools>=6.0.0",
     "gpustack-runner==0.1.27.post4",
-    "gpustack-runtime==0.2.2.post8",
+    "gpustack-runtime==0.2.3",
     "gpustack-higress-plugins==0.3.0.post1",
     "websockets==16.0",
     "py-radix>=1.1.0",

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -12,7 +12,7 @@ from gpustack.schemas.models import (
     SourceEnum,
 )
 from gpustack.server.bus import Event, EventType
-from gpustack.worker.serve_manager import ServeManager
+from gpustack.worker.serve_manager import ServeManager, _describe_workload_failure
 from gpustack_runtime.deployer import WorkloadStatusStateEnum
 from tests.utils.model import new_model, new_model_instance
 
@@ -852,6 +852,123 @@ def test_error_state_falls_back_to_generic_message():
         model_instance.id,
         state=ModelInstanceStateEnum.ERROR,
         state_message="Inference server exited or unhealthy.",
+    )
+
+
+def _workload_exit(name="default", exit_code=None, reason=""):
+    return SimpleNamespace(name=name, exit_code=exit_code, reason=reason)
+
+
+def test_error_state_surfaces_the_container_exit_code():
+    """gpustack/gpustack#4217: the exit code must reach the instance, not just
+    the runtime's workload status."""
+    manager, clientset = _build_vgpu_manager(worker_id=1)
+
+    model_instance = new_model_instance(
+        1,
+        "vgpu-instance",
+        1,
+        worker_id=1,
+        state=ModelInstanceStateEnum.INITIALIZING,
+    )
+    clientset.model_instances.list.return_value = SimpleNamespace(
+        items=[model_instance]
+    )
+
+    workload = SimpleNamespace(
+        state="Failed",
+        state_message="Error",
+        exits=[_workload_exit(exit_code=7, reason="Error")],
+    )
+
+    with (
+        patch("gpustack.worker.serve_manager.get_workload", return_value=workload),
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch.object(manager, "_update_model_instance") as update_model_instance,
+    ):
+        manager.sync_model_instances_state()
+
+    update_model_instance.assert_called_once_with(
+        model_instance.id,
+        state=ModelInstanceStateEnum.ERROR,
+        state_message="Error (exit code 7)",
+    )
+
+
+def test_workload_failure_appends_the_exit_code():
+    """Both backends must answer gpustack/gpustack#4217, and they arrive at it
+    differently: Docker names the reason on state_message, Kubernetes leaves it
+    empty and the exits are the only source."""
+    assert (
+        _describe_workload_failure(
+            SimpleNamespace(
+                state_message="OOMKilled",
+                exits=[_workload_exit(exit_code=137, reason="OOMKilled")],
+            )
+        )
+        == "OOMKilled (exit code 137)"
+    )
+    assert (
+        _describe_workload_failure(
+            SimpleNamespace(
+                state_message="",
+                exits=[_workload_exit(exit_code=1, reason="Error")],
+            )
+        )
+        == "Error (exit code 1)"
+    )
+
+
+def test_workload_failure_keeps_the_image_pull_diagnosis():
+    """gpustack/gpustack#5869: a container blocked on its image pull never
+    terminated, so it has no exit code, and its state message already carries
+    the registry error the Pod's Events explain it with. Nothing may displace
+    or pad it."""
+    message = (
+        'ImagePullBackOff: Back-off pulling image "registry.invalid/nope:latest"; '
+        "Failed to pull image: not found"
+    )
+
+    assert (
+        _describe_workload_failure(
+            SimpleNamespace(
+                state_message=message,
+                exits=[_workload_exit(reason="ImagePullBackOff")],
+            )
+        )
+        == message
+    )
+
+
+def test_workload_failure_names_each_container_when_several_exit():
+    assert (
+        _describe_workload_failure(
+            SimpleNamespace(
+                state_message="",
+                exits=[
+                    _workload_exit(exit_code=1, reason="Error"),
+                    _workload_exit(name="ray-head", exit_code=137, reason="OOMKilled"),
+                ],
+            )
+        )
+        == "Error, OOMKilled (default exit code 1, ray-head exit code 137)"
+    )
+
+
+def test_workload_failure_falls_back_when_the_workload_explains_nothing():
+    # A workload reaped out from under the sync, and one that failed without a
+    # message or any exit entry (the pre-0.2.3 shape, which has no `exits` at
+    # all) both land on the generic message.
+    assert _describe_workload_failure(None) == "Inference server exited or unhealthy."
+    assert (
+        _describe_workload_failure(SimpleNamespace(state="Failed"))
+        == "Inference server exited or unhealthy."
+    )
+    assert (
+        _describe_workload_failure(
+            SimpleNamespace(state_message="", exits=[_workload_exit(exit_code=2)])
+        )
+        == "Inference server exited or unhealthy. (exit code 2)"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1241,7 +1241,7 @@ requires-dist = [
     { name = "fastapi-cdn-host", specifier = ">=0.8.0" },
     { name = "gpustack-higress-plugins", specifier = "==0.3.0.post1" },
     { name = "gpustack-runner", specifier = "==0.1.27.post4" },
-    { name = "gpustack-runtime", specifier = "==0.2.2.post8" },
+    { name = "gpustack-runtime", specifier = "==0.2.3" },
     { name = "hf-xet", specifier = ">=1.3.1,<2.0.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "huggingface-hub", specifier = ">=1.0.0" },
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "gpustack-runtime"
-version = "0.2.2.post8"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -1351,9 +1351,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/0e/9b67d9793eae19126e2389446ea544ddb4431ce5a67644bf03e068099b26/gpustack_runtime-0.2.2.post8.tar.gz", hash = "sha256:a8776af5bbfd437f2dc539eae501fb57b4e4b00adff5e2f2bbad355be85810f8", size = 1476137, upload-time = "2026-08-04T06:39:17.184Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/c9/f9704041b9a550cac4cd9ee7e89d747b3c9d8dd68b49d66f5ed3b3af09d7/gpustack_runtime-0.2.3.tar.gz", hash = "sha256:a1ff6ddcdbcf1b204ab8c4e03aa57badfe7acddeb0cae560e1116e2a7194088a", size = 1589779, upload-time = "2026-08-15T04:02:26.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/1d/2d8c564be202224d98a053e8d9292108b4f6d570c0a6dc5289fa0ecbf7de/gpustack_runtime-0.2.2.post8-py3-none-any.whl", hash = "sha256:d0245ddd0fc5dd5da519d84da1485849448ba93fd09e67df6d214fa82eacf500", size = 1453143, upload-time = "2026-08-04T06:39:15.826Z" },
+    { url = "https://files.pythonhosted.org/packages/90/3e/f2790d57f64fb3a1d1aee992279fff7fd5f69595656d8825157cb7fd9bb5/gpustack_runtime-0.2.3-py3-none-any.whl", hash = "sha256:f62a8c942d73b2517c3c9e17779a966594bd961ceae73ab3ba16ba8b69caec98", size = 1480734, upload-time = "2026-08-15T04:02:24.779Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue

#5869, #4217, #6041

## Problem

Three reports, one theme: a model instance that failed did not say why.

**#5869 — a Kubernetes image-pull failure showed nothing at all.** A Pod blocked on an
unpullable image sat at `Pending`, and the worker's state sync skips `Pending`:

```python
if workload and workload.state in [
    WorkloadStatusStateEnum.PENDING,
    WorkloadStatusStateEnum.INITIALIZING,
]:
    continue
```

So the instance never left its pre-error state and the UI showed no error or notice.

**#4217 — no exit code, on either backend.** Nothing in this repo read the runtime's exit
information, so a container that ran and died reported:

| Scenario | Backend | What the instance said |
| --- | --- | --- |
| Exit non-zero | Docker | `Error` — no code |
| Out of memory | Docker | `OOMKilled` — no code |
| Container crash | Kubernetes | `Inference server exited or unhealthy.` — the Pod's `status.message` is empty for a terminated container, so the reason was lost too |

**#6041 — CUDA enumerated devices in a different order than `nvidia-smi`.** CUDA's default
`CUDA_DEVICE_ORDER=FASTEST_FIRST` reshuffles ordinals on a heterogeneous host, so an index
computed from detection addressed another device inside the container.

## Changes

### `gpustack-runtime` 0.2.2.post8 → 0.2.3

The runtime does the work for all three; the pin is what delivers it, and none of it needs
code here:

- **#6041** — the deployers stamp `CUDA_DEVICE_ORDER=PCI_BUS_ID` themselves
  (`Deployer.map_visible_devices_ordering`, applied in `docker.py`, `podman.py` and
  `kuberentes.py`), so worker and inference containers alike enumerate devices as
  `nvidia-smi` and the detector do. Verified new in this release: `v0.2.2.post8` has no
  occurrence of `CUDA_DEVICE_ORDER`, `v0.2.3` has it in both the helper and its docstring.
- **#5869** — a workload blocked on an unpullable image now reports `Failed` rather than
  `Pending`, which is what makes the sync above stop skipping it, and its `state_message`
  carries the Pod Event behind the waiting reason.
- **#4217** — `WorkloadStatus` gains per-container `exits` (`exit_code`, `reason`, `name`,
  timestamps, restart count) on the Docker and the Kubernetes deployer alike.

### `charts/`: `get` and `list` on core `events`

The worker ClusterRole already had an `events` rule — with **`create` only**, which does not
permit the read. The runtime lists a workload Pod's Events to name the registry error behind
a bare `ImagePullBackOff`; without the read that list 403s and the diagnosis degrades to the
bare waiting reason, leaving #5869 broken in practice even with the runtime side fixed.

`get` and `list` are added and nothing else. The rule stays separate from the `"*"` grant
above it so Events do not inherit create and delete from it, and it is bound by a
namespace-scoped `RoleBinding`, so the read reaches exactly the namespace whose Pods the
same role already reads.

```console
$ helm template charts/gpustack-chart --set worker.enabled=true \
    --set operator.image.tag=v0.0.0 -s templates/worker-rbac.yaml
...
  - apiGroups:
      - ""
    resources:
      - "events"
    verbs:
      - "get"
      - "list"
      - "create"
```

**On the asymmetry:** `gpustack/k8s/manifests.jinja` — the Cluster Register path — binds its
worker ServiceAccount to **`cluster-admin`** (`manifests.jinja:25-36`), so the Event read
already succeeds there and it needs no rule. The two install paths are deliberately unequal
— the chart is least-privilege, Cluster Register is not — and this PR does not change that.

### `gpustack/worker/serve_manager.py`: the exit code reaches the instance

**Does the model-instance API expose the failure reason and exit code?**

- **The reason: already, and it needed no work.** `WorkloadStatus.state_message` →
  `ServeManager.sync_model_instances_state` → `_update_model_instance` →
  `model_instances.state_message` (`ModelInstanceBase`, `gpustack/schemas/models.py:734`) →
  `ModelInstancePublic.state_message` → the API. That is what carries
  `UnexpectedAdmissionError: Allocate failed ...` today and, with 0.2.3, the image-pull
  reason plus its registry error.
- **The exit code: no — wired up here.** `_describe_workload_failure` takes the reason from
  `exits` when there is no state message, and appends the code either way:

| Scenario | Backend | State message now |
| --- | --- | --- |
| Exit non-zero | Docker | `Error (exit code 7)` |
| Out of memory | Docker | `OOMKilled (exit code 137)` |
| Killed (SIGKILL) | Docker | `Error (exit code 137)` |
| Container crash | Kubernetes | `Error (exit code 1)` |
| Unpullable image | Kubernetes | `ImagePullBackOff: Back-off pulling image "..."; <registry error>` — unchanged |

A container blocked from starting never terminated, so it reports no exit code and its
reason is already what the state message is built from. Skipping those entries is what
leaves the image-pull message untouched, and the existing `if state != ERROR` guard means
the first, most specific message wins. No schema change and no migration — the answer rides
the `state_message` field the UI already renders, which is where #4217's screenshot shows
the gap.

## Verification

- `helm template ... -s templates/worker-rbac.yaml` — output above.
- `uv run pytest` — 2406 passed, 11 skipped. One pre-existing unrelated failure,
  `tests/server/test_catalog.py::test_model_catalog_modelscope`: it makes a live call to
  `modelscope.cn` for `openai/whisper-large-v3-turbo`, which now 404s upstream
  (`curl -o /dev/null -w '%{http_code}' https://modelscope.cn/openapi/v1/models/openai/whisper-large-v3-turbo`
  → `404`). It fails identically without this branch.
- `uv run pre-commit run --all-files` — all hooks pass.
- New tests in `tests/worker/test_serve_manager.py` cover the four runtime behaviours
  verified on real hardware, the image-pull message staying intact, the multi-container
  case, and the pre-0.2.3 workload shape that has no `exits` attribute at all.
