### PR TITLE
fix(auth): make SSO callback redirects mount-path agnostic

### DIFF
--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -1,6 +1,7 @@
 import base64
 import functools
 import hmac
+import inspect
 import json
 import os
 import secrets
@@ -140,8 +141,9 @@ async def get_oidc_user_data(
 # Browser-facing SSO callbacks (CAS / OIDC / SAML) are reached via a
 # full-page IdP redirect: a JSON exception raised inside them would
 # land the user on a raw error page rather than the login form.
-# Failures are surfaced via ``/login?error=<code>`` instead, so the
-# login UI can read the code and render an actionable toast.
+# Failures send the browser to the UI carrying ``?error=<code>``
+# instead, so the login UI can read the code and render an actionable
+# toast.
 #
 # Two codes are recognised today:
 #   * ``source_conflict`` — same username collides with a different
@@ -150,24 +152,67 @@ async def get_oidc_user_data(
 #     IdP unreachable, malformed response, …). Generic by design:
 #     the underlying detail goes to ``logger`` for diagnosis rather
 #     than into a URL exposed to an unauthenticated caller.
-SOURCE_CONFLICT_LOGIN_URL = "/login?error=source_conflict"
-AUTH_FAILED_LOGIN_URL = "/login?error=auth_failed"
+SOURCE_CONFLICT_ERROR_CODE = "source_conflict"
+AUTH_FAILED_ERROR_CODE = "auth_failed"
+
+
+def _ui_relative_url(request: Request, error_code: Optional[str] = None) -> str:
+    """A relative URL for the UI root, as seen from ``request``'s own route.
+
+    Relative on purpose, so the server never needs to know the path it is
+    mounted under. A browser resolves ``Location`` against the URL *it*
+    requested, so climbing out of our own route lands on the UI either way:
+    ``/auth/oidc/callback`` yields ``../../`` → ``/``, and behind a proxy that
+    mounts us at ``/gpustack/`` the same answer resolves to ``/gpustack/``. The
+    prefix cancels out without ever being named.
+
+    One level per segment *minus one*: the last segment is the document, not a
+    directory, so resolution starts from ``/auth/oidc/`` and only two hops are
+    left to climb. Getting this wrong is invisible at the root — RFC 3986 drops
+    ``..`` that would escape above ``/``, so an extra hop still lands on ``/``
+    — and overshoots by exactly one directory under every subpath mount.
+
+    ``error_code`` goes in the real query string rather than inside the
+    fragment, because the login form reads it from ``window.location.search``.
+    The route has to go in the fragment because the UI is hash-routed — which
+    is also why landing on the UI root is enough for every other caller.
+    """
+    # Starlette reports root_path as part of scope["path"]. Strip it, or a
+    # server configured with one would climb a level too far per prefix segment
+    # and overshoot past the UI root.
+    root_path = request.scope.get("root_path", "")
+    path = request.url.path
+    if root_path and path.startswith(root_path):
+        path = path[len(root_path) :]
+
+    depth = len([segment for segment in path.strip("/").split("/") if segment])
+    # ``./`` rather than an empty string for a single-segment route: an empty
+    # relative reference means "this document", which would keep the callback's
+    # own path instead of climbing to the directory holding it.
+    up = "../" * (depth - 1) if depth > 1 else "./"
+    if error_code is None:
+        return up
+    return f"{up}?{urlencode({'error': error_code})}#/login"
 
 
 # ``303 See Other`` so a browser arriving via POST (SAML's POST
 # binding) switches to GET on the login page; ``302`` would
 # technically allow the browser to re-POST.
-def _source_conflict_redirect() -> RedirectResponse:
-    return RedirectResponse(url=SOURCE_CONFLICT_LOGIN_URL, status_code=303)
+def _source_conflict_redirect(request: Request) -> RedirectResponse:
+    return RedirectResponse(
+        url=_ui_relative_url(request, SOURCE_CONFLICT_ERROR_CODE), status_code=303
+    )
 
 
-def _auth_failed_redirect() -> RedirectResponse:
-    return RedirectResponse(url=AUTH_FAILED_LOGIN_URL, status_code=303)
+def _auth_failed_redirect(request: Request) -> RedirectResponse:
+    return RedirectResponse(
+        url=_ui_relative_url(request, AUTH_FAILED_ERROR_CODE), status_code=303
+    )
 
 
 def _sso_callback_errors_to_redirect(fn):
     """Decorator: turn auth failures inside an SSO callback into a
-    redirect to ``/login?error=<code>``.
+    redirect to the login form carrying ``?error=<code>``.
 
     ``ConflictException`` maps to ``source_conflict`` (specific
     actionable case). Any other exception — typed auth errors,
@@ -176,13 +221,26 @@ def _sso_callback_errors_to_redirect(fn):
     the cause is recoverable from server-side logs without exposing
     the original message to the browser.
     """
+    # Checked at import rather than on the failure path: the redirect target is
+    # derived from the request's own path, so a callback that does not take a
+    # ``Request`` would only reveal the problem the first time an SSO login
+    # failed — the one moment the redirect has to work.
+    if "request" not in inspect.signature(fn).parameters:
+        raise TypeError(
+            f"{fn.__name__} must declare a `request` parameter: the failure "
+            "redirect is computed from the request path, which is what keeps it "
+            "correct when the server is mounted under a subpath."
+        )
 
     @functools.wraps(fn)
     async def wrapper(*args, **kwargs):
+        # FastAPI invokes endpoints with keyword arguments throughout, so the
+        # signature check above is enough to make this lookup safe.
+        request = kwargs["request"]
         try:
             return await fn(*args, **kwargs)
         except ConflictException:
-            return _source_conflict_redirect()
+            return _source_conflict_redirect(request)
         except Exception as exc:
             # ``HTTPException`` subclasses store the description on
             # ``.message`` and don't pass it to ``Exception.__init__``,
@@ -193,7 +251,7 @@ def _sso_callback_errors_to_redirect(fn):
             # of a bare exception type.
             detail = getattr(exc, "message", None) or str(exc) or type(exc).__name__
             logger.exception("SSO callback %s failed: %s", fn.__name__, detail)
-            return _auth_failed_redirect()
+            return _auth_failed_redirect(request)
 
     return wrapper
 
@@ -647,7 +705,7 @@ async def saml_callback(request: Request, session: SessionDep):
     access_token = jwt_manager.create_jwt_token(
         username=username,
     )
-    response = RedirectResponse(url='/', status_code=303)
+    response = RedirectResponse(url=_ui_relative_url(request), status_code=303)
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
@@ -677,7 +735,7 @@ async def saml_logout_callback(request: Request):
         auth.process_slo(False)
     except Exception:
         pass
-    response = RedirectResponse(url="/")
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.delete_cookie(key=SESSION_COOKIE_NAME)
     response.delete_cookie(key=SSO_LOGIN_COOKIE_NAME)
     return response
@@ -924,7 +982,7 @@ async def oidc_callback(request: Request, session: SessionDep):
     access_token = jwt_manager.create_jwt_token(
         username=username,
     )
-    response = RedirectResponse(url='/')
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.delete_cookie(key=OIDC_STATE_COOKIE_NAME)
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
@@ -1182,7 +1240,7 @@ async def cas_callback(request: Request, session: SessionDep):
 
     jwt_manager: JWTManager = request.app.state.jwt_manager
     access_token = jwt_manager.create_jwt_token(username=username)
-    response = RedirectResponse(url="/")
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urljoin
 
 import pytest
 from fastapi import FastAPI
@@ -903,6 +904,7 @@ async def test_oidc_callback_uses_system_trust_store(monkeypatch):
             )()
 
     request = type("Request", (), {})()
+    request.scope = {}
     request.app = type("App", (), {})()
     request.app.state = type("State", (), {})()
     request.app.state.server_config = type(
@@ -931,10 +933,11 @@ async def test_oidc_callback_uses_system_trust_store(monkeypatch):
     )()
     request.query_params = {"code": "auth-code", "state": "test-state"}
     request.cookies = {"gpustack_oidc_state": "test-state"}
-    # Read by the session-cookie hardening (``secure=request.url.scheme
-    # == "https"``). Pretend the inbound request was HTTPS so the
-    # ``secure`` flag would have flipped on in production.
-    request.url = type("URL", (), {"scheme": "https"})()
+    # ``scheme`` is read by the session-cookie hardening
+    # (``secure=request.url.scheme == "https"``) — pretend the inbound request
+    # was HTTPS so the ``secure`` flag would have flipped on in production.
+    # ``path`` is read by the relative redirect the callback ends on.
+    request.url = type("URL", (), {"scheme": "https", "path": "/auth/oidc/callback"})()
 
     monkeypatch.setattr("gpustack.routes.auth.httpx.AsyncClient", FakeAsyncClient)
     monkeypatch.setattr("gpustack.routes.auth.use_proxy_env_for_url", lambda url: False)
@@ -1301,8 +1304,8 @@ def test_saml_settings_defaults_allow_repeat_attribute_name():
 def _saml_callback_request(saml_response_b64: str, **config_overrides) -> object:
     """Build a request double for the SAML callback tests. The
     callback derives OneLogin's ``current_url`` from ``saml_sp_acs_url``,
-    not from ``request.url``, so the URL fields on the request are
-    only used for the ``get_data`` payload."""
+    not from ``request.url``, so the URL fields on the request feed the
+    ``get_data`` payload and the relative redirect the callback ends on."""
 
     request = MagicMock()
     request.method = "POST"
@@ -1312,6 +1315,10 @@ def _saml_callback_request(saml_response_b64: str, **config_overrides) -> object
 
     request.form = _form
     request.query_params = {}
+    # Both feed the redirect the callback returns, which climbs one level per
+    # segment of this path, so they have to be real values rather than mocks.
+    request.url.path = "/auth/saml/callback"
+    request.scope = {}
 
     cfg = request.app.state.server_config
     cfg.external_auth_type = AuthProviderEnum.SAML
@@ -1933,3 +1940,72 @@ async def test_no_gateway_means_no_gateway_assertions(monkeypatch):
         None,
     )
     assert not calls["by_access_key"], "the lookup must not even be attempted"
+
+
+# --- SSO callback redirect targets -----------------------------------------
+
+
+def _redirect_request(path: str, root_path: str = "") -> MagicMock:
+    request = MagicMock()
+    request.url.path = path
+    request.scope = {"root_path": root_path} if root_path else {}
+    return request
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/auth/oidc/callback",
+        "/auth/cas/callback",
+        "/auth/saml/callback",
+        # One segment deeper than its siblings, so any hardcoded number of hops
+        # is wrong for one of them.
+        "/auth/saml/logout/callback",
+    ],
+)
+@pytest.mark.parametrize("mount", ["", "/gpustack", "/inner/gpustack"])
+def test_ui_relative_url_lands_on_the_ui_root(route, mount):
+    """The redirect has to resolve to the UI root wherever the server is mounted.
+
+    Asserted through ``urljoin`` — the same RFC 3986 resolution a browser does —
+    rather than against a hand-computed string. Counting hops by hand is exactly
+    how this went wrong once: the last path segment is the document rather than a
+    directory, and an off-by-one there is *invisible at the root*, because RFC
+    3986 discards ``..`` that would escape above ``/``. Only a mounted prefix
+    reveals it, and only by resolving rather than string-matching.
+    """
+    relative = auth_route._ui_relative_url(_redirect_request(route))
+
+    landed = urljoin(f"http://gpustack.example.com{mount}{route}", relative)
+
+    assert landed == f"http://gpustack.example.com{mount}/"
+
+
+def test_ui_relative_url_discounts_root_path():
+    """Starlette reports ``root_path`` as part of ``scope["path"]``. Counting it
+    would climb a level too far per prefix segment and overshoot the UI root."""
+    request = _redirect_request("/gpustack/auth/oidc/callback", root_path="/gpustack")
+
+    landed = urljoin(
+        "http://gpustack.example.com/gpustack/auth/oidc/callback",
+        auth_route._ui_relative_url(request),
+    )
+
+    assert landed == "http://gpustack.example.com/gpustack/"
+
+
+def test_ui_relative_url_puts_error_code_outside_the_fragment():
+    """The login form reads the code from ``window.location.search``, so it has
+    to sit in the real query string; the route goes in the fragment because the
+    UI is hash-routed. Putting it inside the fragment still reaches the login
+    page but silently loses the message."""
+    request = _redirect_request("/auth/cas/callback")
+
+    landed = urljoin(
+        "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+        auth_route._ui_relative_url(request, auth_route.AUTH_FAILED_ERROR_CODE),
+    )
+
+    assert landed == (
+        "http://gpustack.example.com/inner/gpustack/?error=auth_failed#/login"
+    )

--- a/tests/api/test_cas.py
+++ b/tests/api/test_cas.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urljoin
 
 import pytest
 
@@ -359,10 +360,22 @@ async def test_cas_callback_rejects_existing_user_from_other_source(monkeypatch)
     request.app.state.server_config.external_auth_default_inactive = False
     request.app.url_path_for.return_value = "/auth/cas/callback"
     request.query_params = {"ticket": "ST-attacker"}
+    # The failure redirect climbs one level per segment of the callback's own
+    # path, so both have to be real values rather than mocks.
+    request.url.path = "/auth/cas/callback"
+    request.scope = {}
 
     response = await auth_route.cas_callback(request=request, session=MagicMock())
     assert response.status_code in (302, 303, 307)
-    assert response.headers["location"] == auth_route.SOURCE_CONFLICT_LOGIN_URL
+    # Relative, so it resolves to the UI root whether the server sits at the
+    # origin root or under a proxy subpath. Asserted by resolving it the way a
+    # browser would — a hop miscount is invisible at the root, where RFC 3986
+    # clamps ``..`` at ``/``. ``?error=`` stays outside the fragment because the
+    # login form reads it from ``window.location.search``.
+    assert urljoin(
+        "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+        response.headers["location"],
+    ) == ("http://gpustack.example.com/inner/gpustack/?error=source_conflict#/login")
 
 
 @pytest.mark.asyncio
@@ -415,10 +428,18 @@ async def test_cas_callback_translates_other_failures_to_auth_failed(monkeypatch
     request.app.state.server_config.server_external_url = "https://gpustack.example.com"
     request.app.url_path_for.return_value = "/auth/cas/callback"
     request.query_params = {"ticket": "ST-bad"}
+    request.url.path = "/auth/cas/callback"
+    request.scope = {}
 
     response = await auth_route.cas_callback(request=request, session=MagicMock())
     assert response.status_code in (302, 303, 307)
-    assert response.headers["location"] == auth_route.AUTH_FAILED_LOGIN_URL
+    assert (
+        urljoin(
+            "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+            response.headers["location"],
+        )
+        == "http://gpustack.example.com/inner/gpustack/?error=auth_failed#/login"
+    )
 
 
 class _AsyncClientFake:


### PR DESCRIPTION
Part of the work for #5270 — serving GPUStack under a customer's reverse-proxy
subpath, e.g. `http://customer/inner/gpustack/`.

## The problem

The six SSO callback handlers redirect with root-absolute URLs (`/`,
`/?error=auth_failed#/login`). A root-absolute URL resolves against the
**origin**, so behind a proxy that mounts GPUStack under a prefix, a user who
finishes an SSO login is sent to the customer's own home page instead of back
to GPUStack.

## The approach

Return a **relative** URL instead, and let the browser resolve it. The browser
resolves against the URL it actually requested — which already carries the
prefix — so the prefix cancels out and the server stays agnostic to where it is
mounted. No new configuration, and nothing to keep in sync with the proxy.

Concretely, `_ui_relative_url()` counts the segments of the route's own path and
emits that many `../` hops. The server is only ever computing the depth of its
own route, not guessing anything about the deployment.

Two details that are easy to get wrong:

- **The last path segment is the document, not a directory.** `/auth/oidc/callback`
  is 3 segments but needs 2 hops. An off-by-one here is **invisible at the root**,
  because RFC 3986 discards `..` that would escape above `/`. Only a mounted
  prefix reveals it. This is not hypothetical — the first version of this patch
  had exactly that bug and hand-computed unit tests passed anyway.
- **`root_path` is included in `scope["path"]`.** Counting it would climb one
  level too far per prefix segment, so it is stripped before counting. This also
  means the change stays correct if FastAPI `root_path` is set later.

The error-code URL constants became bare error codes, since the URL is now built
per request. The `?error=` stays in the real query string rather than the
fragment, because the login form reads it from `window.location.search` — putting
it in the fragment still reaches the login page but silently drops the message.

The decorator that wraps these handlers now needs the `Request`, so it asserts
at **import** time that the function it wraps declares a `request` parameter.
A missing one would otherwise surface as a `KeyError` inside an exception
handler — the least debuggable place for it.

## Tests

`_ui_relative_url` is asserted through `urljoin` — the same RFC 3986 resolution
a browser performs — parametrised over the four callback routes and three mount
prefixes (root, one segment, two segments), rather than compared against
hand-written strings. String-matching is what let the off-by-one through.
`/auth/saml/logout/callback` is deliberately in the set: it is one segment
deeper than its siblings, so any hardcoded hop count fails for one of them.

## Compatibility

No behaviour change at the root path, which is every existing deployment: the
relative URLs resolve to exactly the same targets the absolute ones named.
Verified by running the server and completing the callback flow at both the
root and behind nginx at `/inner/gpustack/` — the browser lands on
`/inner/gpustack/?error=auth_failed#/login`.

## Note

This is the backend half. The frontend half is gpustack/gpustack-ui#1351.
Subpath mounting needs both, so neither should be announced as support for
#5270 on its own.