### PR TITLE
chore(tool): bump gguf-parser to v0.26.0

### DIFF
--- a/gpustack/worker/tools_manager.py
+++ b/gpustack/worker/tools_manager.py
@@ -16,7 +16,7 @@ from gpustack.worker.backend_dependency_manager import BackendDependencyManager
 logger = logging.getLogger(__name__)
 
 
-BUILTIN_GGUF_PARSER_VERSION = "v0.25.0"
+BUILTIN_GGUF_PARSER_VERSION = "v0.26.0"
 
 
 class ToolsManager:


### PR DESCRIPTION
## Summary

Bumps the built-in `gguf-parser` from **v0.25.0** to **v0.26.0** — one line, `BUILTIN_GGUF_PARSER_VERSION` in `gpustack/worker/tools_manager.py`, which is the single source for both the download URL and the version workers report.

The release is entirely GGUF memory-estimation fixes, all in KV cache / state accounting:

- KV cache was over-estimated for hybrid architectures that declare a full-attention interval;
- per-layer `attention.head_count_kv` is now read, so KV and recurrent state are charged per layer instead of uniformly;
- the sliding-window layout is resolved per layer, mirroring llama.cpp's per-architecture periods.

No CLI surface change, so `_gguf_parser_command` keeps its flags as-is, and the release ships the same seven assets under the same names — the `gguf-parser-{platform}{suffix}` URL template and the platform matrix are unaffected.

**Worth knowing before merge:** this changes what the estimator *reports*, not just its internals. Estimated VRAM/RAM for GGUF models will shift — most visibly for hybrid-attention and sliding-window architectures — and since `GGUFResourceFitSelector` schedules off those numbers, placement decisions can shift with them. That is the point of the bump (the old numbers were over-estimates), but it is a behavioural change, not a no-op.

Not touched, deliberately:

- `tests/fixtures/estimates/*.json` are static outputs recorded against gguf-parser 0.9.2 / 0.13.10 and are not regenerated per bump.
- `tests/policies/candidate_selectors/gguf/test_slow_gguf_resource_fit_selector.py` pins its own parser version (`v0.13.10`) through `check_parser()` + the `GGUF_PARSER_PATH` env var, and skips otherwise — it is decoupled from `BUILTIN_GGUF_PARSER_VERSION`.
- Docs reference the gguf-parser repo but pin no version, so nothing there goes stale.

## Related

- Release: gpustack/gguf-parser-go [v0.26.0](https://github.com/gpustack/gguf-parser-go/releases/tag/v0.26.0)
- Full change set: [v0.25.0...v0.26.0](https://github.com/gpustack/gguf-parser-go/compare/v0.25.0...v0.26.0)
cc @tobocop2 @lyfuci

## Test plan

**Unit.** `2751 passed, 11 skipped, 1 failed` — the one failure is `tests/server/test_catalog.py::test_model_catalog_modelscope`, which resolves real ModelScope file paths over the network and is unrelated to this change (it never reaches `tools_manager`); it was too slow to complete reliably on the dev machine, so it is left to CI. Pre-commit clean (flake8, black).

**Not run, stated plainly:** no live estimate was executed against the v0.26.0 binary, so the numeric effect of the KV-cache fixes above is unverified here. What is verified is the packaging contract the bump depends on — the v0.26.0 release exists and publishes the same seven asset names as v0.25.0 (`gguf-parser-{darwin,linux}-{amd64,arm64}`, `darwin-universal`, `windows-{amd64,arm64}.exe`), and the upstream diff introduces no CLI flag changes.