### PR TITLE
fix(backends): stop treating "no device selected" as Ascend, and bump gpustack-runtime to 0.2.3post1

### DIFF
--- a/gpustack/worker/backends/base.py
+++ b/gpustack/worker/backends/base.py
@@ -1311,9 +1311,14 @@ def _parse_image_cuda_version(image: Optional[str]) -> Optional[str]:
 def is_ascend_310p(devices: GPUDevicesStatus) -> bool:
     """
     Check if the model instance is running on VLLM Ascend 310P.
+
+    An empty device list is not a match: callers gate Ascend 310P specifics on
+    this, and ``all()`` is vacuously true over nothing, so a model instance
+    that named no device -- one scheduled by GPU type rather than by device
+    index, for instance -- would be served as if it ran on 310P.
     """
 
-    return all(
+    return bool(devices) and all(
         gpu.vendor == ManufacturerEnum.ASCEND.value
         and get_ascend_cann_variant(gpu.arch_family) == "310p"
         for gpu in devices
@@ -1323,9 +1328,14 @@ def is_ascend_310p(devices: GPUDevicesStatus) -> bool:
 def is_ascend(devices: GPUDevicesStatus) -> bool:
     """
     Check if all devices are Ascend.
+
+    An empty device list is not a match, for the same reason as
+    :func:`is_ascend_310p`.
     """
 
-    return all(gpu.vendor == ManufacturerEnum.ASCEND.value for gpu in devices)
+    return bool(devices) and all(
+        gpu.vendor == ManufacturerEnum.ASCEND.value for gpu in devices
+    )
 
 
 def cal_distributed_parallelism_arguments(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "msgpack>=1.1.2",
     "cachetools>=6.0.0",
     "gpustack-runner==0.1.27.post4",
-    "gpustack-runtime==0.2.3",
+    "gpustack-runtime==0.2.3.post1",
     "gpustack-higress-plugins==0.3.0.post6",
     "websockets==16.0",
     "py-radix>=1.1.0",

--- a/tests/worker/backends/test_backend.py
+++ b/tests/worker/backends/test_backend.py
@@ -14,6 +14,8 @@ from gpustack.utils.config import apply_registry_override_to_image
 from gpustack.envs import ENABLE_CUDA_MINOR_VERSION_COMPATIBILITY_ENV as _KNOB
 from gpustack.worker.backends.base import (
     InferenceServer,
+    is_ascend,
+    is_ascend_310p,
     read_lora_max_rank,
     _parse_image_cuda_version,
 )
@@ -1322,3 +1324,59 @@ def test_configured_env_no_injection_when_not_triggered(monkeypatch):
     env = server._get_configured_env()
 
     assert "NVIDIA_DISABLE_REQUIRE" not in env
+
+
+def _gpu(vendor: str, arch_family=None):
+    return types.SimpleNamespace(vendor=vendor, arch_family=arch_family)
+
+
+@pytest.mark.parametrize(
+    "name, devices, expected",
+    [
+        # The regression this guards: `all()` is vacuously true over nothing,
+        # so a model instance that named no device -- one scheduled by GPU
+        # type rather than by device index -- used to be served as Ascend
+        # 310P, and got `--enforce-eager --dtype float16` injected on top of
+        # whatever accelerator it actually landed on.
+        ("no device selected", [], False),
+        ("single 310P", [_gpu("ascend", "Ascend310P1")], True),
+        (
+            "several 310P",
+            [_gpu("ascend", "Ascend310P1"), _gpu("ascend", "Ascend310P3")],
+            True,
+        ),
+        ("Ascend but not 310P", [_gpu("ascend", "Ascend910B4")], False),
+        ("NVIDIA", [_gpu("nvidia")], False),
+        (
+            "310P mixed with another Ascend generation",
+            [_gpu("ascend", "Ascend310P1"), _gpu("ascend", "Ascend910B4")],
+            False,
+        ),
+    ],
+)
+def test_is_ascend_310p(name, devices, expected):
+    actual = is_ascend_310p(devices)
+    assert actual == expected, f"case {name} expected {expected}, but got {actual}"
+
+
+@pytest.mark.parametrize(
+    "name, devices, expected",
+    [
+        ("no device selected", [], False),
+        ("single Ascend", [_gpu("ascend", "Ascend910B4")], True),
+        (
+            "several Ascend",
+            [_gpu("ascend", "Ascend910B4"), _gpu("ascend", "Ascend310P1")],
+            True,
+        ),
+        ("NVIDIA", [_gpu("nvidia")], False),
+        (
+            "Ascend mixed with NVIDIA",
+            [_gpu("ascend", "Ascend910B4"), _gpu("nvidia")],
+            False,
+        ),
+    ],
+)
+def test_is_ascend(name, devices, expected):
+    actual = is_ascend(devices)
+    assert actual == expected, f"case {name} expected {expected}, but got {actual}"

--- a/uv.lock
+++ b/uv.lock
@@ -1241,7 +1241,7 @@ requires-dist = [
     { name = "fastapi-cdn-host", specifier = ">=0.8.0" },
     { name = "gpustack-higress-plugins", specifier = "==0.3.0.post6" },
     { name = "gpustack-runner", specifier = "==0.1.27.post4" },
-    { name = "gpustack-runtime", specifier = "==0.2.3" },
+    { name = "gpustack-runtime", specifier = "==0.2.3.post1" },
     { name = "hf-xet", specifier = ">=1.3.1,<2.0.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "huggingface-hub", specifier = ">=1.0.0" },
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "gpustack-runtime"
-version = "0.2.3"
+version = "0.2.3.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -1351,9 +1351,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/c9/f9704041b9a550cac4cd9ee7e89d747b3c9d8dd68b49d66f5ed3b3af09d7/gpustack_runtime-0.2.3.tar.gz", hash = "sha256:a1ff6ddcdbcf1b204ab8c4e03aa57badfe7acddeb0cae560e1116e2a7194088a", size = 1589779, upload-time = "2026-08-15T04:02:26.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/fd/d1654b83a0ac1c0c152121fa918bfbad9f57e958949f9580b0b8e7c4c290/gpustack_runtime-0.2.3.post1.tar.gz", hash = "sha256:d01ed37684ad7318dafb36402cc322e2d45d2f03633c4ecd71079cc2418850c3", size = 1594621, upload-time = "2026-08-17T04:27:32.717Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/3e/f2790d57f64fb3a1d1aee992279fff7fd5f69595656d8825157cb7fd9bb5/gpustack_runtime-0.2.3-py3-none-any.whl", hash = "sha256:f62a8c942d73b2517c3c9e17779a966594bd961ceae73ab3ba16ba8b69caec98", size = 1480734, upload-time = "2026-08-15T04:02:24.779Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a6/62422d9b59532a5d45a0ffca091ae939bb91a565301ea9360e9b1df66a17/gpustack_runtime-0.2.3.post1-py3-none-any.whl", hash = "sha256:58a5c071ae23d402e4bcaf36b18435cd67975c94b7685b65092aa4eaeec1ae23", size = 1483295, upload-time = "2026-08-17T04:27:31.015Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two fixes for GPU Service deployments that were bypassing the operator, both found while deploying models under **Deployments → Scheduling**.

### `all([])` made "no device selected" look like Ascend

`is_ascend_310p()` / `is_ascend()` answered `all(...)` over the model instance's selected devices, and `all()` is vacuously true over nothing.

A model instance scheduled **by GPU type rather than by device index** — Slicing under Deployments → Scheduling — names no device index, so `_get_selected_gpu_devices()` returns an empty list and both predicates passed. Every caller gates Ascend specifics on them, so on a live NVIDIA RTX 4090 the vLLM command came out as:

```
vllm serve … --enforce-eager --dtype float16 --reasoning-parser=qwen3 …
```

Both predicates now require a non-empty device list: "all devices are X" must not open the door to X-only behaviour when there is no device at all. That covers all ten call sites — four in vLLM, four in SGLang (same path, same exposure), two in Ascend MindIE.

**Behaviour change worth reviewing:** the two MindIE call sites now take the non-310P branch when no device is selected — it sets `HCCL_EXEC_TIMEOUT` / `HCCL_OP_EXPANSION_MODE` and no longer defaults `--dtype float16`. The previous branch was the vacuous truth rather than a decision; recognizing 310P for a type-scheduled instance needs a real signal, not an empty list.

### Bump `gpustack-runtime` to 0.2.3post1

Picks up the deployer fixes from gpustack/runtime#18:

- the Kubernetes KDP policy is resolved from the **target node's** allocatable resources instead of the deploying process's own kubelet socket. The Kubernetes deployer orchestrates remotely, so a socket it cannot see says nothing about the node it deploys to — and from a worker Pod that socket is absent, so every accelerated workload fell back to env injection: privileged, holding **every** device of the node, with empty `limits` and its allocation absent from the device plugin's ledger, hence from the operator's accounting;
- `CUDA_DEVICE_ORDER` is pinned from the number of devices a request resolves to rather than from the literal `"all"`, so a multi-device request pins it (gpustack/gpustack#6041) and `"all"` on a single-device host no longer does.

`uv.lock` is regenerated rather than hand-edited; the diff touches only that one package.

## Related

- Runtime PR: gpustack/runtime#18
- Runtime release: `gpustack-runtime` [v0.2.3post1](https://github.com/gpustack/runtime/releases/tag/v0.2.3post1)
- `CUDA_DEVICE_ORDER` background: #6041

## Test plan

**Unit.** `2548 passed, 10 skipped` (excluding the pre-existing network-dependent `tests/server/test_catalog.py::test_model_catalog_modelscope`); `make lint` clean. New cases in `tests/worker/backends/test_backend.py` cover both predicates over an empty list, a single card, several cards, a mixed Ascend generation and a mixed vendor — red-green verified (dropping the guard fails exactly the two `no device selected` cases).

**On a live cluster** (k3s + gpustack-operator v0.8.3, RTX 4090 + Radeon RX 7800 XT):

| | before | after |
|---|---|---|
| exclusive deployment's Pod | `limits: null`, `privileged: true`, `NVIDIA_VISIBLE_DEVICES` = both cards | `limits: {nvidia.com/gpu.shared: "1"}`, `privileged: false`, operator's `accelerator.allocated` + `preferred-index` annotations present |
| slicing deployment's vLLM args | `--enforce-eager --dtype float16` on an RTX 4090 | neither flag |
| slicing deployment's `limits` | `.sliced` + percentage keys | unchanged |

The operator's `InstanceType` status went from not counting the exclusive workload at all to reporting it — the accounting gap this PR set out to close.

One caveat on scope: the cluster ran an image built from the runtime branch **before** its review round, so the per-Pod device injection above is what was exercised. The review-round changes are about how often the node is probed, not about what gets injected, and are covered by unit tests upstream.
