### PR TITLE
fix(benchmark): use HuggingFace repo ID as processor for GGUF models

### DIFF
--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -39,9 +39,9 @@ on:
 
 env:
   INPUT_PYTHON_VERSION: 3.11
-  INPUT_USERNAME: liukuolk
+  INPUT_USERNAME: gpustack
   INPUT_PASSWORD: ${{ secrets.CI_DOCKERHUB_PASSWORD }}
-  INPUT_NAMESPACE: liukuolk
+  INPUT_NAMESPACE: gpustack
   INPUT_REPOSITORY: gpustack
 
 jobs:
@@ -71,7 +71,6 @@ jobs:
             type=pep440,pattern={{raw}}
             type=pep440,pattern=v{{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
-            type=sha,prefix={{branch}}-
           flavor: |
             latest=false
       - name: Get Image Filter Labels

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -39,9 +39,9 @@ on:
 
 env:
   INPUT_PYTHON_VERSION: 3.11
-  INPUT_USERNAME: gpustack
+  INPUT_USERNAME: liukuolk
   INPUT_PASSWORD: ${{ secrets.CI_DOCKERHUB_PASSWORD }}
-  INPUT_NAMESPACE: gpustack
+  INPUT_NAMESPACE: liukuolk
   INPUT_REPOSITORY: gpustack
 
 jobs:

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -64,7 +64,6 @@ jobs:
           images: "${{ env.INPUT_NAMESPACE }}/${{ env.INPUT_REPOSITORY }}"
           tags: |
             type=ref,event=pr
-            type=ref,event=workflow_dispatch
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=dev-,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch,enable=${{ contains(github.ref, 'refs/heads/v') && endsWith(github.ref, '-dev') }}
@@ -72,6 +71,7 @@ jobs:
             type=pep440,pattern={{raw}}
             type=pep440,pattern=v{{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
+            type=sha,prefix={{branch}}-
           flavor: |
             latest=false
       - name: Get Image Filter Labels

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -64,6 +64,7 @@ jobs:
           images: "${{ env.INPUT_NAMESPACE }}/${{ env.INPUT_REPOSITORY }}"
           tags: |
             type=ref,event=pr
+            type=ref,event=workflow_dispatch
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=dev-,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch,enable=${{ contains(github.ref, 'refs/heads/v') && endsWith(github.ref, '-dev') }}

--- a/gpustack/worker/benchmark/runner.py
+++ b/gpustack/worker/benchmark/runner.py
@@ -116,8 +116,11 @@ class BenchmarkRunner:
             # Get model source for tokenizer loading (needed for GGUF models)
             if self._benchmark.model_id is not None:
                 try:
+                    from gpustack.schemas.models import is_gguf_model
+
                     model = self._clientset.models.get(id=self._benchmark.model_id)
-                    self._model_source = model.huggingface_repo_id
+                    if is_gguf_model(model):
+                        self._model_source = model.huggingface_repo_id
                 except Exception:
                     # If we can't get the model source, leave it as None
                     pass

--- a/gpustack/worker/benchmark/runner.py
+++ b/gpustack/worker/benchmark/runner.py
@@ -350,7 +350,7 @@ class BenchmarkRunner:
             and self._benchmark.dataset_input_tokens is not None
             and self._benchmark.dataset_output_tokens is not None
         ):
-            data = f"prompt_tokens={self._benchmark.dataset_input_tokens},output_tokens={self._benchmark.dataset_output_tokens}"
+            data = f"kind=synthetic_text,prompt_tokens={self._benchmark.dataset_input_tokens},output_tokens={self._benchmark.dataset_output_tokens}"
             # Data distribution — spread token lengths around the mean
             # (guidellm prompt_tokens_stdev/min/max + output_tokens_stdev/min/max).
             for attr, key in (

--- a/gpustack/worker/benchmark/runner.py
+++ b/gpustack/worker/benchmark/runner.py
@@ -56,6 +56,8 @@ class BenchmarkRunner:
     _api_url: str
     _api_key: str
     _benchmark_dir: Optional[str]
+    _model_source: Optional[str] = None
+    """Original model source URL (e.g., HuggingFace repo ID) for tokenizer loading."""
     _fallback_registry: Optional[str] = None
     """The fallback container registry to use if needed."""
 
@@ -110,6 +112,15 @@ class BenchmarkRunner:
             self._model_path = instance_snapshot.resolved_path
             self._model_endpoint = f"http://{instance_snapshot.worker_ip}:{instance_snapshot.ports[0] if instance_snapshot.ports else ''}"
             self._model_backend_parameters = instance_snapshot.backend_parameters
+
+            # Get model source for tokenizer loading (needed for GGUF models)
+            if self._benchmark.model_id is not None:
+                try:
+                    model = self._clientset.models.get(id=self._benchmark.model_id)
+                    self._model_source = model.huggingface_repo_id
+                except Exception:
+                    # If we can't get the model source, leave it as None
+                    pass
 
             _api_key = read_worker_token(self._config.data_dir)
             if _api_key is None:
@@ -296,7 +307,7 @@ class BenchmarkRunner:
             "--sample-requests",
             "0",
             "--processor",
-            self._model_path,
+            self._model_source if self._model_source else self._model_path,
             "--output-dir",
             f"{self._benchmark_dir}",
             "--outputs",

--- a/tests/worker/test_benchmark_manager.py
+++ b/tests/worker/test_benchmark_manager.py
@@ -294,6 +294,7 @@ class TestBuildCommandArgs:
             _benchmark=benchmark,
             _model_endpoint="http://127.0.0.1:8000",
             _model_path="/models/qwen3-0.6b",
+            _model_source=None,
             _model_backend_parameters=None,
             _benchmark_dir="/var/lib/gpustack/benchmarks",
             _api_url="http://127.0.0.1:80/v2/benchmarks/1/state",


### PR DESCRIPTION
When benchmarking a GGUF model, the --processor parameter was pointing to the GGUF file itself, which caused AutoTokenizer.from_pretrained() to fail because a GGUF file is not a valid HuggingFace tokenizer directory.

This fix retrieves the model's original HuggingFace repo ID (if available) and uses it as the --processor parameter instead. This allows guidellm to properly load the tokenizer for synthetic text generation.

Changes:
- Added _model_source field to store the model's HuggingFace repo ID
- Retrieve model info via clientset and extract huggingface_repo_id
- Use model_source as --processor if available, otherwise fallback to model_path

Fixes #6020