### PR TITLE
feat(gpu-service): enforce cluster purpose and converge the operator settings

### DIFF
--- a/gpustack/gpu_instances/cluster_apis.py
+++ b/gpustack/gpu_instances/cluster_apis.py
@@ -3,71 +3,100 @@ from __future__ import annotations
 import http
 import logging
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import AsyncIterator, Optional
 
 from kubernetes_asyncio import client, watch
 
 from .cluster_apis_util import (
+    DEFAULT_SYSTEM_NAMESPACE,
     get_namespace_name,
     get_k8s_client,
 )
 
 logger = logging.getLogger(__name__)
 
-_GROUP = "worker.gpustack.ai"
-_VERSION = "v1"
+_DEFAULT_GROUP = "worker.gpustack.ai"
+_DEFAULT_VERSION = "v1"
+
+
+class _Scope(Enum):
+    """Where a resource's objects live, which decides *which* namespace the
+    generic helpers put on the wire — not merely whether they send one.
+
+    The distinction between the two namespaced members is the reason this is
+    an enum rather than a boolean: an Org-namespaced object is per-tenant and
+    lands in a namespace GPUStack creates on demand, while a system-namespaced
+    one lives beside the operator in the cluster's own system namespace, which
+    GPUStack does not own and must never create.
+    """
+
+    CLUSTER = auto()
+    ORG_NAMESPACED = auto()
+    SYSTEM_NAMESPACED = auto()
 
 
 @dataclass(frozen=True)
 class _CRDSpec:
+    """Identifies one resource: its GVR plus the scope its objects live at.
+
+    ``group`` / ``version`` default to ``worker.gpustack.ai/v1`` because that
+    is what every worker CRD uses; they are per-spec so a resource served by
+    another operator API group can be addressed by the same client.
+    """
+
     plural: str
     kind: str
-    namespaced: bool
+    scope: _Scope
+    group: str = _DEFAULT_GROUP
+    version: str = _DEFAULT_VERSION
 
     @property
     def api_version(self) -> str:
-        return f"{_GROUP}/{_VERSION}"
+        return f"{self.group}/{self.version}"
 
 
 _SSH_PUBLIC_KEY = _CRDSpec(
     plural="instancesshpublickeys",
     kind="InstanceSSHPublicKey",
-    namespaced=True,
+    scope=_Scope.ORG_NAMESPACED,
 )
 _PV_TYPE = _CRDSpec(
     plural="instancepersistentvolumetypes",
     kind="InstancePersistentVolumeType",
-    namespaced=False,
+    scope=_Scope.CLUSTER,
 )
 _PV = _CRDSpec(
     plural="instancepersistentvolumes",
     kind="InstancePersistentVolume",
-    namespaced=True,
+    scope=_Scope.ORG_NAMESPACED,
 )
 _INSTANCE_TYPE = _CRDSpec(
     plural="instancetypes",
     kind="InstanceType",
-    namespaced=False,
+    scope=_Scope.CLUSTER,
 )
 _INSTANCE_TYPE_FLAVOR = _CRDSpec(
     plural="instancetypeflavors",
     kind="InstanceTypeFlavor",
-    namespaced=False,
+    scope=_Scope.CLUSTER,
 )
 _INSTANCE = _CRDSpec(
     plural="instances",
     kind="Instance",
-    namespaced=True,
+    scope=_Scope.ORG_NAMESPACED,
 )
 _DEVICES = _CRDSpec(
     plural="devices",
     kind="Devices",
-    namespaced=False,
+    scope=_Scope.CLUSTER,
 )
 
 
 class ClusterOps:
-    """Raw CRD client for ``worker.gpustack.ai/v1`` resources.
+    """Raw CRD client for a worker cluster, addressing each resource at the
+    group/version its :class:`_CRDSpec` names (``worker.gpustack.ai/v1`` unless
+    the spec says otherwise).
 
     Owns a :class:`kubernetes_asyncio.client.api_client.ApiClient` which must
     be closed. Use as an async context manager so the client is released on
@@ -84,6 +113,7 @@ class ClusterOps:
     cluster_owner_principal_identifier: str
     api_client: client.api_client.ApiClient
     org_namespace: str
+    system_namespace: str
 
     def __init__(
         self,
@@ -91,7 +121,15 @@ class ClusterOps:
         cluster_id: int,
         cluster_registration_token: str,
         cluster_owner_principal_identifier: str,
+        system_namespace: Optional[str] = None,
     ):
+        """``system_namespace`` is the cluster's ``k8s_options.namespace`` —
+        where its operator runs — and is only consulted by
+        :attr:`_Scope.SYSTEM_NAMESPACED` resources. It falls back to
+        ``gpustack-system``, the same default the manifest renderer applies, so
+        a caller that only touches cluster- or Org-scoped resources can leave
+        it out.
+        """
         self.cluster_id = cluster_id
         self.cluster_owner_principal_identifier = cluster_owner_principal_identifier
         self.api_client = get_k8s_client(
@@ -102,6 +140,7 @@ class ClusterOps:
         self.org_namespace = get_namespace_name(
             principal_identifier=cluster_owner_principal_identifier,
         )
+        self.system_namespace = system_namespace or DEFAULT_SYSTEM_NAMESPACE
 
     async def __aenter__(self) -> "ClusterOps":
         return self
@@ -119,20 +158,30 @@ class ClusterOps:
     def _crd(self) -> client.CustomObjectsApi:
         return client.CustomObjectsApi(self.api_client)
 
+    def _namespace(self, spec: _CRDSpec) -> Optional[str]:
+        """The namespace ``spec``'s objects live in, or ``None`` when the
+        resource is cluster-scoped and the call must go out without one."""
+        if spec.scope is _Scope.ORG_NAMESPACED:
+            return self.org_namespace
+        if spec.scope is _Scope.SYSTEM_NAMESPACED:
+            return self.system_namespace
+        return None
+
     async def _read(self, spec: _CRDSpec, name: str) -> Optional[dict]:
         crd = self._crd()
+        namespace = self._namespace(spec)
         try:
-            if spec.namespaced:
+            if namespace is not None:
                 return await crd.get_namespaced_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
-                    namespace=self.org_namespace,
+                    namespace=namespace,
                     name=name,
                 )
             return await crd.get_cluster_custom_object(
-                group=_GROUP,
-                version=_VERSION,
+                group=spec.group,
+                version=spec.version,
                 plural=spec.plural,
                 name=name,
             )
@@ -147,20 +196,21 @@ class ClusterOps:
         """List CRD objects. When ``resource_version`` is given it is passed
         through to the Kubernetes list call (e.g. resume/consistency hints)."""
         crd = self._crd()
+        namespace = self._namespace(spec)
         kwargs = {}
         if resource_version is not None:
             kwargs["resource_version"] = resource_version
-        if spec.namespaced:
+        if namespace is not None:
             return await crd.list_namespaced_custom_object(
-                group=_GROUP,
-                version=_VERSION,
+                group=spec.group,
+                version=spec.version,
                 plural=spec.plural,
-                namespace=self.org_namespace,
+                namespace=namespace,
                 **kwargs,
             )
         return await crd.list_cluster_custom_object(
-            group=_GROUP,
-            version=_VERSION,
+            group=spec.group,
+            version=spec.version,
             plural=spec.plural,
             **kwargs,
         )
@@ -193,6 +243,7 @@ class ClusterOps:
         caller handles as a watch failure instead of the watcher crashing.
         """
         crd = self._crd()
+        namespace = self._namespace(spec)
         if resource_version is None:
             resource_version = ((await self._list(spec)).get("metadata") or {}).get(
                 "resourceVersion"
@@ -201,20 +252,20 @@ class ClusterOps:
         if resource_version is not None:
             kwargs["resource_version"] = resource_version
         async with watch.Watch() as w:
-            if spec.namespaced:
+            if namespace is not None:
                 stream = w.stream(
                     crd.list_namespaced_custom_object,
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
-                    namespace=self.org_namespace,
+                    namespace=namespace,
                     **kwargs,
                 )
             else:
                 stream = w.stream(
                     crd.list_cluster_custom_object,
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
                     **kwargs,
                 )
@@ -227,8 +278,9 @@ class ClusterOps:
         and, when namespaced, ``metadata.namespace``.
         """
         metadata = {**body.get("metadata", {})}
-        if spec.namespaced:
-            metadata["namespace"] = self.org_namespace
+        namespace = self._namespace(spec)
+        if namespace is not None:
+            metadata["namespace"] = namespace
         return {
             **body,
             "apiVersion": spec.api_version,
@@ -253,7 +305,11 @@ class ClusterOps:
         consistent post-condition.
         """
         name = body["metadata"]["name"]
-        if spec.namespaced:
+        namespace = self._namespace(spec)
+        # Only the Org namespace is ours to create; a system-namespaced
+        # resource lives in the operator's own namespace, which is already
+        # there and is not GPUStack's to provision.
+        if spec.scope is _Scope.ORG_NAMESPACED:
             await self.ensure_org_namespace()
 
         if ignore_existed:
@@ -265,18 +321,18 @@ class ClusterOps:
 
         crd = self._crd()
         try:
-            if spec.namespaced:
+            if namespace is not None:
                 created = await crd.create_namespaced_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
-                    namespace=self.org_namespace,
+                    namespace=namespace,
                     body=body,
                 )
             else:
                 created = await crd.create_cluster_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
                     body=body,
                 )
@@ -309,7 +365,9 @@ class ClusterOps:
         require last-writer-wins must retry on their side.
         """
         name = body["metadata"]["name"]
-        if spec.namespaced:
+        namespace = self._namespace(spec)
+        # See :meth:`_create`: only the Org namespace is ours to create.
+        if spec.scope is _Scope.ORG_NAMESPACED:
             await self.ensure_org_namespace()
 
         crd = self._crd()
@@ -318,20 +376,20 @@ class ClusterOps:
         patch_body = {"spec": body["spec"]}
 
         try:
-            if spec.namespaced:
+            if namespace is not None:
                 patched = await crd.patch_namespaced_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
-                    namespace=self.org_namespace,
+                    namespace=namespace,
                     name=name,
                     body=patch_body,
                     _content_type="application/merge-patch+json",
                 )
             else:
                 patched = await crd.patch_cluster_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
                     name=name,
                     body=patch_body,
@@ -351,18 +409,18 @@ class ClusterOps:
         create_body = self._envelope(spec, body)
 
         try:
-            if spec.namespaced:
+            if namespace is not None:
                 created = await crd.create_namespaced_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
-                    namespace=self.org_namespace,
+                    namespace=namespace,
                     body=create_body,
                 )
             else:
                 created = await crd.create_cluster_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
                     body=create_body,
                 )
@@ -389,22 +447,23 @@ class ClusterOps:
         spec by merge-patch semantics.
         """
         crd = self._crd()
+        namespace = self._namespace(spec)
         body = {"spec": body_spec}
         try:
-            if spec.namespaced:
+            if namespace is not None:
                 patched = await crd.patch_namespaced_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
-                    namespace=self.org_namespace,
+                    namespace=namespace,
                     name=name,
                     body=body,
                     _content_type="application/merge-patch+json",
                 )
             else:
                 patched = await crd.patch_cluster_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
                     name=name,
                     body=body,
@@ -426,19 +485,20 @@ class ClusterOps:
         """Delete the object by name. Returns whether it existed (``True`` when
         a delete was issued, ``False`` when it was already gone / a 404)."""
         crd = self._crd()
+        namespace = self._namespace(spec)
         try:
-            if spec.namespaced:
+            if namespace is not None:
                 await crd.delete_namespaced_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
-                    namespace=self.org_namespace,
+                    namespace=namespace,
                     name=name,
                 )
             else:
                 await crd.delete_cluster_custom_object(
-                    group=_GROUP,
-                    version=_VERSION,
+                    group=spec.group,
+                    version=spec.version,
                     plural=spec.plural,
                     name=name,
                 )

--- a/gpustack/gpu_instances/cluster_apis.py
+++ b/gpustack/gpu_instances/cluster_apis.py
@@ -91,6 +91,18 @@ _DEVICES = _CRDSpec(
     kind="Devices",
     scope=_Scope.CLUSTER,
 )
+# The operator's own settings catalog, and the only resource here outside
+# ``worker.gpustack.ai``: it lives in ``gpustack.ai/v1``, namespaced beside the
+# operator in the cluster's system namespace rather than in the per-Org
+# namespace every other namespaced resource uses. Addressing the wrong
+# namespace answers 404, which reads as "absent" everywhere below — see
+# :meth:`ClusterOps.patch_setting_value`.
+_SETTING = _CRDSpec(
+    plural="settings",
+    kind="Setting",
+    scope=_Scope.SYSTEM_NAMESPACED,
+    group="gpustack.ai",
+)
 
 
 class ClusterOps:
@@ -815,3 +827,33 @@ class ClusterOps:
         Returns whether it existed (``False`` when already gone / a 404).
         """
         return await self._delete(_INSTANCE, name)
+
+    #
+    # Operator Setting Operations
+    #
+
+    async def read_setting(self, name: str) -> Optional[dict]:
+        """Read one operator setting by name. Return ``None`` when absent.
+
+        Read and write are asymmetric on this resource: ``spec.value`` is a
+        write-only input that always reads back as ``{}``, and ``status.value``
+        is the read-back (``"(sensitive)"`` for a sensitive setting). A caller
+        comparing a desired value must compare it against ``status.value``.
+        """
+        return await self._read(_SETTING, name)
+
+    async def patch_setting_value(self, name: str, value: str) -> Optional[dict]:
+        """Merge-patch one operator setting's ``spec.value``. Return ``None``
+        when absent.
+
+        Deliberately not an upsert: the settings catalog is fixed upstream and
+        the resource serves no create, so :meth:`_upsert`'s 404-then-create
+        fallthrough would turn a mistake into a ``405 Method Not Allowed``.
+        There is nothing to create here — only a value to write.
+
+        ``None`` is not "absent, so nothing to do": every managed name exists in
+        a healthy cluster, so it means the namespace or the operator is wrong.
+        Callers must treat it as a failure to log and retry, otherwise a
+        mis-namespaced writer loops forever writing nothing.
+        """
+        return await self._patch_spec(_SETTING, name, {"value": value})

--- a/gpustack/gpu_instances/cluster_apis_util.py
+++ b/gpustack/gpu_instances/cluster_apis_util.py
@@ -150,6 +150,14 @@ def principal_namespace_identifier(principal: Principal) -> str:
     return principal.name
 
 
+DEFAULT_SYSTEM_NAMESPACE = "gpustack-system"
+"""Namespace a cluster's own GPUStack components (operator, workers) live in
+when its ``k8s_options.namespace`` is unset — the same fallback the manifest
+renderer applies, mirrored here because the CRD client resolves the namespace
+of system-scoped resources without going through a render.
+"""
+
+
 def get_namespace_name(
     principal_identifier: Optional[str] = None,
 ) -> str:

--- a/gpustack/gpu_instances/controllers.py
+++ b/gpustack/gpu_instances/controllers.py
@@ -478,19 +478,24 @@ class GPUInstanceController:
         it raises :class:`_InstanceAssetsError` carrying the matching
         ``*CreateFailed`` phase; the caller records that phase and stops.
         """
-        # SSH public key.
-        if fresh.spec.ssh_public_keys is not None:
-            try:
-                data = await self._aggregate_ssh_public_key_data(session, fresh)
-                await ops.upsert_ssh_public_key(name=fresh.name, spec={"data": data})
-            except Exception as e:
-                logger.exception(
-                    f"Failed to sync worker-side ssh public key for {fresh.name}"
-                )
-                raise _InstanceAssetsError(
-                    self.PHASE_SSH_KEY_CREATE_FAILED,
-                    f"Failed to sync worker-side ssh public key: {e}",
-                )
+        # SSH public key. Unconditional, matching the resync path below and
+        # ``to_kuberes``, which always writes ``spec.sshPublicKey``: the operator
+        # therefore always mounts a secret named after the instance, and an
+        # instance that referenced no keys used to leave that mount pointing at
+        # a secret nobody ever created — the pod then waits in ContainerCreating
+        # forever. An empty body is the right answer; the operator renders it as
+        # an empty ``authorized_keys``.
+        try:
+            data = await self._aggregate_ssh_public_key_data(session, fresh)
+            await ops.upsert_ssh_public_key(name=fresh.name, spec={"data": data})
+        except Exception as e:
+            logger.exception(
+                f"Failed to sync worker-side ssh public key for {fresh.name}"
+            )
+            raise _InstanceAssetsError(
+                self.PHASE_SSH_KEY_CREATE_FAILED,
+                f"Failed to sync worker-side ssh public key: {e}",
+            )
 
         # Persistent volume (type).
         pv_name: Optional[str] = None

--- a/gpustack/gpu_instances/gateway.py
+++ b/gpustack/gpu_instances/gateway.py
@@ -108,7 +108,24 @@ class OperatorSubscriptionReconciler:
             return
 
         cluster: Cluster = event.data
-        if cluster is None or cluster.provider != ClusterProvider.Kubernetes:
+        if cluster is None:
+            return
+
+        # A DELETED event can arrive as the raw row id rather than a Cluster
+        # (see :func:`deleted_cluster_id`). The id is all this path needs — the
+        # cluster is gone either way — and reading ``provider`` off that dict
+        # would raise, be swallowed by the watcher, and leave the operator
+        # proxying a deleted cluster forever: the retry sweep only unsubscribes
+        # what left ``_eligible``, which is exactly what the raise skipped.
+        if isinstance(cluster, dict):
+            cluster_id = deleted_cluster_id(event)
+            if cluster_id is not None:
+                async with self._lock:
+                    self._eligible.pop(cluster_id, None)
+                    await self._unsubscribe(cluster_id)
+            return
+
+        if cluster.provider != ClusterProvider.Kubernetes:
             return
 
         async with self._lock:
@@ -120,7 +137,7 @@ class OperatorSubscriptionReconciler:
             self._eligible[cluster.id] = cluster.registration_token
             if cluster.id in self._subscribed:
                 return
-            if await _count_ready_workers(cluster.id) > 0:
+            if await count_ready_workers(cluster.id) > 0:
                 await self._subscribe(cluster.id)
 
     async def _retry_stale_subscriptions(self):
@@ -147,7 +164,7 @@ class OperatorSubscriptionReconciler:
             # heartbeat. That is the price of recovering a lost subscribe.
             for cluster_id in sorted(set(self._eligible) - self._subscribed):
                 try:
-                    if await _count_ready_workers(cluster_id) > 0:
+                    if await count_ready_workers(cluster_id) > 0:
                         await self._subscribe(cluster_id)
                 except Exception as e:
                     logger.error(f"Failed to retry subscribing {cluster_id}: {e}")
@@ -183,7 +200,7 @@ class OperatorSubscriptionReconciler:
             # for that case alone, keeping worker status events cheap.
             if cluster_id not in self._subscribed:
                 return
-            if await _count_ready_workers(cluster_id) == 0:
+            if await count_ready_workers(cluster_id) == 0:
                 await self._unsubscribe(cluster_id)
 
     async def _subscribe(self, cluster_id: int):
@@ -210,8 +227,35 @@ def _has_gpu_instances(cluster: Cluster) -> bool:
     return is_gpu_service_cluster(cluster)
 
 
-async def _count_ready_workers(cluster_id: int) -> int:
+async def count_ready_workers(cluster_id: int) -> int:
+    """How many of a cluster's workers are READY — its reachability.
+
+    Public because ``settings.py``'s reconciler decides reachability the same
+    way and from the same query: a cluster with no READY worker has no reachable
+    proxy, so every call would 503. Shared rather than copied so the two cannot
+    drift apart on what "reachable" means.
+    """
     async with async_session() as session:
         return await Worker.count_by_fields(
             session, {"cluster_id": cluster_id, "state": WorkerStateEnum.READY}
         )
+
+
+def deleted_cluster_id(event: Event) -> Optional[int]:
+    """The row id a cluster DELETED event carries when its payload never became
+    a ``Cluster``, or ``None`` when the event is anything else.
+
+    The bus enriches a DELETED event from the change-detector cache, and that
+    cache is empty for clusters — the topic is not preloaded (see
+    ``Server._preload_change_detector_cache``) — so the event is routed carrying
+    nothing but ``{"id": ...}``. Every reconciler watching clusters therefore
+    has to read the id off a raw dict, and a deletion is all the id is needed
+    for; ``None`` for any other event type on such a payload, which has no model
+    to read and nothing safe to do.
+    """
+    if event.type != EventType.DELETED:
+        return None
+    if event.id is not None:
+        return event.id
+    data = event.data
+    return data.get("id") if isinstance(data, dict) else None

--- a/gpustack/gpu_instances/gateway.py
+++ b/gpustack/gpu_instances/gateway.py
@@ -16,7 +16,7 @@ import logging
 from typing import Dict, Optional, Set
 
 from gpustack.gpu_instances import gateway_client
-from gpustack.schemas.clusters import Cluster, ClusterProvider, K8sOptions
+from gpustack.schemas.clusters import Cluster, ClusterProvider, is_gpu_service_cluster
 from gpustack.schemas.workers import Worker, WorkerStateEnum
 from gpustack.server.bus import Event, EventType
 from gpustack.server.db import async_session
@@ -204,12 +204,10 @@ class OperatorSubscriptionReconciler:
 
 def _has_gpu_instances(cluster: Cluster) -> bool:
     # Over the bus the ``k8s_options`` JSON column can arrive as a plain dict
-    # (nested pydantic_column_type isn't re-validated on replay), so coerce it
-    # back to the model before reading nested fields.
-    k8s_options = cluster.k8s_options
-    if isinstance(k8s_options, dict):
-        k8s_options = K8sOptions.model_validate(k8s_options)
-    return k8s_options is not None and k8s_options.gpu_instance_options is not None
+    # (nested pydantic_column_type isn't re-validated on replay). The schema-level
+    # predicate reads that raw shape directly — both key spellings — so the dict no
+    # longer has to be re-validated back into a model here just to read one field.
+    return is_gpu_service_cluster(cluster)
 
 
 async def _count_ready_workers(cluster_id: int) -> int:

--- a/gpustack/gpu_instances/settings.py
+++ b/gpustack/gpu_instances/settings.py
@@ -1,0 +1,473 @@
+"""Converge the operator settings GPUStack manages onto each GPU Service cluster.
+
+The operator seeds every ``Setting`` from ``GPUSTACK_<UPPER_SNAKE_NAME>`` on its
+first deploy and never overwrites a stored value afterwards, so editing an
+already-registered cluster's environment is inert — the ``Setting`` itself has
+to be patched. The two paths do not replace each other: the rendered environment
+covers the window before the operator has ever run (so a cluster never derives
+instance types the administrator disabled), and this reconciler covers
+everything after.
+
+Delivery is a background reconciler rather than an inline patch inside
+``PUT /v2/clusters/{id}`` because of registration itself: the administrator
+configures a cluster *before* applying its manifest, so at save time there is no
+operator to talk to. An inline patch would silently do nothing exactly when the
+values matter most, or would make the cluster uneditable while it is
+unreachable. Here a failure only leaves work stale, and stale work is retried.
+
+Runs leader-only, unlike the gateway subscription in ``gateway.py``: that one
+feeds each server's own operator subprocess, while this one writes into the
+cluster, and one writer is enough.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Set, Tuple
+
+from gpustack.config.config import Config
+from gpustack.gpu_instances.cluster_apis import ClusterOps
+
+# Reachability and the bus's id-only DELETED payload are both read exactly as
+# the operator subscription reads them. Shared rather than copied so the two
+# reconcilers cannot drift apart on what "reachable" means, or on which events
+# carry a model at all.
+from gpustack.gpu_instances.gateway import count_ready_workers, deleted_cluster_id
+from gpustack.schemas.clusters import Cluster, ClusterProvider, is_gpu_service_cluster
+from gpustack.schemas.principals import PLATFORM_PRINCIPAL_NAME
+from gpustack.schemas.workers import Worker, WorkerStateEnum
+from gpustack.server.bus import Event, EventType
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "gpustack_operator_settings"
+
+# One entry per knob GPUStack can manage: the ``GpuInstanceOptions`` field, its
+# serialized camelCase spelling, and the operator ``Setting`` it mirrors. The
+# names are the operator's; ``gpu_instances_access_static_address`` keeps its
+# legacy field name because renaming it would break every existing client.
+_MANAGED_SETTINGS = (
+    (
+        "gpu_instances_access_static_address",
+        "gpuInstancesAccessStaticAddress",
+        "instance-access-static-address",
+    ),
+    (
+        "gpu_instance_type_derived_from_node",
+        "gpuInstanceTypeDerivedFromNode",
+        "instance-type-derived-from-node",
+    ),
+    (
+        "gpu_instance_type_mixed_on_node",
+        "gpuInstanceTypeMixedOnNode",
+        "instance-type-mixed-on-node",
+    ),
+)
+
+SETTING_REQUEST_TIMEOUT = 15
+"""How long one setting's read or patch may take before it counts as failed.
+
+``ClusterOps`` sets no request timeout and ``kubernetes_asyncio`` builds a bare
+``aiohttp.ClientTimeout()`` when none is given, so a call that gets no answer
+waits forever. Convergence is driven from a watcher task and from the heartbeat,
+both of which walk their clusters one at a time — so a single cluster whose proxy
+accepts the connection and then goes silent (its workers still READY, the tunnel
+behind them a black hole) would stop every other cluster's event and retry for
+the lifetime of the process.
+
+Bounding it here rather than on the client keeps the blast radius to this
+reconciler: a timeout is just another failed convergence, reported once and
+retried on the next heartbeat.
+"""
+
+RESYNC_HEARTBEAT_INTERVAL = 20
+"""How many heartbeats apart the level-triggered resync runs, as a multiple of
+the bus's 15s idle heartbeat — so roughly five minutes.
+
+Stale work is retried on *every* heartbeat; this is the slower sweep that
+re-reads clusters already converged, so an administrator's ``kubectl`` edit of
+one of the three managed settings is repaired instead of leaving the cluster
+silently disagreeing with what GPUStack shows. It is a divisor on the cost of
+that guarantee: each sweep is one read per managed knob per GPU Service cluster,
+over the cluster proxy.
+"""
+
+
+async def reconcile_gpustack_operator_settings(config: Config):
+    """Watch Cluster and Worker events and keep the operator settings converged."""
+    await OperatorSettingsReconciler(config).start()
+
+
+@dataclass
+class _Target:
+    """What one cluster needs and what it takes to reach it.
+
+    Compared as a whole to decide whether a cluster event changed anything: a
+    rotated registration token or a moved system namespace invalidates a
+    previous convergence just as a new desired value does.
+    """
+
+    registration_token: Optional[str]
+    system_namespace: Optional[str]
+    settings: Dict[str, str] = field(default_factory=dict)
+
+
+class OperatorSettingsReconciler:
+    """Keeps each GPU Service cluster's managed operator settings at the value
+    its cluster row asks for.
+
+    Two event streams feed one decision, as in
+    :class:`~gpustack.gpu_instances.gateway.OperatorSubscriptionReconciler`:
+    ``Cluster`` carries the desired values and the registration token, ``Worker``
+    carries reachability — and no Cluster event fires when a cluster becomes
+    reachable, so the desired values alone would strand a cluster that was empty
+    when the administrator saved.
+
+    Convergence is level-triggered in both directions. A cluster whose write
+    failed stays in ``_pending`` and is retried on every heartbeat; a cluster
+    that succeeded is re-read every :data:`RESYNC_HEARTBEAT_INTERVAL`
+    heartbeats, which is what repairs an external edit of a managed setting.
+    Only the settings GPUStack manages are ever touched: an unset knob is not
+    read and not written, so an administrator's ``kubectl`` edit of anything
+    else cannot be reverted.
+    """
+
+    def __init__(self, config: Config):
+        self._config = config
+        # Every cluster with at least one managed knob. A cluster absent here is
+        # one this reconciler has nothing to say about — Model Service, no
+        # managed knob, or not Kubernetes at all.
+        self._targets: Dict[int, _Target] = {}
+        # Clusters whose desired values are not known to be converged yet.
+        self._pending: Set[int] = set()
+        # ``(cluster id, setting name)`` currently failing, so a persistent
+        # failure is reported when it starts and when it ends instead of on
+        # every retry.
+        self._failing: Set[Tuple[int, str]] = set()
+        self._heartbeats = 0
+        # Both watchers mutate the state above across await points.
+        self._lock = asyncio.Lock()
+
+    async def start(self):
+        watchers = [
+            asyncio.create_task(
+                self._watch(
+                    "cluster",
+                    Cluster.subscribe(source=_SOURCE),
+                    self._reconcile_cluster,
+                )
+            ),
+            # ``replay_existing=False``: the Cluster stream's own startup replay
+            # already resolves every target's reachability from the database, so
+            # replaying each worker row would only repeat that. A worker event
+            # that lands before its cluster is known is dropped, and recovered
+            # by the cluster heartbeat's retry.
+            asyncio.create_task(
+                self._watch(
+                    "worker",
+                    Worker.subscribe(source=_SOURCE, replay_existing=False),
+                    self._reconcile_worker,
+                )
+            ),
+        ]
+        try:
+            await asyncio.gather(*watchers)
+        finally:
+            # gather leaves the other watcher running when one raises. Both are
+            # needed to decide a convergence, so a half-dead reconciler would
+            # keep the process up while silently converging nothing. The
+            # cancellation is joined so the survivor is stopped, not merely
+            # asked to stop, before this returns.
+            for watcher in watchers:
+                watcher.cancel()
+            await asyncio.gather(*watchers, return_exceptions=True)
+
+    async def _watch(self, name, stream, reconcile):
+        async for event in stream:
+            try:
+                await reconcile(event)
+            except Exception as e:
+                logger.exception(
+                    f"Failed to reconcile the operator settings "
+                    f"on a {name} event: {e}"
+                )
+
+    async def _reconcile_cluster(self, event: Event):
+        if event.type == EventType.HEARTBEAT:
+            await self._on_heartbeat()
+            return
+
+        cluster: Cluster = event.data
+        if cluster is None:
+            return
+
+        # A DELETED event can arrive as the raw row id rather than a Cluster
+        # (see :func:`~gpustack.gpu_instances.gateway.deleted_cluster_id`). The
+        # id is all this path needs — a deletion is a forget either way — and
+        # reading any other attribute off that dict would raise, be swallowed by
+        # the watcher, and strand the target's registration token for the
+        # lifetime of the process.
+        if isinstance(cluster, dict):
+            cluster_id = deleted_cluster_id(event)
+            if cluster_id is not None:
+                async with self._lock:
+                    self._forget(cluster_id)
+            return
+
+        if cluster.provider != ClusterProvider.Kubernetes:
+            return
+
+        async with self._lock:
+            target = None if event.type == EventType.DELETED else _target_of(cluster)
+            if target is None:
+                self._forget(cluster.id)
+                return
+
+            if self._targets.get(cluster.id) != target:
+                self._targets[cluster.id] = target
+                self._pending.add(cluster.id)
+            stale = cluster.id in self._pending
+
+        if stale and await count_ready_workers(cluster.id) > 0:
+            await self._converge(cluster.id)
+
+    async def _reconcile_worker(self, event: Event):
+        worker: Worker = event.data
+        if worker is None or worker.cluster_id is None:
+            return
+
+        if event.type == EventType.UPDATED and "state" not in (
+            event.changed_fields or {}
+        ):
+            # Every worker still posting status is republished every few
+            # seconds. Only a state change can make a cluster reachable, so
+            # anything else is dropped before it can cost a call.
+            return
+
+        if event.type == EventType.DELETED or worker.state != WorkerStateEnum.READY:
+            # A worker leaving READY can only make a cluster unreachable, and
+            # unreachable work is already pending and retried on the heartbeat.
+            return
+
+        async with self._lock:
+            stale = worker.cluster_id in self._pending
+
+        if stale:
+            await self._converge(worker.cluster_id)
+
+    async def _on_heartbeat(self):
+        """Retry stale work, and periodically re-read what already converged.
+
+        The sweep is serial, so one cluster cannot be allowed to hold it: each
+        is retried on its own so a raise cannot starve the rest, and every
+        round-trip inside is bounded by :data:`SETTING_REQUEST_TIMEOUT` so
+        silence cannot either.
+        """
+        async with self._lock:
+            self._heartbeats += 1
+            resync = self._heartbeats % RESYNC_HEARTBEAT_INTERVAL == 0
+            cluster_ids = sorted(self._targets if resync else self._pending)
+
+        for cluster_id in cluster_ids:
+            try:
+                if await count_ready_workers(cluster_id) > 0:
+                    await self._converge(cluster_id)
+            except Exception as e:
+                logger.error(
+                    f"Failed to retry the operator settings "
+                    f"of cluster {cluster_id}: {e}"
+                )
+
+    def _forget(self, cluster_id: int):
+        """Drop everything about a cluster this reconciler no longer owns — it
+        was deleted, switched to Model Service, or stopped managing any knob."""
+        self._targets.pop(cluster_id, None)
+        self._pending.discard(cluster_id)
+        self._failing = {key for key in self._failing if key[0] != cluster_id}
+
+    async def _converge(self, cluster_id: int):
+        """Bring one cluster's managed settings in line with its row.
+
+        Each setting is converged on its own so a failing one cannot cost its
+        siblings their write. The cluster leaves ``_pending`` only when every
+        one of them is known good, which is what makes a partial failure retry.
+
+        Runs **outside** ``_lock``: it is one proxy round-trip per managed knob,
+        each bounded by :data:`SETTING_REQUEST_TIMEOUT`, so holding the lock
+        across it would let a single unreachable cluster block every event this
+        reconciler handles — and every other cluster's retry — for as long as
+        that budget lasts. Callers therefore snapshot under the lock
+        and call this after releasing it, which means the cluster may be
+        forgotten in between; that is what the ``None`` check below is for. The
+        writes are idempotent patches, so overlapping passes over one cluster
+        cost an extra round-trip and nothing else.
+
+        The same window is why the cluster is only cleared from ``_pending``
+        when its target is still the one this pass carried: an edit that landed
+        mid-flight has already re-marked it, and clearing that would drop the
+        newer values until the next resync.
+        """
+        target = self._targets.get(cluster_id)
+        if target is None:
+            return
+        converged = True
+        async with ClusterOps(
+            server_api_port=self._config.get_api_port(),
+            cluster_id=cluster_id,
+            cluster_registration_token=target.registration_token,
+            # Setting is system-namespaced, so the Org namespace this identifier
+            # derives never reaches the wire; the constructor requires one anyway.
+            cluster_owner_principal_identifier=PLATFORM_PRINCIPAL_NAME,
+            system_namespace=target.system_namespace,
+        ) as ops:
+            for name, desired in target.settings.items():
+                try:
+                    ok = await asyncio.wait_for(
+                        self._converge_one(ops, cluster_id, name, desired),
+                        SETTING_REQUEST_TIMEOUT,
+                    )
+                except asyncio.TimeoutError:
+                    # Reported by hand: a TimeoutError stringifies to nothing.
+                    ok = False
+                    self._report_failure(
+                        cluster_id,
+                        name,
+                        ops.system_namespace,
+                        f"it did not answer within {SETTING_REQUEST_TIMEOUT}s",
+                    )
+                except Exception as e:
+                    ok = False
+                    self._report_failure(cluster_id, name, ops.system_namespace, e)
+                converged = converged and ok
+        async with self._lock:
+            if converged and self._targets.get(cluster_id) == target:
+                self._pending.discard(cluster_id)
+
+    async def _converge_one(
+        self, ops: ClusterOps, cluster_id: int, name: str, desired: str
+    ) -> bool:
+        """Patch one setting when it differs, and report whether it is now good.
+
+        ``spec.value`` is write-only and reads back as ``{}``, so the comparison
+        is against ``status.value`` and the write goes to ``spec.value`` —
+        comparing against the spec would diff against nothing and patch on every
+        pass.
+
+        That comparison assumes none of :data:`_MANAGED_SETTINGS` is a sensitive
+        setting, which holds for all three: a sensitive one reads back as the
+        literal ``"(sensitive)"`` rather than its value, so it could never
+        compare equal and every resync would rewrite it. The failure mode is
+        write amplification, not a loop — the patch still succeeds and clears
+        ``_pending`` — so should the operator ever mark one of the three
+        sensitive, this is where to short-circuit it.
+        """
+        observed = await ops.read_setting(name)
+        if observed is None:
+            self._report_failure(
+                cluster_id, name, ops.system_namespace, "it does not exist"
+            )
+            return False
+
+        if (observed.get("status") or {}).get("value") == desired:
+            self._report_recovery(cluster_id, name)
+            return True
+
+        if await ops.patch_setting_value(name, desired) is None:
+            # A 404 on a name the read just resolved means the write went
+            # somewhere else; never read it as "nothing to do".
+            self._report_failure(
+                cluster_id, name, ops.system_namespace, "the patch found it absent"
+            )
+            return False
+
+        logger.info(
+            "Set operator setting %s to %r in namespace %s of cluster %s.",
+            name,
+            desired,
+            ops.system_namespace,
+            cluster_id,
+        )
+        self._report_recovery(cluster_id, name)
+        return True
+
+    def _report_failure(self, cluster_id: int, name: str, namespace: str, reason: Any):
+        """Report a setting that could not be converged — once when it breaks,
+        then quietly, so one broken cluster neither floods the log every
+        heartbeat nor disappears from it during a long outage."""
+        message = (
+            "Failed to converge operator setting %s in namespace %s of cluster %s: %s"
+        )
+        args = (name, namespace, cluster_id, reason)
+        key = (cluster_id, name)
+        if key in self._failing:
+            logger.debug(message, *args)
+            return
+        self._failing.add(key)
+        logger.warning(message, *args)
+
+    def _report_recovery(self, cluster_id: int, name: str):
+        key = (cluster_id, name)
+        if key not in self._failing:
+            return
+        self._failing.discard(key)
+        logger.info(
+            "Operator setting %s of cluster %s converged again.", name, cluster_id
+        )
+
+
+def _target_of(cluster: Cluster) -> Optional[_Target]:
+    """What this reconciler owes the cluster, or ``None`` when it owes nothing."""
+    settings = _desired_settings(cluster)
+    if not settings:
+        return None
+    return _Target(
+        registration_token=cluster.registration_token,
+        # The operator's own namespace, which ClusterOps resolves to
+        # ``gpustack-system`` when the cluster did not name one.
+        system_namespace=_field(cluster.k8s_options, "namespace"),
+        settings=settings,
+    )
+
+
+def _desired_settings(cluster: Cluster) -> Dict[str, str]:
+    """The operator settings GPUStack manages for this cluster, on-the-wire.
+
+    Empty for a Model Service cluster, and for a GPU Service cluster whose knobs
+    are all unset — in both cases nothing is read and nothing is written, which
+    is what keeps an unmanaged setting safe from this reconciler (AC4.4).
+    """
+    if not is_gpu_service_cluster(cluster):
+        return {}
+
+    options = _field(cluster.k8s_options, "gpu_instance_options", "gpuInstanceOptions")
+    desired: Dict[str, str] = {}
+    for snake, camel, setting in _MANAGED_SETTINGS:
+        value = _field(options, snake, camel)
+        # ``None`` — the field absent from the persisted JSON — is the only
+        # unmanaged state. ``False`` and ``""`` are values an administrator
+        # asked for, and asserting them is the whole point of the feature.
+        if value is None:
+            continue
+        desired[setting] = _wire_value(value)
+    return desired
+
+
+def _field(source: Any, snake: str, camel: Optional[str] = None) -> Any:
+    """Read one field off a value that may be a model or the raw dict the bus
+    replays — nested ``pydantic_column_type`` is not re-validated there — while
+    tolerating both serialized key spellings (snake from ``model_dump``, camel
+    from an API/UI submission). Mirrors ``is_gpu_service_k8s_options``: the raw
+    shape is read directly rather than parsed back into a model, so schema drift
+    cannot turn a watch tick into a ``ValidationError``."""
+    if isinstance(source, dict):
+        value = source.get(snake)
+        return value if value is not None else source.get(camel or snake)
+    return getattr(source, snake, None)
+
+
+def _wire_value(value: Any) -> str:
+    """A ``Setting`` value is a string on the wire, so a bool knob has to go out
+    in the operator's spelling rather than Python's ``True`` / ``False``."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)

--- a/gpustack/k8s/manifest_template.py
+++ b/gpustack/k8s/manifest_template.py
@@ -47,6 +47,24 @@ _RUNTIME_ORDER: Dict[ManufacturerEnum, int] = {
 }
 
 
+def _env_bool(value: Optional[bool]) -> Optional[str]:
+    """
+    Render one tri-state ``GpuInstanceOptions`` knob as the string its
+    ``GPUSTACK_*`` environment variable carries.
+
+    A *string*, not a bool, for two reasons. A Kubernetes env value is a string,
+    so the template quotes it and YAML never turns it back into a boolean. And
+    the template has to tell "unmanaged" apart from an explicit off: ``None``
+    stays ``None`` so no entry is rendered at all and the operator's own default
+    applies, while ``False`` must render the literal ``"false"``. A jinja
+    truthiness test on a raw bool would collapse those two into the same
+    (wrong) answer, which is why the template tests ``is not none`` instead.
+    """
+    if value is None:
+        return None
+    return "true" if value else "false"
+
+
 class ImagePullSecretRenderSpec(BaseModel):
     """
     One materialised ``kubernetes.io/dockerconfigjson`` Secret derived from
@@ -202,6 +220,34 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
                 self.k8s_options.gpu_instance_options.gpu_instances_access_static_address
             )
         return None
+
+    @computed_field
+    @property
+    def operator_instance_type_derived_from_node(self) -> Optional[str]:
+        """
+        First-deploy seed for the operator's ``instance-type-derived-from-node``
+        setting. The operator seeds each ``Setting`` from ``GPUSTACK_<NAME>``
+        on first deploy and never overwrites a stored value afterwards, so this
+        is what keeps a cluster from deriving instance types the administrator
+        asked it not to derive in the window before anything else can reach it.
+
+        ``None`` when the knob is unmanaged (or the cluster is not a GPU Service
+        cluster at all) — the template then renders no entry and the operator's
+        own default stands. See :func:`_env_bool`.
+        """
+        options = self.k8s_options.gpu_instance_options if self.k8s_options else None
+        return _env_bool(options.instance_type_derived_from_node if options else None)
+
+    @computed_field
+    @property
+    def operator_instance_type_mixed_on_node(self) -> Optional[str]:
+        """
+        First-deploy seed for the operator's ``instance-type-mixed-on-node``
+        setting, on the same terms as
+        :attr:`operator_instance_type_derived_from_node`.
+        """
+        options = self.k8s_options.gpu_instance_options if self.k8s_options else None
+        return _env_bool(options.instance_type_mixed_on_node if options else None)
 
     @computed_field
     @property

--- a/gpustack/k8s/manifest_template.py
+++ b/gpustack/k8s/manifest_template.py
@@ -236,7 +236,9 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
         own default stands. See :func:`_env_bool`.
         """
         options = self.k8s_options.gpu_instance_options if self.k8s_options else None
-        return _env_bool(options.instance_type_derived_from_node if options else None)
+        return _env_bool(
+            options.gpu_instance_type_derived_from_node if options else None
+        )
 
     @computed_field
     @property
@@ -247,7 +249,7 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
         :attr:`operator_instance_type_derived_from_node`.
         """
         options = self.k8s_options.gpu_instance_options if self.k8s_options else None
-        return _env_bool(options.instance_type_mixed_on_node if options else None)
+        return _env_bool(options.gpu_instance_type_mixed_on_node if options else None)
 
     @computed_field
     @property

--- a/gpustack/k8s/operator.jinja
+++ b/gpustack/k8s/operator.jinja
@@ -201,9 +201,26 @@ data:
                 - name: GPUSTACK_IMAGE_PULL_SECRETS
                   value: {{  config.image_pull_secrets | map(attribute='name') | join(',') }}
                 {%- endif %}
+                {#- JSON-quoted like the free-form operator_env entries below:
+                    an administrator's address is arbitrary text, and an
+                    unquoted YAML scalar carrying a `: ` would parse as a
+                    mapping rather than the string an env value has to be. #}
                 {%- if config.operator_instance_access_static_address  %}
                 - name: GPUSTACK_INSTANCE_ACCESS_STATIC_ADDRESS
-                  value: {{ config.operator_instance_access_static_address }}
+                  value: {{ config.operator_instance_access_static_address | tojson }}
+                {%- endif %}
+                {#- The two tri-state knobs test `is not none`, never truthiness:
+                    an unmanaged knob renders no entry so the operator's own
+                    default applies, while an explicit off must still render the
+                    literal "false". Quoted, because an unquoted YAML `false` is
+                    a boolean and a container env value must be a string. #}
+                {%- if config.operator_instance_type_derived_from_node is not none %}
+                - name: GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE
+                  value: "{{ config.operator_instance_type_derived_from_node }}"
+                {%- endif %}
+                {%- if config.operator_instance_type_mixed_on_node is not none %}
+                - name: GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE
+                  value: "{{ config.operator_instance_type_mixed_on_node }}"
                 {%- endif %}
                 {%- if config.operator_env %}
                 {%- for k, v in config.operator_env.items() %}

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -53,6 +53,8 @@ from gpustack.schemas.clusters import (
     WorkerPool,
     CloudOptions,
     K8sOptions,
+    is_gpu_service_cluster,
+    is_gpu_service_k8s_options,
 )
 from gpustack.schemas.cluster_access import ClusterAccess
 from gpustack.schemas.gpu_instances import GPUInstance
@@ -148,28 +150,15 @@ def _cluster_manageable_conditions(ctx: TenantContext) -> List[Any]:
 def _k8s_options_has_gpu_instance_options(k8s_options: Any) -> bool:
     """Whether a ``k8s_options`` value opts in to GPU-instance handling.
 
-    Mirrors the gateway-side check (``gpu_instances/gateway.py``):
-    ``k8s_options.gpu_instance_options`` being set is the signal. Runs
-    once per cluster on every list/watch tick, so we look at the raw
-    shape instead of re-running ``K8sOptions.model_validate`` — a full
-    nested parse on the hot path would also propagate any future
-    schema drift as a request-level ``ValidationError``. The dict
-    branch tolerates both serialized key forms (snake from
-    ``model_dump``, camel from API/UI submissions).
+    Delegates to the schema-level home of the purpose signal
+    (``schemas/clusters.py``), which the gateway subscription reads too.
     """
-    if isinstance(k8s_options, K8sOptions):
-        return k8s_options.gpu_instance_options is not None
-    if isinstance(k8s_options, dict):
-        return (
-            k8s_options.get("gpu_instance_options") is not None
-            or k8s_options.get("gpuInstanceOptions") is not None
-        )
-    return False
+    return is_gpu_service_k8s_options(k8s_options)
 
 
 def _cluster_has_gpu_instance_options(cluster: Cluster) -> bool:
     """Whether the cluster opts in to GPU-instance handling."""
-    return _k8s_options_has_gpu_instance_options(cluster.k8s_options)
+    return is_gpu_service_cluster(cluster)
 
 
 @router.get("", response_model=ClustersPublic, response_model_exclude_none=True)

--- a/gpustack/routes/gpu_instance_type_flavors.py
+++ b/gpustack/routes/gpu_instance_type_flavors.py
@@ -21,7 +21,7 @@ from gpustack.schemas import (
     GPUInstanceTypeFlavorPublic,
     GPUInstanceTypeFlavorsPublic,
 )
-from gpustack.schemas.clusters import ClusterProvider
+from gpustack.schemas.clusters import ClusterProvider, is_gpu_service_cluster
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 
@@ -51,13 +51,20 @@ async def get_gpu_aggregated_instance_type_flavors(
             extra_conditions=cluster_visibility_conditions(ctx, Cluster),
         )
 
+    # ...then narrow to the ones registered for GPU Service. A Model Service
+    # cluster's operator still publishes flavors for its nodes, but they
+    # describe capacity committed to model deployment, so offering them here
+    # would let a caller launch a GPU Instance against a cluster that was never
+    # provisioned to host one. Purpose lives inside the ``k8s_options`` JSON
+    # column, so it narrows here rather than in the query's ``fields``.
     # gateway_client list/watch take cluster ids as strings.
-    cluster_ids = [str(c.id) for c in clusters]
+    cluster_ids = [str(c.id) for c in clusters if is_gpu_service_cluster(c)]
 
     if not cluster_ids:
-        # No visible clusters → return an empty aggregate. The gateway treats an
-        # empty cluster filter as "all clusters", so forwarding the empty set
-        # would leak the whole fleet to a caller who can see nothing.
+        # No visible GPU Service clusters → return an empty aggregate. The
+        # gateway treats an empty cluster filter as "all clusters", so
+        # forwarding the empty set would leak the whole fleet to a caller who
+        # can see nothing.
         return GPUAggregatedInstanceTypeFlavorsPublic(items=[])
 
     if watch:

--- a/gpustack/routes/gpu_instance_types.py
+++ b/gpustack/routes/gpu_instance_types.py
@@ -11,6 +11,7 @@ from gpustack.api.tenant import cluster_visibility_conditions
 from gpustack.gpu_instances import gateway_client
 from gpustack.gpu_instances.cluster_apis import ClusterOps
 from gpustack.routes.gpu_instances_helper import (
+    assert_cluster_gpu_service,
     build_cluster_ops,
     ensure_visible,
     ensure_writable,
@@ -27,7 +28,7 @@ from gpustack.schemas import (
     GPUInstanceTypePublic,
     GPUInstanceTypesPublic,
 )
-from gpustack.schemas.clusters import ClusterProvider
+from gpustack.schemas.clusters import ClusterProvider, is_gpu_service_cluster
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 
@@ -57,13 +58,20 @@ async def get_gpu_aggregated_instance_types(
             extra_conditions=cluster_visibility_conditions(ctx, Cluster),
         )
 
+    # ...then narrow to the ones registered for GPU Service. A Model Service
+    # cluster's operator still derives instance types from its nodes, but they
+    # describe capacity committed to model deployment, so offering them here
+    # would let a caller launch a GPU Instance against a cluster that was never
+    # provisioned to host one. Purpose lives inside the ``k8s_options`` JSON
+    # column, so it narrows here rather than in the query's ``fields``.
     # gateway_client list/watch take cluster ids as strings.
-    cluster_ids = [str(c.id) for c in clusters]
+    cluster_ids = [str(c.id) for c in clusters if is_gpu_service_cluster(c)]
 
     if not cluster_ids:
-        # No visible clusters → return an empty aggregate. The gateway treats an
-        # empty cluster filter as "all clusters", so forwarding the empty set
-        # would leak the whole fleet to a caller who can see nothing.
+        # No visible GPU Service clusters → return an empty aggregate. The
+        # gateway treats an empty cluster filter as "all clusters", so
+        # forwarding the empty set would leak the whole fleet to a caller who
+        # can see nothing.
         return GPUAggregatedInstanceTypesPublic(items=[])
 
     if watch:
@@ -140,6 +148,7 @@ async def create_gpu_instance_type(
         ),
         ctx,
     )
+    assert_cluster_gpu_service(cluster)
     ops = await build_cluster_ops(request, session, cluster)
 
     spec = create.spec.model_dump(by_alias=True, exclude_none=True)
@@ -167,6 +176,7 @@ async def update_gpu_instance_type(
         ),
         ctx,
     )
+    assert_cluster_gpu_service(cluster)
     ops = await build_cluster_ops(request, session, cluster)
 
     spec = update.spec.model_dump(by_alias=True, exclude_none=True)
@@ -192,6 +202,7 @@ async def delete_gpu_instance_type(
         ),
         ctx,
     )
+    assert_cluster_gpu_service(cluster)
     ops = await build_cluster_ops(request, session, cluster)
 
     async with ops, handle_error():
@@ -219,6 +230,7 @@ async def deactivate_gpu_instance_type(
         ),
         ctx,
     )
+    assert_cluster_gpu_service(cluster)
     ops = await build_cluster_ops(request, session, cluster)
 
     async with ops, handle_error():
@@ -247,6 +259,7 @@ async def activate_gpu_instance_type(
         ),
         ctx,
     )
+    assert_cluster_gpu_service(cluster)
     ops = await build_cluster_ops(request, session, cluster)
 
     async with ops, handle_error():

--- a/gpustack/routes/gpu_instance_types.py
+++ b/gpustack/routes/gpu_instance_types.py
@@ -29,6 +29,7 @@ from gpustack.schemas import (
     GPUInstanceTypesPublic,
 )
 from gpustack.schemas.clusters import ClusterProvider, is_gpu_service_cluster
+from gpustack.schemas.gpu_instance_types import DERIVED_FROM_NODE_LABEL
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 
@@ -314,13 +315,17 @@ async def _aggregated_instance_type_events(
 
 def _to_instance_type_public(item: dict) -> GPUInstanceTypePublic:
     """Map a raw ``worker.gpustack.ai/v1`` InstanceType dict into the public
-    schema, hoisting ``metadata.name`` to ``name``. A freshly-created CR may
-    lack a reconciled status, so an empty status maps to ``{}`` (every
+    schema, hoisting ``metadata.name`` to ``name`` and the operator's
+    derived-from-node marker out of ``metadata.labels``. A freshly-created CR
+    may lack a reconciled status, so an empty status maps to ``{}`` (every
     ``GPUInstanceTypeStatus`` field is Optional)."""
+    metadata = item.get("metadata") or {}
+    labels = metadata.get("labels") or {}
     return GPUInstanceTypePublic(
-        name=item.get("metadata", {}).get("name"),
+        name=metadata.get("name"),
         spec=item.get("spec") or {},
         status=item.get("status") or {},
+        derived_from_node=labels.get(DERIVED_FROM_NODE_LABEL) == "true",
     )
 
 

--- a/gpustack/routes/gpu_instances.py
+++ b/gpustack/routes/gpu_instances.py
@@ -52,6 +52,7 @@ from gpustack.api.tenant import (
 from gpustack.gpu_instances import validate_k8s_object_name
 from gpustack.gpu_instances.placeholders import substitute_generated_placeholders
 from gpustack.routes.gpu_instance_persistent_volumes import resolve_pv_type_for_ctx
+from gpustack.routes.gpu_instances_helper import assert_cluster_gpu_service
 from gpustack.schemas.clusters import Cluster
 
 from gpustack.schemas import (
@@ -166,6 +167,7 @@ async def create_gpu_instance(
         assert_cluster_visible(ctx, cluster, not_found_message=not_found)
         if cluster.deleted_at is not None:
             raise NotFoundException(message=not_found)
+        assert_cluster_gpu_service(cluster)
 
     persistent_volume_id = await _validate_create_obj(session, ctx, create_obj)
 

--- a/gpustack/routes/gpu_instances_helper.py
+++ b/gpustack/routes/gpu_instances_helper.py
@@ -21,6 +21,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from gpustack.api.exceptions import (
     AlreadyExistsException,
+    ConflictException,
     InternalServerErrorException,
     InvalidException,
     NotFoundException,
@@ -33,6 +34,7 @@ from gpustack.api.tenant import (
 from gpustack.gpu_instances.cluster_apis import ClusterOps
 from gpustack.gpu_instances.cluster_apis_util import principal_namespace_identifier
 from gpustack.schemas import Cluster
+from gpustack.schemas.clusters import is_gpu_service_cluster
 from gpustack.schemas.principals import PLATFORM_PRINCIPAL_NAME, Principal
 from gpustack.server.bus import Event, EventType
 
@@ -74,6 +76,33 @@ def ensure_writable(obj: Cluster, ctx: TenantContext) -> Cluster:
     assert_cluster_visible(ctx, obj)
     assert_cluster_writable(ctx, obj)
     return obj
+
+
+def assert_cluster_gpu_service(cluster: Cluster) -> None:
+    """Refuse a cluster that is not registered for GPU Service.
+
+    A cluster's purpose is decided at registration and is the presence of
+    ``k8s_options.gpu_instance_options`` (see ``schemas/clusters.py``). A Model
+    Service cluster's capacity is committed to model deployment, so it has no
+    GPU-instance infrastructure to write to.
+
+    409 rather than 404 or 403: the caller may well see the cluster and own it
+    — what is wrong is the cluster's purpose, which is a thing the caller can
+    change. Run it *after* the visibility/ownership checks so a cluster the
+    caller cannot see still 404s and never has its purpose disclosed.
+
+    Writes only. The per-cluster instance-type **read** deliberately keeps
+    serving Model Service clusters: it is what the model deploy form's slicing
+    picker reads.
+    """
+    if is_gpu_service_cluster(cluster):
+        return
+    raise ConflictException(
+        message=(
+            f"Cluster '{cluster.name}' is registered for model service, "
+            f"not GPU service. Switch the cluster to GPU service first."
+        )
+    )
 
 
 async def build_cluster_ops(

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -180,8 +180,20 @@ class GpuInstanceOptions(BaseModel):
     for this cluster — leaving the field unset opts the cluster out, so
     no separate boolean flag is needed.
 
-    Not wired into manifest rendering yet; persisted so the operator /
-    future render paths can pick it up without another schema change.
+    Each knob mirrors a gpustack-operator ``Setting`` of the same name and is
+    **tri-state**: ``None`` means GPUStack does not manage that setting and the
+    cluster's own value is left alone, which is a different instruction from an
+    explicit ``True`` or ``False``. The operator catalog is also administered by
+    ``kubectl``, so an unmanaged knob must never be asserted.
+
+    Every default stays ``None``. The column persists with ``exclude_none`` /
+    ``exclude_unset`` / ``exclude_defaults`` (see ``ClusterUpdate.k8s_options``),
+    so a non-``None`` default would be stripped back out of the JSON and read
+    back as unmanaged. That same serialization is why an all-unset
+    ``GpuInstanceOptions()`` still lands as a *present* ``{}`` rather than
+    ``null`` — and its presence is the cluster-purpose signal
+    (:func:`is_gpu_service_k8s_options`), so a knob-less GPU Service cluster
+    must never serialize itself into a Model Service one.
     """
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
@@ -190,7 +202,33 @@ class GpuInstanceOptions(BaseModel):
         alias="gpuInstancesAccessStaticAddress",
         description=(
             "Static address surfaced to the operator for accessing GPU "
-            "instances in this cluster (e.g. LoadBalancer VIP)."
+            "instances in this cluster (e.g. LoadBalancer VIP). Mirrors the "
+            "operator's ``instance-access-static-address`` setting (operator "
+            "default: blank, i.e. the address is generated from host IPs). "
+            "Keeps its legacy name: renaming it to match the operator would "
+            "break the payload for every existing client."
+        ),
+    )
+    instance_type_derived_from_node: Optional[bool] = PydanticField(
+        default=None,
+        alias="instanceTypeDerivedFromNode",
+        description=(
+            "Whether the operator auto-derives InstanceTypes (and their backing "
+            "ClusterQueues) from node hardware. Mirrors the operator's "
+            "``instance-type-derived-from-node`` setting (operator default: "
+            "true). Unset means GPUStack does not manage it and the cluster's "
+            "own value stands."
+        ),
+    )
+    instance_type_mixed_on_node: Optional[bool] = PydanticField(
+        default=None,
+        alias="instanceTypeMixedOnNode",
+        description=(
+            "Whether one node may surface both an accelerated and a CPU-only "
+            "InstanceType. Mirrors the operator's "
+            "``instance-type-mixed-on-node`` setting (operator default: true). "
+            "Unset means GPUStack does not manage it and the cluster's own "
+            "value stands."
         ),
     )
 

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -209,9 +209,9 @@ class GpuInstanceOptions(BaseModel):
             "break the payload for every existing client."
         ),
     )
-    instance_type_derived_from_node: Optional[bool] = PydanticField(
+    gpu_instance_type_derived_from_node: Optional[bool] = PydanticField(
         default=None,
-        alias="instanceTypeDerivedFromNode",
+        alias="gpuInstanceTypeDerivedFromNode",
         description=(
             "Whether the operator auto-derives InstanceTypes (and their backing "
             "ClusterQueues) from node hardware. Mirrors the operator's "
@@ -220,9 +220,9 @@ class GpuInstanceOptions(BaseModel):
             "own value stands."
         ),
     )
-    instance_type_mixed_on_node: Optional[bool] = PydanticField(
+    gpu_instance_type_mixed_on_node: Optional[bool] = PydanticField(
         default=None,
-        alias="instanceTypeMixedOnNode",
+        alias="gpuInstanceTypeMixedOnNode",
         description=(
             "Whether one node may surface both an accelerated and a CPU-only "
             "InstanceType. Mirrors the operator's "

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -279,6 +279,48 @@ class K8sOptions(BaseModel):
     )
 
 
+def is_gpu_service_k8s_options(k8s_options: Any) -> bool:
+    """Whether a ``k8s_options`` value opts the cluster in to GPU Service.
+
+    A cluster carries no purpose column: ``k8s_options.gpu_instance_options``
+    being set *is* the signal — present means GPU Service, absent means Model
+    Service. This is the single home for that test; the route layer
+    (``routes/clusters.py``) and the gateway subscription
+    (``gpu_instances/gateway.py``) both delegate here, so the two halves of the
+    product can never disagree about what a cluster is for.
+
+    Runs once per cluster on every list/watch tick, so we look at the raw shape
+    instead of re-running ``K8sOptions.model_validate`` — a full nested parse on
+    the hot path would also propagate any future schema drift as a
+    request-level ``ValidationError``. The dict branch tolerates both serialized
+    key forms (snake from ``model_dump``, camel from API/UI submissions).
+
+    Presence, not validity, is what is read: a dict carrying an unparseable
+    ``gpu_instance_options`` value still counts as GPU Service. Nothing writes
+    such a row — the column is only ever written from a validated model — and
+    answering by presence keeps a malformed row from raising on a watch tick.
+    Any other shape reads as Model Service, so a cluster whose purpose cannot be
+    established is excluded from GPU Service rather than included.
+    """
+    if isinstance(k8s_options, K8sOptions):
+        return k8s_options.gpu_instance_options is not None
+    if isinstance(k8s_options, dict):
+        return (
+            k8s_options.get("gpu_instance_options") is not None
+            or k8s_options.get("gpuInstanceOptions") is not None
+        )
+    return False
+
+
+def is_gpu_service_cluster(cluster: "Cluster") -> bool:
+    """Whether the cluster is registered for GPU Service rather than Model Service.
+
+    The cluster-shaped entry point onto :func:`is_gpu_service_k8s_options`,
+    which carries the invariant and the reason for the shape.
+    """
+    return is_gpu_service_k8s_options(cluster.k8s_options)
+
+
 class CloudOptions(BaseModel):
     volumes: Optional[List[Volume]] = None
 

--- a/gpustack/schemas/gpu_instance_types.py
+++ b/gpustack/schemas/gpu_instance_types.py
@@ -716,13 +716,27 @@ class GPUInstanceTypeUpdate(BaseModel):
     """
 
 
+DERIVED_FROM_NODE_LABEL = "schedule.gpustack.ai/derived-from-node"
+"""
+Label the GPUStack Operator stamps on the GPU instance types it derives from a
+node's resource flavors, as opposed to the ones an admin created by hand.
+"""
+
+
 class GPUInstanceTypePublic(GPUInstanceTypeBase):
     """
     Represents the public view of a GPU instance type,
     containing only fields that are safe to expose to clients.
     """
 
-    pass
+    derived_from_node: bool = False
+    """
+    Whether the GPUStack Operator derived this GPU instance type from a node
+    (see :data:`DERIVED_FROM_NODE_LABEL`). While the cluster's
+    ``instance-type-derived-from-node`` setting is on the operator owns such a
+    type's existence and re-creates it as soon as it is deleted, so clients
+    present it as read-only rather than offering a delete that cannot stick.
+    """
 
 
 GPUInstanceTypesPublic = ItemList[GPUInstanceTypePublic]

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -133,6 +133,9 @@ from gpustack.gpu_instances import gateway_client
 from gpustack.gpu_instances.gateway import (
     reconcile_gpustack_operator_subscription,
 )
+from gpustack.gpu_instances.settings import (
+    reconcile_gpustack_operator_settings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -474,6 +477,18 @@ class Server:
         self._create_async_task(reconcile_gpustack_operator_subscription())
 
         logger.debug("GPUStack operator subscription started.")
+
+    def _start_gpustack_operator_settings(self):
+        """Converge the operator settings each GPU Service cluster is configured
+        with onto the cluster itself.
+
+        Leader-only, unlike the subscription above: that one feeds this server's
+        own operator subprocess, while this one writes into the cluster, and one
+        writer is enough.
+        """
+        self._create_async_task(reconcile_gpustack_operator_settings(self._config))
+
+        logger.debug("GPUStack operator settings reconciler started.")
 
     def _start_gateway_metrics_flusher(self):
         # Always start — both the gateway report endpoint and the in-process
@@ -1389,3 +1404,7 @@ class Server:
 
         # Scaling Scheduler (drives model replicas on a cron timetable)
         self._start_scaling_scheduler()
+
+        # Operator Settings (converges the operator settings GPU Service
+        # clusters are configured with)
+        self._start_gpustack_operator_settings()

--- a/tests/api/test_resource_scoping.py
+++ b/tests/api/test_resource_scoping.py
@@ -24,10 +24,13 @@ from gpustack.routes import clusters as clusters_route
 from gpustack.routes import cloud_credentials as cloud_credentials_route
 from gpustack.routes import gpu_instances as gpu_instances_route
 from gpustack.routes import model_instances as model_instances_route
-from gpustack.schemas.clusters import ClusterProvider
+from gpustack.schemas.clusters import (
+    ClusterProvider,
+    GpuInstanceOptions,
+    K8sOptions,
+)
 from gpustack.schemas.principals import PrincipalType
 from gpustack.server import services as services_module
-
 
 OWNER_PRINCIPAL = 999
 CALLER_PRINCIPAL = 7
@@ -314,6 +317,11 @@ async def test_gpu_instance_create_allows_granted_cluster(monkeypatch):
         deleted_at=None,
         owner_principal_id=OWNER_PRINCIPAL,
         provider=ClusterProvider.Kubernetes,
+        # Registered for GPU Service: a cluster that can host a GPU instance at
+        # all. This test is about visibility-vs-ownership, so the purpose has to
+        # be the one that lets the call through — otherwise it would be
+        # asserting against a refusal that has nothing to do with access.
+        k8s_options=K8sOptions(gpu_instance_options=GpuInstanceOptions()),
     )
     monkeypatch.setattr(
         gpu_instances_route.Cluster,

--- a/tests/controller/test_gpu_instance_reconcile.py
+++ b/tests/controller/test_gpu_instance_reconcile.py
@@ -472,7 +472,7 @@ async def test_failed_is_noop(engine, controller):
     assert (await _get(engine)).status.phase == GPUInstancePhase.CREATE_FAILED
 
 
-# --- SSH resync on spec change --------------------------------------------- #
+# --- SSH provisioning and resync ------------------------------------------- #
 
 
 @pytest.mark.asyncio
@@ -483,6 +483,24 @@ async def test_spec_change_resyncs_ssh_public_key(engine, controller):
     await controller._reconcile_instance(1, {"spec": (None, None)})
 
     ops.upsert_ssh_public_key.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_creating_provisions_the_key_even_with_no_keys_referenced(
+    engine, controller
+):
+    # ``to_kuberes`` writes ``spec.sshPublicKey`` unconditionally, so the
+    # operator always mounts a secret named after the instance. Skipping the
+    # upsert when nothing is referenced leaves that mount dangling and the pod
+    # sits in ContainerCreating forever on a secret that will never appear.
+    # An empty body is the right answer, not a missing one: the operator
+    # renders it as an empty ``authorized_keys``.
+    await _seed(engine, phase=None)  # is_creating; spec has no ssh_public_keys
+    ops = _with_ops(controller, FakeOps(read_return=None))
+
+    await controller._reconcile_instance(1, {})
+
+    ops.upsert_ssh_public_key.assert_awaited_once_with(name="gi-1", spec={"data": ""})
 
 
 # --- _process backoff wiring ----------------------------------------------- #

--- a/tests/gateway/test_operator_subscription.py
+++ b/tests/gateway/test_operator_subscription.py
@@ -79,7 +79,7 @@ def harness(monkeypatch):
         h.queries += 1
         return h.ready_workers
 
-    monkeypatch.setattr(gateway, "_count_ready_workers", count_ready_workers)
+    monkeypatch.setattr(gateway, "count_ready_workers", count_ready_workers)
     return h
 
 
@@ -202,6 +202,45 @@ async def test_deleted_cluster_unsubscribes_once(harness):
         )
 
     harness.unsubscribe.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deleted_cluster_unsubscribes_from_an_id_only_event(harness):
+    """G3: a DELETED event carrying only an id still unsubscribes.
+
+    In distributed mode the bus hands subscribers ``Event(data={"id": N})``
+    whenever its change-detector cache holds no entry for the row
+    (``bus.py``: "No cached object, route ID-only event for DELETED"). That is
+    the normal state for a freshly elected leader, because ``cluster`` is not in
+    ``_preload_change_detector_cache``'s topic list. Reading ``provider`` off
+    that dict raises and ``_watch`` swallows it, which leaves the cluster in
+    ``_eligible`` — so the retry sweep, which only unsubscribes what left
+    ``_eligible``, never repairs it and the operator keeps proxying a cluster
+    that is gone.
+    """
+    harness.ready_workers = 1
+    await harness.reconciler._reconcile_cluster(
+        Event(type=EventType.CREATED, data=_cluster())
+    )
+
+    await harness.reconciler._reconcile_cluster(
+        Event(type=EventType.DELETED, data={"id": CLUSTER_ID})
+    )
+
+    harness.unsubscribe.assert_awaited_once()
+    assert harness.reconciler._eligible == {}
+
+
+@pytest.mark.asyncio
+async def test_id_only_event_that_is_not_a_deletion_is_dropped(harness):
+    """An id-only payload on any other event type has no model to read."""
+    harness.ready_workers = 1
+    await harness.reconciler._reconcile_cluster(
+        Event(type=EventType.UPDATED, data={"id": CLUSTER_ID})
+    )
+
+    harness.subscribe.assert_not_awaited()
+    harness.unsubscribe.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gpu_instances/test_cluster_apis_list.py
+++ b/tests/gpu_instances/test_cluster_apis_list.py
@@ -1,18 +1,57 @@
+import http
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
+from kubernetes_asyncio import client
 
 from gpustack.gpu_instances import cluster_apis
 from gpustack.gpu_instances.cluster_apis import (
     ClusterOps,
-    _GROUP,
-    _VERSION,
+    _CRDSpec,
+    _Scope,
     _INSTANCE,
     _INSTANCE_TYPE,
     _INSTANCE_TYPE_FLAVOR,
     _SSH_PUBLIC_KEY,
 )
+from gpustack.gpu_instances.cluster_apis_util import DEFAULT_SYSTEM_NAMESPACE
+
+# The worker CRD group/version as they must appear on the wire, pinned here
+# instead of imported from the module under test: an assertion that reads the
+# same constant the code reads would mirror a regression rather than catch it.
+_GROUP = "worker.gpustack.ai"
+_VERSION = "v1"
+
+# The org namespace the ``ops`` fixture's principal derives.
+_ORG_NAMESPACE = "gpustack-default"
+
+# A system-namespaced spec in a *different* group, standing in for the
+# operator's ``gpustack.ai/v1 Setting`` (owned by the task that adds it for
+# real). It exists so the scope cases below prove group, version and namespace
+# are all read off the spec rather than off the worker defaults.
+_FOREIGN_SYSTEM = _CRDSpec(
+    plural="settings",
+    kind="Setting",
+    scope=_Scope.SYSTEM_NAMESPACED,
+    group="gpustack.ai",
+)
+
+# (spec, expected group, expected version, expected namespace) — ``None``
+# namespace means the call must go out cluster-scoped.
+_SCOPE_CASES = [
+    pytest.param(_INSTANCE_TYPE, _GROUP, _VERSION, None, id="cluster-scoped"),
+    pytest.param(
+        _SSH_PUBLIC_KEY, _GROUP, _VERSION, _ORG_NAMESPACE, id="org-namespaced"
+    ),
+    pytest.param(
+        _FOREIGN_SYSTEM,
+        "gpustack.ai",
+        "v1",
+        DEFAULT_SYSTEM_NAMESPACE,
+        id="system-namespaced",
+    ),
+]
 
 
 @pytest_asyncio.fixture
@@ -111,7 +150,7 @@ async def test_list_devices_delegates(monkeypatch, ops):
     assert out["items"][0]["metadata"]["name"] == "node-a"
     # Devices is cluster-scoped: one object per node, not per namespace.
     assert captured["spec"].plural == "devices"
-    assert captured["spec"].namespaced is False
+    assert captured["spec"].scope is _Scope.CLUSTER
 
 
 @pytest.mark.asyncio
@@ -376,3 +415,516 @@ async def test_list_instance_type_flavors_delegates(monkeypatch, ops):
 
     assert captured["spec"] is _INSTANCE_TYPE_FLAVOR
     assert captured["rv"] == "5"
+
+
+#
+# Group / version / namespace resolution off the spec
+#
+
+
+def _fake_crd(monkeypatch, ops, **returns):
+    """Install a ``CustomObjectsApi`` double on ``ops`` with every generic
+    call stubbed, so a helper's choice of call *and* its kwargs can be
+    asserted without a live cluster."""
+    crd = MagicMock()
+    for name in (
+        "get_cluster_custom_object",
+        "get_namespaced_custom_object",
+        "list_cluster_custom_object",
+        "list_namespaced_custom_object",
+        "create_cluster_custom_object",
+        "create_namespaced_custom_object",
+        "patch_cluster_custom_object",
+        "patch_namespaced_custom_object",
+        "delete_cluster_custom_object",
+        "delete_namespaced_custom_object",
+    ):
+        setattr(crd, name, AsyncMock(return_value=returns.get(name, {"ok": True})))
+    monkeypatch.setattr(ops, "_crd", lambda: crd)
+    return crd
+
+
+def _api_exception(status: int) -> client.exceptions.ApiException:
+    return client.exceptions.ApiException(status=status, reason="boom")
+
+
+def test_system_namespace_defaults_to_gpustack_system(ops):
+    # A cluster whose ``k8s_options.namespace`` is unset renders its operator
+    # into ``gpustack-system``, so that is where its system-namespaced
+    # resources are read from.
+    assert DEFAULT_SYSTEM_NAMESPACE == "gpustack-system"
+    assert ops.system_namespace == "gpustack-system"
+
+
+@pytest.mark.asyncio
+async def test_system_namespace_follows_cluster_k8s_options_namespace(monkeypatch):
+    o = ClusterOps(
+        server_api_port=1,
+        cluster_id=42,
+        cluster_registration_token="tok",
+        cluster_owner_principal_identifier="default",
+        system_namespace="ops-ns",
+    )
+    try:
+        assert o.system_namespace == "ops-ns"
+        crd = _fake_crd(monkeypatch, o)
+
+        await o._read(_FOREIGN_SYSTEM, "instance-type-derived-from-node")
+
+        crd.get_namespaced_custom_object.assert_awaited_once_with(
+            group="gpustack.ai",
+            version="v1",
+            plural="settings",
+            namespace="ops-ns",
+            name="instance-type-derived-from-node",
+        )
+    finally:
+        await o.close()
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+@pytest.mark.asyncio
+async def test_read_resolves_gvr_and_namespace(
+    monkeypatch, ops, spec, group, version, namespace
+):
+    crd = _fake_crd(monkeypatch, ops)
+
+    assert await ops._read(spec, "obj") == {"ok": True}
+
+    if namespace is None:
+        crd.get_cluster_custom_object.assert_awaited_once_with(
+            group=group, version=version, plural=spec.plural, name="obj"
+        )
+        crd.get_namespaced_custom_object.assert_not_awaited()
+    else:
+        crd.get_namespaced_custom_object.assert_awaited_once_with(
+            group=group,
+            version=version,
+            plural=spec.plural,
+            namespace=namespace,
+            name="obj",
+        )
+        crd.get_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+@pytest.mark.asyncio
+async def test_list_resolves_gvr_and_namespace(
+    monkeypatch, ops, spec, group, version, namespace
+):
+    crd = _fake_crd(monkeypatch, ops)
+
+    await ops._list(spec)
+
+    if namespace is None:
+        crd.list_cluster_custom_object.assert_awaited_once_with(
+            group=group, version=version, plural=spec.plural
+        )
+        crd.list_namespaced_custom_object.assert_not_awaited()
+    else:
+        crd.list_namespaced_custom_object.assert_awaited_once_with(
+            group=group, version=version, plural=spec.plural, namespace=namespace
+        )
+        crd.list_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+@pytest.mark.asyncio
+async def test_watch_resolves_gvr_and_namespace(
+    monkeypatch, ops, spec, group, version, namespace
+):
+    captured = {}
+    _install_fake_watch(monkeypatch, captured)
+    crd = _fake_crd(monkeypatch, ops)
+
+    _ = [evt async for evt in ops._watch(spec, resource_version="7")]
+
+    expected = {
+        "group": group,
+        "version": version,
+        "plural": spec.plural,
+        "resource_version": "7",
+    }
+    if namespace is None:
+        assert captured["func"] is crd.list_cluster_custom_object
+    else:
+        assert captured["func"] is crd.list_namespaced_custom_object
+        expected["namespace"] = namespace
+    assert captured["kwargs"] == expected
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+@pytest.mark.asyncio
+async def test_create_resolves_gvr_and_namespace(
+    monkeypatch, ops, spec, group, version, namespace
+):
+    crd = _fake_crd(monkeypatch, ops)
+    monkeypatch.setattr(ops, "ensure_org_namespace", AsyncMock())
+
+    await ops._create(spec, {"metadata": {"name": "obj"}, "spec": {"a": 1}}, False)
+
+    body = {
+        "apiVersion": f"{group}/{version}",
+        "kind": spec.kind,
+        "metadata": {"name": "obj"},
+        "spec": {"a": 1},
+    }
+    if namespace is None:
+        crd.create_cluster_custom_object.assert_awaited_once_with(
+            group=group, version=version, plural=spec.plural, body=body
+        )
+        crd.create_namespaced_custom_object.assert_not_awaited()
+    else:
+        body["metadata"] = {"name": "obj", "namespace": namespace}
+        crd.create_namespaced_custom_object.assert_awaited_once_with(
+            group=group,
+            version=version,
+            plural=spec.plural,
+            namespace=namespace,
+            body=body,
+        )
+        crd.create_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+@pytest.mark.asyncio
+async def test_upsert_patches_with_resolved_gvr_and_namespace(
+    monkeypatch, ops, spec, group, version, namespace
+):
+    crd = _fake_crd(monkeypatch, ops)
+    monkeypatch.setattr(ops, "ensure_org_namespace", AsyncMock())
+
+    await ops._upsert(spec, {"metadata": {"name": "obj"}, "spec": {"a": 1}})
+
+    if namespace is None:
+        crd.patch_cluster_custom_object.assert_awaited_once_with(
+            group=group,
+            version=version,
+            plural=spec.plural,
+            name="obj",
+            body={"spec": {"a": 1}},
+            _content_type="application/merge-patch+json",
+        )
+        crd.patch_namespaced_custom_object.assert_not_awaited()
+    else:
+        crd.patch_namespaced_custom_object.assert_awaited_once_with(
+            group=group,
+            version=version,
+            plural=spec.plural,
+            namespace=namespace,
+            name="obj",
+            body={"spec": {"a": 1}},
+            _content_type="application/merge-patch+json",
+        )
+        crd.patch_cluster_custom_object.assert_not_awaited()
+    # The upsert's patch branch never falls through to a create.
+    crd.create_cluster_custom_object.assert_not_awaited()
+    crd.create_namespaced_custom_object.assert_not_awaited()
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+@pytest.mark.asyncio
+async def test_patch_spec_resolves_gvr_and_namespace(
+    monkeypatch, ops, spec, group, version, namespace
+):
+    crd = _fake_crd(monkeypatch, ops)
+
+    assert await ops._patch_spec(spec, "obj", {"value": "on"}) == {"ok": True}
+
+    if namespace is None:
+        crd.patch_cluster_custom_object.assert_awaited_once_with(
+            group=group,
+            version=version,
+            plural=spec.plural,
+            name="obj",
+            body={"spec": {"value": "on"}},
+            _content_type="application/merge-patch+json",
+        )
+        crd.patch_namespaced_custom_object.assert_not_awaited()
+    else:
+        crd.patch_namespaced_custom_object.assert_awaited_once_with(
+            group=group,
+            version=version,
+            plural=spec.plural,
+            namespace=namespace,
+            name="obj",
+            body={"spec": {"value": "on"}},
+            _content_type="application/merge-patch+json",
+        )
+        crd.patch_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+@pytest.mark.asyncio
+async def test_delete_resolves_gvr_and_namespace(
+    monkeypatch, ops, spec, group, version, namespace
+):
+    crd = _fake_crd(monkeypatch, ops)
+
+    assert await ops._delete(spec, "obj") is True
+
+    if namespace is None:
+        crd.delete_cluster_custom_object.assert_awaited_once_with(
+            group=group, version=version, plural=spec.plural, name="obj"
+        )
+        crd.delete_namespaced_custom_object.assert_not_awaited()
+    else:
+        crd.delete_namespaced_custom_object.assert_awaited_once_with(
+            group=group,
+            version=version,
+            plural=spec.plural,
+            namespace=namespace,
+            name="obj",
+        )
+        crd.delete_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+def test_envelope_stamps_api_version_and_scope_namespace(
+    ops, spec, group, version, namespace
+):
+    body = ops._envelope(spec, {"metadata": {"name": "obj"}, "spec": {"a": 1}})
+
+    assert body["apiVersion"] == f"{group}/{version}"
+    assert body["kind"] == spec.kind
+    assert body["spec"] == {"a": 1}
+    if namespace is None:
+        assert "namespace" not in body["metadata"]
+    else:
+        assert body["metadata"]["namespace"] == namespace
+
+
+@pytest.mark.parametrize(
+    "spec, ensured",
+    [
+        pytest.param(_INSTANCE_TYPE, False, id="cluster-scoped"),
+        pytest.param(_SSH_PUBLIC_KEY, True, id="org-namespaced"),
+        pytest.param(_FOREIGN_SYSTEM, False, id="system-namespaced"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_ensures_only_the_org_namespace(monkeypatch, ops, spec, ensured):
+    # The org namespace is GPUStack's to create; the cluster's system namespace
+    # belongs to the operator's own deployment and must never be created here.
+    _fake_crd(monkeypatch, ops)
+    ensure = AsyncMock()
+    monkeypatch.setattr(ops, "ensure_org_namespace", ensure)
+
+    await ops._create(spec, {"metadata": {"name": "obj"}, "spec": {}}, False)
+
+    assert ensure.await_count == (1 if ensured else 0)
+
+
+@pytest.mark.parametrize(
+    "spec, ensured",
+    [
+        pytest.param(_INSTANCE_TYPE, False, id="cluster-scoped"),
+        pytest.param(_SSH_PUBLIC_KEY, True, id="org-namespaced"),
+        pytest.param(_FOREIGN_SYSTEM, False, id="system-namespaced"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_upsert_ensures_only_the_org_namespace(monkeypatch, ops, spec, ensured):
+    _fake_crd(monkeypatch, ops)
+    ensure = AsyncMock()
+    monkeypatch.setattr(ops, "ensure_org_namespace", ensure)
+
+    await ops._upsert(spec, {"metadata": {"name": "obj"}, "spec": {}})
+
+    assert ensure.await_count == (1 if ensured else 0)
+
+
+#
+# Error paths shared by every scope
+#
+
+
+@pytest.mark.asyncio
+async def test_read_returns_none_on_404(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.get_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+
+    assert await ops._read(_INSTANCE_TYPE, "gone") is None
+
+
+@pytest.mark.asyncio
+async def test_read_reraises_other_api_errors(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.get_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.FORBIDDEN
+    )
+
+    with pytest.raises(client.exceptions.ApiException):
+        await ops._read(_INSTANCE_TYPE, "denied")
+
+
+@pytest.mark.asyncio
+async def test_create_reads_back_when_ignoring_an_existing_object(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    monkeypatch.setattr(ops, "_read", AsyncMock(return_value={"existing": True}))
+
+    out = await ops._create(
+        _INSTANCE_TYPE, {"metadata": {"name": "obj"}, "spec": {}}, True
+    )
+
+    assert out == {"existing": True}
+    crd.create_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_reads_back_on_a_raced_409(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.create_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.CONFLICT
+    )
+    # Absent up-front, then created by a racing writer between the two calls.
+    monkeypatch.setattr(ops, "_read", AsyncMock(side_effect=[None, {"raced": True}]))
+
+    out = await ops._create(
+        _INSTANCE_TYPE, {"metadata": {"name": "obj"}, "spec": {}}, True
+    )
+
+    assert out == {"raced": True}
+
+
+@pytest.mark.asyncio
+async def test_create_reraises_409_when_not_ignoring_existed(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.create_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.CONFLICT
+    )
+
+    with pytest.raises(client.exceptions.ApiException):
+        await ops._create(
+            _INSTANCE_TYPE, {"metadata": {"name": "obj"}, "spec": {}}, False
+        )
+
+
+@pytest.mark.parametrize("spec, group, version, namespace", _SCOPE_CASES)
+@pytest.mark.asyncio
+async def test_upsert_creates_with_the_resolved_gvr_when_the_patch_404s(
+    monkeypatch, ops, spec, group, version, namespace
+):
+    crd = _fake_crd(monkeypatch, ops)
+    monkeypatch.setattr(ops, "ensure_org_namespace", AsyncMock())
+    crd.patch_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+    crd.patch_namespaced_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+
+    out = await ops._upsert(spec, {"metadata": {"name": "obj"}, "spec": {}})
+
+    assert out == {"ok": True}
+    body = {
+        "apiVersion": f"{group}/{version}",
+        "kind": spec.kind,
+        "metadata": {"name": "obj"},
+        "spec": {},
+    }
+    if namespace is None:
+        crd.create_cluster_custom_object.assert_awaited_once_with(
+            group=group, version=version, plural=spec.plural, body=body
+        )
+        crd.create_namespaced_custom_object.assert_not_awaited()
+    else:
+        body["metadata"] = {"name": "obj", "namespace": namespace}
+        crd.create_namespaced_custom_object.assert_awaited_once_with(
+            group=group,
+            version=version,
+            plural=spec.plural,
+            namespace=namespace,
+            body=body,
+        )
+        crd.create_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_reraises_a_non_404_patch_failure(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.patch_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.FORBIDDEN
+    )
+
+    with pytest.raises(client.exceptions.ApiException):
+        await ops._upsert(_INSTANCE_TYPE, {"metadata": {"name": "obj"}, "spec": {}})
+
+    crd.create_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_reads_back_when_the_create_races(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.patch_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+    crd.create_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.CONFLICT
+    )
+    monkeypatch.setattr(ops, "_read", AsyncMock(return_value={"raced": True}))
+
+    out = await ops._upsert(_INSTANCE_TYPE, {"metadata": {"name": "obj"}, "spec": {}})
+
+    assert out == {"raced": True}
+
+
+@pytest.mark.asyncio
+async def test_upsert_reraises_when_the_raced_object_is_already_gone(monkeypatch, ops):
+    # 409 then a read-back that finds nothing: there is no post-condition to
+    # return, so the conflict propagates instead of reading as a success.
+    crd = _fake_crd(monkeypatch, ops)
+    crd.patch_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+    crd.create_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.CONFLICT
+    )
+    monkeypatch.setattr(ops, "_read", AsyncMock(return_value=None))
+
+    with pytest.raises(client.exceptions.ApiException):
+        await ops._upsert(_INSTANCE_TYPE, {"metadata": {"name": "obj"}, "spec": {}})
+
+
+@pytest.mark.asyncio
+async def test_patch_spec_returns_none_on_404(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.patch_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+
+    assert await ops._patch_spec(_INSTANCE_TYPE, "gone", {"inactive": True}) is None
+
+
+@pytest.mark.asyncio
+async def test_patch_spec_reraises_other_api_errors(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.patch_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.FORBIDDEN
+    )
+
+    with pytest.raises(client.exceptions.ApiException):
+        await ops._patch_spec(_INSTANCE_TYPE, "denied", {"inactive": True})
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_false_on_404(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.delete_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+
+    assert await ops._delete(_INSTANCE_TYPE, "gone") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_reraises_other_api_errors(monkeypatch, ops):
+    crd = _fake_crd(monkeypatch, ops)
+    crd.delete_cluster_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.FORBIDDEN
+    )
+
+    with pytest.raises(client.exceptions.ApiException):
+        await ops._delete(_INSTANCE_TYPE, "denied")

--- a/tests/gpu_instances/test_operator_settings.py
+++ b/tests/gpu_instances/test_operator_settings.py
@@ -1,0 +1,912 @@
+"""Guards for the operator ``Setting`` client and its convergence reconciler.
+
+The operator seeds each ``Setting`` from ``GPUSTACK_<UPPER_SNAKE_NAME>`` on its
+first deploy and never overwrites a stored value afterwards, so editing a
+registered cluster's environment is inert and the ``Setting`` itself has to be
+patched. Three facts measured against a live cluster shape everything below and
+are pinned here so a regression cannot pass:
+
+* ``spec`` reads back as ``{}`` — ``spec.value`` is write-only and
+  ``status.value`` is the only observable value. The fake below therefore always
+  answers ``spec={}``, so an implementation that compared ``spec`` would diff
+  against nothing forever and patch on every tick.
+* ``Setting`` has no Creater (a create answers 405), so the path is patch-only.
+* A wrong namespace answers 404, which ``_patch_spec`` swallows into ``None`` —
+  a mis-namespaced reconciler would loop forever writing nothing. ``None`` from
+  a read or a patch is a failure here, never "absent, fine".
+"""
+
+import asyncio
+import http
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from kubernetes_asyncio import client
+
+from gpustack.gpu_instances import settings
+from gpustack.gpu_instances.cluster_apis import ClusterOps
+from gpustack.schemas.clusters import (
+    ClusterProvider,
+    GpuInstanceOptions,
+    K8sOptions,
+)
+from gpustack.schemas.workers import WorkerStateEnum
+from gpustack.server.bus import Event, EventType
+
+CLUSTER_ID = 7
+
+# The operator's setting names and the default system namespace, written out
+# instead of imported from the module under test: an assertion that reads the
+# same constant the code reads would mirror a regression rather than catch it.
+DERIVED = "instance-type-derived-from-node"
+MIXED = "instance-type-mixed-on-node"
+ADDRESS = "instance-access-static-address"
+DEFAULT_NAMESPACE = "gpustack-system"
+
+_MISSING = object()
+
+
+def _cluster(
+    gpu_instance_options=_MISSING,
+    cluster_id: int = CLUSTER_ID,
+    namespace=None,
+    provider: ClusterProvider = ClusterProvider.Kubernetes,
+    k8s_options=_MISSING,
+):
+    """A cluster row as the bus delivers it.
+
+    ``k8s_options`` may be handed in as a raw dict: the JSON column is not
+    re-validated on replay, so the reconciler has to read both shapes.
+    """
+    cluster = MagicMock()
+    cluster.id = cluster_id
+    cluster.provider = provider
+    cluster.registration_token = "tok"
+    if k8s_options is _MISSING:
+        options = (
+            GpuInstanceOptions(gpu_instance_type_derived_from_node=False)
+            if gpu_instance_options is _MISSING
+            else gpu_instance_options
+        )
+        k8s_options = K8sOptions(namespace=namespace, gpu_instance_options=options)
+    cluster.k8s_options = k8s_options
+    return cluster
+
+
+def _worker(
+    cluster_id: int = CLUSTER_ID,
+    state: WorkerStateEnum = WorkerStateEnum.READY,
+    worker_id: int = 1,
+):
+    worker = MagicMock()
+    worker.id = worker_id
+    worker.cluster_id = cluster_id
+    worker.state = state
+    return worker
+
+
+class _FakeOps:
+    """A ``ClusterOps`` double serving one in-memory ``Setting`` catalog.
+
+    Mirrors the two shapes that matter: a read answers ``spec={}`` plus the
+    value under ``status``, and an unknown name answers ``None`` the way a 404
+    does.
+    """
+
+    def __init__(self, harness, **kwargs):
+        self._h = harness
+        self.kwargs = kwargs
+        self.cluster_id = kwargs["cluster_id"]
+        # ClusterOps' own fallback, mirrored so the namespace on the wire can
+        # be asserted rather than the argument that produced it.
+        self.system_namespace = kwargs.get("system_namespace") or DEFAULT_NAMESPACE
+        self.closed = False
+        harness.ops.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+        return False
+
+    async def read_setting(self, name):
+        self._h.reads.append((self.cluster_id, name))
+        # Lets a test park one cluster's read mid-flight, the way an
+        # unreachable proxy does — deterministically, without a sleep.
+        stall = self._h.stall.get(self.cluster_id)
+        if stall is not None:
+            stall["entered"].set()
+            await stall["release"].wait()
+        if self._h.read_error is not None:
+            raise self._h.read_error
+        value = self._h.remote.get(name, _MISSING)
+        if value is _MISSING:
+            return None
+        return {
+            "apiVersion": "gpustack.ai/v1",
+            "kind": "Setting",
+            "metadata": {"name": name, "namespace": self.system_namespace},
+            "spec": {},
+            "status": {"value": value, "editable": True, "sensitive": False},
+        }
+
+    async def patch_setting_value(self, name, value):
+        self._h.patches.append((self.cluster_id, name, value))
+        if name in self._h.failing_names:
+            raise _api_exception(http.HTTPStatus.INTERNAL_SERVER_ERROR)
+        if self._h.patch_returns_none:
+            return None
+        self._h.remote[name] = value
+        return {"metadata": {"name": name}, "spec": {"value": value}}
+
+
+def _api_exception(status: int) -> client.exceptions.ApiException:
+    return client.exceptions.ApiException(status=status, reason="boom")
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    """A reconciler whose cluster client and reachability query are stubbed."""
+    config = MagicMock()
+    config.get_api_port.return_value = 80
+
+    h = SimpleNamespace(
+        ops=[],
+        reads=[],
+        patches=[],
+        # The operator's own defaults, as a freshly deployed catalog reports them.
+        remote={DERIVED: "true", MIXED: "true", ADDRESS: ""},
+        read_error=None,
+        stall={},
+        failing_names=set(),
+        patch_returns_none=False,
+        ready_workers=1,
+        reconciler=settings.OperatorSettingsReconciler(config),
+    )
+    monkeypatch.setattr(settings, "ClusterOps", lambda **kwargs: _FakeOps(h, **kwargs))
+
+    async def count_ready_workers(cluster_id: int) -> int:
+        return h.ready_workers
+
+    monkeypatch.setattr(settings, "count_ready_workers", count_ready_workers)
+    return h
+
+
+async def _cluster_event(harness, cluster, event_type=EventType.CREATED):
+    await harness.reconciler._reconcile_cluster(Event(type=event_type, data=cluster))
+
+
+async def _heartbeats(harness, count: int = 1):
+    for _ in range(count):
+        await harness.reconciler._reconcile_cluster(
+            Event(type=EventType.HEARTBEAT, data=None)
+        )
+
+
+def _names(entries):
+    """The setting names touched, whatever the entry arity."""
+    return {entry[1] for entry in entries}
+
+
+#
+# The three knobs: what is managed, and what is left alone
+#
+
+
+@pytest.mark.asyncio
+async def test_unmanaged_knobs_are_never_read_or_written(harness):
+    """AC4.4: an unset knob is not GPUStack's, so it is not even looked at —
+    the operator catalog is administered by ``kubectl`` too, and reverting an
+    administrator's edit is the failure this rule exists to prevent."""
+    await _cluster_event(
+        harness,
+        _cluster(GpuInstanceOptions(gpu_instance_type_derived_from_node=False)),
+    )
+
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+    assert _names(harness.reads) == {DERIVED}
+    assert MIXED not in _names(harness.reads) | _names(harness.patches)
+    assert ADDRESS not in _names(harness.reads) | _names(harness.patches)
+
+
+@pytest.mark.asyncio
+async def test_false_and_blank_are_managed_values(harness):
+    """Only ``None`` is unmanaged: ``False`` and ``""`` are values an
+    administrator asked for, and a bool goes out as the operator's string."""
+    harness.remote[ADDRESS] = "10.0.0.1"
+    await _cluster_event(
+        harness,
+        _cluster(
+            GpuInstanceOptions(
+                gpu_instance_type_derived_from_node=False,
+                gpu_instance_type_mixed_on_node=True,
+                gpu_instances_access_static_address="",
+            )
+        ),
+    )
+
+    # ``mixed_on_node=True`` already matches the catalog, so it is read and left.
+    assert sorted(harness.patches) == [
+        (CLUSTER_ID, ADDRESS, ""),
+        (CLUSTER_ID, DERIVED, "false"),
+    ]
+    assert _names(harness.reads) == {DERIVED, MIXED, ADDRESS}
+
+
+@pytest.mark.asyncio
+async def test_status_value_is_what_desired_is_compared_against(harness):
+    """AC4.2: ``spec`` reads back as ``{}`` and ``status.value`` carries the
+    value, so an equal setting must produce no write at all. An implementation
+    comparing ``spec`` would diff against ``{}`` and patch here."""
+    harness.remote[DERIVED] = "false"
+
+    await _cluster_event(harness, _cluster())
+
+    assert harness.reads == [(CLUSTER_ID, DERIVED)]
+    assert harness.patches == []
+
+
+@pytest.mark.asyncio
+async def test_drift_patches_exactly_once(harness):
+    """The catalog says ``true``, the cluster row says ``false``: one patch, and
+    no repeat while the desired value is unchanged."""
+    await _cluster_event(harness, _cluster())
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+    # A re-published row and the heartbeats before the next resync add nothing.
+    await _cluster_event(harness, _cluster(), event_type=EventType.UPDATED)
+    await _heartbeats(harness, settings.RESYNC_HEARTBEAT_INTERVAL - 1)
+
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+
+@pytest.mark.asyncio
+async def test_a_desired_value_edit_converges(harness):
+    """The administrator's edit is the whole point: a new desired value on an
+    already converged cluster is patched through."""
+    await _cluster_event(harness, _cluster())
+
+    await _cluster_event(
+        harness,
+        _cluster(GpuInstanceOptions(gpu_instance_type_derived_from_node=True)),
+        event_type=EventType.UPDATED,
+    )
+
+    assert harness.patches == [
+        (CLUSTER_ID, DERIVED, "false"),
+        (CLUSTER_ID, DERIVED, "true"),
+    ]
+
+
+#
+# Which clusters are touched at all
+#
+
+
+@pytest.mark.asyncio
+async def test_model_service_cluster_is_never_touched(harness):
+    """A cluster with no ``gpu_instance_options`` is registered for Model
+    Service; it has no operator settings GPUStack owns, so no client is even
+    built for it."""
+    await _cluster_event(harness, _cluster(None))
+    await _heartbeats(harness, settings.RESYNC_HEARTBEAT_INTERVAL)
+
+    assert harness.ops == []
+    assert harness.reads == []
+    assert harness.patches == []
+
+
+@pytest.mark.asyncio
+async def test_gpu_service_cluster_without_a_managed_knob_is_not_contacted(harness):
+    """A GPU Service cluster that manages nothing costs no call either."""
+    await _cluster_event(harness, _cluster(GpuInstanceOptions()))
+    await _heartbeats(harness, settings.RESYNC_HEARTBEAT_INTERVAL)
+
+    assert harness.ops == []
+
+
+@pytest.mark.asyncio
+async def test_non_kubernetes_cluster_is_ignored(harness):
+    """Docker and cloud clusters have no operator to converge."""
+    await _cluster_event(harness, _cluster(provider=ClusterProvider.Docker))
+
+    assert harness.ops == []
+
+
+@pytest.mark.asyncio
+async def test_switching_to_model_service_stops_convergence(harness):
+    """After a purpose switch the settings stop being GPUStack's, so later drift
+    in the cluster's own catalog is left alone."""
+    await _cluster_event(harness, _cluster())
+    await _cluster_event(harness, _cluster(None), event_type=EventType.UPDATED)
+
+    harness.remote[DERIVED] = "true"
+    await _heartbeats(harness, settings.RESYNC_HEARTBEAT_INTERVAL)
+
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+
+@pytest.mark.asyncio
+async def test_deleted_cluster_is_forgotten(harness):
+    """A deleted cluster keeps no work behind it."""
+    harness.ready_workers = 0
+    await _cluster_event(harness, _cluster())
+    await _cluster_event(harness, _cluster(), event_type=EventType.DELETED)
+
+    harness.ready_workers = 1
+    await _heartbeats(harness, settings.RESYNC_HEARTBEAT_INTERVAL)
+
+    assert harness.ops == []
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_cluster_does_not_block_another(harness):
+    """A cluster hung mid-converge must not hold up anyone else.
+
+    ``ClusterOps`` sets no request timeout of its own, so a converge against an
+    unreachable cluster runs until ``SETTING_REQUEST_TIMEOUT`` gives up on it —
+    once per managed knob. If the reconciler held ``_lock`` across that, one
+    cluster would stall every other cluster's convergence and every event this
+    reconciler handles, which is the isolation ``_on_heartbeat``'s docstring
+    promises.
+    """
+    other = CLUSTER_ID + 1
+    harness.ready_workers = 0
+    await _cluster_event(harness, _cluster())
+    await _cluster_event(harness, _cluster(cluster_id=other))
+    harness.ready_workers = 1
+
+    harness.stall[CLUSTER_ID] = {
+        "entered": asyncio.Event(),
+        "release": asyncio.Event(),
+    }
+    hung = asyncio.create_task(
+        harness.reconciler._reconcile_worker(
+            Event(type=EventType.CREATED, data=_worker())
+        )
+    )
+    await asyncio.wait_for(harness.stall[CLUSTER_ID]["entered"].wait(), timeout=2)
+
+    # The second cluster gets its writes while the first is still parked.
+    await asyncio.wait_for(
+        harness.reconciler._reconcile_worker(
+            Event(type=EventType.CREATED, data=_worker(cluster_id=other))
+        ),
+        timeout=2,
+    )
+    assert other in {patch[0] for patch in harness.patches}
+
+    harness.stall[CLUSTER_ID]["release"].set()
+    await asyncio.wait_for(hung, timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_a_silent_proxy_times_out_instead_of_hanging(harness, monkeypatch):
+    """A call that is accepted and never answered is bounded, not waited on.
+
+    ``kubernetes_asyncio`` builds a bare ``aiohttp.ClientTimeout()`` when no
+    request timeout is given — every field ``None``, so nothing ever expires.
+    A cluster whose workers are still READY while the tunnel behind them is a
+    black hole would therefore park the watcher task forever, taking every
+    other cluster's events and retries with it. The bound turns that into an
+    ordinary failed convergence: nothing written, still pending, retried on the
+    next heartbeat.
+    """
+    monkeypatch.setattr(settings, "SETTING_REQUEST_TIMEOUT", 0.05)
+    harness.stall[CLUSTER_ID] = {
+        "entered": asyncio.Event(),
+        "release": asyncio.Event(),
+    }
+
+    await asyncio.wait_for(_cluster_event(harness, _cluster()), timeout=2)
+
+    assert harness.patches == []
+    assert CLUSTER_ID in harness.reconciler._pending
+
+    harness.stall[CLUSTER_ID]["release"].set()
+
+
+@pytest.mark.asyncio
+async def test_an_update_during_convergence_is_not_swallowed(harness):
+    """A cluster edited mid-converge stays pending.
+
+    Convergence runs outside the lock, so a Cluster update can land while it is
+    awaiting the proxy. The pass that finishes is carrying the *previous*
+    desired values, so clearing the cluster's pending flag on its way out would
+    drop the newer edit on the floor — and nothing would notice until the next
+    resync, up to five minutes later.
+    """
+    harness.ready_workers = 0
+    await _cluster_event(harness, _cluster())
+    harness.ready_workers = 1
+
+    stall = {"entered": asyncio.Event(), "release": asyncio.Event()}
+    harness.stall[CLUSTER_ID] = stall
+    converging = asyncio.create_task(
+        harness.reconciler._reconcile_worker(
+            Event(type=EventType.CREATED, data=_worker())
+        )
+    )
+    await asyncio.wait_for(stall["entered"].wait(), timeout=2)
+
+    # A new desired value lands while that pass is still parked. Unreachable
+    # for the moment, so the update only records the work rather than racing
+    # the pass in flight for it.
+    harness.ready_workers = 0
+    await _cluster_event(
+        harness,
+        _cluster(
+            gpu_instance_options=GpuInstanceOptions(
+                gpu_instance_type_derived_from_node=True
+            )
+        ),
+    )
+
+    stall["release"].set()
+    await asyncio.wait_for(converging, timeout=2)
+
+    assert CLUSTER_ID in harness.reconciler._pending
+
+
+@pytest.mark.asyncio
+async def test_deleted_cluster_is_forgotten_from_an_id_only_event(harness):
+    """A DELETED event carrying only an id still forgets the cluster.
+
+    In distributed mode the bus hands subscribers ``Event(data={"id": N})``
+    whenever its change-detector cache holds no entry for the row
+    (``bus.py``: "No cached object, route ID-only event for DELETED"). That is
+    the normal state for a freshly elected leader, because ``cluster`` is not
+    in ``_preload_change_detector_cache``'s topic list. Reading an attribute
+    off that dict raises, ``_watch`` swallows the exception, and the target —
+    registration token and all — would then outlive the cluster and be retried
+    on every resync.
+    """
+    harness.ready_workers = 0
+    await _cluster_event(harness, _cluster())
+    await harness.reconciler._reconcile_cluster(
+        Event(type=EventType.DELETED, data={"id": CLUSTER_ID})
+    )
+
+    harness.ready_workers = 1
+    await _heartbeats(harness, settings.RESYNC_HEARTBEAT_INTERVAL)
+
+    assert harness.ops == []
+
+
+@pytest.mark.parametrize(
+    "options_key, knob_key",
+    [
+        pytest.param("gpuInstanceOptions", "gpuInstanceTypeMixedOnNode", id="camel"),
+        pytest.param(
+            "gpu_instance_options", "gpu_instance_type_mixed_on_node", id="snake"
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_bus_delivered_dict_options_are_understood(
+    harness, options_key, knob_key
+):
+    """``k8s_options`` arrives from the bus as a plain dict — camel from an API
+    submission, snake from ``model_dump`` — and both must read the same."""
+    k8s_options = {"namespace": "ops-ns", options_key: {knob_key: False}}
+
+    await _cluster_event(harness, _cluster(k8s_options=k8s_options))
+
+    assert harness.patches == [(CLUSTER_ID, MIXED, "false")]
+    assert harness.ops[-1].system_namespace == "ops-ns"
+
+
+@pytest.mark.asyncio
+async def test_client_addresses_the_cluster_system_namespace(harness):
+    """AC4.1: settings live beside the operator in the cluster's *system*
+    namespace, not in the per-Org namespace every other namespaced resource
+    uses — and a wrong namespace fails silently, so this is pinned."""
+    await _cluster_event(harness, _cluster(namespace="ops-ns"))
+    assert harness.ops[-1].system_namespace == "ops-ns"
+    assert harness.ops[-1].kwargs["cluster_registration_token"] == "tok"
+
+    # A cluster registered without an explicit namespace falls back to the
+    # namespace the manifest renderer defaults to.
+    await _cluster_event(harness, _cluster(cluster_id=8))
+    assert harness.ops[-1].system_namespace == DEFAULT_NAMESPACE
+
+
+#
+# Reachability, failure and retry
+#
+
+
+@pytest.mark.asyncio
+async def test_unreachable_cluster_is_retried_not_dropped(harness):
+    """AC4.3: a cluster that is unreachable when the administrator saves must
+    converge on its own once it comes back, with no further user action."""
+    harness.read_error = _api_exception(http.HTTPStatus.SERVICE_UNAVAILABLE)
+
+    await _cluster_event(harness, _cluster())
+    assert harness.patches == []
+
+    await _heartbeats(harness)
+    assert len(harness.reads) == 2  # retried, not dropped
+    assert harness.patches == []
+
+    harness.read_error = None
+    await _heartbeats(harness)
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+
+@pytest.mark.asyncio
+async def test_empty_cluster_is_not_contacted_until_a_worker_is_ready(harness):
+    """Reachability arrives as a Worker event: the cluster row does not change
+    when a worker registers, so no Cluster event ever fires for it."""
+    harness.ready_workers = 0
+    await _cluster_event(harness, _cluster())
+    assert harness.ops == []
+
+    harness.ready_workers = 1
+    await harness.reconciler._reconcile_worker(
+        Event(
+            type=EventType.UPDATED,
+            data=_worker(),
+            changed_fields={
+                "state": (WorkerStateEnum.NOT_READY, WorkerStateEnum.READY)
+            },
+        )
+    )
+
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+
+@pytest.mark.asyncio
+async def test_worker_status_flush_does_not_reconverge(harness):
+    """Every posting worker is republished every few seconds; an event that does
+    not move its state cannot change reachability, so it must cost nothing."""
+    await _cluster_event(harness, _cluster())
+    reads = len(harness.reads)
+
+    await harness.reconciler._reconcile_worker(
+        Event(type=EventType.UPDATED, data=_worker())
+    )
+
+    assert len(harness.reads) == reads
+
+
+@pytest.mark.asyncio
+async def test_a_worker_leaving_ready_costs_nothing(harness):
+    """A worker going away can only make a cluster *less* reachable, and a
+    cluster that cannot be reached is already stale and already retried."""
+    harness.read_error = _api_exception(http.HTTPStatus.SERVICE_UNAVAILABLE)
+    await _cluster_event(harness, _cluster())
+    reads = len(harness.reads)
+
+    await harness.reconciler._reconcile_worker(
+        Event(
+            type=EventType.UPDATED,
+            data=_worker(state=WorkerStateEnum.UNREACHABLE),
+            changed_fields={
+                "state": (WorkerStateEnum.READY, WorkerStateEnum.UNREACHABLE)
+            },
+        )
+    )
+    await harness.reconciler._reconcile_worker(
+        Event(type=EventType.DELETED, data=_worker())
+    )
+
+    assert len(harness.reads) == reads
+
+
+@pytest.mark.asyncio
+async def test_a_worker_without_a_cluster_is_ignored(harness):
+    """A worker that names no cluster resolves to nothing to converge."""
+    await harness.reconciler._reconcile_worker(
+        Event(type=EventType.CREATED, data=_worker(cluster_id=None))
+    )
+
+    assert harness.ops == []
+
+
+@pytest.mark.asyncio
+async def test_a_silent_404_from_a_patch_is_a_failure(harness):
+    """``_patch_spec`` answers ``None`` on a 404 — the shape a wrong namespace
+    takes. Treating it as "absent, fine" would loop forever writing nothing, so
+    it keeps the cluster stale and is retried."""
+    harness.patch_returns_none = True
+
+    await _cluster_event(harness, _cluster())
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+    await _heartbeats(harness)
+    assert len(harness.patches) == 2
+
+    harness.patch_returns_none = False
+    await _heartbeats(harness)
+    assert len(harness.patches) == 3
+    await _heartbeats(harness)
+    assert len(harness.patches) == 3  # converged, so the retry stops
+
+
+@pytest.mark.asyncio
+async def test_an_absent_setting_is_a_failure(harness):
+    """A name the catalog does not serve is a misconfiguration, not a no-op:
+    the catalog is fixed, so there is nothing to create and nothing to skip."""
+    harness.remote.pop(DERIVED)
+
+    await _cluster_event(harness, _cluster())
+
+    assert harness.patches == []
+    await _heartbeats(harness)
+    assert len(harness.reads) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_failing_setting_does_not_block_the_others(harness):
+    """AC4.5: a patch failure is logged and retried; it never wedges the loop,
+    and it never costs the sibling knobs their convergence."""
+    harness.failing_names = {DERIVED}
+
+    await _cluster_event(
+        harness,
+        _cluster(
+            GpuInstanceOptions(
+                gpu_instance_type_derived_from_node=False,
+                gpu_instance_type_mixed_on_node=False,
+            )
+        ),
+    )
+
+    # The raising knob did not take its sibling down with it ...
+    assert (CLUSTER_ID, MIXED, "false") in harness.patches
+    assert harness.remote[MIXED] == "false"
+
+    # ... and the cluster stays stale, so the failing knob is retried.
+    await _heartbeats(harness)
+    assert len([p for p in harness.patches if p[1] == DERIVED]) == 2
+    # The converged sibling is re-read on the retry but not written again.
+    assert len([p for p in harness.patches if p[1] == MIXED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_one_failing_cluster_does_not_starve_the_others(harness, monkeypatch):
+    """The heartbeat retries every stale cluster under one lock, so a cluster
+    that keeps failing must not stop the rest from being retried."""
+    harness.ready_workers = 0
+    await _cluster_event(harness, _cluster(cluster_id=1))
+    await _cluster_event(harness, _cluster(cluster_id=2))
+
+    async def count_ready_workers(cluster_id: int) -> int:
+        if cluster_id == 1:
+            raise RuntimeError("database is down")
+        return 1
+
+    monkeypatch.setattr(settings, "count_ready_workers", count_ready_workers)
+    await _heartbeats(harness)
+
+    assert harness.patches == [(2, DERIVED, "false")]
+
+
+#
+# The event streams themselves
+#
+
+
+@pytest.mark.asyncio
+async def test_a_failing_event_does_not_kill_the_watcher(harness, caplog):
+    """One event that blows up must not take its stream down: the next event
+    still has to be reconciled, or the reconciler dies without saying so."""
+    seen = []
+
+    async def stream():
+        yield Event(type=EventType.CREATED, data=None)
+        yield Event(type=EventType.CREATED, data=_cluster())
+
+    async def reconcile(event):
+        seen.append(event)
+        if event.data is None:
+            raise RuntimeError("boom")
+
+    with caplog.at_level(logging.ERROR, logger=settings.logger.name):
+        await harness.reconciler._watch("cluster", stream(), reconcile)
+
+    assert len(seen) == 2
+    assert caplog.records
+
+
+@pytest.mark.asyncio
+async def test_a_dying_watcher_takes_the_other_down(harness, monkeypatch):
+    """Both streams are needed to decide a convergence, so one dying must not
+    leave the other running: a half-dead reconciler keeps the process up while
+    converging nothing."""
+    worker_watching = asyncio.Event()
+    worker_cancelled = asyncio.Event()
+
+    async def failing_clusters(**kwargs):
+        # Die only once the other watcher is actually watching. A watcher
+        # cancelled before its first step never enters its own body, so without
+        # this the evidence below would be a matter of scheduling rather than of
+        # the reconciler's behaviour.
+        await worker_watching.wait()
+        raise RuntimeError("cluster stream died")
+        yield  # unreachable, but makes this an async generator
+
+    async def idle_workers(**kwargs):
+        worker_watching.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            worker_cancelled.set()
+            raise
+        yield  # unreachable, but makes this an async generator
+
+    monkeypatch.setattr(settings.Cluster, "subscribe", failing_clusters)
+    monkeypatch.setattr(settings.Worker, "subscribe", idle_workers)
+
+    with pytest.raises(RuntimeError):
+        await harness.reconciler.start()
+
+    # The cancellation is joined before start() returns, so the survivor cannot
+    # still be running — nor be garbage-collected while pending — once the
+    # caller is back.
+    assert worker_cancelled.is_set()
+
+
+#
+# Level-triggered resync
+#
+
+
+@pytest.mark.asyncio
+async def test_external_drift_is_repaired_by_the_periodic_resync(harness):
+    """AC4.3: convergence is level-triggered. A ``kubectl`` edit of one of the
+    three settings GPUStack manages would otherwise leave the UI and the cluster
+    silently disagreeing — which is exactly what F4 exists to prevent."""
+    # ~5 minutes at the bus's 15s idle heartbeat: cheap enough to run forever,
+    # short enough that a drifted cluster is not left wrong for long.
+    assert settings.RESYNC_HEARTBEAT_INTERVAL == 20
+
+    await _cluster_event(harness, _cluster())
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+    harness.remote[DERIVED] = "true"  # an administrator's kubectl edit
+
+    await _heartbeats(harness, settings.RESYNC_HEARTBEAT_INTERVAL - 1)
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+    await _heartbeats(harness)
+    assert harness.patches == [
+        (CLUSTER_ID, DERIVED, "false"),
+        (CLUSTER_ID, DERIVED, "false"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_resync_reads_but_does_not_write_a_converged_cluster(harness):
+    """The resync is a comparison, not a write: a cluster still carrying the
+    desired value costs one read per managed knob and no patch."""
+    await _cluster_event(harness, _cluster())
+    reads = len(harness.reads)
+
+    await _heartbeats(harness, settings.RESYNC_HEARTBEAT_INTERVAL)
+
+    assert len(harness.reads) == reads + 1
+    assert harness.patches == [(CLUSTER_ID, DERIVED, "false")]
+
+
+#
+# Log volume: a broken cluster must neither flood nor vanish
+#
+
+
+@pytest.mark.asyncio
+async def test_a_persistent_failure_is_reported_once_then_quietly(harness, caplog):
+    """One WARNING when it breaks, DEBUG while it stays broken, INFO when it
+    recovers — a bad cluster must not put four lines a minute in the log, and a
+    long outage must not disappear from it either."""
+    harness.read_error = _api_exception(http.HTTPStatus.SERVICE_UNAVAILABLE)
+
+    with caplog.at_level(logging.DEBUG, logger=settings.logger.name):
+        await _cluster_event(harness, _cluster())
+        await _heartbeats(harness, 3)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert DERIVED in warnings[0].getMessage()
+        assert DEFAULT_NAMESPACE in warnings[0].getMessage()
+        assert [r for r in caplog.records if r.levelno == logging.DEBUG]
+
+        caplog.clear()
+        harness.read_error = None
+        await _heartbeats(harness)
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+    assert [r for r in caplog.records if r.levelno == logging.INFO]
+
+
+#
+# The ClusterOps client the reconciler drives
+#
+
+
+@pytest_asyncio.fixture
+async def ops():
+    o = ClusterOps(
+        server_api_port=1,
+        cluster_id=CLUSTER_ID,
+        cluster_registration_token="tok",
+        cluster_owner_principal_identifier="default",
+        system_namespace="ops-ns",
+    )
+    yield o
+    await o.close()
+
+
+def _fake_crd(monkeypatch, ops):
+    crd = MagicMock()
+    for name in (
+        "get_namespaced_custom_object",
+        "patch_namespaced_custom_object",
+        "get_cluster_custom_object",
+        "patch_cluster_custom_object",
+        "create_namespaced_custom_object",
+    ):
+        setattr(crd, name, AsyncMock(return_value={"ok": True}))
+    monkeypatch.setattr(ops, "_crd", lambda: crd)
+    return crd
+
+
+@pytest.mark.asyncio
+async def test_read_setting_addresses_the_operator_group(monkeypatch, ops):
+    """``Setting`` is ``gpustack.ai/v1``, not the ``worker.gpustack.ai/v1`` every
+    other resource here uses, and it is namespaced in the system namespace."""
+    crd = _fake_crd(monkeypatch, ops)
+
+    assert await ops.read_setting(DERIVED) == {"ok": True}
+
+    crd.get_namespaced_custom_object.assert_awaited_once_with(
+        group="gpustack.ai",
+        version="v1",
+        plural="settings",
+        namespace="ops-ns",
+        name=DERIVED,
+    )
+    crd.get_cluster_custom_object.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_patch_setting_value_merge_patches_spec_value(monkeypatch, ops):
+    """The write goes to ``spec.value`` — ``status`` is the operator's — as a
+    merge patch, and never falls through to a create: the catalog is fixed and
+    the aggregated apiserver answers a create with 405."""
+    crd = _fake_crd(monkeypatch, ops)
+
+    assert await ops.patch_setting_value(DERIVED, "false") == {"ok": True}
+
+    crd.patch_namespaced_custom_object.assert_awaited_once_with(
+        group="gpustack.ai",
+        version="v1",
+        plural="settings",
+        namespace="ops-ns",
+        name=DERIVED,
+        body={"spec": {"value": "false"}},
+        _content_type="application/merge-patch+json",
+    )
+    crd.create_namespaced_custom_object.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_setting_calls_answer_none_when_absent(monkeypatch, ops):
+    """A wrong namespace 404s, and both helpers report it as ``None`` — the
+    signal the reconciler has to treat as a failure rather than as nothing to
+    do."""
+    crd = _fake_crd(monkeypatch, ops)
+    crd.get_namespaced_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+    crd.patch_namespaced_custom_object.side_effect = _api_exception(
+        http.HTTPStatus.NOT_FOUND
+    )
+
+    assert await ops.read_setting(DERIVED) is None
+    assert await ops.patch_setting_value(DERIVED, "false") is None

--- a/tests/k8s/test_template_render.py
+++ b/tests/k8s/test_template_render.py
@@ -1,5 +1,8 @@
+import json
+
 import yaml
 from gpustack_runtime.detector import ManufacturerEnum
+from sqlalchemy.dialects import sqlite
 
 from gpustack.k8s.manifest_template import (
     WORKER_DS_BASENAME,
@@ -7,12 +10,15 @@ from gpustack.k8s.manifest_template import (
 )
 from gpustack.schemas.clusters import ClusterRegistrationTokenPublic
 from gpustack.schemas.clusters import (
+    Cluster,
+    GpuInstanceOptions,
     HostPathVolumeSource,
     ImageCredential,
     K8sOptions,
     K8sVolumeMount,
     OperatorOptions,
     VolumeSource,
+    is_gpu_service_k8s_options,
 )
 
 # PCI presence labels per vendor (mirrors _MANUFACTURER_PCI_ID).
@@ -685,3 +691,215 @@ def test_worker_ports_override_propagates_everywhere():
     env = _container_env_map(container)
     assert env["GPUSTACK_WORKER_PORT"] == "10152"
     assert env["GPUSTACK_WORKER_METRICS_PORT"] == "10153"
+
+
+# ---------------------------------------------------------------------------
+# GPU Service operator knobs — the three settings GPUStack manages on a GPU
+# Service cluster. Each is tri-state: unset means GPUStack does not manage it
+# and the cluster's own value stands, which is a different instruction from an
+# explicit off. Two things are under test here: that the tri-state survives
+# both the schema round trip and the persisted column (the column's presence
+# is the cluster-purpose signal), and that each *set* knob renders the
+# GPUSTACK_* env entry the operator seeds its Setting from on first deploy.
+# ---------------------------------------------------------------------------
+
+
+def _persisted_k8s_options(k8s_options: K8sOptions) -> dict:
+    """Serialize through the real ``clusters.k8s_options`` column.
+
+    Drives the column's own bind processor rather than a hand-rolled
+    ``jsonable_encoder`` call, so the test reads the
+    ``exclude_none`` / ``exclude_unset`` / ``exclude_defaults`` flags off the
+    schema itself. Changing them there has to fail here rather than slip past
+    a duplicated literal.
+    """
+    processor = Cluster.__table__.c.k8s_options.type.bind_processor(sqlite.dialect())
+    dumped = processor(k8s_options)
+    return json.loads(dumped) if isinstance(dumped, str) else dumped
+
+
+def _operator_env_map(**render_kwargs):
+    docs = _render_docs(runtimes=[ManufacturerEnum.NVIDIA], **render_kwargs)
+    return {
+        e["name"]: e.get("value")
+        for e in _operator_deployment_env(docs)
+        if "value" in e
+    }
+
+
+def _gpu_instance_env(**gpu_instance_options):
+    """Operator container env map for a GPU Service cluster with these knobs."""
+    return _operator_env_map(
+        k8s_options=K8sOptions(
+            gpu_instance_options=GpuInstanceOptions(**gpu_instance_options)
+        )
+    )
+
+
+def test_gpu_instance_options_round_trips_snake_keys():
+    options = GpuInstanceOptions.model_validate(
+        {
+            "gpu_instances_access_static_address": "10.0.0.1",
+            "instance_type_derived_from_node": False,
+            "instance_type_mixed_on_node": True,
+        }
+    )
+    assert options.gpu_instances_access_static_address == "10.0.0.1"
+    assert options.instance_type_derived_from_node is False
+    assert options.instance_type_mixed_on_node is True
+
+
+def test_gpu_instance_options_round_trips_camel_keys():
+    """The aliases must equal the operator/gateway keys exactly: the UI and API
+    submit camel, and the column persists camel (``by_alias``)."""
+    options = GpuInstanceOptions.model_validate(
+        {
+            "gpuInstancesAccessStaticAddress": "10.0.0.1",
+            "instanceTypeDerivedFromNode": True,
+            "instanceTypeMixedOnNode": False,
+        }
+    )
+    assert options.instance_type_derived_from_node is True
+    assert options.instance_type_mixed_on_node is False
+    assert options.model_dump(by_alias=True, exclude_none=True) == {
+        "gpuInstancesAccessStaticAddress": "10.0.0.1",
+        "instanceTypeDerivedFromNode": True,
+        "instanceTypeMixedOnNode": False,
+    }
+
+
+def test_unset_gpu_instance_knobs_are_none_not_false():
+    """Tri-state at construction: an unset knob is ``None`` (unmanaged), never
+    ``False``. The settings reconciler only ever writes a knob that is set, so
+    collapsing the two would make it assert a value nobody asked GPUStack to
+    own — on a catalog that is also administered by ``kubectl``."""
+    options = GpuInstanceOptions()
+    assert options.instance_type_derived_from_node is None
+    assert options.instance_type_mixed_on_node is None
+
+
+def test_all_unset_gpu_instance_options_persists_as_a_present_object():
+    """The cluster-purpose signal has to survive the new knobs.
+
+    ``k8s_options.gpu_instance_options`` being *present* is what makes a
+    cluster GPU Service. The column persists with ``exclude_none`` /
+    ``exclude_unset`` / ``exclude_defaults``, so a knob carrying a non-``None``
+    default would be stripped back out — and if that ever emptied the object
+    into ``null``, every knob-less GPU Service cluster would silently convert
+    to Model Service on its next write, across the whole fleet.
+    """
+    persisted = _persisted_k8s_options(
+        K8sOptions(gpu_instance_options=GpuInstanceOptions())
+    )
+    assert persisted == {"gpuInstanceOptions": {}}
+    assert is_gpu_service_k8s_options(persisted) is True
+
+
+def test_unmanaged_gpu_instance_knob_is_dropped_from_the_persisted_row():
+    """An explicit null — what the form submits for "not managed" — is dropped,
+    so an unmanaged knob reads back as unset rather than as ``False``, while a
+    sibling explicit ``False`` is kept."""
+    persisted = _persisted_k8s_options(
+        K8sOptions.model_validate(
+            {
+                "gpuInstanceOptions": {
+                    "instanceTypeDerivedFromNode": None,
+                    "instanceTypeMixedOnNode": False,
+                }
+            }
+        )
+    )
+    assert persisted == {"gpuInstanceOptions": {"instanceTypeMixedOnNode": False}}
+    assert is_gpu_service_k8s_options(persisted) is True
+
+
+def test_model_service_cluster_persists_without_gpu_instance_options():
+    """The negative half of the signal: no knobs object, Model Service."""
+    persisted = _persisted_k8s_options(K8sOptions())
+    assert persisted == {}
+    assert is_gpu_service_k8s_options(persisted) is False
+
+
+def test_operator_env_seeds_set_gpu_instance_knobs():
+    env = _gpu_instance_env(
+        instance_type_derived_from_node=True,
+        instance_type_mixed_on_node=True,
+    )
+    assert env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"] == "true"
+    assert env["GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE"] == "true"
+
+
+def test_operator_env_seeds_explicit_false_as_the_string_false():
+    """The sharp edge of the tri-state: an explicit off renders ``"false"``,
+    not nothing — and as a *string*, because an unquoted YAML ``false`` is a
+    boolean and a container env value must be a string."""
+    env = _gpu_instance_env(
+        instance_type_derived_from_node=False,
+        instance_type_mixed_on_node=False,
+    )
+    assert env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"] == "false"
+    assert env["GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE"] == "false"
+    assert isinstance(env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"], str)
+    assert isinstance(env["GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE"], str)
+
+
+def test_operator_env_omits_unset_gpu_instance_knobs():
+    """A GPU Service cluster managing none of the three seeds none of them, so
+    the operator's own defaults apply."""
+    env = _gpu_instance_env()
+    assert "GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE" not in env
+    assert "GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE" not in env
+    assert "GPUSTACK_INSTANCE_ACCESS_STATIC_ADDRESS" not in env
+
+
+def test_operator_env_seeds_one_knob_without_the_other():
+    """The knobs are independent — managing one must not seed the other."""
+    env = _gpu_instance_env(instance_type_derived_from_node=False)
+    assert env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"] == "false"
+    assert "GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE" not in env
+
+
+def test_operator_env_omits_gpu_instance_knobs_for_a_model_service_cluster():
+    """No ``gpu_instance_options`` at all, with and without a k8s_options
+    object — nothing to seed either way."""
+    for k8s_options in (K8sOptions(), None):
+        env = (
+            _operator_env_map(k8s_options=k8s_options)
+            if k8s_options is not None
+            else _operator_env_map()
+        )
+        assert "GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE" not in env
+        assert "GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE" not in env
+
+
+def test_operator_env_seeds_the_static_access_address():
+    """The pre-existing third knob still seeds, alongside the two new ones."""
+    env = _gpu_instance_env(
+        gpu_instances_access_static_address="10.0.0.1",
+        instance_type_derived_from_node=True,
+    )
+    assert env["GPUSTACK_INSTANCE_ACCESS_STATIC_ADDRESS"] == "10.0.0.1"
+    assert env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"] == "true"
+
+
+def test_operator_env_static_address_survives_yaml_metacharacters():
+    """The static address is administrator-supplied free text — the field takes
+    any string — so it is JSON-quoted rather than interpolated bare.
+
+    Each shape below breaks an unquoted ``value:`` differently: the bracket form
+    of an IPv6 address with a port opens a flow sequence, ``{`` a flow mapping,
+    ``*`` an alias, and a `` #`` starts a comment that truncates the value
+    without any error at all. Plain double quotes would cover those four but
+    break on the last two, which carry a quote and a backslash of their own —
+    hence ``tojson``, which escapes them.
+    """
+    for address in (
+        "[2001:db8::1]:8080",
+        "{a}",
+        "*anchor",
+        "1.2.3.4 # note",
+        'say "hi"',
+        "back\\slash",
+    ):
+        env = _gpu_instance_env(gpu_instances_access_static_address=address)
+        assert env["GPUSTACK_INSTANCE_ACCESS_STATIC_ADDRESS"] == address, address

--- a/tests/k8s/test_template_render.py
+++ b/tests/k8s/test_template_render.py
@@ -740,13 +740,13 @@ def test_gpu_instance_options_round_trips_snake_keys():
     options = GpuInstanceOptions.model_validate(
         {
             "gpu_instances_access_static_address": "10.0.0.1",
-            "instance_type_derived_from_node": False,
-            "instance_type_mixed_on_node": True,
+            "gpu_instance_type_derived_from_node": False,
+            "gpu_instance_type_mixed_on_node": True,
         }
     )
     assert options.gpu_instances_access_static_address == "10.0.0.1"
-    assert options.instance_type_derived_from_node is False
-    assert options.instance_type_mixed_on_node is True
+    assert options.gpu_instance_type_derived_from_node is False
+    assert options.gpu_instance_type_mixed_on_node is True
 
 
 def test_gpu_instance_options_round_trips_camel_keys():
@@ -755,16 +755,16 @@ def test_gpu_instance_options_round_trips_camel_keys():
     options = GpuInstanceOptions.model_validate(
         {
             "gpuInstancesAccessStaticAddress": "10.0.0.1",
-            "instanceTypeDerivedFromNode": True,
-            "instanceTypeMixedOnNode": False,
+            "gpuInstanceTypeDerivedFromNode": True,
+            "gpuInstanceTypeMixedOnNode": False,
         }
     )
-    assert options.instance_type_derived_from_node is True
-    assert options.instance_type_mixed_on_node is False
+    assert options.gpu_instance_type_derived_from_node is True
+    assert options.gpu_instance_type_mixed_on_node is False
     assert options.model_dump(by_alias=True, exclude_none=True) == {
         "gpuInstancesAccessStaticAddress": "10.0.0.1",
-        "instanceTypeDerivedFromNode": True,
-        "instanceTypeMixedOnNode": False,
+        "gpuInstanceTypeDerivedFromNode": True,
+        "gpuInstanceTypeMixedOnNode": False,
     }
 
 
@@ -774,8 +774,8 @@ def test_unset_gpu_instance_knobs_are_none_not_false():
     collapsing the two would make it assert a value nobody asked GPUStack to
     own — on a catalog that is also administered by ``kubectl``."""
     options = GpuInstanceOptions()
-    assert options.instance_type_derived_from_node is None
-    assert options.instance_type_mixed_on_node is None
+    assert options.gpu_instance_type_derived_from_node is None
+    assert options.gpu_instance_type_mixed_on_node is None
 
 
 def test_all_unset_gpu_instance_options_persists_as_a_present_object():
@@ -803,13 +803,13 @@ def test_unmanaged_gpu_instance_knob_is_dropped_from_the_persisted_row():
         K8sOptions.model_validate(
             {
                 "gpuInstanceOptions": {
-                    "instanceTypeDerivedFromNode": None,
-                    "instanceTypeMixedOnNode": False,
+                    "gpuInstanceTypeDerivedFromNode": None,
+                    "gpuInstanceTypeMixedOnNode": False,
                 }
             }
         )
     )
-    assert persisted == {"gpuInstanceOptions": {"instanceTypeMixedOnNode": False}}
+    assert persisted == {"gpuInstanceOptions": {"gpuInstanceTypeMixedOnNode": False}}
     assert is_gpu_service_k8s_options(persisted) is True
 
 
@@ -822,8 +822,8 @@ def test_model_service_cluster_persists_without_gpu_instance_options():
 
 def test_operator_env_seeds_set_gpu_instance_knobs():
     env = _gpu_instance_env(
-        instance_type_derived_from_node=True,
-        instance_type_mixed_on_node=True,
+        gpu_instance_type_derived_from_node=True,
+        gpu_instance_type_mixed_on_node=True,
     )
     assert env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"] == "true"
     assert env["GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE"] == "true"
@@ -834,8 +834,8 @@ def test_operator_env_seeds_explicit_false_as_the_string_false():
     not nothing — and as a *string*, because an unquoted YAML ``false`` is a
     boolean and a container env value must be a string."""
     env = _gpu_instance_env(
-        instance_type_derived_from_node=False,
-        instance_type_mixed_on_node=False,
+        gpu_instance_type_derived_from_node=False,
+        gpu_instance_type_mixed_on_node=False,
     )
     assert env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"] == "false"
     assert env["GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE"] == "false"
@@ -854,7 +854,7 @@ def test_operator_env_omits_unset_gpu_instance_knobs():
 
 def test_operator_env_seeds_one_knob_without_the_other():
     """The knobs are independent — managing one must not seed the other."""
-    env = _gpu_instance_env(instance_type_derived_from_node=False)
+    env = _gpu_instance_env(gpu_instance_type_derived_from_node=False)
     assert env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"] == "false"
     assert "GPUSTACK_INSTANCE_TYPE_MIXED_ON_NODE" not in env
 
@@ -876,7 +876,7 @@ def test_operator_env_seeds_the_static_access_address():
     """The pre-existing third knob still seeds, alongside the two new ones."""
     env = _gpu_instance_env(
         gpu_instances_access_static_address="10.0.0.1",
-        instance_type_derived_from_node=True,
+        gpu_instance_type_derived_from_node=True,
     )
     assert env["GPUSTACK_INSTANCE_ACCESS_STATIC_ADDRESS"] == "10.0.0.1"
     assert env["GPUSTACK_INSTANCE_TYPE_DERIVED_FROM_NODE"] == "true"

--- a/tests/routes/test_gpu_instance_type_flavors.py
+++ b/tests/routes/test_gpu_instance_type_flavors.py
@@ -11,6 +11,7 @@ import pytest
 from gpustack.api.exceptions import NotFoundException
 from gpustack.routes import gpu_instance_type_flavors as flavor_routes
 from gpustack.routes import gpu_instances_helper as helper
+from gpustack.schemas.clusters import GpuInstanceOptions, K8sOptions
 from gpustack.schemas.principals import PrincipalType
 
 # SYSTEM principal → bypasses tenant filters (visible everywhere).
@@ -56,11 +57,23 @@ def _patch_ops(monkeypatch, *, list_result=None):
     monkeypatch.setattr(helper, "ClusterOps", FakeOps)
 
 
-def _cluster(id_=1, owner_principal_id=None):
+def _cluster(id_=1, owner_principal_id=None, gpu_service=True):
+    """A cluster fixture, GPU Service by default.
+
+    Every route in this module is a GPU Service route, so a cluster that can be
+    used here is the norm; a Model Service cluster is the exception, and each
+    test that exercises one passes ``gpu_service=False`` explicitly. The purpose
+    signal is the presence of ``gpu_instance_options`` — see
+    ``schemas/clusters.is_gpu_service_k8s_options``.
+    """
     return SimpleNamespace(
         id=id_,
+        name=f"cluster-{id_}",
         owner_principal_id=owner_principal_id,
         registration_token="tok",
+        k8s_options=K8sOptions(
+            gpu_instance_options=GpuInstanceOptions() if gpu_service else None
+        ),
     )
 
 
@@ -134,6 +147,100 @@ async def test_aggregated_flavors_empty_clusters_short_circuits(monkeypatch):
 
     out = await flavor_routes.get_gpu_aggregated_instance_type_flavors(CTX)
     assert out.items == []
+
+
+def _patch_aggregated_clusters(monkeypatch, clusters):
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(flavor_routes, "async_session", lambda: _FakeSession())
+
+    async def fake_all(session, fields=None, extra_conditions=None, **kw):
+        return clusters
+
+    monkeypatch.setattr(flavor_routes.Cluster, "all_by_fields", fake_all)
+
+
+@pytest.mark.asyncio
+async def test_aggregated_flavors_exclude_model_service_clusters(monkeypatch):
+    # A Model Service cluster is Kubernetes and visible, and its operator still
+    # publishes flavors — but that capacity is committed to model deployment,
+    # so the flavors must not reach the GPU Instance create form.
+    _patch_aggregated_clusters(
+        monkeypatch, [_cluster(id_=1, gpu_service=False), _cluster(id_=2)]
+    )
+
+    captured = {}
+
+    async def fake_list(clusters=None, aggregated=False):
+        captured["clusters"] = clusters
+        captured["aggregated"] = aggregated
+        return {"items": []}
+
+    monkeypatch.setattr(
+        flavor_routes.gateway_client, "list_instance_type_flavors", fake_list
+    )
+
+    await flavor_routes.get_gpu_aggregated_instance_type_flavors(CTX)
+
+    assert captured["clusters"] == ["2"]
+    assert captured["aggregated"] is True
+
+
+@pytest.mark.asyncio
+async def test_aggregated_flavors_all_model_service_short_circuits(monkeypatch):
+    # The sharper form of the empty-cluster guard: clusters ARE visible, they
+    # are just all Model Service. Forwarding the resulting empty filter would
+    # make the gateway return the whole fleet.
+    _patch_aggregated_clusters(
+        monkeypatch,
+        [_cluster(id_=1, gpu_service=False), _cluster(id_=2, gpu_service=False)],
+    )
+
+    async def boom(*a, **kw):
+        raise AssertionError("gateway must not be called for zero GPU Service clusters")
+
+    monkeypatch.setattr(
+        flavor_routes.gateway_client, "list_instance_type_flavors", boom
+    )
+    monkeypatch.setattr(
+        flavor_routes.gateway_client, "watch_instance_type_flavors", boom
+    )
+
+    out = await flavor_routes.get_gpu_aggregated_instance_type_flavors(CTX)
+    assert out.items == []
+
+
+@pytest.mark.asyncio
+async def test_aggregated_flavors_watch_filter_excludes_model_service(monkeypatch):
+    # The watch path takes the same narrowed cluster filter, so no event can be
+    # sourced from a Model Service cluster in the first place.
+    _patch_aggregated_clusters(
+        monkeypatch,
+        [_cluster(id_=1), _cluster(id_=2, gpu_service=False), _cluster(id_=3)],
+    )
+
+    captured = {}
+
+    async def fake_watch(clusters=None, aggregated=False):
+        captured["clusters"] = clusters
+        captured["aggregated"] = aggregated
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    monkeypatch.setattr(
+        flavor_routes.gateway_client, "watch_instance_type_flavors", fake_watch
+    )
+
+    resp = await flavor_routes.get_gpu_aggregated_instance_type_flavors(CTX, watch=True)
+    [frame async for frame in resp.body_iterator]
+
+    assert captured["clusters"] == ["1", "3"]
+    assert captured["aggregated"] is True
 
 
 def test_flavor_routes_registered():

--- a/tests/routes/test_gpu_instance_types.py
+++ b/tests/routes/test_gpu_instance_types.py
@@ -12,9 +12,14 @@ import pytest
 from kubernetes_asyncio import client
 from starlette.responses import StreamingResponse
 
-from gpustack.api.exceptions import ForbiddenException, NotFoundException
+from gpustack.api.exceptions import (
+    ConflictException,
+    ForbiddenException,
+    NotFoundException,
+)
 from gpustack.routes import gpu_instance_types as it_routes
 from gpustack.routes import gpu_instances_helper as helper
+from gpustack.schemas.clusters import GpuInstanceOptions, K8sOptions
 from gpustack.schemas.gpu_instance_types import (
     GPUInstanceTypeCreate,
     GPUInstanceTypeSpec,
@@ -155,11 +160,23 @@ def _patch_watch_ops(monkeypatch, watch_events):
     monkeypatch.setattr(helper, "ClusterOps", FakeWatchOps)
 
 
-def _cluster(id_=1, owner_principal_id=None):
+def _cluster(id_=1, owner_principal_id=None, gpu_service=True):
+    """A cluster fixture, GPU Service by default.
+
+    Every route in this module is a GPU Service route, so a cluster that can be
+    used here is the norm; a Model Service cluster is the exception, and each
+    test that exercises one passes ``gpu_service=False`` explicitly. The purpose
+    signal is the presence of ``gpu_instance_options`` — see
+    ``schemas/clusters.is_gpu_service_k8s_options``.
+    """
     return SimpleNamespace(
         id=id_,
+        name=f"cluster-{id_}",
         owner_principal_id=owner_principal_id,
         registration_token="tok",
+        k8s_options=K8sOptions(
+            gpu_instance_options=GpuInstanceOptions() if gpu_service else None
+        ),
     )
 
 
@@ -411,7 +428,10 @@ async def test_aggregated_watch_wraps_gateway_verbs(monkeypatch):
     monkeypatch.setattr(it_routes, "async_session", lambda: _FakeSession())
 
     async def fake_all(session, fields=None, extra_conditions=None, **kw):
-        return [_cluster(id_=1), _cluster(id_=2)]
+        # Cluster 3 is a Model Service cluster: visible, Kubernetes, and still
+        # dropped from the watch's cluster filter, so no event can be sourced
+        # from it in the first place.
+        return [_cluster(id_=1), _cluster(id_=2), _cluster(id_=3, gpu_service=False)]
 
     monkeypatch.setattr(it_routes.Cluster, "all_by_fields", fake_all)
 
@@ -456,9 +476,154 @@ async def test_aggregated_watch_wraps_gateway_verbs(monkeypatch):
     assert payloads[0]["data"]["name"] == "a100"
     # The aggregated status survives, serialized by camelCase alias.
     assert payloads[0]["data"]["status"]["onceMaxRequest"]["accelerator"] == "4"
-    # Cluster ids forwarded to the gateway as strings, aggregated=True.
+    # Cluster ids forwarded to the gateway as strings, aggregated=True, with
+    # the Model Service cluster absent from the filter.
     assert captured["clusters"] == ["1", "2"]
     assert captured["aggregated"] is True
+
+
+@pytest.mark.asyncio
+async def test_aggregated_excludes_model_service_clusters(monkeypatch):
+    # A Model Service cluster is Kubernetes and visible, but its capacity is
+    # committed to model deployment, so its instance types must not reach the
+    # GPU Instance create form.
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(it_routes, "async_session", lambda: _FakeSession())
+
+    async def fake_all(session, fields=None, extra_conditions=None, **kw):
+        return [_cluster(id_=1, gpu_service=False), _cluster(id_=2)]
+
+    monkeypatch.setattr(it_routes.Cluster, "all_by_fields", fake_all)
+
+    captured = {}
+
+    async def fake_list(clusters=None, aggregated=False):
+        captured["clusters"] = clusters
+        return {"items": []}
+
+    monkeypatch.setattr(it_routes.gateway_client, "list_instance_types", fake_list)
+
+    await it_routes.get_gpu_aggregated_instance_types(CTX)
+
+    assert captured["clusters"] == ["2"]
+
+
+@pytest.mark.asyncio
+async def test_aggregated_all_model_service_short_circuits(monkeypatch):
+    # The sharper form of the empty-cluster guard: clusters ARE visible, they
+    # are just all Model Service. Forwarding the resulting empty filter would
+    # make the gateway return the whole fleet.
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(it_routes, "async_session", lambda: _FakeSession())
+
+    async def fake_all(session, fields=None, extra_conditions=None, **kw):
+        return [
+            _cluster(id_=1, gpu_service=False),
+            _cluster(id_=2, gpu_service=False),
+        ]
+
+    monkeypatch.setattr(it_routes.Cluster, "all_by_fields", fake_all)
+
+    async def boom(*a, **kw):
+        raise AssertionError("gateway must not be called for zero GPU Service clusters")
+
+    monkeypatch.setattr(it_routes.gateway_client, "list_instance_types", boom)
+    monkeypatch.setattr(it_routes.gateway_client, "watch_instance_types", boom)
+
+    out = await it_routes.get_gpu_aggregated_instance_types(CTX)
+    assert out.items == []
+
+
+@pytest.mark.asyncio
+async def test_per_cluster_read_still_serves_a_model_service_cluster(monkeypatch):
+    # The guard is on writes only. This read is what the model deploy form's
+    # Scheduling > Manual > Slicing GPU Type picker calls, and that picker
+    # targets Model Service clusters by definition.
+    _patch_cluster(monkeypatch, _cluster(gpu_service=False))
+    _patch_ops(
+        monkeypatch,
+        list_result={"items": [{"metadata": {"name": "it-a"}, "spec": {}}]},
+    )
+
+    out = await it_routes.get_gpu_instance_types(REQUEST, None, CTX, 1)
+
+    assert [i.name for i in out.items] == ["it-a"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(
+            lambda: it_routes.create_gpu_instance_type(
+                REQUEST,
+                None,
+                CTX,
+                GPUInstanceTypeCreate(
+                    name="new-it",
+                    spec=GPUInstanceTypeSpec(acceleratable=True),
+                ),
+                1,
+            ),
+            id="create",
+        ),
+        pytest.param(
+            lambda: it_routes.update_gpu_instance_type(
+                REQUEST,
+                None,
+                CTX,
+                GPUInstanceTypeUpdate(
+                    name="it-a",
+                    spec=GPUInstanceTypeSpecUpdate(display_name="x"),
+                ),
+                1,
+            ),
+            id="update",
+        ),
+        pytest.param(
+            lambda: it_routes.delete_gpu_instance_type(REQUEST, None, CTX, "it-a", 1),
+            id="delete",
+        ),
+        pytest.param(
+            lambda: it_routes.deactivate_gpu_instance_type(
+                REQUEST, None, CTX, "it-a", 1
+            ),
+            id="deactivate",
+        ),
+        pytest.param(
+            lambda: it_routes.activate_gpu_instance_type(REQUEST, None, CTX, "it-a", 1),
+            id="activate",
+        ),
+    ],
+)
+async def test_writes_to_a_model_service_cluster_raise_409(monkeypatch, call):
+    _patch_cluster(monkeypatch, _cluster(gpu_service=False))
+
+    async def boom(*a, **kw):
+        raise AssertionError("must refuse before reaching the cluster")
+
+    monkeypatch.setattr(helper, "build_cluster_ops", boom)
+
+    with pytest.raises(ConflictException) as excinfo:
+        await call()
+
+    assert excinfo.value.status_code == 409
+    # The refusal names the cluster and its purpose, so an API caller is not
+    # left guessing why an otherwise-visible, otherwise-owned cluster refused.
+    assert "cluster-1" in excinfo.value.message
+    assert "model service" in excinfo.value.message
 
 
 def test_spec_create_display_name_camel_alias():

--- a/tests/routes/test_gpu_instance_types.py
+++ b/tests/routes/test_gpu_instance_types.py
@@ -211,6 +211,53 @@ async def test_list_maps_metadata_name(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_reads_the_derived_from_node_marker(monkeypatch):
+    # The operator stamps its own instance types with the derived-from-node
+    # label; an admin-created one carries the rest of the schedule labels but
+    # not that marker, and a CR with no labels at all must not blow up.
+    _patch_cluster(monkeypatch, _cluster())
+    _patch_ops(
+        monkeypatch,
+        list_result={
+            "items": [
+                {
+                    "metadata": {
+                        "name": "derived",
+                        "labels": {
+                            "schedule.gpustack.ai/derived-from-node": "true",
+                            "schedule.gpustack.ai/queue-entrance": "gpustack-fnv64-1",
+                        },
+                    },
+                    "spec": {},
+                    "status": {},
+                },
+                {
+                    "metadata": {
+                        "name": "hand-made",
+                        "labels": {
+                            "schedule.gpustack.ai/queue-entrance": "gpustack-fnv64-2",
+                        },
+                    },
+                    "spec": {},
+                    "status": {},
+                },
+                {"metadata": {"name": "bare"}, "spec": {}, "status": {}},
+            ]
+        },
+    )
+
+    out = await it_routes.get_gpu_instance_types(REQUEST, None, CTX, 1)
+
+    assert [(i.name, i.derived_from_node) for i in out.items] == [
+        ("derived", True),
+        ("hand-made", False),
+        ("bare", False),
+    ]
+    # The field reaches the client under its camelCase alias.
+    assert out.items[0].model_dump(by_alias=True)["derivedFromNode"] is True
+
+
+@pytest.mark.asyncio
 async def test_create_sends_spec_and_defaults_missing_status(monkeypatch):
     _patch_cluster(monkeypatch, _cluster())
     capture = {}

--- a/tests/routes/test_gpu_instances.py
+++ b/tests/routes/test_gpu_instances.py
@@ -15,8 +15,9 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from gpustack.api.exceptions import InvalidException
+from gpustack.api.exceptions import ConflictException, InvalidException
 from gpustack.routes import gpu_instances as routes
+from gpustack.schemas.clusters import GpuInstanceOptions, K8sOptions
 from gpustack.schemas.gpu_instances import (
     GPUInstance,
     GPUInstanceCreate,
@@ -357,6 +358,67 @@ async def test_create_without_cluster_id_rejected():
 
     with pytest.raises(InvalidException):
         await routes.create_gpu_instance(session=None, ctx=None, create_obj=create_obj)
+
+
+def _patch_create_preflight(monkeypatch, *, gpu_service):
+    """Stub everything ahead of the purpose guard in ``create_gpu_instance``.
+
+    Leaves exactly one decision under test: whether a cluster's purpose lets a
+    GPU Instance be created on it. ``_validate_create_obj`` is the first step
+    *after* the guard, so patching it to raise proves the guard runs before any
+    of the payload is resolved against the cluster.
+    """
+    cluster = SimpleNamespace(
+        id=2,
+        name="cluster-2",
+        deleted_at=None,
+        k8s_options=K8sOptions(
+            gpu_instance_options=GpuInstanceOptions() if gpu_service else None
+        ),
+    )
+
+    async def fake_one_by_id(session, id=None, *args, **kwargs):
+        return cluster
+
+    monkeypatch.setattr(routes.Cluster, "one_by_id", fake_one_by_id)
+    monkeypatch.setattr(routes, "assert_cluster_visible", lambda *a, **kw: None)
+    monkeypatch.setattr(routes, "validate_owner_principal", lambda *a, **kw: None)
+
+    async def past_the_guard(*a, **kw):
+        raise RuntimeError("reached the payload validation")
+
+    monkeypatch.setattr(routes, "_validate_create_obj", past_the_guard)
+
+
+@pytest.mark.asyncio
+async def test_create_on_a_model_service_cluster_rejected(monkeypatch):
+    # A GPU Instance is a workload for GPU Service capacity. A Model Service
+    # cluster has none, so create must refuse it with a 409 that says why —
+    # before resolving any of the payload against the cluster.
+    _patch_create_preflight(monkeypatch, gpu_service=False)
+    create_obj = GPUInstanceCreate(
+        name="gi-1", spec=_ephemeral_spec(), cluster_id=2, owner_principal_id=1
+    )
+
+    with pytest.raises(ConflictException) as excinfo:
+        await routes.create_gpu_instance(session=None, ctx=CTX, create_obj=create_obj)
+
+    assert excinfo.value.status_code == 409
+    assert "cluster-2" in excinfo.value.message
+    assert "model service" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_on_a_gpu_service_cluster_passes_the_purpose_guard(monkeypatch):
+    # The negative case above must fail for the right reason: on a GPU Service
+    # cluster the same call gets past the guard and on to payload validation.
+    _patch_create_preflight(monkeypatch, gpu_service=True)
+    create_obj = GPUInstanceCreate(
+        name="gi-1", spec=_ephemeral_spec(), cluster_id=2, owner_principal_id=1
+    )
+
+    with pytest.raises(RuntimeError, match="reached the payload validation"):
+        await routes.create_gpu_instance(session=None, ctx=CTX, create_obj=create_obj)
 
 
 @pytest.mark.asyncio

--- a/tests/schemas/test_cluster_purpose.py
+++ b/tests/schemas/test_cluster_purpose.py
@@ -1,0 +1,106 @@
+"""The cluster-purpose predicate: one home for "is this a GPU Service cluster".
+
+A cluster carries no purpose column. The presence or absence of
+``k8s_options.gpu_instance_options`` *is* the signal — present means GPU
+Service, absent means Model Service — and that one bit is read from three
+different shapes depending on where the cluster came from:
+
+* a ``K8sOptions`` model, as constructed by the route layer;
+* a snake-cased dict, as produced by ``model_dump`` and stored in the JSON
+  column (and replayed over the event bus without re-validation);
+* a camel-cased dict, as submitted by the API / UI.
+
+These lock all three to the same answer. A disagreement between them would
+split the product in half: a cluster the deploy picker calls Model Service
+while the GPU Service pages call it GPU Service.
+"""
+
+import pytest
+
+from gpustack.schemas.clusters import (
+    Cluster,
+    GpuInstanceOptions,
+    K8sOptions,
+    is_gpu_service_cluster,
+    is_gpu_service_k8s_options,
+)
+
+# The same cluster expressed the three ways it can reach the predicate. All-defaults
+# ``GpuInstanceOptions()`` is deliberate: it is what a GPU Service cluster with no knobs
+# set persists as, and it must still read as GPU Service.
+GPU_SERVICE_FORMS = {
+    "model": K8sOptions(gpu_instance_options=GpuInstanceOptions()),
+    "snake_dict": {"gpu_instance_options": {}},
+    "camel_dict": {"gpuInstanceOptions": {}},
+}
+
+MODEL_SERVICE_FORMS = {
+    "model": K8sOptions(),
+    "snake_dict": {"gpu_instance_options": None},
+    "camel_dict": {"gpuInstanceOptions": None},
+}
+
+
+def test_model_form_reads_the_purpose():
+    """The K8sOptions branch: a set ``gpu_instance_options`` is the whole signal."""
+    assert is_gpu_service_k8s_options(
+        K8sOptions(gpu_instance_options=GpuInstanceOptions())
+    )
+    assert not is_gpu_service_k8s_options(K8sOptions())
+
+
+@pytest.mark.parametrize("form", GPU_SERVICE_FORMS.values(), ids=GPU_SERVICE_FORMS)
+def test_every_form_of_a_gpu_service_cluster_agrees(form):
+    assert is_gpu_service_k8s_options(form) is True
+
+
+@pytest.mark.parametrize("form", MODEL_SERVICE_FORMS.values(), ids=MODEL_SERVICE_FORMS)
+def test_every_form_of_a_model_service_cluster_agrees(form):
+    assert is_gpu_service_k8s_options(form) is False
+
+
+def test_snake_and_camel_dicts_are_both_honoured():
+    """A populated payload, not just an empty marker, under either key spelling.
+
+    ``model_dump`` writes snake, the API/UI submits camel, and the JSON column
+    replays whichever was written — so both spellings have to be live.
+    """
+    options = {"gpuInstancesAccessStaticAddress": "10.0.0.1"}
+    assert is_gpu_service_k8s_options({"gpu_instance_options": options})
+    assert is_gpu_service_k8s_options({"gpuInstanceOptions": options})
+
+
+def test_absent_options_is_model_service():
+    assert not is_gpu_service_k8s_options({})
+    assert not is_gpu_service_k8s_options({"namespace": "gpustack-system"})
+
+
+def test_none_is_model_service():
+    """An unset ``k8s_options`` column is a Model Service cluster, not an error."""
+    assert not is_gpu_service_k8s_options(None)
+
+
+@pytest.mark.parametrize("value", ["gpuInstanceOptions", 42, [], object()])
+def test_a_shape_we_never_write_is_model_service(value):
+    """Fail closed: a shape the predicate cannot read is excluded from GPU Service.
+
+    Nothing writes these — the column is only ever written from a validated
+    model — so the branch exists to keep an unreadable row out of the GPU
+    Service surfaces rather than to raise on a list/watch tick.
+    """
+    assert is_gpu_service_k8s_options(value) is False
+
+
+@pytest.mark.parametrize("form", GPU_SERVICE_FORMS.values(), ids=GPU_SERVICE_FORMS)
+def test_cluster_delegates_to_its_k8s_options(form):
+    """Real ``Cluster`` rows, not mocks: SQLModel keeps a dict assignment as a raw
+    dict, which is exactly the shape the event bus and the JSON column hand back.
+    """
+    assert is_gpu_service_cluster(Cluster(name="gpu-service", k8s_options=form))
+
+
+def test_a_cluster_without_options_is_model_service():
+    assert not is_gpu_service_cluster(Cluster(name="model-service", k8s_options=None))
+    assert not is_gpu_service_cluster(
+        Cluster(name="model-service", k8s_options=K8sOptions())
+    )


### PR DESCRIPTION
## Summary

A Kubernetes cluster registered in GPUStack is either a **Model Service** cluster or a **GPU Service** cluster, but nothing enforced that: GPU Service pages listed every Kubernetes cluster, the aggregated instance-type endpoints aggregated every cluster's types, and the write paths accepted any cluster by id. This PR makes the purpose an enforced boundary, and completes the operator-settings story behind it.

The signal is unchanged and stays implicit — `k8s_options.gpu_instance_options` present ⇒ GPU Service, absent ⇒ Model Service. No new enum, no migration.

- **Purpose gating.** `GET /v2/gpu-instance-types/aggregated` and `.../gpu-instance-type-flavors/aggregated` drop Model Service clusters, on the watch streams as well as the plain reads. When no GPU Service cluster remains they return an empty list rather than calling the gateway — an empty cluster filter reads as *all clusters* there, which would have leaked the whole fleet. The five instance-type write paths and GPU-instance create refuse a Model Service cluster with a 409 that names it; reads stay open, because the Deployment slicing picker reads them.
- **Operator settings.** `GpuInstanceOptions` carries all three knobs the operator exposes, not just the static address. They are tri-state — unset means GPUStack does not manage that setting — and `operator.jinja` renders a `GPUSTACK_*` seed only for a set one.
- **Convergence.** The operator seeds each `Setting` from its environment on **first deploy only**, so editing a registered cluster used to be inert. A leader-only reconciler now patches the three managed `Setting`s through the cluster proxy when they drift. `Setting` is served by an aggregated APIServer with no `create` verb, so the write is a patch and never an upsert; `spec.value` is write-only and reads back empty, so the comparison is against `status.value`. Level-triggered with a decimated resync, so an administrator's `kubectl` edit of a managed setting is repaired instead of silently disagreeing with the UI.

## Verified live

Against a two-node k3s cluster with RTX 4090 and RX 7800 XT pools, running the packaged image.

- A Model Service cluster with **two ready workers still holding four `InstanceType`s** returns them on `GET /v2/gpu-instance-types?cluster_id=`, while both aggregated endpoints return `{"items":[]}` — the data is present and reachable, and it is being filtered.
- With the cluster already Model Service, two `InstanceType`s were deleted straight at the aggregated APIServer (one then recreated by the operator). Both watch streams stayed silent for 45s, their only output the initial — empty — snapshot.
- Setting `gpuInstanceTypeMixedOnNode: false` reached the `Setting` in 0.4s with no redeploy, and the server logged **exactly one** write: nothing for the unmanaged address, nothing for the already-equal knob. The value survived an operator restart.
- Purpose switching: refused with a 409 while the cluster owns a GPU Instance or a Model — including a deployment **scaled to zero**, which is deliberate, since a scaled-to-zero deployment still belongs to the cluster.

## Notes for review

- `check_cluster_purpose_switch` counts the `Model`, not its instances. That is what makes the scaled-to-zero case a 409.
- Two defects found by review are fixed here and pinned by tests that fail without them: an id-only `DELETED` cluster event used to raise (the bus routes `Event(data={"id": N})` when its change-detector cache is cold, which is the normal state for a freshly elected leader), and convergence used to run under the reconciler's lock, where one unreachable cluster could block every other cluster's retry.
- The last commit is out of the original scope and shipped on request: a GPU Instance created with **no** SSH keys never started, because `to_kuberes` writes `spec.sshPublicKey` unconditionally while the create path only provisioned the referenced key. It now provisions an empty one, which the operator renders as an empty `authorized_keys`.

Frontend counterpart: gpustack/gpustack-ui#1337
