### PR TITLE
feat(models): gracefully drain replicas before hard-delete

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -111,7 +111,7 @@ After scoring, the scheduler picks the candidate with the highest total score an
 
 ## Scale-Down Scheduling
 
-When the desired replica count is lower than the number of existing model instances, the controller ranks current instances and deletes the lowest-ranked ones first.
+When the desired replica count is lower than the number of existing model instances, the controller ranks current instances and removes the lowest-ranked ones first.
 
 Scale-down uses a separate scorer chain over existing model instances:
 
@@ -120,6 +120,16 @@ Scale-down uses a separate scorer chain over existing model instances:
 3. **Placement Scorer**
 
 The resulting instances are sorted by score in ascending order, and the lowest-scoring instances are removed first.
+
+### Graceful delete (DRAINING)
+
+Running replicas are not hard-deleted immediately. Scale-down (and `DELETE` of a running instance) first moves the instance to `DRAINING`:
+
+- The instance is dropped from load balancing and `ready_replicas` right away (`state == running` filters).
+- The worker keeps the inference workload up until in-flight proxied requests finish (or the drain timeout elapses).
+- A server-side drain finalizer then hard-deletes the row; the worker's existing reap path tears down the workload.
+
+Configure the hard timeout with `GPUSTACK_MODEL_INSTANCE_DRAIN_TIMEOUT` (default 120 seconds). Offline workers still hard-delete without waiting for drain.
 
 ### Status Scorer
 

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -121,6 +121,15 @@ MODEL_INSTANCE_HEALTH_CHECK_INTERVAL = int(
 MODEL_INSTANCE_STATE_RECONCILE_INTERVAL = int(
     os.getenv("GPUSTACK_MODEL_INSTANCE_STATE_RECONCILE_INTERVAL", 0)
 )
+# Max time a model instance may stay in DRAINING before hard-delete, even if
+# in-flight requests have not finished (protects against stuck streams).
+MODEL_INSTANCE_DRAIN_TIMEOUT = int(
+    os.getenv("GPUSTACK_MODEL_INSTANCE_DRAIN_TIMEOUT", 120)
+)  # in seconds
+# How often the server drain finalizer scans DRAINING instances.
+MODEL_INSTANCE_DRAIN_FINALIZER_INTERVAL = int(
+    os.getenv("GPUSTACK_MODEL_INSTANCE_DRAIN_FINALIZER_INTERVAL", 3)
+)  # in seconds
 DISABLE_OS_FILELOCK = os.getenv("GPUSTACK_DISABLE_OS_FILELOCK", "false").lower() in [
     "true",
     "1",

--- a/gpustack/migrations/versions/2026_08_16_1118-a1b2c3d4e5f6_add_model_instance_drain_fields.py
+++ b/gpustack/migrations/versions/2026_08_16_1118-a1b2c3d4e5f6_add_model_instance_drain_fields.py
@@ -1,0 +1,49 @@
+"""Add model instance drain fields for graceful replica delete.
+
+Adds ``drain_started_at`` and ``drain_idle`` on ``model_instances`` so scale-down
+/ DELETE can enter DRAINING, wait for in-flight proxy requests (or timeout),
+then hard-delete.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 367a3982fcde
+Create Date: 2026-08-16 11:18:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from gpustack.schemas.common import UTCDateTime
+from gpustack.migrations.utils import column_exists
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "367a3982fcde"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    if not column_exists("model_instances", "drain_started_at"):
+        op.add_column(
+            "model_instances",
+            sa.Column("drain_started_at", UTCDateTime(), nullable=True),
+        )
+    if not column_exists("model_instances", "drain_idle"):
+        op.add_column(
+            "model_instances",
+            sa.Column(
+                "drain_idle",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if column_exists("model_instances", "drain_idle"):
+        op.drop_column("model_instances", "drain_idle")
+    if column_exists("model_instances", "drain_started_at"):
+        op.drop_column("model_instances", "drain_started_at")

--- a/gpustack/routes/model_instances.py
+++ b/gpustack/routes/model_instances.py
@@ -2,8 +2,13 @@ import asyncio
 import json
 from typing import List, Optional, Tuple
 import aiohttp
-from fastapi import APIRouter, Request, status, HTTPException
-from fastapi.responses import PlainTextResponse, StreamingResponse, RedirectResponse
+from fastapi import APIRouter, Request, status, HTTPException, Response
+from fastapi.responses import (
+    PlainTextResponse,
+    StreamingResponse,
+    RedirectResponse,
+    JSONResponse,
+)
 from urllib.parse import urlencode
 
 from gpustack.api.responses import StreamingResponseWithStatusCode
@@ -508,8 +513,24 @@ async def update_model_instance(
     return model_instance
 
 
+def _drain_accepted_response(model_instance: ModelInstance) -> JSONResponse:
+    """202 Accepted body for RUNNING→DRAINING and idempotent DRAINING DELETE."""
+    return JSONResponse(
+        status_code=status.HTTP_202_ACCEPTED,
+        content=ModelInstancePublic.model_validate(model_instance).model_dump(
+            mode="json"
+        ),
+    )
+
+
 @router.delete("/{id}")
 async def delete_model_instance(session: SessionDep, ctx: TenantContextDep, id: int):
+    """Gracefully delete a RUNNING instance (DRAINING), or hard-delete otherwise.
+
+    RUNNING → DRAINING (202): wait for in-flight requests / drain timeout.
+    Already DRAINING → idempotent 202.
+    Other states → immediate hard-delete (204).
+    """
     model_instance = await ModelInstance.one_by_id(session, id, for_update=True)
     assert_resource_visible(
         ctx,
@@ -518,8 +539,18 @@ async def delete_model_instance(session: SessionDep, ctx: TenantContextDep, id: 
     )
 
     try:
+        if model_instance.state == ModelInstanceStateEnum.DRAINING:
+            return _drain_accepted_response(model_instance)
+
+        if model_instance.state == ModelInstanceStateEnum.RUNNING:
+            await ModelInstanceService(session).begin_drain([model_instance])
+            await model_instance.refresh(session)
+            return _drain_accepted_response(model_instance)
+
         await ModelInstanceService(session).delete(model_instance)
     except Exception as e:
         raise InternalServerErrorException(
             message=f"Failed to delete model instance: {e}"
         )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gpustack/routes/worker/proxy.py
+++ b/gpustack/routes/worker/proxy.py
@@ -70,6 +70,23 @@ async def proxy(path: str, request: Request):  # noqa: C901
             detail="Missing target port; ensure the request includes the routing header",
         )
 
+    target_instance_id = getattr(request.state, "x_target_instance_id", None)
+    begin_fn = getattr(request.app.state, "begin_proxy_request", None)
+    end_fn = getattr(request.app.state, "end_proxy_request", None)
+    # Exactly one of (stream finally, outer finally) must decrement inflight.
+    # After StreamingResponse is created, ownership moves to the stream.
+    decremented = {"done": False}
+    owned_by_stream = False
+
+    def _end_inflight():
+        if decremented["done"] or target_instance_id is None or not end_fn:
+            return
+        decremented["done"] = True
+        end_fn(int(target_instance_id))
+
+    if target_instance_id is not None and begin_fn:
+        begin_fn(int(target_instance_id))
+
     try:
         logger.debug(
             f"Proxying request to worker at port {target_service_port} for path: {path}"
@@ -91,8 +108,11 @@ async def proxy(path: str, request: Request):  # noqa: C901
             content = await request.body()
 
         async def stream_response(resp):
-            async for chunk in resp.content.iter_chunked(1024):
-                yield chunk
+            try:
+                async for chunk in resp.content.iter_chunked(1024):
+                    yield chunk
+            finally:
+                _end_inflight()
 
         use_proxy_env = use_proxy_env_for_url(url)
         http_client: aiohttp.ClientSession = (
@@ -114,7 +134,6 @@ async def proxy(path: str, request: Request):  # noqa: C901
         # For streaming responses the status is available before body
         # transfer, so a mid-stream failure will still be counted — this is
         # acceptable as a best-effort optimisation.
-        target_instance_id = getattr(request.state, "x_target_instance_id", None)
         if resp.status < 400 and target_instance_id:
             record_fn = getattr(request.app.state, "record_successful_inference", None)
             if record_fn:
@@ -130,6 +149,7 @@ async def proxy(path: str, request: Request):  # noqa: C901
         # Starlette's MutableHeaders.update.
         for k, v in _filter_response_headers(resp.headers):
             response.headers.append(k, v)
+        owned_by_stream = True
         return response
 
     except asyncio.TimeoutError as e:
@@ -148,6 +168,9 @@ async def proxy(path: str, request: Request):  # noqa: C901
             message=error_message,
             is_openai_exception=True,
         )
+    finally:
+        if not owned_by_stream:
+            _end_inflight()
 
 
 def localhost_fallback() -> str:
@@ -180,6 +203,30 @@ async def set_port_from_model_name(request: Request, call_next):
     if model_name is None:
         return await call_next(request)
     try:
+        model_instance_id = None
+        try:
+            model_instance_id = get_instance_id_from_header(request.headers)
+        except (HTTPException, NotFoundException):
+            model_instance_id = None
+
+        is_draining_fn = getattr(request.app.state, "is_instance_draining", None)
+        if (
+            model_instance_id is not None
+            and is_draining_fn
+            and is_draining_fn(model_instance_id)
+        ):
+            return JSONResponse(
+                status_code=503,
+                content=ErrorResponse(
+                    code=503,
+                    reason="Service Unavailable",
+                    message=(
+                        f"Model instance {model_instance_id} is draining; "
+                        "rejecting new requests"
+                    ),
+                ).model_dump(),
+            )
+
         port, model_instance_id = get_model_instance_info_from_model_name(request)
         request.scope["path"] = f"/proxy{request.url.path}"
         request.state.x_target_port = str(port)

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -604,6 +604,9 @@ class ModelInstanceStateEnum(str, Enum):
                                   |                  ERROR                                       |(Worker unreachable)
                                   └--------------------┘                                         v
                                     (Restart on Error)                                       UNREACHABLE
+
+    Scale-down / DELETE of a RUNNING instance goes RUNNING ---> DRAINING ---> (hard delete).
+    DRAINING is sticky: excluded from LB / ready_replicas; ServeManager must not revive it.
     """
 
     INITIALIZING = "initializing"
@@ -615,6 +618,7 @@ class ModelInstanceStateEnum(str, Enum):
     DOWNLOADING = "downloading"
     ANALYZING = "analyzing"
     UNREACHABLE = "unreachable"
+    DRAINING = "draining"
 
     def __str__(self):
         return self.value
@@ -730,6 +734,12 @@ class ModelInstanceBase(SQLModel, ModelSource):
     last_restart_time: Optional[datetime] = Field(
         sa_column=Column(UTCDateTime), default=None
     )
+    # Set when entering DRAINING; used by the drain finalizer timeout.
+    drain_started_at: Optional[datetime] = Field(
+        sa_column=Column(UTCDateTime), default=None
+    )
+    # Worker reports True when in-flight proxy requests for this instance hit 0.
+    drain_idle: bool = Field(default=False)
     state: ModelInstanceStateEnum = ModelInstanceStateEnum.PENDING
     state_message: Optional[str] = Field(
         default=None, sa_column=Column(Text, nullable=True)

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -297,6 +297,11 @@ class ModelInstanceController:
             )
 
 
+def _non_draining(instances: List[ModelInstance]) -> List[ModelInstance]:
+    """Active replicas: everything except rows already in graceful delete."""
+    return [i for i in instances if i.state != ModelInstanceStateEnum.DRAINING]
+
+
 async def sync_replicas(session: AsyncSession, model: Model):
     """
     Synchronize the replicas.
@@ -339,24 +344,57 @@ async def sync_replicas(session: AsyncSession, model: Model):
             await ModelInstanceService(session).create(instance)
             logger.debug(f"Created model instance for model {model.name}")
 
-    elif len(instances) > model.replicas:
-        # Get instances for update lock, to avoid race condition with scheduler
-        instances = await ModelInstance.all_by_field(
-            session, "model_id", model.id, for_update=True
-        )
-        candidates = await find_scale_down_candidates(instances, model)
+    else:
+        # Scale-down targets active (non-draining) replicas. DRAINING rows still
+        # count toward len(instances), so we do not create replacements while
+        # graceful delete is in progress.
+        active_instances = _non_draining(instances)
+        if len(active_instances) > model.replicas:
+            # Get instances for update lock, to avoid race condition with scheduler
+            instances = await ModelInstance.all_by_field(
+                session, "model_id", model.id, for_update=True
+            )
+            active_instances = _non_draining(instances)
+            if len(active_instances) <= model.replicas:
+                return
 
-        scale_down_count = len(candidates) - model.replicas
-        if scale_down_count > 0:
-            scale_down_instances = []
-            for candidate in candidates[:scale_down_count]:
-                scale_down_instances.append(candidate.model_instance)
+            candidates = await find_scale_down_candidates(active_instances, model)
 
-            scale_down_instance_names = await ModelInstanceService(
-                session
-            ).batch_delete(scale_down_instances)
-            if scale_down_instance_names:
-                logger.debug(f"Deleted model instances: {scale_down_instance_names}")
+            scale_down_count = len(candidates) - model.replicas
+            if scale_down_count > 0:
+                scale_down_instances = []
+                for candidate in candidates[:scale_down_count]:
+                    scale_down_instances.append(candidate.model_instance)
+
+                # RUNNING → DRAINING (graceful); non-RUNNING → hard-delete.
+                to_drain = [
+                    mi
+                    for mi in scale_down_instances
+                    if mi.state == ModelInstanceStateEnum.RUNNING
+                ]
+                to_delete = [
+                    mi
+                    for mi in scale_down_instances
+                    if mi.state != ModelInstanceStateEnum.RUNNING
+                ]
+
+                if to_drain:
+                    drained_names = await ModelInstanceService(session).begin_drain(
+                        to_drain
+                    )
+                    if drained_names:
+                        logger.debug(
+                            f"Draining model instances for scale-down: {drained_names}"
+                        )
+
+                if to_delete:
+                    deleted_names = await ModelInstanceService(session).batch_delete(
+                        to_delete
+                    )
+                    if deleted_names:
+                        logger.debug(
+                            f"Deleted model instances for scale-down: {deleted_names}"
+                        )
 
 
 async def distribute_models_to_user(

--- a/gpustack/server/model_instance_drain_finalizer.py
+++ b/gpustack/server/model_instance_drain_finalizer.py
@@ -1,0 +1,95 @@
+"""Lightweight finalizer for gracefully drained model replicas.
+
+When a model instance enters DRAINING (scale-down or DELETE), this loop waits
+until the worker reports ``drain_idle`` or ``MODEL_INSTANCE_DRAIN_TIMEOUT``
+elapses, then hard-deletes the row so ServeManager's existing reap path tears
+down the workload. Intentionally not a CR-style multi-cluster finalizer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import List
+
+from gpustack import envs
+from gpustack.schemas.models import ModelInstance, ModelInstanceStateEnum
+from gpustack.server.db import async_session
+from gpustack.server.services import ModelInstanceService
+
+logger = logging.getLogger(__name__)
+
+
+def _drain_timed_out(mi: ModelInstance, now: datetime, timeout_seconds: int) -> bool:
+    if not mi.drain_started_at:
+        # Missing timestamp: treat as already expired so we cannot stick forever.
+        return True
+    started = mi.drain_started_at
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    return (now - started).total_seconds() >= timeout_seconds
+
+
+class ModelInstanceDrainFinalizer:
+    """Periodically hard-deletes DRAINING instances that are idle or timed out."""
+
+    def __init__(
+        self,
+        interval: float | None = None,
+        timeout_seconds: int | None = None,
+    ):
+        self._interval = (
+            interval
+            if interval is not None
+            else float(envs.MODEL_INSTANCE_DRAIN_FINALIZER_INTERVAL)
+        )
+        self._timeout_seconds = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else envs.MODEL_INSTANCE_DRAIN_TIMEOUT
+        )
+
+    async def start(self):
+        logger.debug("Model instance drain finalizer started.")
+        while True:
+            try:
+                await self.reconcile()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(f"Model instance drain finalizer error: {e}")
+            await asyncio.sleep(self._interval)
+
+    async def reconcile(self) -> List[str]:
+        """Hard-delete draining instances that are ready. Returns deleted names."""
+        deleted: List[str] = []
+        now = datetime.now(timezone.utc)
+
+        async with async_session() as session:
+            draining = await ModelInstance.all_by_field(
+                session,
+                "state",
+                ModelInstanceStateEnum.DRAINING,
+                for_update=True,
+            )
+            if not draining:
+                return deleted
+
+            service = ModelInstanceService(session)
+            to_delete = []
+            for mi in draining:
+                idle = bool(mi.drain_idle)
+                timed_out = _drain_timed_out(mi, now, self._timeout_seconds)
+                if idle or timed_out:
+                    reason = "idle" if idle else "timeout"
+                    logger.info(
+                        f"Hard-deleting draining model instance {mi.name} "
+                        f"(id={mi.id}, reason={reason})"
+                    )
+                    to_delete.append(mi)
+
+            if to_delete:
+                deleted = await service.batch_delete(to_delete)
+
+        return deleted

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -90,6 +90,7 @@ from gpustack.server.usage_archiver import TableArchiver
 from gpustack.schemas.metered_usage import MeteredUsage, MeteredUsageArchive
 from gpustack.schemas.resource_events import ResourceEvent, ResourceEventArchive
 from gpustack.server.worker_instance_cleaner import WorkerInstanceCleaner
+from gpustack.server.model_instance_drain_finalizer import ModelInstanceDrainFinalizer
 from gpustack.server.worker_syncer import WorkerSyncer
 from gpustack.server.scaling_scheduler import ScalingScheduler
 from gpustack.utils.platform import is_inside_kubernetes
@@ -488,6 +489,12 @@ class Server:
         self._create_async_task(worker_instance_cleaner.start())
 
         logger.debug("Worker instance cleaner started.")
+
+    def _start_model_instance_drain_finalizer(self):
+        drain_finalizer = ModelInstanceDrainFinalizer()
+        self._create_async_task(drain_finalizer.start())
+
+        logger.debug("Model instance drain finalizer started.")
 
     def _start_scaling_scheduler(self):
         scaling_scheduler = ScalingScheduler()
@@ -1377,6 +1384,9 @@ class Server:
 
         # Worker Instance Cleaner
         self._start_worker_instance_cleaner()
+
+        # Model instance drain finalizer (graceful replica delete)
+        self._start_model_instance_drain_finalizer()
 
         # Usage Details Archiver (move aged rows to archive table)
         self._start_usage_details_archiver()

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -55,7 +55,6 @@ class RouteTargetResolution(NamedTuple):
 
 
 class UserService:
-
     def __init__(self, session: AsyncSession):
         self.session = session
 
@@ -180,7 +179,7 @@ class UserService:
         )
         if not allowed:
             logger.info(
-                "Access denied: model_name=%r user_id=%d " "accessible=%s limited=%s",
+                "Access denied: model_name=%r user_id=%d accessible=%s limited=%s",
                 model_name,
                 user_id,
                 sorted(accessible_model_names),
@@ -996,6 +995,55 @@ class ModelInstanceService:
             await self.session.rollback()
             raise InternalServerErrorException(
                 message=f"Failed to update model instances {names}: {e}"
+            )
+
+    async def begin_drain(self, model_instances: List[ModelInstance]) -> List[str]:
+        """Mark RUNNING instances as DRAINING for graceful teardown.
+
+        Excludes them from LB immediately (get_running_instances filters
+        RUNNING only). Hard-delete is deferred to the drain finalizer once
+        the worker reports idle or the drain timeout elapses.
+        """
+        if not model_instances:
+            return []
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        to_drain: List[ModelInstance] = []
+        for mi in model_instances:
+            if mi.state == ModelInstanceStateEnum.DRAINING:
+                continue
+            to_drain.append(mi)
+
+        if not to_drain:
+            return []
+
+        names = [mi.name for mi in to_drain]
+        ids: Set[int] = set()
+        try:
+            for mi in to_drain:
+                await mi.update(
+                    self.session,
+                    {
+                        "state": ModelInstanceStateEnum.DRAINING,
+                        "state_message": "Draining: waiting for in-flight requests",
+                        "drain_started_at": now,
+                        "drain_idle": False,
+                    },
+                    auto_commit=False,
+                )
+                ids.add(mi.model_id)
+            await self.session.commit()
+            await ModelInstance._invalidate_cached_all()
+
+            for model_id in ids:
+                await delete_cache_by_key(self.get_running_instances, model_id)
+            await invalidate_workers_allocated(to_drain)
+
+            return names
+        except Exception as e:
+            await self.session.rollback()
+            raise InternalServerErrorException(
+                message=f"Failed to drain model instances {names}: {e}"
             )
 
 

--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -220,6 +220,12 @@ class ServeManager:
         # Track last health check time per model instance
         self._last_health_check_time: Dict[int, float] = {}
 
+        # Graceful drain: instances waiting for in-flight proxy requests to finish
+        self._draining_instance_ids: Set[int] = set()
+        self._inflight_requests: Dict[int, int] = {}
+        # Avoid spamming drain_idle PATCHes once the server already knows.
+        self._drain_idle_reported: Set[int] = set()
+
         # Timestamp of the last authoritative (uncached) DB reconciliation in
         # the state sync, for the optional periodic backstop. Starts "now" so
         # the first forced reconciliation is one full period in, not immediate.
@@ -230,6 +236,63 @@ class ServeManager:
     def record_successful_inference(self, instance_id: int):
         """Called by worker proxy on successful inference response."""
         self._last_successful_inference[instance_id] = time.time()
+
+    def is_instance_draining(self, instance_id: int) -> bool:
+        return instance_id in self._draining_instance_ids
+
+    def begin_proxy_request(self, instance_id: int):
+        """Increment in-flight count for a proxied inference request."""
+        self._inflight_requests[instance_id] = (
+            self._inflight_requests.get(instance_id, 0) + 1
+        )
+
+    def end_proxy_request(self, instance_id: int):
+        """Decrement in-flight count; report drain idle when it hits zero."""
+        count = self._inflight_requests.get(instance_id, 0) - 1
+        if count <= 0:
+            self._inflight_requests.pop(instance_id, None)
+            if instance_id in self._draining_instance_ids:
+                self._report_drain_idle(instance_id)
+        else:
+            self._inflight_requests[instance_id] = count
+
+    def _mark_draining(self, mi: ModelInstance):
+        self._draining_instance_ids.add(mi.id)
+        self._model_instance_by_instance_id[mi.id] = mi
+        if mi.drain_idle:
+            self._drain_idle_reported.add(mi.id)
+        elif self._inflight_requests.get(mi.id, 0) == 0:
+            self._report_drain_idle(mi.id)
+
+    def _report_drain_idle(self, instance_id: int):
+        """Tell the server this draining instance has no in-flight requests.
+
+        Idempotent: once reported (or already drain_idle on the cached row),
+        further calls are no-ops so health sync does not PATCH every tick.
+
+        The HTTP call is offloaded to a daemon thread to avoid blocking the
+        async event loop (this is called from the proxy route handler).
+        """
+        if instance_id in self._drain_idle_reported:
+            return
+        cached = self._model_instance_by_instance_id.get(instance_id)
+        if cached is not None and cached.drain_idle:
+            self._drain_idle_reported.add(instance_id)
+            return
+
+        def do_report():
+            try:
+                self._update_model_instance(instance_id, drain_idle=True)
+                self._drain_idle_reported.add(instance_id)
+                if cached is not None:
+                    cached.drain_idle = True
+                logger.info(f"Reported drain idle for model instance id={instance_id}")
+            except Exception as e:
+                logger.warning(
+                    f"Failed to report drain idle for model instance id={instance_id}: {e}"
+                )
+
+        threading.Thread(target=do_report, daemon=True).start()
 
     async def watch_models(self):
         """
@@ -406,6 +469,32 @@ class ServeManager:
                 logger.trace(
                     f"Model instance {model_instance.name} is provisioning. Skipping sync."
                 )
+                continue
+
+            # DRAINING is sticky: do not revive to RUNNING / ERROR via health sync.
+            # If the workload is already gone, report idle so the finalizer can finish.
+            if model_instance.state == ModelInstanceStateEnum.DRAINING:
+                self._draining_instance_ids.add(model_instance.id)
+                if model_instance.drain_idle:
+                    self._drain_idle_reported.add(model_instance.id)
+                is_main_worker = model_instance.worker_id == self._worker_id
+                if is_main_worker:
+                    workload = get_workload(model_instance.name)
+                else:
+                    deployment_metadata = model_instance.get_deployment_metadata(
+                        self._worker_id
+                    )
+                    workload_name = (
+                        deployment_metadata.name
+                        if deployment_metadata
+                        else model_instance.name
+                    )
+                    workload = get_workload(workload_name)
+                if (
+                    not workload
+                    and self._inflight_requests.get(model_instance.id, 0) == 0
+                ):
+                    self._report_drain_idle(model_instance.id)
                 continue
 
             is_main_worker = model_instance.worker_id == self._worker_id
@@ -1004,6 +1093,9 @@ class ServeManager:
             # DELETEDs missed during a watch disconnect. Tearing down here too
             # would give a second concurrent caller racing the reap on
             # delete_workload, so just let the reap reap it (within one tick).
+            self._draining_instance_ids.discard(mi.id)
+            self._inflight_requests.pop(mi.id, None)
+            self._drain_idle_reported.discard(mi.id)
             logger.trace(
                 f"DELETED event for model instance {mi.name}; "
                 "teardown deferred to reap."
@@ -1011,6 +1103,16 @@ class ServeManager:
             return
 
         if event.type == EventType.UPDATED:
+            # Graceful drain: keep workload alive, reject new proxy traffic,
+            # report idle when in-flight hits zero. Do not restart or stop.
+            if mi.state == ModelInstanceStateEnum.DRAINING:
+                self._mark_draining(mi)
+                logger.trace(
+                    f"UPDATED event: model instance {mi.name} is draining; "
+                    "teardown deferred until hard-delete."
+                )
+                return
+
             # Caching matched ERROR instances for restart handling.
             if mi.state == ModelInstanceStateEnum.ERROR:
                 model = self._get_model(mi)
@@ -1786,6 +1888,9 @@ class ServeManager:
         self._inference_health_check_failures.pop(mi.id, None)
         self._last_health_check_time.pop(mi.id, None)
         self._last_successful_inference.pop(mi.id, None)
+        self._draining_instance_ids.discard(mi.id)
+        self._inflight_requests.pop(mi.id, None)
+        self._drain_idle_reported.discard(mi.id)
 
         logger.info(f"Stopped model instance {mi.name or mi.id}")
 

--- a/gpustack/worker/worker.py
+++ b/gpustack/worker/worker.py
@@ -365,6 +365,9 @@ class Worker:
         app.state.record_successful_inference = (
             self._serve_manager.record_successful_inference
         )
+        app.state.is_instance_draining = self._serve_manager.is_instance_draining
+        app.state.begin_proxy_request = self._serve_manager.begin_proxy_request
+        app.state.end_proxy_request = self._serve_manager.end_proxy_request
         app.add_middleware(BaseHTTPMiddleware, dispatch=proxy.set_port_from_model_name)
         app.include_router(
             route_config.router,

--- a/tests/routes/test_model_instance_delete_drain.py
+++ b/tests/routes/test_model_instance_delete_drain.py
@@ -1,0 +1,126 @@
+"""Tests for DELETE /model-instances graceful drain."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import status
+
+from gpustack.routes import model_instances as routes
+from gpustack.schemas.models import ModelInstanceStateEnum
+
+
+def _ctx():
+    return MagicMock()
+
+
+def _mi(*, state, id=1, name="m-a"):
+    mi = MagicMock()
+    mi.id = id
+    mi.name = name
+    mi.state = state
+    mi.refresh = AsyncMock()
+    return mi
+
+
+@pytest.mark.asyncio
+async def test_delete_running_enters_draining_202():
+    mi = _mi(state=ModelInstanceStateEnum.RUNNING)
+
+    async def _refresh(_session):
+        mi.state = ModelInstanceStateEnum.DRAINING
+
+    mi.refresh = _refresh
+    session = MagicMock()
+    begin_drain = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.routes.model_instances.ModelInstance.one_by_id",
+            new=AsyncMock(return_value=mi),
+        ),
+        patch("gpustack.routes.model_instances.assert_resource_visible"),
+        patch("gpustack.routes.model_instances.ModelInstanceService") as service_cls,
+        patch(
+            "gpustack.routes.model_instances.ModelInstancePublic.model_validate",
+            side_effect=lambda obj: MagicMock(
+                model_dump=lambda mode="json": {
+                    "id": obj.id,
+                    "name": obj.name,
+                    "state": str(obj.state),
+                }
+            ),
+        ),
+    ):
+        service = MagicMock()
+        service.begin_drain = begin_drain
+        service.delete = AsyncMock()
+        service_cls.return_value = service
+
+        resp = await routes.delete_model_instance(session, _ctx(), 1)
+
+    assert resp.status_code == status.HTTP_202_ACCEPTED
+    begin_drain.assert_awaited_once()
+    service.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_already_draining_idempotent_202():
+    mi = _mi(state=ModelInstanceStateEnum.DRAINING)
+    session = MagicMock()
+    begin_drain = AsyncMock()
+    delete = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.routes.model_instances.ModelInstance.one_by_id",
+            new=AsyncMock(return_value=mi),
+        ),
+        patch("gpustack.routes.model_instances.assert_resource_visible"),
+        patch("gpustack.routes.model_instances.ModelInstanceService") as service_cls,
+        patch(
+            "gpustack.routes.model_instances.ModelInstancePublic.model_validate",
+            side_effect=lambda obj: MagicMock(
+                model_dump=lambda mode="json": {
+                    "id": obj.id,
+                    "state": "draining",
+                }
+            ),
+        ),
+    ):
+        service = MagicMock()
+        service.begin_drain = begin_drain
+        service.delete = delete
+        service_cls.return_value = service
+
+        resp = await routes.delete_model_instance(session, _ctx(), 1)
+
+    assert resp.status_code == status.HTTP_202_ACCEPTED
+    begin_drain.assert_not_awaited()
+    delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_pending_hard_deletes_204():
+    mi = _mi(state=ModelInstanceStateEnum.PENDING)
+    session = MagicMock()
+    begin_drain = AsyncMock()
+    delete = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.routes.model_instances.ModelInstance.one_by_id",
+            new=AsyncMock(return_value=mi),
+        ),
+        patch("gpustack.routes.model_instances.assert_resource_visible"),
+        patch("gpustack.routes.model_instances.ModelInstanceService") as service_cls,
+    ):
+        service = MagicMock()
+        service.begin_drain = begin_drain
+        service.delete = delete
+        service_cls.return_value = service
+
+        resp = await routes.delete_model_instance(session, _ctx(), 1)
+
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    begin_drain.assert_not_awaited()
+    delete.assert_awaited_once_with(mi)

--- a/tests/server/test_draining_lb_exclusion.py
+++ b/tests/server/test_draining_lb_exclusion.py
@@ -1,0 +1,66 @@
+"""LB / ready_replicas exclusion of DRAINING instances."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gpustack.schemas.models import ModelInstanceStateEnum
+from gpustack.server.controllers import sync_ready_replicas
+from gpustack.server.services import ModelInstanceService
+from tests.utils.model import new_model_instance
+
+
+@pytest.mark.asyncio
+async def test_sync_ready_replicas_excludes_draining():
+    model = MagicMock()
+    model.deleted_at = None
+    model.id = 1
+    model.ready_replicas = 2
+    running = new_model_instance(
+        1, "m-a", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    draining = new_model_instance(
+        2, "m-b", 1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+
+    session = MagicMock()
+    update = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.server.controllers.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=[running, draining]),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelService",
+        ) as service_cls,
+    ):
+        service = MagicMock()
+        service.update = update
+        service_cls.return_value = service
+
+        updated = await sync_ready_replicas(session, model)
+
+    assert updated is True
+    assert model.ready_replicas == 1
+    update.assert_awaited_once_with(model)
+
+
+@pytest.mark.asyncio
+async def test_get_running_instances_filter_is_running_only():
+    """Document the LB contract: get_running_instances queries state=RUNNING."""
+    session = MagicMock()
+    service = ModelInstanceService(session)
+
+    with patch(
+        "gpustack.server.services.ModelInstance.all_by_fields",
+        new=AsyncMock(return_value=[]),
+    ) as all_by_fields:
+        await service.get_running_instances.__wrapped__(service, 42)
+
+    all_by_fields.assert_awaited_once()
+    kwargs = all_by_fields.await_args.kwargs
+    assert kwargs["fields"] == {
+        "model_id": 42,
+        "state": ModelInstanceStateEnum.RUNNING,
+    }

--- a/tests/server/test_model_instance_drain_finalizer.py
+++ b/tests/server/test_model_instance_drain_finalizer.py
@@ -1,0 +1,219 @@
+"""Tests for ModelInstanceDrainFinalizer."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gpustack.schemas.models import ModelInstanceStateEnum
+from gpustack.server.model_instance_drain_finalizer import (
+    ModelInstanceDrainFinalizer,
+    _drain_timed_out,
+)
+from tests.utils.mock import mock_async_session
+from tests.utils.model import new_model_instance
+
+
+def test_drain_timed_out_false_within_window():
+    mi = new_model_instance(1, "m-a", 1, state=ModelInstanceStateEnum.DRAINING)
+    mi.drain_started_at = datetime.now(timezone.utc) - timedelta(seconds=10)
+    now = datetime.now(timezone.utc)
+    assert _drain_timed_out(mi, now, timeout_seconds=120) is False
+
+
+def test_drain_timed_out_true_after_window():
+    mi = new_model_instance(1, "m-a", 1, state=ModelInstanceStateEnum.DRAINING)
+    mi.drain_started_at = datetime.now(timezone.utc) - timedelta(seconds=200)
+    now = datetime.now(timezone.utc)
+    assert _drain_timed_out(mi, now, timeout_seconds=120) is True
+
+
+def test_drain_timed_out_missing_started_at():
+    mi = new_model_instance(1, "m-a", 1, state=ModelInstanceStateEnum.DRAINING)
+    mi.drain_started_at = None
+    now = datetime.now(timezone.utc)
+    assert _drain_timed_out(mi, now, timeout_seconds=120) is True
+
+
+@pytest.mark.asyncio
+async def test_reconcile_deletes_when_idle():
+    mi = new_model_instance(1, "m-a", 1, state=ModelInstanceStateEnum.DRAINING)
+    mi.drain_idle = True
+    mi.drain_started_at = datetime.now(timezone.utc)
+
+    session_cm = mock_async_session()
+    batch_delete = AsyncMock(return_value=["m-a"])
+    delete = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.async_session",
+            return_value=session_cm,
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=[mi]),
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstanceService"
+        ) as service_cls,
+    ):
+        service = MagicMock()
+        service.batch_delete = batch_delete
+        service.delete = delete
+        service_cls.return_value = service
+
+        finalizer = ModelInstanceDrainFinalizer(timeout_seconds=120)
+        deleted = await finalizer.reconcile()
+
+    assert deleted == ["m-a"]
+    batch_delete.assert_awaited_once_with([mi])
+    delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_keeps_busy_until_timeout():
+    mi = new_model_instance(1, "m-a", 1, state=ModelInstanceStateEnum.DRAINING)
+    mi.drain_idle = False
+    mi.drain_started_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+
+    session_cm = mock_async_session()
+    batch_delete = AsyncMock()
+    delete = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.async_session",
+            return_value=session_cm,
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=[mi]),
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstanceService"
+        ) as service_cls,
+    ):
+        service = MagicMock()
+        service.batch_delete = batch_delete
+        service.delete = delete
+        service_cls.return_value = service
+
+        finalizer = ModelInstanceDrainFinalizer(timeout_seconds=120)
+        deleted = await finalizer.reconcile()
+
+    assert deleted == []
+    batch_delete.assert_not_awaited()
+    delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_force_deletes_on_timeout():
+    mi = new_model_instance(1, "m-a", 1, state=ModelInstanceStateEnum.DRAINING)
+    mi.drain_idle = False
+    mi.drain_started_at = datetime.now(timezone.utc) - timedelta(seconds=200)
+
+    session_cm = mock_async_session()
+    batch_delete = AsyncMock(return_value=["m-a"])
+    delete = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.async_session",
+            return_value=session_cm,
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=[mi]),
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstanceService"
+        ) as service_cls,
+    ):
+        service = MagicMock()
+        service.batch_delete = batch_delete
+        service.delete = delete
+        service_cls.return_value = service
+
+        finalizer = ModelInstanceDrainFinalizer(timeout_seconds=120)
+        deleted = await finalizer.reconcile()
+
+    assert deleted == ["m-a"]
+    batch_delete.assert_awaited_once_with([mi])
+    delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_batch_deletes_multiple_instances():
+    mi_a = new_model_instance(1, "m-a", 1, state=ModelInstanceStateEnum.DRAINING)
+    mi_a.drain_idle = True
+    mi_a.drain_started_at = datetime.now(timezone.utc)
+
+    mi_b = new_model_instance(2, "m-b", 2, state=ModelInstanceStateEnum.DRAINING)
+    mi_b.drain_idle = False
+    mi_b.drain_started_at = datetime.now(timezone.utc) - timedelta(seconds=200)
+
+    session_cm = mock_async_session()
+    batch_delete = AsyncMock(return_value=["m-a", "m-b"])
+    delete = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.async_session",
+            return_value=session_cm,
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=[mi_a, mi_b]),
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstanceService"
+        ) as service_cls,
+    ):
+        service = MagicMock()
+        service.batch_delete = batch_delete
+        service.delete = delete
+        service_cls.return_value = service
+
+        finalizer = ModelInstanceDrainFinalizer(timeout_seconds=120)
+        deleted = await finalizer.reconcile()
+
+    assert deleted == ["m-a", "m-b"]
+    batch_delete.assert_awaited_once_with([mi_a, mi_b])
+    delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_no_delete_when_none_ready():
+    mi = new_model_instance(1, "m-a", 1, state=ModelInstanceStateEnum.DRAINING)
+    mi.drain_idle = False
+    mi.drain_started_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+
+    session_cm = mock_async_session()
+    batch_delete = AsyncMock()
+    delete = AsyncMock()
+
+    with (
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.async_session",
+            return_value=session_cm,
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=[mi]),
+        ),
+        patch(
+            "gpustack.server.model_instance_drain_finalizer.ModelInstanceService"
+        ) as service_cls,
+    ):
+        service = MagicMock()
+        service.batch_delete = batch_delete
+        service.delete = delete
+        service_cls.return_value = service
+
+        finalizer = ModelInstanceDrainFinalizer(timeout_seconds=120)
+        deleted = await finalizer.reconcile()
+
+    assert deleted == []
+    batch_delete.assert_not_awaited()
+    delete.assert_not_awaited()

--- a/tests/server/test_sync_replicas_drain.py
+++ b/tests/server/test_sync_replicas_drain.py
@@ -1,0 +1,182 @@
+"""Tests for graceful scale-down via DRAINING."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gpustack.schemas.models import ModelInstanceStateEnum
+from gpustack.server.controllers import sync_replicas
+from tests.utils.model import new_model, new_model_instance
+
+
+def _patch_service(begin_drain=None, batch_delete=None, create=None):
+    service = MagicMock()
+    service.begin_drain = begin_drain or AsyncMock(return_value=[])
+    service.batch_delete = batch_delete or AsyncMock(return_value=[])
+    service.create = create or AsyncMock()
+    return service
+
+
+@pytest.mark.asyncio
+async def test_sync_replicas_scale_down_drains_running_not_delete():
+    model = new_model(1, "m", replicas=1, huggingface_repo_id="org/m")
+    running_a = new_model_instance(
+        1, "m-a", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    running_b = new_model_instance(
+        2, "m-b", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    instances = [running_a, running_b]
+
+    session = MagicMock()
+    begin_drain = AsyncMock(return_value=["m-b"])
+    batch_delete = AsyncMock(return_value=[])
+    service = _patch_service(begin_drain=begin_drain, batch_delete=batch_delete)
+
+    with (
+        patch(
+            "gpustack.server.controllers.Model.one_by_id",
+            new=AsyncMock(return_value=model),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=instances),
+        ),
+        patch(
+            "gpustack.server.controllers.find_scale_down_candidates",
+            new=AsyncMock(
+                return_value=[
+                    MagicMock(model_instance=running_b, score=10),
+                    MagicMock(model_instance=running_a, score=100),
+                ]
+            ),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstanceService",
+            return_value=service,
+        ),
+    ):
+        await sync_replicas(session, model)
+
+    begin_drain.assert_awaited_once()
+    drained = begin_drain.await_args.args[0]
+    assert drained == [running_b]
+    batch_delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_replicas_does_not_drain_already_draining_twice():
+    model = new_model(1, "m", replicas=1, huggingface_repo_id="org/m")
+    running = new_model_instance(
+        1, "m-a", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    draining = new_model_instance(
+        2, "m-b", 1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    instances = [running, draining]
+
+    session = MagicMock()
+    begin_drain = AsyncMock(return_value=[])
+    batch_delete = AsyncMock(return_value=[])
+    create = AsyncMock()
+    service = _patch_service(
+        begin_drain=begin_drain, batch_delete=batch_delete, create=create
+    )
+
+    with (
+        patch(
+            "gpustack.server.controllers.Model.one_by_id",
+            new=AsyncMock(return_value=model),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=instances),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstanceService",
+            return_value=service,
+        ),
+    ):
+        await sync_replicas(session, model)
+
+    begin_drain.assert_not_awaited()
+    batch_delete.assert_not_awaited()
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_replicas_no_scale_up_while_draining_keeps_count():
+    """Draining rows count toward len(instances); no premature scale-up."""
+    model = new_model(1, "m", replicas=1, huggingface_repo_id="org/m")
+    draining = new_model_instance(
+        1, "m-a", 1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    instances = [draining]
+
+    session = MagicMock()
+    create = AsyncMock()
+    service = _patch_service(create=create)
+
+    with (
+        patch(
+            "gpustack.server.controllers.Model.one_by_id",
+            new=AsyncMock(return_value=model),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=instances),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstanceService",
+            return_value=service,
+        ),
+    ):
+        await sync_replicas(session, model)
+
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_replicas_hard_deletes_non_running_scale_down():
+    model = new_model(1, "m", replicas=1, huggingface_repo_id="org/m")
+    running = new_model_instance(
+        1, "m-a", 1, worker_id=1, state=ModelInstanceStateEnum.RUNNING
+    )
+    pending = new_model_instance(
+        2, "m-b", 1, worker_id=1, state=ModelInstanceStateEnum.PENDING
+    )
+    instances = [running, pending]
+
+    session = MagicMock()
+    begin_drain = AsyncMock(return_value=[])
+    batch_delete = AsyncMock(return_value=["m-b"])
+    service = _patch_service(begin_drain=begin_drain, batch_delete=batch_delete)
+
+    with (
+        patch(
+            "gpustack.server.controllers.Model.one_by_id",
+            new=AsyncMock(return_value=model),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstance.all_by_field",
+            new=AsyncMock(return_value=instances),
+        ),
+        patch(
+            "gpustack.server.controllers.find_scale_down_candidates",
+            new=AsyncMock(
+                return_value=[
+                    MagicMock(model_instance=pending, score=0),
+                    MagicMock(model_instance=running, score=100),
+                ]
+            ),
+        ),
+        patch(
+            "gpustack.server.controllers.ModelInstanceService",
+            return_value=service,
+        ),
+    ):
+        await sync_replicas(session, model)
+
+    begin_drain.assert_not_awaited()
+    batch_delete.assert_awaited_once()
+    assert batch_delete.await_args.args[0] == [pending]

--- a/tests/server/test_worker_instance_cleaner.py
+++ b/tests/server/test_worker_instance_cleaner.py
@@ -129,3 +129,49 @@ async def test_cleanup_offline_worker_instances_deletes_distributed_instances_wi
     batch_delete.assert_awaited_once()
     deleted_instances = batch_delete.await_args.args[-1]
     assert [item.name for item in deleted_instances] == [instance.name]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_offline_worker_instances_hard_deletes_draining():
+    """Offline workers bypass drain — DRAINING instances are hard-deleted."""
+    offline_worker = _offline_worker(linux_nvidia_1_4090_24gx1())
+
+    instance = new_model_instance(
+        1,
+        "draining-instance",
+        1,
+        worker_id=offline_worker.id,
+        state=ModelInstanceStateEnum.DRAINING,
+    )
+    instance.worker_name = offline_worker.name
+
+    batch_delete = AsyncMock(return_value=[instance.name])
+
+    with (
+        patch(
+            "gpustack.server.worker_instance_cleaner.async_session",
+            return_value=mock_async_session(),
+        ),
+        patch(
+            "gpustack.server.worker_instance_cleaner.Worker.all",
+            AsyncMock(return_value=[offline_worker]),
+        ),
+        patch(
+            "gpustack.server.worker_instance_cleaner.ModelInstance.all",
+            AsyncMock(return_value=[instance]),
+        ),
+        patch(
+            "gpustack.server.worker_instance_cleaner.ModelInstanceService.batch_delete",
+            batch_delete,
+        ),
+        patch(
+            "gpustack.server.worker_instance_cleaner.envs.MODEL_INSTANCE_RESCHEDULE_GRACE_PERIOD",
+            300,
+        ),
+    ):
+        cleaner = WorkerInstanceCleaner()
+        await cleaner._cleanup_offline_worker_instances()
+
+    batch_delete.assert_awaited_once()
+    deleted_instances = batch_delete.await_args.args[-1]
+    assert [item.name for item in deleted_instances] == [instance.name]

--- a/tests/worker/test_proxy_inflight.py
+++ b/tests/worker/test_proxy_inflight.py
@@ -1,0 +1,314 @@
+"""Tests for worker proxy in-flight tracking and draining rejection."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gpustack.api.exceptions import ServiceUnavailableException
+from gpustack.routes.worker import proxy as proxy_mod
+from gpustack.schemas.models import ModelInstanceStateEnum, SourceEnum
+from gpustack.server.bus import Event, EventType
+from tests.utils.model import new_model_instance
+from tests.worker.test_serve_manager import _build_serve_manager
+
+
+def _mi_with_source(**kwargs):
+    mi = new_model_instance(**kwargs)
+    mi.source = SourceEnum.HUGGING_FACE
+    mi.huggingface_repo_id = "org/model"
+    return mi
+
+
+def test_begin_end_proxy_request_reports_idle_when_draining():
+    manager, _ = _build_serve_manager()
+    mi = _mi_with_source(
+        id=7, name="m-a", model_id=1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    manager._draining_instance_ids.add(mi.id)
+
+    with patch.object(manager, "_report_drain_idle") as report:
+        manager.begin_proxy_request(mi.id)
+        assert manager._inflight_requests[mi.id] == 1
+        report.assert_not_called()
+
+        manager.end_proxy_request(mi.id)
+        assert mi.id not in manager._inflight_requests
+        report.assert_called_once_with(mi.id)
+
+
+def test_end_proxy_request_no_idle_report_when_not_draining():
+    manager, _ = _build_serve_manager()
+    with patch.object(manager, "_report_drain_idle") as report:
+        manager.begin_proxy_request(3)
+        manager.end_proxy_request(3)
+        report.assert_not_called()
+
+
+def test_report_drain_idle_is_idempotent():
+    """Once idle is reported, further calls must not spawn another thread."""
+    manager, _ = _build_serve_manager()
+    mi = _mi_with_source(
+        id=1, name="m-a", model_id=1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    mi.drain_idle = False
+    manager._model_instance_by_instance_id[mi.id] = mi
+    manager._draining_instance_ids.add(mi.id)
+
+    with (
+        patch.object(manager, "_update_model_instance") as update,
+        patch("gpustack.worker.serve_manager.threading.Thread") as mock_thread_cls,
+    ):
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        manager._report_drain_idle(mi.id)
+        # Execute the thread target to simulate completion
+        mock_thread_cls.call_args.kwargs["target"]()
+
+        # Second call should be a no-op (already reported)
+        manager._report_drain_idle(mi.id)
+        # Third call should also be a no-op
+        manager._report_drain_idle(mi.id)
+
+    update.assert_called_once_with(mi.id, drain_idle=True)
+    assert mi.id in manager._drain_idle_reported
+    assert mi.drain_idle is True
+    # Only one thread was spawned
+    mock_thread_cls.assert_called_once()
+    assert mock_thread_cls.call_args.kwargs["daemon"] is True
+
+
+def test_report_drain_idle_offloads_to_thread():
+    """The blocking HTTP call must not execute on the calling thread."""
+    manager, _ = _build_serve_manager()
+    mi = _mi_with_source(
+        id=2, name="m-b", model_id=1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    mi.drain_idle = False
+    manager._model_instance_by_instance_id[mi.id] = mi
+    manager._draining_instance_ids.add(mi.id)
+
+    with (
+        patch.object(manager, "_update_model_instance") as update,
+        patch("gpustack.worker.serve_manager.threading.Thread") as mock_thread_cls,
+    ):
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        manager._report_drain_idle(mi.id)
+
+        # The update must NOT have been called synchronously
+        update.assert_not_called()
+        # But a thread was spawned
+        mock_thread_cls.assert_called_once()
+        assert mock_thread_cls.call_args.kwargs["daemon"] is True
+
+        # Simulate thread execution
+        mock_thread_cls.call_args.kwargs["target"]()
+        update.assert_called_once_with(mi.id, drain_idle=True)
+
+
+def test_report_drain_idle_thread_exception_caught():
+    """If the HTTP call fails in the thread, the exception is swallowed and
+    the instance is NOT marked as reported (retry possible)."""
+    manager, _ = _build_serve_manager()
+    mi = _mi_with_source(
+        id=3, name="m-c", model_id=1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    mi.drain_idle = False
+    manager._model_instance_by_instance_id[mi.id] = mi
+    manager._draining_instance_ids.add(mi.id)
+
+    with (
+        patch.object(
+            manager, "_update_model_instance", side_effect=RuntimeError("boom")
+        ) as update,
+        patch("gpustack.worker.serve_manager.threading.Thread") as mock_thread_cls,
+    ):
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        manager._report_drain_idle(mi.id)
+        # Execute the thread target — should not raise
+        mock_thread_cls.call_args.kwargs["target"]()
+
+    update.assert_called_once_with(mi.id, drain_idle=True)
+    # Instance NOT marked as reported (retry possible)
+    assert mi.id not in manager._drain_idle_reported
+    assert mi.drain_idle is False
+
+
+def test_draining_sync_skips_idle_report_when_already_idle():
+    manager, clientset = _build_serve_manager()
+    mi = _mi_with_source(
+        id=1, name="m-a", model_id=1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    mi.drain_idle = True
+    manager._model_instance_by_instance_id[mi.id] = mi
+    clientset.model_instances.list.return_value = SimpleNamespace(items=[mi])
+
+    with (
+        patch.object(manager, "_update_model_instance") as update,
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            return_value=None,
+        ),
+    ):
+        manager.sync_model_instances_state()
+        manager.sync_model_instances_state()
+
+    update.assert_not_called()
+    assert mi.id in manager._drain_idle_reported
+
+
+def test_updated_draining_marks_and_does_not_stop():
+    manager, _ = _build_serve_manager()
+    mi = _mi_with_source(
+        id=1, name="m-a", model_id=1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    event = Event(type=EventType.UPDATED, data=mi)
+
+    with (
+        patch.object(manager, "_stop_model_instance") as stop,
+        patch.object(manager, "_report_drain_idle") as report,
+        patch.object(manager, "_restart_model_instance") as restart,
+    ):
+        manager._dispatch_model_instance_event(event)
+
+    assert 1 in manager._draining_instance_ids
+    stop.assert_not_called()
+    restart.assert_not_called()
+    report.assert_called_once_with(1)
+
+
+def test_draining_sticky_skips_running_sync():
+    manager, clientset = _build_serve_manager()
+    mi = _mi_with_source(
+        id=1, name="m-a", model_id=1, worker_id=1, state=ModelInstanceStateEnum.DRAINING
+    )
+    manager._model_instance_by_instance_id[mi.id] = mi
+    clientset.model_instances.list.return_value = SimpleNamespace(items=[mi])
+
+    with (
+        patch.object(manager, "_update_model_instance") as update,
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch(
+            "gpustack.worker.serve_manager.get_workload",
+            return_value=SimpleNamespace(state="RUNNING"),
+        ),
+    ):
+        manager.sync_model_instances_state()
+
+    update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_port_rejects_draining_with_503():
+    request = MagicMock()
+    request.headers = {proxy_mod.router_header_key: "model-1-42.openai"}
+    request.app.state.is_instance_draining = lambda iid: iid == 42
+    request.app.state.get_instance_port_by_model_instance_id = lambda _: 8000
+    call_next = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "gpustack.routes.worker.proxy.get_instance_id_from_header",
+        return_value=42,
+    ):
+        resp = await proxy_mod.set_port_from_model_name(request, call_next)
+
+    assert resp.status_code == 503
+    assert b"draining" in resp.body
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_proxy_inflight_dec_on_error():
+    begin = MagicMock()
+    end = MagicMock()
+
+    request = MagicMock()
+    request.state.x_target_port = "8000"
+    request.state.x_target_instance_id = 9
+    request.method = "POST"
+    request.url.query = ""
+    request.headers = {}
+    request.body = AsyncMock(return_value=b"{}")
+    request.app.state.worker_ip_getter = lambda: "127.0.0.1"
+    request.app.state.begin_proxy_request = begin
+    request.app.state.end_proxy_request = end
+    request.app.state.http_client = SimpleNamespace(
+        request=AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    request.app.state.http_client_no_proxy = SimpleNamespace(
+        request=AsyncMock(side_effect=RuntimeError("boom"))
+    )
+
+    with (
+        patch("gpustack.routes.worker.proxy.use_proxy_env_for_url", return_value=False),
+        pytest.raises(ServiceUnavailableException),
+    ):
+        await proxy_mod.proxy("v1/chat/completions", request)
+
+    begin.assert_called_once_with(9)
+    end.assert_called_once_with(9)
+
+
+@pytest.mark.asyncio
+async def test_set_port_malformed_header_no_500():
+    """A malformed router header must not cause a 500; the request should
+    fall through to the normal port-resolution path (which will 404)."""
+    from gpustack.api.exceptions import NotFoundException
+
+    request = MagicMock()
+    request.headers = {proxy_mod.router_header_key: "garbage-not-a-model-id"}
+    request.app.state.is_instance_draining = MagicMock(return_value=False)
+    request.app.state.get_instance_port_by_model_instance_id = MagicMock(
+        side_effect=NotFoundException(message="not found")
+    )
+    call_next = AsyncMock(return_value=MagicMock())
+
+    resp = await proxy_mod.set_port_from_model_name(request, call_next)
+
+    # Should return 404 from get_model_instance_info_from_model_name, not 500
+    assert resp.status_code == 404
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_port_missing_header_no_500():
+    """When the router header is absent, the request passes through
+    immediately without any draining check."""
+    request = MagicMock()
+    request.headers = {}
+    request.app.state.is_instance_draining = MagicMock(return_value=False)
+    call_next = AsyncMock(return_value=MagicMock())
+
+    await proxy_mod.set_port_from_model_name(request, call_next)
+
+    # Early return: call_next is invoked, no draining check
+    call_next.assert_awaited_once_with(request)
+    request.app.state.is_instance_draining.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_port_draining_check_uses_int_directly():
+    """The draining check receives the int instance ID directly from
+    get_instance_id_from_header (no redundant int() cast)."""
+    request = MagicMock()
+    request.headers = {proxy_mod.router_header_key: "model-1-42.openai"}
+    is_draining = MagicMock(return_value=True)
+    request.app.state.is_instance_draining = is_draining
+    request.app.state.get_instance_port_by_model_instance_id = lambda _: 8000
+    call_next = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "gpustack.routes.worker.proxy.get_instance_id_from_header",
+        return_value=42,
+    ):
+        resp = await proxy_mod.set_port_from_model_name(request, call_next)
+
+    assert resp.status_code == 503
+    # is_instance_draining received the int 42 directly
+    is_draining.assert_called_once_with(42)


### PR DESCRIPTION
## Summary

- Fixes abrupt teardown of in-flight inference when scaling down or deleting a running model replica (503 / `Server disconnected`). #6059
- Introduces sticky `DRAINING` state: exclude from LB / `ready_replicas` immediately, keep workload until worker reports idle or `GPUSTACK_MODEL_INSTANCE_DRAIN_TIMEOUT` (default 120s), then hard-delete and reuse existing ServeManager reap.
- Covers scale-down (`sync_replicas`), `DELETE /model-instances/{id}` (202 for RUNNING/DRAINING, 204 for non-running), worker proxy in-flight tracking, and offline hard-delete bypass via `WorkerInstanceCleaner`.

Closes #6059

## Motivation

See #6059. Scale-down previously called `batch_delete` immediately; mid-request connections were killed when the workload was reaped.

## Design notes

- Soft-intent + finalizer pattern (sibling to GPU `Deleting` UX), **without** CR multi-cluster finalizer machinery.
- Worker `/proxy` tracks in-flight; new requests to draining instances get 503; idle report accelerates delete; timeout is the hard ceiling.
- Docs: scale-down section in `docs/scheduler.md`.

## Test plan

- [x] Unit: scale-down drains RUNNING (no immediate `batch_delete`); no double-drain / no premature scale-up while draining
- [x] Unit: drain finalizer deletes on idle and on timeout; keeps busy instances until timeout
- [x] Unit: DELETE RUNNING → 202 + DRAINING; idempotent DELETE while draining; PENDING → 204 hard-delete
- [x] Unit: worker sticky DRAINING (no revive/stop); idempotent idle report; proxy inflight + 503 for new traffic
- [x] Unit: offline cleaner still hard-deletes draining instances
- [ ] Manual: 2 replicas, long stream, scale to 1 — stream completes; new requests go to remaining RUNNING