### PR TITLE
feat(server): serve the mount prefix the reverse proxy puts us behind

### DIFF
--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -11,7 +11,7 @@ from starlette.datastructures import Headers
 from gpustack.config.config import Config
 from gpustack.schemas.config import GatewayModeEnum
 from gpustack.server.db import async_session
-from typing import Annotated, Optional, Set, Tuple, List, Dict
+from typing import Annotated, Any, Optional, Set, Tuple, List, Dict
 from fastapi.security import (
     APIKeyCookie,
     APIKeyHeader,
@@ -53,6 +53,46 @@ SESSION_COOKIE_NAME = "gpustack_session"
 OIDC_ID_TOKEN_COOKIE_NAME = "gpustack_oidc_id_token"
 OIDC_STATE_COOKIE_NAME = "gpustack_oidc_state"
 SSO_LOGIN_COOKIE_NAME = "gpustack_sso_login"
+
+
+def auth_cookie_attrs(request: Request, max_age: int) -> Dict[str, Any]:
+    """Security attributes shared by every cookie this server sets.
+
+    One source for them, because they are set from a dozen places and a site
+    that spells them out by hand is a site that can fall behind. What makes that
+    hard to notice is that Starlette's own defaults are ``samesite="lax"`` and
+    ``path="/"`` — the same values the explicit call sites pass. A site can
+    therefore omit an attribute and still behave identically, right up until one
+    of those values stops being the default we want. ``path`` is exactly that
+    case once the server learns its mount prefix.
+
+    ``secure`` has no such cover: it defaults to ``False``, so omitting it
+    downgrades the cookie outright.
+
+    It is decided per request from the scheme, which reads ``http`` whenever TLS
+    terminates at a proxy — uvicorn only honours ``X-Forwarded-Proto`` from
+    ``forwarded_allow_ips``, which defaults to loopback and is not configured.
+    So this returns the right answer only for a direct HTTPS listener until that
+    is addressed; it is still set here so there is one place to fix rather than
+    a dozen.
+
+    ``samesite="lax"`` is load-bearing rather than cosmetic: it keeps the session
+    cookie out of a cross-site ``<iframe>``, and since the server sends no
+    ``X-Frame-Options`` or CSP ``frame-ancestors``, it is the only thing standing
+    between a logged-in admin and a clickjacking page. Stated explicitly here so
+    that protection does not rest on a framework default.
+    """
+    return {
+        "httponly": True,
+        # Max-Age is authoritative in every browser that matters; Expires is
+        # sent alongside for ancient clients that only understand that one.
+        "max_age": max_age,
+        "expires": max_age,
+        "samesite": "lax",
+        "secure": request.url.scheme == "https",
+    }
+
+
 SYSTEM_USER_PREFIX = "system/"
 SYSTEM_WORKER_USER_PREFIX = "system/worker/"
 GATEWAY_AUTH_TOKEN_HEADER = "X-GPUStack-Auth-Token"

--- a/gpustack/api/auth.py
+++ b/gpustack/api/auth.py
@@ -8,7 +8,7 @@ import aiohttp
 from aiocache import cached
 from fastapi import Depends, Request, WebSocket
 from starlette.datastructures import Headers
-from gpustack.config.config import Config
+from gpustack.config.config import Config, get_global_config
 from gpustack.schemas.config import GatewayModeEnum
 from gpustack.server.db import async_session
 from typing import Annotated, Any, Optional, Set, Tuple, List, Dict
@@ -60,11 +60,10 @@ def auth_cookie_attrs(request: Request, max_age: int) -> Dict[str, Any]:
 
     One source for them, because they are set from a dozen places and a site
     that spells them out by hand is a site that can fall behind. What makes that
-    hard to notice is that Starlette's own defaults are ``samesite="lax"`` and
-    ``path="/"`` — the same values the explicit call sites pass. A site can
-    therefore omit an attribute and still behave identically, right up until one
-    of those values stops being the default we want. ``path`` is exactly that
-    case once the server learns its mount prefix.
+    hard to notice is that Starlette's own default ``samesite`` is ``"lax"``, the
+    same value we want: a site can omit it and behave identically, right up until
+    that stops being the default. ``path`` was the same story and is no longer,
+    because under a mount prefix the value we want is not ``"/"``.
 
     ``secure`` has no such cover: it defaults to ``False``, so omitting it
     downgrades the cookie outright.
@@ -90,7 +89,23 @@ def auth_cookie_attrs(request: Request, max_age: int) -> Dict[str, Any]:
         "expires": max_age,
         "samesite": "lax",
         "secure": request.url.scheme == "https",
+        "path": auth_cookie_path(),
     }
+
+
+def auth_cookie_path() -> str:
+    """``Path`` for the cookies this server sets and deletes.
+
+    Its own function because deletion needs it without the rest: a
+    ``delete_cookie`` that omits ``path`` addresses a *different* cookie than the
+    one that was set, so logout would appear to work and change nothing.
+
+    Reads the global config rather than ``request.app.state`` so that both the
+    routes and the renewal middleware can call it, and so it degrades to the root
+    before a config is installed instead of raising.
+    """
+    cfg = get_global_config()
+    return cfg.get_cookie_path() if cfg else "/"
 
 
 SYSTEM_USER_PREFIX = "system/"

--- a/gpustack/api/middlewares.py
+++ b/gpustack/api/middlewares.py
@@ -25,7 +25,7 @@ from gpustack.schemas.models import Model
 from gpustack.schemas.users import User
 from gpustack.security import JWTManager
 from gpustack import envs
-from gpustack.api.auth import SESSION_COOKIE_NAME
+from gpustack.api.auth import SESSION_COOKIE_NAME, auth_cookie_attrs
 
 from gpustack.server.metrics_collector import (
     ModelUsageMetrics,
@@ -422,12 +422,17 @@ class RefreshTokenMiddleware(BaseHTTPMiddleware):
                         new_token = jwt_manager.create_jwt_token(
                             username=payload['sub']
                         )
+                        # Through the shared helper so a renewed cookie keeps
+                        # every attribute the login path gave it. Spelling them
+                        # out here instead loses `secure`, which defaults to
+                        # False: over HTTPS the session silently continues on a
+                        # cookie weaker than the one it replaced.
                         response.set_cookie(
                             key=SESSION_COOKIE_NAME,
                             value=new_token,
-                            httponly=True,
-                            max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                            expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
+                            **auth_cookie_attrs(
+                                request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60
+                            ),
                         )
             except (ExpiredSignatureError, DecodeError):
                 pass

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -931,6 +931,53 @@ class Config(WorkerConfig, BaseSettings):
         except Exception:
             return hostname
 
+    def get_base_path(self) -> str:
+        """The path prefix this server is reached at, or ``""`` at the root.
+
+        Third consumer of ``server_external_url``, and the first to look past its
+        hostname: mounting GPUStack under a customer's reverse proxy at, say,
+        ``https://example.com/gpustack/`` means every absolute URL the server
+        hands out or generates has to carry ``/gpustack``.
+
+        The prefix cannot be derived from a request. The proxy strips it before
+        forwarding, and no header carries it — ``X-Forwarded-Host`` names the
+        host, nothing names the path. The browser knows it (it is in
+        ``location.pathname``, which is why the UI needs no configuration for
+        this), but the server can only be told.
+
+        Normalised to either ``""`` or a leading-slash, no-trailing-slash path so
+        callers can concatenate without re-checking: ASGI ``root_path`` and the
+        ``Path`` attribute of a cookie both want exactly that shape.
+        """
+        if not self.server_external_url:
+            return ""
+        path = urlparse(self.server_external_url).path.strip()
+        # ``https://host`` parses to "" and ``https://host/`` to "/"; both mean
+        # the root, where a prefix would only add an empty path segment.
+        path = path.rstrip("/")
+        if not path:
+            return ""
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return path
+
+    def get_cookie_path(self) -> str:
+        """``Path`` for every cookie this server sets.
+
+        Scoped to the mount prefix so a session cookie is not offered to the rest
+        of a shared origin — under a subpath mount the customer's own application
+        is typically what sits at ``/``.
+
+        Evaluated by the browser against *its* URL, which still carries the
+        prefix the proxy stripped. So this is correct even though the server
+        never sees a prefixed path itself.
+
+        Falls back to ``"/"`` rather than ``""``: an empty ``Path`` is not a
+        valid cookie attribute, and ``/`` is what the root deployment wants
+        anyway.
+        """
+        return self.get_base_path() or "/"
+
     def get_trusted_hosts(self) -> List[str]:
         """Resolve the allowlist gating X-Forwarded-Host rewriting.
 

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -29,6 +29,7 @@ from gpustack.api.auth import (
     OIDC_ID_TOKEN_COOKIE_NAME,
     OIDC_STATE_COOKIE_NAME,
     SSO_LOGIN_COOKIE_NAME,
+    auth_cookie_attrs,
     authenticate_user,
 )
 from gpustack.server.deps import CurrentUserDep, SessionDep
@@ -154,6 +155,10 @@ async def get_oidc_user_data(
 #     than into a URL exposed to an unauthenticated caller.
 SOURCE_CONFLICT_ERROR_CODE = "source_conflict"
 AUTH_FAILED_ERROR_CODE = "auth_failed"
+
+# The OIDC state cookie only has to outlive the round trip to the IdP, so it
+# expires long before the session cookies do.
+OIDC_STATE_COOKIE_MAX_AGE_SECONDS = 600
 
 
 def _ui_relative_url(request: Request, error_code: Optional[str] = None) -> str:
@@ -709,20 +714,12 @@ async def saml_callback(request: Request, session: SessionDep):
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
     response.set_cookie(
         key=SSO_LOGIN_COOKIE_NAME,
         value="true",
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
 
     return response
@@ -879,10 +876,7 @@ async def oidc_login(request: Request):
     response.set_cookie(
         key=OIDC_STATE_COOKIE_NAME,
         value=state,
-        httponly=True,
-        max_age=600,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, OIDC_STATE_COOKIE_MAX_AGE_SECONDS),
     )
     return response
 
@@ -987,11 +981,7 @@ async def oidc_callback(request: Request, session: SessionDep):
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
     try:
         id_token = res_data.get("id_token")
@@ -999,20 +989,12 @@ async def oidc_callback(request: Request, session: SessionDep):
             response.set_cookie(
                 key=OIDC_ID_TOKEN_COOKIE_NAME,
                 value=id_token,
-                httponly=True,
-                max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                samesite="lax",
-                secure=request.url.scheme == "https",
+                **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
             )
             response.set_cookie(
                 key=SSO_LOGIN_COOKIE_NAME,
                 value="true",
-                httponly=True,
-                max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-                samesite="lax",
-                secure=request.url.scheme == "https",
+                **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
             )
     except Exception as e:
         logger.warning(f"Failed to set id_token cookie: {str(e)}")
@@ -1244,20 +1226,12 @@ async def cas_callback(request: Request, session: SessionDep):
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
     response.set_cookie(
         key=SSO_LOGIN_COOKIE_NAME,
         value="true",
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
     return response
 
@@ -1281,11 +1255,7 @@ async def login(
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        max_age=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        expires=envs.JWT_TOKEN_EXPIRE_MINUTES * 60,
-        samesite="lax",
-        secure=request.url.scheme == "https",
+        **auth_cookie_attrs(request, envs.JWT_TOKEN_EXPIRE_MINUTES * 60),
     )
 
 

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -1,6 +1,7 @@
 import base64
 import functools
 import hmac
+import inspect
 import json
 import os
 import secrets
@@ -140,8 +141,9 @@ async def get_oidc_user_data(
 # Browser-facing SSO callbacks (CAS / OIDC / SAML) are reached via a
 # full-page IdP redirect: a JSON exception raised inside them would
 # land the user on a raw error page rather than the login form.
-# Failures are surfaced via ``/login?error=<code>`` instead, so the
-# login UI can read the code and render an actionable toast.
+# Failures send the browser to the UI carrying ``?error=<code>``
+# instead, so the login UI can read the code and render an actionable
+# toast.
 #
 # Two codes are recognised today:
 #   * ``source_conflict`` — same username collides with a different
@@ -150,24 +152,67 @@ async def get_oidc_user_data(
 #     IdP unreachable, malformed response, …). Generic by design:
 #     the underlying detail goes to ``logger`` for diagnosis rather
 #     than into a URL exposed to an unauthenticated caller.
-SOURCE_CONFLICT_LOGIN_URL = "/login?error=source_conflict"
-AUTH_FAILED_LOGIN_URL = "/login?error=auth_failed"
+SOURCE_CONFLICT_ERROR_CODE = "source_conflict"
+AUTH_FAILED_ERROR_CODE = "auth_failed"
+
+
+def _ui_relative_url(request: Request, error_code: Optional[str] = None) -> str:
+    """A relative URL for the UI root, as seen from ``request``'s own route.
+
+    Relative on purpose, so the server never needs to know the path it is
+    mounted under. A browser resolves ``Location`` against the URL *it*
+    requested, so climbing out of our own route lands on the UI either way:
+    ``/auth/oidc/callback`` yields ``../../`` → ``/``, and behind a proxy that
+    mounts us at ``/gpustack/`` the same answer resolves to ``/gpustack/``. The
+    prefix cancels out without ever being named.
+
+    One level per segment *minus one*: the last segment is the document, not a
+    directory, so resolution starts from ``/auth/oidc/`` and only two hops are
+    left to climb. Getting this wrong is invisible at the root — RFC 3986 drops
+    ``..`` that would escape above ``/``, so an extra hop still lands on ``/``
+    — and overshoots by exactly one directory under every subpath mount.
+
+    ``error_code`` goes in the real query string rather than inside the
+    fragment, because the login form reads it from ``window.location.search``.
+    The route has to go in the fragment because the UI is hash-routed — which
+    is also why landing on the UI root is enough for every other caller.
+    """
+    # Starlette reports root_path as part of scope["path"]. Strip it, or a
+    # server configured with one would climb a level too far per prefix segment
+    # and overshoot past the UI root.
+    root_path = request.scope.get("root_path", "")
+    path = request.url.path
+    if root_path and path.startswith(root_path):
+        path = path[len(root_path) :]
+
+    depth = len([segment for segment in path.strip("/").split("/") if segment])
+    # ``./`` rather than an empty string for a single-segment route: an empty
+    # relative reference means "this document", which would keep the callback's
+    # own path instead of climbing to the directory holding it.
+    up = "../" * (depth - 1) if depth > 1 else "./"
+    if error_code is None:
+        return up
+    return f"{up}?{urlencode({'error': error_code})}#/login"
 
 
 # ``303 See Other`` so a browser arriving via POST (SAML's POST
 # binding) switches to GET on the login page; ``302`` would
 # technically allow the browser to re-POST.
-def _source_conflict_redirect() -> RedirectResponse:
-    return RedirectResponse(url=SOURCE_CONFLICT_LOGIN_URL, status_code=303)
+def _source_conflict_redirect(request: Request) -> RedirectResponse:
+    return RedirectResponse(
+        url=_ui_relative_url(request, SOURCE_CONFLICT_ERROR_CODE), status_code=303
+    )
 
 
-def _auth_failed_redirect() -> RedirectResponse:
-    return RedirectResponse(url=AUTH_FAILED_LOGIN_URL, status_code=303)
+def _auth_failed_redirect(request: Request) -> RedirectResponse:
+    return RedirectResponse(
+        url=_ui_relative_url(request, AUTH_FAILED_ERROR_CODE), status_code=303
+    )
 
 
 def _sso_callback_errors_to_redirect(fn):
     """Decorator: turn auth failures inside an SSO callback into a
-    redirect to ``/login?error=<code>``.
+    redirect to the login form carrying ``?error=<code>``.
 
     ``ConflictException`` maps to ``source_conflict`` (specific
     actionable case). Any other exception — typed auth errors,
@@ -176,13 +221,26 @@ def _sso_callback_errors_to_redirect(fn):
     the cause is recoverable from server-side logs without exposing
     the original message to the browser.
     """
+    # Checked at import rather than on the failure path: the redirect target is
+    # derived from the request's own path, so a callback that does not take a
+    # ``Request`` would only reveal the problem the first time an SSO login
+    # failed — the one moment the redirect has to work.
+    if "request" not in inspect.signature(fn).parameters:
+        raise TypeError(
+            f"{fn.__name__} must declare a `request` parameter: the failure "
+            "redirect is computed from the request path, which is what keeps it "
+            "correct when the server is mounted under a subpath."
+        )
 
     @functools.wraps(fn)
     async def wrapper(*args, **kwargs):
+        # FastAPI invokes endpoints with keyword arguments throughout, so the
+        # signature check above is enough to make this lookup safe.
+        request = kwargs["request"]
         try:
             return await fn(*args, **kwargs)
         except ConflictException:
-            return _source_conflict_redirect()
+            return _source_conflict_redirect(request)
         except Exception as exc:
             # ``HTTPException`` subclasses store the description on
             # ``.message`` and don't pass it to ``Exception.__init__``,
@@ -193,7 +251,7 @@ def _sso_callback_errors_to_redirect(fn):
             # of a bare exception type.
             detail = getattr(exc, "message", None) or str(exc) or type(exc).__name__
             logger.exception("SSO callback %s failed: %s", fn.__name__, detail)
-            return _auth_failed_redirect()
+            return _auth_failed_redirect(request)
 
     return wrapper
 
@@ -647,7 +705,7 @@ async def saml_callback(request: Request, session: SessionDep):
     access_token = jwt_manager.create_jwt_token(
         username=username,
     )
-    response = RedirectResponse(url='/', status_code=303)
+    response = RedirectResponse(url=_ui_relative_url(request), status_code=303)
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
@@ -677,7 +735,7 @@ async def saml_logout_callback(request: Request):
         auth.process_slo(False)
     except Exception:
         pass
-    response = RedirectResponse(url="/")
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.delete_cookie(key=SESSION_COOKIE_NAME)
     response.delete_cookie(key=SSO_LOGIN_COOKIE_NAME)
     return response
@@ -924,7 +982,7 @@ async def oidc_callback(request: Request, session: SessionDep):
     access_token = jwt_manager.create_jwt_token(
         username=username,
     )
-    response = RedirectResponse(url='/')
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.delete_cookie(key=OIDC_STATE_COOKIE_NAME)
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
@@ -1182,7 +1240,7 @@ async def cas_callback(request: Request, session: SessionDep):
 
     jwt_manager: JWTManager = request.app.state.jwt_manager
     access_token = jwt_manager.create_jwt_token(username=username)
-    response = RedirectResponse(url="/")
+    response = RedirectResponse(url=_ui_relative_url(request))
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,

--- a/gpustack/routes/auth.py
+++ b/gpustack/routes/auth.py
@@ -30,6 +30,7 @@ from gpustack.api.auth import (
     OIDC_STATE_COOKIE_NAME,
     SSO_LOGIN_COOKIE_NAME,
     auth_cookie_attrs,
+    auth_cookie_path,
     authenticate_user,
 )
 from gpustack.server.deps import CurrentUserDep, SessionDep
@@ -733,8 +734,8 @@ async def saml_logout_callback(request: Request):
     except Exception:
         pass
     response = RedirectResponse(url=_ui_relative_url(request))
-    response.delete_cookie(key=SESSION_COOKIE_NAME)
-    response.delete_cookie(key=SSO_LOGIN_COOKIE_NAME)
+    response.delete_cookie(key=SESSION_COOKIE_NAME, path=auth_cookie_path())
+    response.delete_cookie(key=SSO_LOGIN_COOKIE_NAME, path=auth_cookie_path())
     return response
 
 
@@ -977,7 +978,7 @@ async def oidc_callback(request: Request, session: SessionDep):
         username=username,
     )
     response = RedirectResponse(url=_ui_relative_url(request))
-    response.delete_cookie(key=OIDC_STATE_COOKIE_NAME)
+    response.delete_cookie(key=OIDC_STATE_COOKIE_NAME, path=auth_cookie_path())
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=access_token,
@@ -1304,9 +1305,13 @@ async def logout(request: Request):
     sso_login = request.cookies.get(SSO_LOGIN_COOKIE_NAME)
     content = json.dumps({"logout_url": external_logout_url}) if sso_login else ""
     resp = Response(content=content, media_type="application/json")
-    resp.delete_cookie(key=SESSION_COOKIE_NAME)
-    resp.delete_cookie(key=OIDC_ID_TOKEN_COOKIE_NAME)
-    resp.delete_cookie(key=SSO_LOGIN_COOKIE_NAME)
+    # ``path`` is not optional here. A cookie is identified by name+domain+path,
+    # so a deletion that omits it addresses the one at ``/`` — a different cookie
+    # than the one login set once the server is mounted under a prefix. Logout
+    # would return 200 and leave the session intact.
+    resp.delete_cookie(key=SESSION_COOKIE_NAME, path=auth_cookie_path())
+    resp.delete_cookie(key=OIDC_ID_TOKEN_COOKIE_NAME, path=auth_cookie_path())
+    resp.delete_cookie(key=SSO_LOGIN_COOKIE_NAME, path=auth_cookie_path())
     return resp
 
 

--- a/gpustack/server/app.py
+++ b/gpustack/server/app.py
@@ -14,6 +14,7 @@ from gpustack.config.config import Config
 from gpustack import envs
 from gpustack.routes import ui
 from gpustack.routes.routes import api_router
+from gpustack.utils.base_path import BasePathMiddleware
 from gpustack.utils.forwarded import ForwardedHostPortMiddleware
 from gpustack.security import JWTManager
 from gpustack.gateway.utils import worker_websocket_connect_callback
@@ -47,6 +48,20 @@ def create_app(cfg: Config) -> FastAPI:
         docs_url=None if (cfg and cfg.disable_openapi_docs) else "/docs",
         redoc_url=None if (cfg and cfg.disable_openapi_docs) else "/redoc",
         openapi_url=None if (cfg and cfg.disable_openapi_docs) else "/openapi.json",
+        # Tells FastAPI where it is mounted, so the URLs it generates for the
+        # browser carry the prefix. Most visibly /docs, whose page asks for
+        # /openapi.json: without this it asks at the origin root, which under a
+        # subpath mount is the customer's own application rather than us. That is
+        # two of the five extra `location` blocks #5270's reporter had to add.
+        #
+        # It also makes routing tolerate a proxy that does *not* strip the prefix
+        # (AWS ALB cannot), because Starlette matches against the path with
+        # root_path removed. Empty string is FastAPI's own default, so the root
+        # deployment is unaffected.
+        #
+        # Paired with BasePathMiddleware below, which is what makes it safe for a
+        # proxy that *does* strip.
+        root_path=cfg.get_base_path() if cfg else "",
     )
     # Before patch_docs: it auto-mounts its own plain StaticFiles at /static
     # unless that path is already taken, and whichever mount lands first wins
@@ -73,6 +88,12 @@ def create_app(cfg: Config) -> FastAPI:
     app.include_router(api_router)
     _load_extension_plugins(app, cfg)
     exceptions.register_handlers(app)
+
+    # Added last, so it runs first: add_middleware prepends, and this one has to
+    # settle what `path` means before anything else reads it. Skipped entirely at
+    # the root, where there is no prefix to restore.
+    if base_path := app.root_path:
+        app.add_middleware(BasePathMiddleware, prefix=base_path)
 
     app.state.jwt_manager = JWTManager(cfg.jwt_secret_key)
     app.state.websocket_authenticator = BearerTokenAuthenticator()

--- a/gpustack/utils/base_path.py
+++ b/gpustack/utils/base_path.py
@@ -1,0 +1,64 @@
+import logging
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+class BasePathMiddleware:
+    """Restore the mount prefix onto ``scope["path"]`` when a proxy stripped it.
+
+    ASGI says ``root_path`` is a *prefix of* ``path``: an app mounted at
+    ``/gpustack`` and asked for ``/gpustack/docs`` sees ``root_path="/gpustack"``
+    and ``path="/gpustack/docs"``. Starlette's routing is written to that
+    contract, and one place depends on it strictly. ``Mount.matches`` hands its
+    child ``root_path + matched_path``, so ``/static`` under a ``/gpustack``
+    root_path becomes ``root_path="/gpustack/static"`` — which the ``StaticFiles``
+    inside then tries to strip off a path that never had it, leaving the mount
+    looking for a file named after its own URL prefix. Plain routes survive
+    because ``get_route_path`` gives up gracefully when ``path`` does not start
+    with ``root_path``; mounts do not, and the three that serve the UI (``/css``,
+    ``/js``, ``/static``) would 404 for every asset.
+
+    That is not hypothetical, because the common nginx recipe strips: a
+    ``proxy_pass`` with a trailing slash forwards ``/docs`` for a browser request
+    to ``/gpustack/docs``, which is precisely the off-contract shape. So rather
+    than support one proxy style and break the UI under the other, this
+    normalises the shape once, outermost, and lets everything downstream see the
+    spec's version of events.
+
+    It also makes ``request.url`` agree with what the browser typed, which is
+    what the redirects and cookie scoping downstream are reasoning about.
+
+    A path that already carries the prefix is left alone, so a proxy that
+    preserves it is unaffected — as is the root deployment, where ``prefix`` is
+    empty and this middleware is not installed at all.
+    """
+
+    def __init__(self, app: ASGIApp, prefix: str):
+        self.app = app
+        self.prefix = prefix.rstrip("/")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if not self.prefix or scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        # Exact match included: ``/gpustack`` is the prefix itself, already in
+        # the shape root_path wants. Guarding on the separator rather than a bare
+        # ``startswith`` keeps a sibling route like ``/gpustack-internal`` from
+        # being mistaken for a path under the mount.
+        if path == self.prefix or path.startswith(f"{self.prefix}/"):
+            await self.app(scope, receive, send)
+            return
+
+        scope = dict(scope)
+        scope["path"] = f"{self.prefix}{path}"
+        raw_path = scope.get("raw_path")
+        if raw_path is not None:
+            # The undecoded twin of ``path``. Nothing in the installed Starlette
+            # routes on it, but leaving the two disagreeing would plant a
+            # difference that only shows up in whatever reads the other one.
+            scope["raw_path"] = self.prefix.encode("latin-1") + raw_path
+        await self.app(scope, receive, send)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,7 +1,9 @@
+import ast
 import asyncio
 import ssl
 from datetime import datetime, timezone
 from contextlib import asynccontextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from urllib.parse import urljoin
@@ -10,13 +12,17 @@ import pytest
 from fastapi import FastAPI
 from fastapi.security import HTTPAuthorizationCredentials
 from fastapi.testclient import TestClient
+from starlette.responses import Response
 from gpustack.api.exceptions import register_handlers
 from gpustack.api.auth import (
     GATEWAY_AUTH_TOKEN_HEADER,
+    auth_cookie_attrs,
+    auth_cookie_path,
     client_ip_getter,
     get_current_user,
     worker_auth,
 )
+from gpustack.config.config import Config, get_global_config, set_global_config
 from gpustack.api.exceptions import BadRequestException, UnauthorizedException
 from gpustack.schemas.config import GatewayModeEnum
 from gpustack.schemas.users import AuthProviderEnum
@@ -2009,3 +2015,116 @@ def test_ui_relative_url_puts_error_code_outside_the_fragment():
     assert landed == (
         "http://gpustack.example.com/inner/gpustack/?error=auth_failed#/login"
     )
+
+
+# --- Cookie Path under a mount prefix --------------------------------------
+
+
+@pytest.fixture
+def mounted_config(tmp_path):
+    """Install a server mounted at ``/gpustack`` as the process-wide config.
+
+    ``auth_cookie_path`` reads the global rather than ``request.app.state`` so the
+    renewal middleware can call it too, so this is the seam to drive it from. The
+    previous config is put back because conftest installs a root-path one for the
+    whole module.
+    """
+    previous = get_global_config()
+    set_global_config(
+        Config(
+            token="test",
+            jwt_secret_key="test",
+            data_dir=str(tmp_path / "data"),
+            server_external_url="https://example.com/gpustack",
+        )
+    )
+    yield
+    set_global_config(previous)
+
+
+def _cookie_attr(header: str, name: str):
+    for part in header.split(";"):
+        key, _, value = part.strip().partition("=")
+        if key.lower() == name.lower():
+            return value
+    return None
+
+
+def _http_request():
+    return SimpleNamespace(url=SimpleNamespace(scheme="http"))
+
+
+def test_cookies_are_scoped_to_the_mount_prefix(mounted_config):
+    response = Response()
+    response.set_cookie(
+        key="gpustack_session", value="token", **auth_cookie_attrs(_http_request(), 60)
+    )
+
+    assert _cookie_attr(response.headers["set-cookie"], "path") == "/gpustack"
+
+
+def test_cookie_path_degrades_to_the_root_without_a_config(monkeypatch):
+    # The renewal middleware and the routes both reach for this, and a request
+    # can arrive before a config is installed — a raise there would turn every
+    # response into a 500 rather than an unscoped cookie.
+    monkeypatch.setattr("gpustack.api.auth.get_global_config", lambda: None)
+
+    assert auth_cookie_path() == "/"
+
+
+@pytest.mark.asyncio
+async def test_logout_deletes_the_cookie_it_actually_set(mounted_config):
+    """Deletion has to name the same ``Path`` as the cookie it is removing.
+
+    A cookie is identified by name+domain+path, so a ``delete_cookie`` that omits
+    ``path`` addresses the one at ``/`` — a cookie login never created. The
+    request succeeds, the response looks right, and the session survives logout.
+    Asserted against the set side rather than the literal prefix so the two
+    cannot drift apart in opposite directions and still pass.
+    """
+    set_header = Response()
+    set_header.set_cookie(
+        key="gpustack_session", value="token", **auth_cookie_attrs(_http_request(), 60)
+    )
+    expected_path = _cookie_attr(set_header.headers["set-cookie"], "path")
+
+    request = MagicMock()
+    request.app.state.server_config = SimpleNamespace(external_auth_type=None)
+    request.cookies = {}
+
+    response = await auth_route.logout(request)
+
+    deletions = response.headers.getlist("set-cookie")
+    assert len(deletions) == 3
+    for header in deletions:
+        assert _cookie_attr(header, "path") == expected_path
+        # Max-Age=0 is what makes it a deletion rather than a fresh cookie.
+        assert _cookie_attr(header, "max-age") == "0"
+
+
+def test_every_cookie_deletion_names_a_path():
+    """Structural, because the six call sites are not reachable from one test.
+
+    They sit across SAML logout, OIDC callback and ``/auth/logout``, each with its
+    own prerequisites, and the omission is invisible where it is easiest to look:
+    at the root deployment the prefix is ``""`` and Starlette's default ``path``
+    is already ``"/"``, so the header comes out byte-identical either way.
+    """
+    tree = ast.parse(Path(auth_route.__file__).read_text())
+    deletions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "delete_cookie"
+    ]
+
+    # Guard the guard: an empty list would pass the assertion below vacuously if
+    # the deletions ever moved to another module.
+    assert deletions
+    missing = [
+        node.lineno
+        for node in deletions
+        if not any(keyword.arg == "path" for keyword in node.keywords)
+    ]
+    assert missing == []

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urljoin
 
 import pytest
 from fastapi import FastAPI
@@ -903,6 +904,7 @@ async def test_oidc_callback_uses_system_trust_store(monkeypatch):
             )()
 
     request = type("Request", (), {})()
+    request.scope = {}
     request.app = type("App", (), {})()
     request.app.state = type("State", (), {})()
     request.app.state.server_config = type(
@@ -931,10 +933,11 @@ async def test_oidc_callback_uses_system_trust_store(monkeypatch):
     )()
     request.query_params = {"code": "auth-code", "state": "test-state"}
     request.cookies = {"gpustack_oidc_state": "test-state"}
-    # Read by the session-cookie hardening (``secure=request.url.scheme
-    # == "https"``). Pretend the inbound request was HTTPS so the
-    # ``secure`` flag would have flipped on in production.
-    request.url = type("URL", (), {"scheme": "https"})()
+    # ``scheme`` is read by the session-cookie hardening
+    # (``secure=request.url.scheme == "https"``) — pretend the inbound request
+    # was HTTPS so the ``secure`` flag would have flipped on in production.
+    # ``path`` is read by the relative redirect the callback ends on.
+    request.url = type("URL", (), {"scheme": "https", "path": "/auth/oidc/callback"})()
 
     monkeypatch.setattr("gpustack.routes.auth.httpx.AsyncClient", FakeAsyncClient)
     monkeypatch.setattr("gpustack.routes.auth.use_proxy_env_for_url", lambda url: False)
@@ -1301,8 +1304,8 @@ def test_saml_settings_defaults_allow_repeat_attribute_name():
 def _saml_callback_request(saml_response_b64: str, **config_overrides) -> object:
     """Build a request double for the SAML callback tests. The
     callback derives OneLogin's ``current_url`` from ``saml_sp_acs_url``,
-    not from ``request.url``, so the URL fields on the request are
-    only used for the ``get_data`` payload."""
+    not from ``request.url``, so the URL fields on the request feed the
+    ``get_data`` payload and the relative redirect the callback ends on."""
 
     request = MagicMock()
     request.method = "POST"
@@ -1312,6 +1315,10 @@ def _saml_callback_request(saml_response_b64: str, **config_overrides) -> object
 
     request.form = _form
     request.query_params = {}
+    # Both feed the redirect the callback returns, which climbs one level per
+    # segment of this path, so they have to be real values rather than mocks.
+    request.url.path = "/auth/saml/callback"
+    request.scope = {}
 
     cfg = request.app.state.server_config
     cfg.external_auth_type = AuthProviderEnum.SAML
@@ -1933,3 +1940,72 @@ async def test_no_gateway_means_no_gateway_assertions(monkeypatch):
         None,
     )
     assert not calls["by_access_key"], "the lookup must not even be attempted"
+
+
+# --- SSO callback redirect targets -----------------------------------------
+
+
+def _redirect_request(path: str, root_path: str = "") -> MagicMock:
+    request = MagicMock()
+    request.url.path = path
+    request.scope = {"root_path": root_path} if root_path else {}
+    return request
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/auth/oidc/callback",
+        "/auth/cas/callback",
+        "/auth/saml/callback",
+        # One segment deeper than its siblings, so any hardcoded number of hops
+        # is wrong for one of them.
+        "/auth/saml/logout/callback",
+    ],
+)
+@pytest.mark.parametrize("mount", ["", "/gpustack", "/inner/gpustack"])
+def test_ui_relative_url_lands_on_the_ui_root(route, mount):
+    """The redirect has to resolve to the UI root wherever the server is mounted.
+
+    Asserted through ``urljoin`` — the same RFC 3986 resolution a browser does —
+    rather than against a hand-computed string. Counting hops by hand is exactly
+    how this went wrong once: the last path segment is the document rather than a
+    directory, and an off-by-one there is *invisible at the root*, because RFC
+    3986 discards ``..`` that would escape above ``/``. Only a mounted prefix
+    reveals it, and only by resolving rather than string-matching.
+    """
+    relative = auth_route._ui_relative_url(_redirect_request(route))
+
+    landed = urljoin(f"http://gpustack.example.com{mount}{route}", relative)
+
+    assert landed == f"http://gpustack.example.com{mount}/"
+
+
+def test_ui_relative_url_discounts_root_path():
+    """Starlette reports ``root_path`` as part of ``scope["path"]``. Counting it
+    would climb a level too far per prefix segment and overshoot the UI root."""
+    request = _redirect_request("/gpustack/auth/oidc/callback", root_path="/gpustack")
+
+    landed = urljoin(
+        "http://gpustack.example.com/gpustack/auth/oidc/callback",
+        auth_route._ui_relative_url(request),
+    )
+
+    assert landed == "http://gpustack.example.com/gpustack/"
+
+
+def test_ui_relative_url_puts_error_code_outside_the_fragment():
+    """The login form reads the code from ``window.location.search``, so it has
+    to sit in the real query string; the route goes in the fragment because the
+    UI is hash-routed. Putting it inside the fragment still reaches the login
+    page but silently loses the message."""
+    request = _redirect_request("/auth/cas/callback")
+
+    landed = urljoin(
+        "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+        auth_route._ui_relative_url(request, auth_route.AUTH_FAILED_ERROR_CODE),
+    )
+
+    assert landed == (
+        "http://gpustack.example.com/inner/gpustack/?error=auth_failed#/login"
+    )

--- a/tests/api/test_cas.py
+++ b/tests/api/test_cas.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urljoin
 
 import pytest
 
@@ -359,10 +360,22 @@ async def test_cas_callback_rejects_existing_user_from_other_source(monkeypatch)
     request.app.state.server_config.external_auth_default_inactive = False
     request.app.url_path_for.return_value = "/auth/cas/callback"
     request.query_params = {"ticket": "ST-attacker"}
+    # The failure redirect climbs one level per segment of the callback's own
+    # path, so both have to be real values rather than mocks.
+    request.url.path = "/auth/cas/callback"
+    request.scope = {}
 
     response = await auth_route.cas_callback(request=request, session=MagicMock())
     assert response.status_code in (302, 303, 307)
-    assert response.headers["location"] == auth_route.SOURCE_CONFLICT_LOGIN_URL
+    # Relative, so it resolves to the UI root whether the server sits at the
+    # origin root or under a proxy subpath. Asserted by resolving it the way a
+    # browser would — a hop miscount is invisible at the root, where RFC 3986
+    # clamps ``..`` at ``/``. ``?error=`` stays outside the fragment because the
+    # login form reads it from ``window.location.search``.
+    assert urljoin(
+        "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+        response.headers["location"],
+    ) == ("http://gpustack.example.com/inner/gpustack/?error=source_conflict#/login")
 
 
 @pytest.mark.asyncio
@@ -415,10 +428,18 @@ async def test_cas_callback_translates_other_failures_to_auth_failed(monkeypatch
     request.app.state.server_config.server_external_url = "https://gpustack.example.com"
     request.app.url_path_for.return_value = "/auth/cas/callback"
     request.query_params = {"ticket": "ST-bad"}
+    request.url.path = "/auth/cas/callback"
+    request.scope = {}
 
     response = await auth_route.cas_callback(request=request, session=MagicMock())
     assert response.status_code in (302, 303, 307)
-    assert response.headers["location"] == auth_route.AUTH_FAILED_LOGIN_URL
+    assert (
+        urljoin(
+            "http://gpustack.example.com/inner/gpustack/auth/cas/callback",
+            response.headers["location"],
+        )
+        == "http://gpustack.example.com/inner/gpustack/?error=auth_failed#/login"
+    )
 
 
 class _AsyncClientFake:

--- a/tests/api/test_middlewares.py
+++ b/tests/api/test_middlewares.py
@@ -6,6 +6,7 @@ principal id that would otherwise violate the FK and roll back the whole
 usage flush batch.
 """
 
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -79,3 +80,99 @@ async def test_resolve_direct_consumer_org_non_member_dropped(monkeypatch):
         monkeypatch, exc=ForbiddenException(message="Not a member of organization 7")
     )
     assert await middlewares._resolve_direct_consumer_org(_REQUEST, _USER, "7") is None
+
+
+# --- Session-cookie renewal attributes -------------------------------------
+#
+# The renewal in ``RefreshTokenMiddleware`` reissues the session cookie
+# mid-session, so an attribute it omits is one the session silently loses
+# ~105 minutes in while continuing to work.
+#
+# Most omissions are masked by Starlette's defaults happening to match what the
+# login path passes (``samesite="lax"``, ``path="/"``). ``secure`` is not: it
+# defaults to ``False``. So the assertions below check the whole attribute set
+# rather than the one that was wrong, because which attribute is exposed by an
+# omission changes as soon as a default stops matching — as ``path`` will once
+# the server scopes cookies to its mount prefix.
+
+
+def _renewal_set_cookie(scheme: str) -> str:
+    """Drive the middleware to the renewal branch; return its Set-Cookie."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from gpustack.api.auth import SESSION_COOKIE_NAME
+    from gpustack.api.middlewares import RefreshTokenMiddleware
+
+    app = FastAPI()
+    app.add_middleware(RefreshTokenMiddleware)
+
+    @app.get("/")
+    def _root():
+        return {}
+
+    # ``exp`` inside the 15-minute window is what selects the renewal branch.
+    app.state.jwt_manager = SimpleNamespace(
+        decode_jwt_token=lambda token: {"sub": "admin", "exp": time.time() + 60},
+        create_jwt_token=lambda username: "renewed-token",
+    )
+
+    client = TestClient(app, base_url=f"{scheme}://testserver")
+    client.cookies.set(SESSION_COOKIE_NAME, "about-to-expire")
+    response = client.get("/")
+    header = response.headers.get("set-cookie")
+    assert header, "the renewal branch did not fire, so this asserts nothing"
+    return header
+
+
+def _attr_names(set_cookie: str) -> set:
+    """Attribute names in a Set-Cookie header, lowercased, minus the pair."""
+    return {part.strip().split("=", 1)[0].lower() for part in set_cookie.split(";")[1:]}
+
+
+def test_renewed_session_cookie_keeps_samesite_and_secure():
+    header = _renewal_set_cookie("https")
+
+    assert "renewed-token" in header
+    assert "samesite=lax" in header.lower()
+    assert "secure" in _attr_names(header)
+
+
+def test_renewed_session_cookie_omits_secure_over_plain_http():
+    # Marking a cookie Secure on an http origin would stop the browser sending
+    # it back at all, so the flag has to track the scheme rather than be
+    # unconditional.
+    header = _renewal_set_cookie("http")
+
+    assert "samesite=lax" in header.lower()
+    assert "secure" not in _attr_names(header)
+
+
+def test_renewal_sets_every_attribute_the_shared_helper_defines():
+    """The drift guard.
+
+    Naming individual attributes only catches the one that happened to be
+    exposed — ``secure``, because its default is ``False``. Comparing against
+    ``auth_cookie_attrs`` instead covers the ones Starlette's defaults currently
+    mask, so they are still covered when a default stops matching.
+    """
+    from gpustack.api.auth import auth_cookie_attrs
+
+    expected = {
+        # kwarg name -> the attribute name it lands as in the header
+        "httponly": "httponly",
+        "max_age": "max-age",
+        "expires": "expires",
+        "samesite": "samesite",
+        "secure": "secure",
+    }
+    helper_kwargs = auth_cookie_attrs(
+        SimpleNamespace(url=SimpleNamespace(scheme="https")), 60
+    )
+    assert set(helper_kwargs) == set(expected), (
+        "auth_cookie_attrs grew or lost a kwarg; map it in `expected` so this "
+        "test keeps covering every attribute the login path sets"
+    )
+
+    present = _attr_names(_renewal_set_cookie("https"))
+    assert {expected[k] for k in helper_kwargs} <= present

--- a/tests/api/test_middlewares.py
+++ b/tests/api/test_middlewares.py
@@ -165,6 +165,11 @@ def test_renewal_sets_every_attribute_the_shared_helper_defines():
         "expires": "expires",
         "samesite": "samesite",
         "secure": "secure",
+        # The one the guard was written for. Renewal that omits it writes a
+        # *second* cookie of the same name at Path=/; both get sent, and
+        # Starlette's parser keeps the last — the stale one. Symptom is a session
+        # that drops at random.
+        "path": "path",
     }
     helper_kwargs = auth_cookie_attrs(
         SimpleNamespace(url=SimpleNamespace(scheme="https")), 60

--- a/tests/config/test_base_path.py
+++ b/tests/config/test_base_path.py
@@ -1,0 +1,50 @@
+import pytest
+
+from gpustack.config.config import Config
+
+
+def _config(tmp_path, external_url):
+    return Config(data_dir=str(tmp_path / "data"), server_external_url=external_url)
+
+
+@pytest.mark.parametrize(
+    "external_url, base_path",
+    [
+        # Nothing to go on: the server is at the root until told otherwise.
+        (None, ""),
+        # A URL with no path means the root, and so does a bare "/" — a prefix of
+        # "/" would only add an empty path segment to everything.
+        ("https://example.com", ""),
+        ("https://example.com/", ""),
+        ("https://example.com:30080", ""),
+        ("https://example.com/gpustack", "/gpustack"),
+        # Normalised to no trailing slash, because both consumers want it that
+        # way: ASGI root_path is concatenated with a path that has its own
+        # leading slash, and a cookie ``Path`` compares segment by segment.
+        ("https://example.com/gpustack/", "/gpustack"),
+        ("https://example.com:30080/gpustack", "/gpustack"),
+        # More than one segment deep is legal and has to survive intact.
+        ("https://example.com/inner/gpustack", "/inner/gpustack"),
+    ],
+)
+def test_base_path_is_the_path_component_of_the_external_url(
+    tmp_path, external_url, base_path
+):
+    assert _config(tmp_path, external_url).get_base_path() == base_path
+
+
+@pytest.mark.parametrize("external_url", [None, "https://example.com"])
+def test_cookie_path_at_the_root_is_a_slash_not_empty(tmp_path, external_url):
+    # "" is the right answer for root_path — it is FastAPI's own default — but an
+    # empty ``Path`` is not a valid cookie attribute, so the two diverge here.
+    assert _config(tmp_path, external_url).get_base_path() == ""
+    assert _config(tmp_path, external_url).get_cookie_path() == "/"
+
+
+def test_cookie_path_is_scoped_to_the_mount_prefix(tmp_path):
+    # Not "/": under a subpath mount the rest of the origin is typically the
+    # customer's own application, which has no business being offered a GPUStack
+    # session cookie.
+    config = _config(tmp_path, "https://example.com/gpustack")
+
+    assert config.get_cookie_path() == "/gpustack"

--- a/tests/server/test_base_path_app.py
+++ b/tests/server/test_base_path_app.py
@@ -1,0 +1,100 @@
+import re
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+import gpustack
+from gpustack.config.config import Config
+from gpustack.server.app import create_app
+
+# Same gate as tests/routes/test_ui_static.py: `hack/install.sh` skips the UI
+# download when UI_DOWNLOAD=false, and create_app mounts from this directory.
+UI_DIR = Path(gpustack.__file__).parent / "ui"
+
+pytestmark = pytest.mark.skipif(
+    not UI_DIR.is_dir(),
+    reason="UI assets not downloaded; create_app requires gpustack/ui",
+)
+
+PREFIX = "/gpustack"
+
+
+def _client(tmp_path, external_url):
+    cfg = Config(
+        token="test",
+        jwt_secret_key="test",
+        data_dir=str(tmp_path / "data"),
+        server_external_url=external_url,
+    )
+    return TestClient(create_app(cfg))
+
+
+@pytest.fixture
+def mounted(tmp_path):
+    return _client(tmp_path, f"https://example.com{PREFIX}")
+
+
+def _absolute_refs(html: str):
+    """Every root-relative URL the docs page tells the browser to fetch."""
+    return re.findall(r"""["'](/[^"']*)["']""", html)
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [
+        # What a prefix-preserving proxy forwards...
+        f"{PREFIX}/docs",
+        f"{PREFIX}/openapi.json",
+        f"{PREFIX}/version",
+        # ...and what a stripping one does. Both have to work, because which of
+        # the two a customer runs is not something the server can find out.
+        "/docs",
+        "/openapi.json",
+        "/version",
+    ],
+)
+def test_reachable_whichever_way_the_proxy_forwards(mounted, requested):
+    assert mounted.get(requested).status_code == 200
+
+
+def test_docs_page_asks_for_everything_under_the_prefix(mounted):
+    """This is the part of #5270 that needed a server-side fix.
+
+    The UI is hash-routed, so it needs no configuration to live under a subpath.
+    The docs page is the opposite: it is served HTML that names absolute paths —
+    ``/openapi.json`` and the swagger-ui bundle — and at the origin root those
+    are the customer's own application, not us. That is why the reporter had to
+    add ``location`` blocks for them by hand.
+    """
+    refs = _absolute_refs(mounted.get("/docs").text)
+
+    assert refs, "expected the docs page to reference assets by absolute path"
+    assert any(ref.endswith("/openapi.json") for ref in refs)
+    assert all(ref.startswith(f"{PREFIX}/") for ref in refs), refs
+
+
+def test_static_assets_are_served_under_the_prefix(mounted):
+    """The mounts are the reason ``root_path`` alone is not enough.
+
+    ``/static`` here is one of three (``/css`` and ``/js`` carry the UI bundles),
+    and a ``Mount`` under a ``root_path`` looks for a file named after its own URL
+    prefix unless the path arrives in the shape ASGI describes. Plain routes
+    tolerate the mismatch, so the API above would answer while every asset 404s.
+    """
+    for requested in (f"{PREFIX}/static/swagger-ui.css", "/static/swagger-ui.css"):
+        assert mounted.get(requested).status_code == 200, requested
+
+
+@pytest.mark.parametrize("external_url", [None, "https://example.com"])
+def test_root_deployment_keeps_the_prefix_meaningless(tmp_path, external_url):
+    # The overwhelmingly common deployment. Nothing above may leak into it: a
+    # prefixed path is not a route here, and the docs page must not invent one.
+    client = _client(tmp_path, external_url)
+
+    assert client.get("/docs").status_code == 200
+    assert client.get(f"{PREFIX}/docs").status_code == 404
+    assert all(
+        not ref.startswith(f"{PREFIX}/")
+        for ref in _absolute_refs(client.get("/docs").text)
+    )

--- a/tests/utils/test_base_path_middleware.py
+++ b/tests/utils/test_base_path_middleware.py
@@ -1,0 +1,155 @@
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.staticfiles import StaticFiles
+from starlette.testclient import TestClient
+
+from gpustack.utils.base_path import BasePathMiddleware
+
+PREFIX = "/gpustack"
+
+
+async def _noop(*args, **kwargs):
+    pass
+
+
+async def _run(prefix, path, scope_type="http", raw_path=None):
+    """Return the scope the wrapped app was called with."""
+    seen = {}
+
+    async def app(scope, receive, send):
+        seen.update(scope)
+
+    scope = {"type": scope_type, "path": path}
+    if raw_path is not None:
+        scope["raw_path"] = raw_path
+
+    await BasePathMiddleware(app, prefix=prefix)(scope, _noop, _noop)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_stripped_path_gets_the_prefix_back():
+    scope = await _run(PREFIX, "/v1/models")
+
+    assert scope["path"] == "/gpustack/v1/models"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/gpustack/v1/models", "/gpustack/", "/gpustack"])
+async def test_path_that_already_carries_the_prefix_is_left_alone(path):
+    # A proxy that preserves the prefix (AWS ALB cannot rewrite paths) already
+    # sends the shape root_path wants. Prefixing again would 404 everything.
+    scope = await _run(PREFIX, path)
+
+    assert scope["path"] == path
+
+
+@pytest.mark.asyncio
+async def test_a_sibling_of_the_prefix_is_not_inside_the_mount():
+    # ``/gpustack-internal`` shares the prefix's characters but not its path
+    # segment, so under a stripping proxy it is a real path below the mount and
+    # has to be restored like any other.
+    scope = await _run(PREFIX, "/gpustack-internal")
+
+    assert scope["path"] == "/gpustack/gpustack-internal"
+
+
+@pytest.mark.asyncio
+async def test_websocket_scopes_are_normalised_too():
+    # Workers reach the server over a websocket, and the /docs-style URL
+    # generation is not what matters there: routing is.
+    scope = await _run(PREFIX, "/v2/workers/ws", scope_type="websocket")
+
+    assert scope["path"] == "/gpustack/v2/workers/ws"
+
+
+@pytest.mark.asyncio
+async def test_non_request_scopes_pass_through_untouched():
+    scope = await _run(PREFIX, "/v1/models", scope_type="lifespan")
+
+    assert scope["path"] == "/v1/models"
+
+
+@pytest.mark.asyncio
+async def test_empty_prefix_is_a_no_op():
+    scope = await _run("", "/v1/models")
+
+    assert scope["path"] == "/v1/models"
+
+
+@pytest.mark.asyncio
+async def test_raw_path_is_kept_in_step_with_path():
+    scope = await _run(PREFIX, "/v1/mo dels", raw_path=b"/v1/mo%20dels")
+
+    assert scope["path"] == "/gpustack/v1/mo dels"
+    # Still undecoded: rewriting it from the decoded ``path`` would quietly
+    # normalise the escape away.
+    assert scope["raw_path"] == b"/gpustack/v1/mo%20dels"
+
+
+@pytest.mark.asyncio
+async def test_absent_raw_path_is_not_invented():
+    scope = await _run(PREFIX, "/v1/models")
+
+    assert "raw_path" not in scope
+
+
+def _mounted_app(prefix, directory, with_middleware):
+    """The shape create_app builds: a root_path plus a StaticFiles mount."""
+    app = Starlette(
+        routes=[
+            Route("/version", lambda request: PlainTextResponse("ok")),
+        ],
+    )
+    app.mount("/js", StaticFiles(directory=directory), name="js")
+    app.router.redirect_slashes = False
+    if with_middleware:
+        app.add_middleware(BasePathMiddleware, prefix=prefix)
+    return app
+
+
+@pytest.fixture
+def asset_dir(tmp_path):
+    (tmp_path / "bundle.js").write_text("console.log('bundle');\n")
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [
+        # What a prefix-preserving proxy forwards.
+        "/gpustack/js/bundle.js",
+        # What the common nginx recipe forwards: a `proxy_pass` with a trailing
+        # slash strips the prefix.
+        "/js/bundle.js",
+    ],
+)
+def test_mounted_assets_survive_either_kind_of_proxy(asset_dir, requested):
+    client = TestClient(
+        _mounted_app(PREFIX, asset_dir, with_middleware=True),
+        root_path=PREFIX,
+    )
+
+    assert client.get(requested).status_code == 200
+
+
+def test_a_mount_under_root_path_is_why_this_middleware_exists(asset_dir):
+    """Pins the failure the middleware prevents, so it is not deleted as inert.
+
+    ASGI says ``root_path`` is a prefix *of* ``path``, and ``Mount.matches``
+    takes that literally: it hands its child ``root_path + matched_path``, here
+    ``/gpustack/js``, which the ``StaticFiles`` inside then tries to strip off a
+    path that never carried it. Plain routes survive the same mismatch because
+    ``get_route_path`` gives up gracefully — which is exactly what makes this
+    dangerous to eyeball. The API answers, so the deployment looks fine, while
+    every UI asset 404s.
+    """
+    client = TestClient(
+        _mounted_app(PREFIX, asset_dir, with_middleware=False),
+        root_path=PREFIX,
+    )
+
+    assert client.get("/version").status_code == 200
+    assert client.get("/js/bundle.js").status_code == 404


### PR DESCRIPTION
Refs #5270.

> **Stacked on #6082 and #6093.** GitHub will not accept a fork branch as a base, so the diff here carries both parents' commits. Only the last one belongs to this PR:
>
> - `554700e4` — #6082
> - `90205b76` — #6093
> - `ba091297` — **this PR**

## What was actually missing

Almost everything a subpath deployment needs was already prefix-agnostic — the UI derives the prefix from the browser's location at runtime, which is exact because the router is hash-based. Auditing #5270's list against a real deployment:

| Resource the reporter lists | Status |
|---|---|
| Web UI | already worked |
| Static assets (`/js` `/css` `/static`, not `/assets`) | already worked |
| Management API (`/v2`, not `/api`) | already worked |
| Inference API | already worked |
| **Swagger `/docs` + `/openapi.json`** | **the gap this PR closes** |
| WebSocket | the UI opens none |

The Swagger page is served HTML that names absolute paths — `/openapi.json` and the swagger-ui bundle. Under a subpath mount those are whatever application sits at the origin root, which is the customer's, not ours. That is why the reporter had to add extra `location` blocks by hand.

## Change

`Config.get_base_path()` takes the path from `server_external_url` — a value with three consumers already, and the first to look past its hostname — and hands it to FastAPI as `root_path`. No new flag: the prefix is part of the external URL, not a separate fact.

`root_path` is worth more than `/docs` alone. It also makes routing work behind a proxy that *cannot* strip the prefix — AWS ALB listener rules route on a path but forward it unchanged.

## Why `root_path` alone would have been a regression

ASGI says `root_path` is a prefix *of* `path`, and `Mount.matches` takes that literally: it hands its child `root_path + matched_path`, which the `StaticFiles` inside then tries to strip off a path that never carried it. Plain routes survive the same mismatch because `get_route_path` gives up gracefully when `path` does not start with `root_path`. Mounts do not.

Measured with the pinned deps (fastapi 0.136.3 / starlette 1.3.1), `root_path="/gpustack"`:

| Request the app receives | Plain route | **Mount** |
|---|---|---|
| `/gpustack/static/x.css` (proxy preserves prefix) | 200 | 200 |
| `/static/x.css` (**proxy strips** — the common nginx recipe) | 200 | **404** |

So shipping `root_path` on its own would have turned a working strip-mode deployment into a blank page the moment `server_external_url` gained a path: the API answers, the deployment looks healthy, and every asset under `/css`, `/js` and `/static` 404s.

`BasePathMiddleware` restores the prefix onto `path` when it is missing, outermost and installed only when the prefix is non-empty, so the app always sees the shape the spec describes and both proxy styles work. Fixing it at the path layer rather than per-mount also means it covers mounts registered by plugins — the enterprise UI override replaces all three of those mounts with its own and needs no change.

## Cookies

Cookies move to `Path=<prefix>` in the same change, because the browser evaluates `Path` against *its* URL, which still carries the prefix the proxy stripped. All six `delete_cookie` calls have to name it too: a cookie is identified by name+domain+path, so a deletion that omits it addresses one that login never created — logout returns 200 and leaves the session intact. #6093's helper is why this is one change rather than fifteen, which is why this branch is stacked on it.

## Verification

End to end through a real nginx (`proxy_pass .../`, strip mode) at `/inner/gpustack/`:

- the docs page names only prefixed URLs, and all four of them resolve
- UI mount assets serve
- login sets `Path=/inner/gpustack`; logout's three deletions name the same path
- authenticated `/v1/models` succeeds

Repeated with the **embedded gateway** in front (`gpustack/gpustack:dev`, branch files mounted, nginx → Higress → uvicorn), since outside Kubernetes `--gateway-mode auto` resolves to `embedded` and the gateway owns the public port. Same results, plus `/v2/models`, `/v2/workers`, `/v2/clusters`.

Tests are mutation-checked — each fails when the thing it covers is reverted:

| File | Covers |
|---|---|
| `tests/config/test_base_path.py` | the normalisation table |
| `tests/utils/test_base_path_middleware.py` | the middleware, and the mount 404 it prevents pinned as a negative test so it is not deleted as inert |
| `tests/server/test_base_path_app.py` | `create_app` end to end: `/docs`, `/openapi.json`, mounts, both proxy modes, root deployment unchanged |
| `tests/api/test_auth.py` | cookie `Path` on set and on logout's deletions, plus an AST guard that no `delete_cookie` omits `path` |

## Not covered by this PR

- **The released UI does not work under a subpath.** Its `index.html` names assets root-absolutely (`/css/...`), so the browser requests them at the origin root and gets a blank page. The relative form comes from gpustack/gpustack-ui#1351, which has to ship alongside this.
- **Generic-proxy inference routes behind a proxy that preserves the prefix.** The gateway matches `/model/proxy/...` on an absolute path prefix (verified against the running `gpustack-model-router` WasmPlugin), which a preserved prefix does not match. `/v1/...` routes are matched on the path suffix and are unaffected.
- **Documentation** follows in its own PR.
