### PR TITLE
fix(gpuservice-instance-types): return an empty page for a worker-less cluster's live instance-type list

### DIFF
--- a/gpustack/routes/gpu_instance_types.py
+++ b/gpustack/routes/gpu_instance_types.py
@@ -19,6 +19,7 @@ from gpustack.api.exceptions import BadRequestException, NotFoundException
 from gpustack.api.tenant import TenantContext, cluster_visibility_conditions
 from gpustack.gpu_instances import gateway_client
 from gpustack.gpu_instances.cluster_apis import ClusterOps
+from gpustack.gpu_instances.gateway import count_ready_workers
 from gpustack.routes.gpu_instances_helper import (
     assert_cluster_gpu_service,
     build_cluster_ops,
@@ -157,11 +158,14 @@ async def get_gpu_instance_types(
     hold: the record projection deliberately drops the volatile resource ledger
     (see ``GPUInstanceTypeStatusPublic``), which the model deploy form's slicing
     GPU type picker sizes its inputs from, so that caller asks for the cluster's
-    live catalog instead. It reads one named cluster and accepts that cluster's
-    failures, including a ``503`` when no worker is ready. The cluster hands back
-    its catalog whole, so ``name`` / ``search`` are rejected rather than silently
-    ignored, while ``page`` / ``perPage`` / ``sort_by`` are simply not applied — the
-    synthesized single-page ``pagination`` in the response states that.
+    live catalog instead. It reads one named cluster. A cluster with no READY
+    worker has no reachable proxy — the read could only 503 (#6096) — and no
+    GPUs to type, so it answers the empty page instead; a reachable cluster's
+    own failures (a transient proxy ``503`` included) still surface. The cluster
+    hands back its catalog whole, so ``name`` / ``search`` are rejected rather
+    than silently ignored, while ``page`` / ``perPage`` / ``sort_by`` are simply
+    not applied — the synthesized single-page ``pagination`` in the response
+    states that.
     """
     if source == "live":
         # Both rejected before anything is resolved: these are malformed requests,
@@ -200,9 +204,7 @@ async def get_gpu_instance_types(
                     media_type="text/event-stream",
                 )
 
-            async with ops, handle_error():
-                result = await ops.list_instance_types()
-            return _to_instance_types_public(result, params)
+            return await _live_instance_types_page(ops, cluster_id, params)
 
         # No cluster to read — a foreign or invisible ``cluster_id``, or a cluster
         # deleted between the two queries. Fall through to the record read rather
@@ -421,6 +423,36 @@ async def _build_instance_type_ops(
         if cluster is None:
             return None
         return await build_cluster_ops(request, session, cluster)
+
+
+async def _live_instance_types_page(
+    ops: ClusterOps,
+    cluster_id: int,
+    params: GPUInstanceTypeListParams,
+) -> GPUInstanceTypesPublic:
+    """Serve one cluster's live catalog, or the empty page when it has no worker.
+
+    A cluster with no READY worker has no reachable proxy — the list could only
+    503 (#6096) — and no GPUs to type, so the empty page IS the catalog, in the
+    same shape the record read gives. The probe answers before the cluster is
+    contacted: the picker gets its empty state without paying for a round trip
+    that must fail. Both probe races stay benign: a worker dropping between the
+    probe and the call is a genuine transient failure and still surfaces as
+    such through ``handle_error`` rather than being masked as empty, and a
+    worker becoming READY just after the probe yields one stale empty page that
+    self-heals on the next read.
+
+    ``ops`` is entered unconditionally — its client is created eagerly, so even
+    the early empty-page return must pass through the context manager to close
+    it.
+    """
+    async with ops:
+        if await count_ready_workers(cluster_id) == 0:
+            return _empty_instance_types_page(params)
+
+        async with handle_error():
+            result = await ops.list_instance_types()
+    return _to_instance_types_public(result, params)
 
 
 async def _cluster_instance_type_events(

--- a/tests/routes/test_gpu_instance_types.py
+++ b/tests/routes/test_gpu_instance_types.py
@@ -187,6 +187,19 @@ def _patch_watch_ops(monkeypatch, watch_events):
     monkeypatch.setattr(helper, "ClusterOps", FakeWatchOps)
 
 
+def _patch_ready_workers(monkeypatch, count=1):
+    """Stub the route's reachability probe (``count_ready_workers``).
+
+    A live read whose ops are faked simulates a contactable cluster, so the
+    tests default to one READY worker; the worker-less test passes 0.
+    """
+
+    async def fake_count(cluster_id: int) -> int:
+        return count
+
+    monkeypatch.setattr(it_routes, "count_ready_workers", fake_count)
+
+
 def _cluster(id_=1, owner_principal_id=None, gpu_service=True):
     """A cluster fixture, GPU Service by default.
 
@@ -679,6 +692,7 @@ async def test_source_live_returns_the_resource_ledger(monkeypatch, engine):
     _patch_db(monkeypatch, engine)
     _patch_visible_clusters(monkeypatch, _cluster(2))
     _patch_cluster(monkeypatch, _cluster(2))
+    _patch_ready_workers(monkeypatch)
     _patch_ops(monkeypatch, list_result={"items": [LIVE_ITEM]})
 
     out = await _list(cluster_id=2, source="live")
@@ -740,6 +754,7 @@ async def test_source_live_does_not_apply_pagination_or_sort(monkeypatch, engine
     _patch_db(monkeypatch, engine)
     _patch_visible_clusters(monkeypatch, _cluster(2))
     _patch_cluster(monkeypatch, _cluster(2))
+    _patch_ready_workers(monkeypatch)
     _patch_ops(
         monkeypatch,
         list_result={
@@ -772,6 +787,7 @@ async def test_source_live_empty_catalog_matches_the_record_empty_page(
     _patch_db(monkeypatch, engine)
     _patch_visible_clusters(monkeypatch, _cluster(2))
     _patch_cluster(monkeypatch, _cluster(2))
+    _patch_ready_workers(monkeypatch)
     _patch_ops(monkeypatch, list_result={"items": []})
 
     live = await _list(cluster_id=2, source="live", page=2, perPage=5)
@@ -815,14 +831,44 @@ async def test_source_live_applies_purpose_like_the_record_read(monkeypatch, eng
 
 
 @pytest.mark.asyncio
-async def test_source_live_reports_an_unreachable_cluster_as_503(monkeypatch, engine):
-    """A live read against a cluster with no ready worker legitimately fails, and
-    reports the cluster's own failure. #6071 is about the page, which never asks
-    for a live read; a caller that explicitly asked to touch the cluster gets
-    503 ServiceUnavailable rather than a 500 contradicting its own message."""
+async def test_source_live_with_no_ready_worker_returns_an_empty_page(
+    monkeypatch, engine
+):
+    """A cluster with no READY worker has no reachable proxy — the read could
+    only 503 — and no GPUs to type, so the empty page IS the answer (#6096),
+    in the same shape the record read gives for "nothing here". The catalog is
+    never listed: the guard answers before the cluster is contacted."""
     _patch_db(monkeypatch, engine)
     _patch_visible_clusters(monkeypatch, _cluster(2))
     _patch_cluster(monkeypatch, _cluster(2))
+    _patch_ready_workers(monkeypatch, 0)
+    _patch_ops(
+        monkeypatch,
+        list_error=client.exceptions.ApiException(
+            status=503, reason="Service Unavailable"
+        ),
+    )
+
+    out = await _list(cluster_id=2, source="live", page=2, perPage=5)
+
+    assert out.items == []
+    assert (out.pagination.total, out.pagination.totalPage) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_source_live_with_ready_workers_still_surfaces_an_upstream_503(
+    monkeypatch, engine
+):
+    """The empty-page guard (#6096) answers only a cluster with no READY
+    worker. A reachable cluster's own failure still surfaces: a transient
+    proxy 503 — e.g. the last worker dropping between the probe and the
+    call — is reported as ServiceUnavailable rather than masked as an empty
+    catalog, and never downgraded to the 500 that contradicted its own
+    message (#6071)."""
+    _patch_db(monkeypatch, engine)
+    _patch_visible_clusters(monkeypatch, _cluster(2))
+    _patch_cluster(monkeypatch, _cluster(2))
+    _patch_ready_workers(monkeypatch, 1)
     _patch_ops(
         monkeypatch,
         list_error=client.exceptions.ApiException(


### PR DESCRIPTION
## Summary

`GET /v2/gpu-instance-types?cluster_id=<id>&source=live` — the read the model deploy form's slicing GPU type picker uses — returned `503 Service Unavailable` whenever the named cluster had no READY worker, instead of an empty list the client could render as an empty state (#6096, which was blocking #6091's diagnosis).

The live read proxies into the cluster's apiserver through the server-side cluster proxy (`/v2/clusters/{id}/proxy`), which answers 503 "No reachable workers" when no worker is READY. `handle_error()` faithfully translated that into `ServiceUnavailableException` — honest, but wrong for this read: no workers means no GPUs to type, so the empty page *is* the catalog.

The route now probes `count_ready_workers` — the same reachability definition the proxy and the operator subscription use — before proxying: zero READY workers answers the empty page, in the same shape the record read and an empty live catalog already return, without contacting the cluster. A worker dropping between the probe and the call still surfaces as a transient 503 rather than being masked as empty, and the watch path is unchanged (it already degraded to a clean, ended stream). The `ClusterOps` context is entered unconditionally on this path so the eagerly-created client is closed even on the early empty-page return.

Regression coverage: worker-less cluster → 200 empty page (fails pre-fix); READY worker + proxy 503 → still `ServiceUnavailableException` (guards against over-correction).

Address #6096