### PR TITLE
fix(gpuservice-instance-types): refuse a duplicate name with an actionable 409

### DIFF
--- a/docs/user-guide/gpuservice-instance-types.md
+++ b/docs/user-guide/gpuservice-instance-types.md
@@ -58,7 +58,7 @@ Add a custom instance type when the derived ones do not fit — for example, a l
 ![Screenshot: the Add Instance Type form](../assets/gpuservice/instance-types/add-form.png)
 
 - **Cluster**: The cluster the type is created in.
-- **Name**: The type name. Lowercase and Kubernetes-safe, since it becomes part of the underlying resource name.
+- **Name**: The type name. Lowercase and Kubernetes-safe, since it becomes part of the underlying resource name. It must be unique within the cluster: reusing the name of an existing type — including a derived one — is rejected rather than overwriting it.
 - **Display Name**: An optional friendly name shown in the UI.
 - **Flavor**: `CPU-only`, or an accelerator flavor the selected cluster carries. The choices follow the Cluster field.
 - **OS / Arch**: The platform the type targets.

--- a/gpustack/routes/gpu_instance_types.py
+++ b/gpustack/routes/gpu_instance_types.py
@@ -273,8 +273,18 @@ async def create_gpu_instance_type(
     ops = await build_cluster_ops(request, session, cluster)
 
     spec = create.spec.model_dump(by_alias=True, exclude_none=True)
-    async with ops, handle_error():
-        result = await ops.create_instance_type(create.name, spec)
+    async with (
+        ops,
+        handle_error(
+            already_exists_message=(
+                f"Instance type {create.name} already exists in cluster {cluster.name}"
+            )
+        ),
+    ):
+        # ignore_existed=False: with the idempotent default the create is never
+        # attempted and the pre-existing object is read back as a 200 — a
+        # "successful" create that created nothing (#6087).
+        result = await ops.create_instance_type(create.name, spec, ignore_existed=False)
     return _to_instance_type_public(result)
 
 

--- a/gpustack/routes/gpu_instances_helper.py
+++ b/gpustack/routes/gpu_instances_helper.py
@@ -136,10 +136,15 @@ async def build_cluster_ops(
 
 
 @asynccontextmanager
-async def handle_error():
+async def handle_error(already_exists_message: Optional[str] = None):
     """Translate a Kubernetes ``ApiException`` into the project's HTTP
     exceptions so a failure surfaces as the right status instead of a
-    blanket 500."""
+    blanket 500.
+
+    ``already_exists_message`` overrides the message of the 409 branch: the
+    upstream exception only carries the bare HTTP reason phrase
+    (``"Conflict"``), which does not tell the caller what already exists.
+    """
     try:
         yield
     except client.exceptions.ApiException as e:
@@ -147,7 +152,7 @@ async def handle_error():
         if e.status == http.HTTPStatus.NOT_FOUND:
             raise NotFoundException(message=message)
         if e.status == http.HTTPStatus.CONFLICT:
-            raise AlreadyExistsException(message=message)
+            raise AlreadyExistsException(message=already_exists_message or message)
         if e.status == http.HTTPStatus.BAD_REQUEST:
             raise InvalidException(message=message)
         # One branch for all three: to the caller they are the same thing —

--- a/tests/routes/test_gpu_instance_types.py
+++ b/tests/routes/test_gpu_instance_types.py
@@ -24,6 +24,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.responses import StreamingResponse
 
 from gpustack.api.exceptions import (
+    AlreadyExistsException,
     BadRequestException,
     ConflictException,
     ForbiddenException,
@@ -89,6 +90,7 @@ def _patch_ops(
     list_result=None,
     list_error=None,
     create_result=None,
+    create_error=None,
     delete_existed=True,
     patch_absent=False,
     capture=None,
@@ -115,6 +117,9 @@ def _patch_ops(
         async def create_instance_type(self, name, spec, ignore_existed=True):
             capture["name"] = name
             capture["spec"] = spec
+            capture["ignore_existed"] = ignore_existed
+            if create_error is not None:
+                raise create_error
             return (
                 create_result
                 if create_result is not None
@@ -951,6 +956,33 @@ async def test_create_sends_spec_and_defaults_missing_status(monkeypatch):
     # The ack dict carries no status → maps to an all-None status.
     assert out.name == "new-it"
     assert out.status.phase is None
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_a_duplicate_name(monkeypatch):
+    """#6087: a taken name must surface as an actionable 409, not a 200 that
+    reads the pre-existing object back — so the create must run with
+    ``ignore_existed=False`` and the upstream conflict must be reported
+    naming the instance type."""
+    _patch_cluster(monkeypatch, _cluster())
+    capture = {}
+    _patch_ops(
+        monkeypatch,
+        create_error=client.exceptions.ApiException(status=409, reason="Conflict"),
+        capture=capture,
+    )
+
+    body = GPUInstanceTypeCreate(
+        name="test",
+        spec=GPUInstanceTypeSpec(acceleratable=False, os="linux"),
+    )
+    with pytest.raises(AlreadyExistsException) as excinfo:
+        await it_routes.create_gpu_instance_type(REQUEST, None, CTX, body, 1)
+
+    assert excinfo.value.status_code == 409
+    assert "test" in excinfo.value.message
+    assert "cluster-1" in excinfo.value.message
+    assert capture["ignore_existed"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_gpu_instances_helper.py
+++ b/tests/routes/test_gpu_instances_helper.py
@@ -75,6 +75,20 @@ async def test_conflict_maps_to_already_exists():
 
 
 @pytest.mark.asyncio
+async def test_conflict_uses_already_exists_message_when_given():
+    """#6087: the upstream 409 only carries the bare reason phrase, so a
+    caller-supplied message must replace it with something actionable."""
+    with pytest.raises(AlreadyExistsException) as excinfo:
+        async with handle_error(
+            already_exists_message="Instance type test already exists in cluster k3s"
+        ):
+            raise _api_exception(http.HTTPStatus.CONFLICT, reason="Conflict")
+
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.message == "Instance type test already exists in cluster k3s"
+
+
+@pytest.mark.asyncio
 async def test_bad_request_maps_to_invalid():
     # Asserted on the exception type, not the status code: ``InvalidException``
     # is 422, which is a pre-existing choice this change does not revisit.


### PR DESCRIPTION
## Summary

Creating an Instance Type with a name that already exists showed a success toast and added no row —
the create silently did nothing, and the user was never told the name was taken (#6087).

`POST /v2/gpu-instance-types` delegated to `ClusterOps.create_instance_type` without overriding
`ignore_existed`, so it inherited `True`. `ClusterOps._create` treats "already there" as success: it
reads the object up front and returns it, **never issuing the create**. The route handed that object
to `_to_instance_type_public` and answered `200`, so the UI — which only calls `message.success`
after a 2xx — reported a create that created nothing.

The idempotent default is right for its other user: `gpu_instances/controllers.py` creates `Instance`
CRs where re-entry must not fail. It is wrong for a tenant-facing create, where "already there" is
exactly what the caller must be told — `GPUInstanceTypeCreate.name` documents the contract ("Must be
unique in the scope of the owning principal"), and `handle_error` already knows how to map an
upstream `409` onto `AlreadyExistsException`. The `409` simply never happened.

So the call site asks for a strict create, and the message is made actionable:

- `create_gpu_instance_type` passes `ignore_existed=False`, so the conflict surfaces instead of being
  read back. `ClusterOps` and `controllers.py` are untouched; `_create`'s strict path is already
  covered by `test_create_reraises_409_when_not_ignoring_existed`.
- `handle_error` accepts an optional `already_exists_message`. Without it the `409` branch reports
  `e.reason`, which for `kubernetes_asyncio` is the bare HTTP reason phrase `"Conflict"` — a status
  the UI can render but nothing a user can act on. The route now supplies
  `Instance type <name> already exists in cluster <cluster>`. Every other branch is unchanged.
- The Instance Types user doc never stated the uniqueness rule the form enforces; its **Name** field
  now does, including that a derived type's name is just as taken.

Race behaviour is a consequence, not a special case: with `ignore_existed=False` the create is always
attempted, so whoever loses a race to the same name gets Kubernetes' own `409` down the same path.

## Verification

Unit: `2890 passed` (the one failure, `test_model_catalog_modelscope`, is an upstream ModelScope
`404` unrelated to this diff). Both new tests fail on the pre-fix source — reverting only the route
turns the message assertion into `assert 'test' in 'Conflict'`.

Live, on a k3s cluster registered as GPU Service (Docker GPUStack + operator v0.8.3), which is also
where the bug was reproduced before the fix:

| | before | after |
| --- | --- | --- |
| `POST` name `test` (taken), different spec | `200` + the **old** object (`FIRST / 4Gi / 20Gi`) | `409 AlreadyExists` — `Instance type test already exists in cluster k3s-gpu-service` |
| `POST` a free name | `200` + created | `200` + created |
| `kubectl get instancetypes` after the duplicate | unchanged (nothing was written) | unchanged |

The "before" row is the bug: the response body was provably the pre-existing object while the
submitted spec said `SECOND-ATTEMPT / 64Gi / 999Gi`.

## Out of scope

An upstream `422` (operator webhook rejection, e.g. `spec.unitResources.cpu: Invalid value: "2":
must be 1 when acceleratable is false`) still surfaces as `500 InternalServerError` with the message
`"Unprocessable Entity"`: `handle_error` has no `422` branch and reports `e.reason` rather than the
Kubernetes `Status.message` that says what is actually wrong. Same shape as the 503-as-500 fixed in
 #6071, found while verifying this one, left for its own change.
