### PR TITLE
fix(auth): keep Secure on the renewed session cookie

### DIFF
--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -11,7 +11,7 @@ from starlette.datastructures import Headers
 from gpustack.config.config import Config
 from gpustack.schemas.config import GatewayModeEnum
 from gpustack.server.db import async_session
-from typing import Annotated, Optional, Set, Tuple, List, Dict
+from typing import Annotated, Any, Optional, Set, Tuple, List, Dict
 from fastapi.security import (
     APIKeyCookie,
     APIKeyHeader,
@@ -53,6 +53,46 @@ SESSION_COOKIE_NAME = "gpustack_session"
 OIDC_ID_TOKEN_COOKIE_NAME = "gpustack_oidc_id_token"
 OIDC_STATE_COOKIE_NAME = "gpustack_oidc_state"
 SSO_LOGIN_COOKIE_NAME = "gpustack_sso_login"
+
+
+def auth_cookie_attrs(request: Request, max_age: int) -> Dict[str, Any]:
+    """Security attributes shared by every cookie this server sets.
+
+    One source for them, because they are set from a dozen places and a site
+    that spells them out by hand is a site that can fall behind. What makes that
+    hard to notice is that Starlette's own defaults are ``samesite="lax"`` and
+    ``path="/"`` — the same values the explicit call sites pass. A site can
+    therefore omit an attribute and still behave identically, right up until one
+    of those values stops being the default we want. ``path`` is exactly that
+    case once the server learns its mount prefix.
+
+    ``secure`` has no such cover: it defaults to ``False``, so omitting it
+    downgrades the cookie outright.
+
+    It is decided per request from the scheme, which reads ``http`` whenever TLS
+    terminates at a proxy — uvicorn only honours ``X-Forwarded-Proto`` from
+    ``forwarded_allow_ips``, which defaults to loopback and is not configured.
+    So this returns the right answer only for a direct HTTPS listener until that
+    is addressed; it is still set here so there is one place to fix rather than
+    a dozen.
+
+    ``samesite="lax"`` is load-bearing rather than cosmetic: it keeps the session
+    cookie out of a cross-site ``<iframe>``, and since the server sends no
+    ``X-Frame-Options`` or CSP ``frame-ancestors``, it is the only thing standing
+    between a logged-in admin and a clickjacking page. Stated explicitly here so
+    that protection does not rest on a framework default.
+    """
+    return {
+        "httponly": True,
+        # Max-Age is authoritative in every browser that matters; Expires is
+        # sent alongside for ancient clients that only understand that one.
+        "max_age": max_age,
+        "expires": max_age,
+        "samesite": "lax",
+        "secure": request.url.scheme == "https",
+    }
+
+
 SYSTEM_USER_PREFIX = "system/"
 SYSTEM_WORKER_USER_PREFIX = "system/worker/"
 GATEWAY_AUTH_TOKEN_HEADER = "X-GPUStack-Auth-Token"

--- a/gpustack/api/middlewares.py
+++ b/gpustack/api/middlewares.py
@@ -25,7 +25,7 @@ from gpustack.schemas.models import Model
 from gpustack.schemas.users import User
 from gpustack.security import JWTManager
 from gpustack import envs
-from gpustack.api.auth import SESSION_COOKIE_NAME
+from gpustack.api.auth import SESSION_COOKIE_NAME, auth_cookie_attrs
 
 from gpustack.server.metrics_collector import (
     ModelUsageMetrics,
@@ -422,12 +422,17 @@ class RefreshTokenMiddleware(BaseHTTPMiddleware):
                         new_token = jwt_manager.create_jwt_token(
                             username=payload['sub']
                         )
+                        # Through the shared helper so a renewed cookie keeps
+                        # every attribute the login path gave it. Spelling them
+                        # out here instead loses `secure`, which defaults to
+                        # False: over HTTPS the session silently continues on a
+                        # cookie weaker than the one it replaced.
                         response.set_cookie(
                             key=SESSION_COOKIE_NAME,
                             value=new_token,
-                            httponly=True,
-                            max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                            expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
+                            **auth_cookie_attrs(
+                                request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60
+                            ),
                         )
             except (ExpiredSignatureError, DecodeError):
                 pass

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -29,6 +29,7 @@ from gpustack.api.auth import (
     OIDC_ID_TOKEN_COOKIE_NAME,
     OIDC_STATE_COOKIE_NAME,
     SSO_LOGIN_COOKIE_NAME,
+    auth_cookie_attrs,
     authenticate_user,
 )
 from gpustack.server.deps import CurrentUserDep, SessionDep
@@ -154,6 +155,10 @@ async def get_oidc_user_data(
 #     than into a URL exposed to an unauthenticated caller.
 SOURCE_CONFLICT_ERROR_CODE = "source_conflict"
 AUTH_FAILED_ERROR_CODE = "auth_failed"
+
+# The OIDC state cookie only has to outlive the round trip to the IdP, so it
+# expires long before the session cookies do.
+OIDC_STATE_COOKIE_MAX_AGE_SECONDS = 600
 
 
 def _ui_relative_url(request: Request, error_code: Optional[str] = None) -> str:
@@ -709,20 +714,12 @@ async def saml_callback(request: Request, session: SessionDep):
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
     response.set_cookie(
         key=SSO_LOGIN_COOKIE_NAME,
         value="true",
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
 
     return response
@@ -879,10 +876,7 @@ async def oidc_login(request: Request):
     response.set_cookie(
         key=OIDC_STATE_COOKIE_NAME,
         value=state,
-        httponly=True,
-        max_age=600,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, OIDC_STATE_COOKIE_MAX_AGE_SECONDS),
     )
     return response
 
@@ -987,11 +981,7 @@ async def oidc_callback(request: Request, session: SessionDep):
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
     try:
         id_token = res_data.get("id_token")
@@ -999,20 +989,12 @@ async def oidc_callback(request: Request, session: SessionDep):
             response.set_cookie(
                 key=OIDC_ID_TOKEN_COOKIE_NAME,
                 value=id_token,
-                httponly=True,
-                max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                samesite="lax",
-                secure=request.url.scheme == "https",
+                **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
             )
             response.set_cookie(
                 key=SSO_LOGIN_COOKIE_NAME,
                 value="true",
-                httponly=True,
-                max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                samesite="lax",
-                secure=request.url.scheme == "https",
+                **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
             )
     except Exception as e:
         logger.warning(f"Failed to set id_token cookie: {str(e)}")
@@ -1244,20 +1226,12 @@ async def cas_callback(request: Request, session: SessionDep):
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
     response.set_cookie(
         key=SSO_LOGIN_COOKIE_NAME,
         value="true",
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
     return response
 
@@ -1281,11 +1255,7 @@ async def login(
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
 
 

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -1,6 +1,7 @@
 import base64
 import functools
 import hmac
+import inspect
 import json
 import os
 import secrets
@@ -140,8 +141,9 @@ async def get_oidc_user_data(
 # Browser-facing SSO callbacks (CAS / OIDC / SAML) are reached via a
 # full-page IdP redirect: a JSON exception raised inside them would
 # land the user on a raw error page rather than the login form.
-# Failures are surfaced via ``/login?error=<code>`` instead, so the
-# login UI can read the code and render an actionable toast.
+# Failures send the browser to the UI carrying ``?error=<code>``
+# instead, so the login UI can read the code and render an actionable
+# toast.
 #
 # Two codes are recognised today:
 #   * ``source_conflict`` — same username collides with a different
@@ -150,24 +152,67 @@ async def get_oidc_user_data(
 #     IdP unreachable, malformed response, …). Generic by design:
 #     the underlying detail goes to ``logger`` for diagnosis rather
 #     than into a URL exposed to an unauthenticated caller.
-SOURCE_CONFLICT_LOGIN_URL = "/login?error=source_conflict"
-AUTH_FAILED_LOGIN_URL = "/login?error=auth_failed"
+SOURCE_CONFLICT_ERROR_CODE = "source_conflict"
+AUTH_FAILED_ERROR_CODE = "auth_failed"
+
+
+def _ui_relative_url(request: Request, error_code: Optional[str] = None) -> str:
+    """A relative URL for the UI root, as seen from ``request``'s own route.
+
+    Relative on purpose, so the server never needs to know the path it is
+    mounted under. A browser resolves ``Location`` against the URL *it*
+    requested, so climbing out of our own route lands on the UI either way:
+    ``/auth/oidc/callback`` yields ``../../`` → ``/``, and behind a proxy that
+    mounts us at ``/gpustack/`` the same answer resolves to ``/gpustack/``. The
+    prefix cancels out without ever being named.
+
+    One level per segment *minus one*: the last segment is the document, not a
+    directory, so resolution starts from ``/auth/oidc/`` and only two hops are
+    left to climb. Getting this wrong is invisible at the root — RFC 3986 drops
+    ``..`` that would escape above ``/``, so an extra hop still lands on ``/``
+    — and overshoots by exactly one directory under every subpath mount.
+
+    ``error_code`` goes in the real query string rather than inside the
+    fragment, because the login form reads it from ``window.location.search``.
+    The route has to go in the fragment because the UI is hash-routed — which
+    is also why landing on the UI root is enough for every other caller.
+    """
+    # Starlette reports root_path as part of scope["path"]. Strip it, or a
+    # server configured with one would climb a level too far per prefix segment
+    # and overshoot past the UI root.
+    root_path = request.scope.get("root_path", "")
+    path = request.url.path
+    if root_path and path.startswith(root_path):
+        path = path[len(root_path) :]
+
+    depth = len([segment for segment in path.strip("/").split("/") if segment])
+    # ``./`` rather than an empty string for a single-segment route: an empty
+    # relative reference means "this document", which would keep the callback's
+    # own path instead of climbing to the directory holding it.
+    up = "../" * (depth - 1) if depth > 1 else "./"
+    if error_code is None:
+        return up
+    return f"{up}?{urlencode({'error': error_code})}#/login"
 
 
 # ``303 See Other`` so a browser arriving via POST (SAML's POST
 # binding) switches to GET on the login page; ``302`` would
 # technically allow the browser to re-POST.
-def _source_conflict_redirect() -> RedirectResponse:
-    return RedirectResponse(url=SOURCE_CONFLICT_LOGIN_URL, status_code=303)
+def _source_conflict_redirect(request: Request) -> RedirectResponse:
+    return RedirectResponse(
+        url=_ui_relative_url(request, SOURCE_CONFLICT_ERROR_CODE), status_code=303
+    )
 
 
-def _auth_failed_redirect() -> RedirectResponse:
-    return RedirectResponse(url=AUTH_FAILED_LOGIN_URL, status_code=303)
+def _auth_failed_redirect(request: Request) -> RedirectResponse:
+    return RedirectResponse(
+        url=_ui_relative_url(request, AUTH_FAILED_ERROR_CODE), status_code=303
+    )
 
 
 def _sso_callback_errors_to_redirect(fn):
     """Decorator: turn auth failures inside an SSO callback into a
-    redirect to ``/login?error=<code>``.
+    redirect to the login form carrying ``?error=<code>``.
 
     ``ConflictException`` maps to ``source_conflict`` (specific
     actionable case). Any other exception — typed auth errors,
@@ -176,13 +221,26 @@ def _sso_callback_errors_to_redirect(fn):
     the cause is recoverable from server-side logs without exposing
     the original message to the browser.
     """
+    # Checked at import rather than on the failure path: the redirect target is
+    # derived from the request's own path, so a callback that does not take a
+    # ``Request`` would only reveal the problem the first time an SSO login
+    # failed — the one moment the redirect has to work.
+    if "request" not in inspect.signature(fn).parameters:
+        raise TypeError(
+            f"{fn.__name__} must declare a `request` parameter: the failure "
+            "redirect is computed from the request path, which is what keeps it "
+            "correct when the server is mounted under a subpath."
+        )
 
     @functools.wraps(fn)
     async def wrapper(*args, **kwargs):
+        # FastAPI invokes endpoints with keyword arguments throughout, so the
+        # signature check above is enough to make this lookup safe.
+        request = kwargs["request"]
         try:
             return await fn(*args, **kwargs)
         except ConflictException:
-            return _source_conflict_redirect()
+            return _source_conflict_redirect(request)
         except Exception as exc:
             # ``HTTPException`` subclasses store the description on
             # ``.message`` and don't pass it to ``Exception.__init__``,
@@ -193,7 +251,7 @@ def _sso_callback_errors_to_redirect(fn):
             # of a bare exception type.
             detail = getattr(exc, "message", None) or str(exc) or type(exc).__name__
             logger.exception("SSO callback %s failed: %s", fn.__name__, detail)
-            return _auth_failed_redirect()
+            return _auth_failed_redirect(request)
 
     return wrapper
 
@@ -647,7 +705,7 @@ async def saml_callback(request: Request, session: SessionDep):
     access_token = jwt_manager.create_jwt_token(
         username=username,
     )
-    response = RedirectResponse(url='/', status_code=303)
+    response = RedirectResponse(url=_ui_relative_url(request), status_code=303)
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
@@ -677,7 +735,7 @@ async def saml_logout_callback(request: Request):
         auth.process_slo(False)
     except Exception:
         pass
-    response = RedirectResponse(url="/")
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.delete_cookie(key=SESSION_COOKIE_NAME)
     response.delete_cookie(key=SSO_LOGIN_COOKIE_NAME)
     return response
@@ -924,7 +982,7 @@ async def oidc_callback(request: Request, session: SessionDep):
     access_token = jwt_manager.create_jwt_token(
         username=username,
     )
-    response = RedirectResponse(url='/')
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.delete_cookie(key=OIDC_STATE_COOKIE_NAME)
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
@@ -1182,7 +1240,7 @@ async def cas_callback(request: Request, session: SessionDep):
 
     jwt_manager: JWTManager = request.app.state.jwt_manager
     access_token = jwt_manager.create_jwt_token(username=username)
-    response = RedirectResponse(url="/")
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urljoin
 
 import pytest
 from fastapi import FastAPI
@@ -903,6 +904,7 @@ async def test_oidc_callback_uses_system_trust_store(monkeypatch):
             )()
 
     request = type("Request", (), {})()
+    request.scope = {}
     request.app = type("App", (), {})()
     request.app.state = type("State", (), {})()
     request.app.state.server_config = type(
@@ -931,10 +933,11 @@ async def test_oidc_callback_uses_system_trust_store(monkeypatch):
     )()
     request.query_params = {"code": "auth-code", "state": "test-state"}
     request.cookies = {"gpustack_oidc_state": "test-state"}
-    # Read by the session-cookie hardening (``secure=request.url.scheme
-    # == "https"``). Pretend the inbound request was HTTPS so the
-    # ``secure`` flag would have flipped on in production.
-    request.url = type("URL", (), {"scheme": "https"})()
+    # ``scheme`` is read by the session-cookie hardening
+    # (``secure=request.url.scheme == "https"``) — pretend the inbound request
+    # was HTTPS so the ``secure`` flag would have flipped on in production.
+    # ``path`` is read by the relative redirect the callback ends on.
+    request.url = type("URL", (), {"scheme": "https", "path": "/auth/oidc/callback"})()
 
     monkeypatch.setattr("gpustack.routes.auth.httpx.AsyncClient", FakeAsyncClient)
     monkeypatch.setattr("gpustack.routes.auth.use_proxy_env_for_url", lambda url: False)
@@ -1301,8 +1304,8 @@ def test_saml_settings_defaults_allow_repeat_attribute_name():
 def _saml_callback_request(saml_response_b64: str, **config_overrides) -> object:
     """Build a request double for the SAML callback tests. The
     callback derives OneLogin's ``current_url`` from ``saml_sp_acs_url``,
-    not from ``request.url``, so the URL fields on the request are
-    only used for the ``get_data`` payload."""
+    not from ``request.url``, so the URL fields on the request feed the
+    ``get_data`` payload and the relative redirect the callback ends on."""
 
     request = MagicMock()
     request.method = "POST"
@@ -1312,6 +1315,10 @@ def _saml_callback_request(saml_response_b64: str, **config_overrides) -> object
 
     request.form = _form
     request.query_params = {}
+    # Both feed the redirect the callback returns, which climbs one level per
+    # segment of this path, so they have to be real values rather than mocks.
+    request.url.path = "/auth/saml/callback"
+    request.scope = {}
 
     cfg = request.app.state.server_config
     cfg.external_auth_type = AuthProviderEnum.SAML
@@ -1933,3 +1940,72 @@ async def test_no_gateway_means_no_gateway_assertions(monkeypatch):
         None,
     )
     assert not calls["by_access_key"], "the lookup must not even be attempted"
+
+
+# --- SSO callback redirect targets -----------------------------------------
+
+
+def _redirect_request(path: str, root_path: str = "") -> MagicMock:
+    request = MagicMock()
+    request.url.path = path
+    request.scope = {"root_path": root_path} if root_path else {}
+    return request
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/auth/oidc/callback",
+        "/auth/cas/callback",
+        "/auth/saml/callback",
+        # One segment deeper than its siblings, so any hardcoded number of hops
+        # is wrong for one of them.
+        "/auth/saml/logout/callback",
+    ],
+)
+@pytest.mark.parametrize("mount", ["", "/gpustack", "/inner/gpustack"])
+def test_ui_relative_url_lands_on_the_ui_root(route, mount):
+    """The redirect has to resolve to the UI root wherever the server is mounted.
+
+    Asserted through ``urljoin`` — the same RFC 3986 resolution a browser does —
+    rather than against a hand-computed string. Counting hops by hand is exactly
+    how this went wrong once: the last path segment is the document rather than a
+    directory, and an off-by-one there is *invisible at the root*, because RFC
+    3986 discards ``..`` that would escape above ``/``. Only a mounted prefix
+    reveals it, and only by resolving rather than string-matching.
+    """
+    relative = auth_route._ui_relative_url(_redirect_request(route))
+
+    landed = urljoin(f"http://gpustack.example.com{mount}{route}", relative)
+
+    assert landed == f"http://gpustack.example.com{mount}/"
+
+
+def test_ui_relative_url_discounts_root_path():
+    """Starlette reports ``root_path`` as part of ``scope["path"]``. Counting it
+    would climb a level too far per prefix segment and overshoot the UI root."""
+    request = _redirect_request("/gpustack/auth/oidc/callback", root_path="/gpustack")
+
+    landed = urljoin(
+        "http://gpustack.example.com/gpustack/auth/oidc/callback",
+        auth_route._ui_relative_url(request),
+    )
+
+    assert landed == "http://gpustack.example.com/gpustack/"
+
+
+def test_ui_relative_url_puts_error_code_outside_the_fragment():
+    """The login form reads the code from ``window.location.search``, so it has
+    to sit in the real query string; the route goes in the fragment because the
+    UI is hash-routed. Putting it inside the fragment still reaches the login
+    page but silently loses the message."""
+    request = _redirect_request("/auth/cas/callback")
+
+    landed = urljoin(
+        "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+        auth_route._ui_relative_url(request, auth_route.AUTH_FAILED_ERROR_CODE),
+    )
+
+    assert landed == (
+        "http://gpustack.example.com/inner/gpustack/?error=auth_failed#/login"
+    )

--- a/tests/api/test_cas.py
+++ b/tests/api/test_cas.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urljoin
 
 import pytest
 
@@ -359,10 +360,22 @@ async def test_cas_callback_rejects_existing_user_from_other_source(monkeypatch)
     request.app.state.server_config.external_auth_default_inactive = False
     request.app.url_path_for.return_value = "/auth/cas/callback"
     request.query_params = {"ticket": "ST-attacker"}
+    # The failure redirect climbs one level per segment of the callback's own
+    # path, so both have to be real values rather than mocks.
+    request.url.path = "/auth/cas/callback"
+    request.scope = {}
 
     response = await auth_route.cas_callback(request=request, session=MagicMock())
     assert response.status_code in (302, 303, 307)
-    assert response.headers["location"] == auth_route.SOURCE_CONFLICT_LOGIN_URL
+    # Relative, so it resolves to the UI root whether the server sits at the
+    # origin root or under a proxy subpath. Asserted by resolving it the way a
+    # browser would — a hop miscount is invisible at the root, where RFC 3986
+    # clamps ``..`` at ``/``. ``?error=`` stays outside the fragment because the
+    # login form reads it from ``window.location.search``.
+    assert urljoin(
+        "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+        response.headers["location"],
+    ) == ("http://gpustack.example.com/inner/gpustack/?error=source_conflict#/login")
 
 
 @pytest.mark.asyncio
@@ -415,10 +428,18 @@ async def test_cas_callback_translates_other_failures_to_auth_failed(monkeypatch
     request.app.state.server_config.server_external_url = "https://gpustack.example.com"
     request.app.url_path_for.return_value = "/auth/cas/callback"
     request.query_params = {"ticket": "ST-bad"}
+    request.url.path = "/auth/cas/callback"
+    request.scope = {}
 
     response = await auth_route.cas_callback(request=request, session=MagicMock())
     assert response.status_code in (302, 303, 307)
-    assert response.headers["location"] == auth_route.AUTH_FAILED_LOGIN_URL
+    assert (
+        urljoin(
+            "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+            response.headers["location"],
+        )
+        == "http://gpustack.example.com/inner/gpustack/?error=auth_failed#/login"
+    )
 
 
 class _AsyncClientFake:

--- a/tests/api/test_middlewares.py
+++ b/tests/api/test_middlewares.py
@@ -6,6 +6,7 @@ principal id that would otherwise violate the FK and roll back the whole
 usage flush batch.
 """
 
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -79,3 +80,99 @@ async def test_resolve_direct_consumer_org_non_member_dropped(monkeypatch):
         monkeypatch, exc=ForbiddenException(message="Not a member of organization 7")
     )
     assert await middlewares._resolve_direct_consumer_org(_REQUEST, _USER, "7") is None
+
+
+# --- Session-cookie renewal attributes -------------------------------------
+#
+# The renewal in ``RefreshTokenMiddleware`` reissues the session cookie
+# mid-session, so an attribute it omits is one the session silently loses
+# ~105 minutes in while continuing to work.
+#
+# Most omissions are masked by Starlette's defaults happening to match what the
+# login path passes (``samesite="lax"``, ``path="/"``). ``secure`` is not: it
+# defaults to ``False``. So the assertions below check the whole attribute set
+# rather than the one that was wrong, because which attribute is exposed by an
+# omission changes as soon as a default stops matching — as ``path`` will once
+# the server scopes cookies to its mount prefix.
+
+
+def _renewal_set_cookie(scheme: str) -> str:
+    """Drive the middleware to the renewal branch; return its Set-Cookie."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from gpustack.api.auth import SESSION_COOKIE_NAME
+    from gpustack.api.middlewares import RefreshTokenMiddleware
+
+    app = FastAPI()
+    app.add_middleware(RefreshTokenMiddleware)
+
+    @app.get("/")
+    def _root():
+        return {}
+
+    # ``exp`` inside the 15-minute window is what selects the renewal branch.
+    app.state.jwt_manager = SimpleNamespace(
+        decode_jwt_token=lambda token: {"sub": "admin", "exp": time.time() + 60},
+        create_jwt_token=lambda username: "renewed-token",
+    )
+
+    client = TestClient(app, base_url=f"{scheme}://testserver")
+    client.cookies.set(SESSION_COOKIE_NAME, "about-to-expire")
+    response = client.get("/")
+    header = response.headers.get("set-cookie")
+    assert header, "the renewal branch did not fire, so this asserts nothing"
+    return header
+
+
+def _attr_names(set_cookie: str) -> set:
+    """Attribute names in a Set-Cookie header, lowercased, minus the pair."""
+    return {part.strip().split("=", 1)[0].lower() for part in set_cookie.split(";")[1:]}
+
+
+def test_renewed_session_cookie_keeps_samesite_and_secure():
+    header = _renewal_set_cookie("https")
+
+    assert "renewed-token" in header
+    assert "samesite=lax" in header.lower()
+    assert "secure" in _attr_names(header)
+
+
+def test_renewed_session_cookie_omits_secure_over_plain_http():
+    # Marking a cookie Secure on an http origin would stop the browser sending
+    # it back at all, so the flag has to track the scheme rather than be
+    # unconditional.
+    header = _renewal_set_cookie("http")
+
+    assert "samesite=lax" in header.lower()
+    assert "secure" not in _attr_names(header)
+
+
+def test_renewal_sets_every_attribute_the_shared_helper_defines():
+    """The drift guard.
+
+    Naming individual attributes only catches the one that happened to be
+    exposed — ``secure``, because its default is ``False``. Comparing against
+    ``auth_cookie_attrs`` instead covers the ones Starlette's defaults currently
+    mask, so they are still covered when a default stops matching.
+    """
+    from gpustack.api.auth import auth_cookie_attrs
+
+    expected = {
+        # kwarg name -> the attribute name it lands as in the header
+        "httponly": "httponly",
+        "max_age": "max-age",
+        "expires": "expires",
+        "samesite": "samesite",
+        "secure": "secure",
+    }
+    helper_kwargs = auth_cookie_attrs(
+        SimpleNamespace(url=SimpleNamespace(scheme="https")), 60
+    )
+    assert set(helper_kwargs) == set(expected), (
+        "auth_cookie_attrs grew or lost a kwarg; map it in `expected` so this "
+        "test keeps covering every attribute the login path sets"
+    )
+
+    present = _attr_names(_renewal_set_cookie("https"))
+    assert {expected[k] for k in helper_kwargs} <= present


### PR DESCRIPTION
> **Stacked on #6082.** GitHub will not accept a fork branch as a base, so the diff here carries that PR's commit too. Only the second commit belongs to this PR:
>
> - `554700e4` — #6082, review there
> - `90205b76` — **this PR**

## Problem

`RefreshTokenMiddleware` renews the session cookie by writing the attributes out by hand, and it omitted `secure`. Starlette defaults that to `False`, so over HTTPS a session continued on a non-`Secure` cookie from its first renewal onward — a downgrade that happens silently, an hour into a session, on the request that was supposed to keep the user logged in.

## Change

One helper, `auth_cookie_attrs(request, max_age)`, and every site that sets one of these cookies goes through it — nine in the routes plus the renewal.

## Why the whole attribute set rather than the one attribute that was wrong

`secure` was exposed only because its default is `False`. Starlette's defaults for `samesite` and `path` currently happen to match what the login path passes, so those two can be omitted at a call site and behave identically — right up until one of those values stops being the default we want. The test asserts the renewal carries every attribute the helper defines, compared against the helper itself, so the coverage does not depend on remembering to add an assertion.

That guard has already earned its keep: it failed when a later branch added `path` to the helper, which is exactly the case it was written for.

## Correction to an earlier claim in this branch's history

I initially described this as three lost attributes and thought the missing `samesite` had re-opened a Firefox clickjacking path. That was wrong, and the tests are what caught it: only `Secure` was ever lost, because Starlette's defaults supply `samesite="lax"` and `path="/"`. The code comments say so rather than leaving the stronger claim standing.
