### PR TITLE
fix(server): recover the database pool after a PostgreSQL failover

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -50,6 +50,7 @@ The **Applies to** column indicates where the environment variable should be set
 | `GPUSTACK_DB_POOL_SIZE`    | Database connection pool size.               | `30`    | Server     |
 | `GPUSTACK_DB_MAX_OVERFLOW` | Database connection pool max overflow.       | `20`    | Server     |
 | `GPUSTACK_DB_POOL_TIMEOUT` | Database connection pool timeout in seconds. | `30`    | Server     |
+| `GPUSTACK_DB_POOL_RECYCLE` | Database connection recycle time in seconds. | `1800`  | Server     |
 
 ### Network Configuration
 

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -14,6 +14,11 @@ DB_TRACE_SQL_SUBSTR = os.getenv("GPUSTACK_DB_TRACE_SQL_SUBSTR", "")
 DB_POOL_SIZE = int(os.getenv("GPUSTACK_DB_POOL_SIZE", 30))
 DB_MAX_OVERFLOW = int(os.getenv("GPUSTACK_DB_MAX_OVERFLOW", 20))
 DB_POOL_TIMEOUT = int(os.getenv("GPUSTACK_DB_POOL_TIMEOUT", 30))
+# Bound how long a pooled connection may be reused so a node that a database
+# failover demoted cannot be talked to forever. SQLAlchemy's default is -1,
+# meaning a connection is never recycled; 1800 matches the prevailing default
+# for pooled connection lifetime (HikariCP's maxLifetime). 0 disables it.
+DB_POOL_RECYCLE = int(os.getenv("GPUSTACK_DB_POOL_RECYCLE", 1800))
 # Backstop against leaked/long-held sessions accumulating as Postgres
 # "idle in transaction" connections and exhausting the pool (#5678). Only
 # fires while a transaction is open and idle -- an actively-running query,

--- a/gpustack/server/init_db.py
+++ b/gpustack/server/init_db.py
@@ -99,7 +99,7 @@ def is_read_only_transaction_error(exc: BaseException) -> bool:
     return False
 
 
-def readonly_error_is_disconnect(context):
+def flag_readonly_error_as_disconnect(context):
     """Report a read-only failure as a lost connection.
 
     SQLAlchemy does not count SQLSTATE 25006 as a disconnect, and
@@ -123,7 +123,7 @@ def readonly_error_is_disconnect(context):
 
 def register_readonly_disconnect_handler(engine: AsyncEngine):
     """Retire pooled connections whose server stopped accepting writes."""
-    event.listen(engine.sync_engine, "handle_error", readonly_error_is_disconnect)
+    event.listen(engine.sync_engine, "handle_error", flag_readonly_error_as_disconnect)
 
 
 async def init_db_engine(db_url: str):

--- a/gpustack/server/init_db.py
+++ b/gpustack/server/init_db.py
@@ -81,12 +81,19 @@ async def init_db(db_url: str):
 def is_read_only_transaction_error(exc: BaseException) -> bool:
     """Report whether the error says the server refuses to accept writes.
 
-    SQLAlchemy wraps the driver error in its own type and keeps the asyncpg
-    exception as ``__cause__``, so both are inspected. Keying on the SQLSTATE
-    rather than on the exception class also covers PostgreSQL-compatible
-    backends that raise an error type of their own.
+    Three places are checked because the SQLSTATE turns up in a different one
+    depending on where the error was caught. The ``handle_error`` event hands
+    over the driver exception itself, the asyncpg dialect keeps the underlying
+    exception as ``__cause__``, and anything catching SQLAlchemy's wrapped
+    ``DBAPIError`` finds it as ``orig``. Keying on the SQLSTATE rather than on
+    the exception class also covers PostgreSQL-compatible backends that raise
+    an error type of their own.
     """
-    for candidate in (exc, getattr(exc, "__cause__", None)):
+    for candidate in (
+        exc,
+        getattr(exc, "__cause__", None),
+        getattr(exc, "orig", None),
+    ):
         if getattr(candidate, "sqlstate", None) == READ_ONLY_SQL_TRANSACTION_SQLSTATE:
             return True
     return False

--- a/gpustack/server/init_db.py
+++ b/gpustack/server/init_db.py
@@ -121,15 +121,9 @@ def flag_readonly_error_as_disconnect(context):
     context.is_disconnect = True
 
 
-def register_readonly_disconnect_handler(engine: AsyncEngine):
-    """Retire pooled connections whose server stopped accepting writes."""
-    event.listen(engine.sync_engine, "handle_error", flag_readonly_error_as_disconnect)
-
-
 async def init_db_engine(db_url: str):
     connect_args = {}
-    postgres = db_url.startswith("postgresql://")
-    if postgres:
+    if db_url.startswith("postgresql://"):
         # Probe once to see whether we're talking to openGauss — it presents
         # as PostgreSQL but rejects PG's millisecond-scale value for
         # ``idle_in_transaction_session_timeout``. Skip the setting on openGauss.
@@ -172,8 +166,6 @@ async def init_db_engine(db_url: str):
         pool_pre_ping=True,
         connect_args=connect_args,
     )
-    if postgres:
-        register_readonly_disconnect_handler(engine)
     return engine
 
 
@@ -238,6 +230,12 @@ def listen_events(engine: AsyncEngine):
         "after_create",
         DDL(model_user_after_create_view_stmt(dialect_name)),
     )
+
+    if dialect_name == "postgresql":
+        # Retire pooled connections whose server stopped accepting writes.
+        event.listen(
+            engine.sync_engine, "handle_error", flag_readonly_error_as_disconnect
+        )
 
     if engine.dialect.name == "sqlite":
         event.listen(engine.sync_engine, "connect", setup_sqlite_pragmas)

--- a/gpustack/server/init_db.py
+++ b/gpustack/server/init_db.py
@@ -46,6 +46,12 @@ logger = logging.getLogger(__name__)
 
 SLOW_QUERY_THRESHOLD_SECOND = 0.5
 
+# PostgreSQL SQLSTATE 25006, surfaced as "cannot execute <statement> in a
+# read-only transaction". A connection to a primary that a failover demoted to
+# a hot standby keeps serving reads, and keeps answering pool_pre_ping's
+# "SELECT 1", so nothing else marks it as unusable.
+READ_ONLY_SQL_TRANSACTION_SQLSTATE = "25006"
+
 # Query counter for performance monitoring
 _query_counter = 0
 _query_counter_lock = threading.Lock()
@@ -72,9 +78,51 @@ async def init_db(db_url: str):
     await create_db_and_tables(db.engine)
 
 
+def is_read_only_transaction_error(exc: BaseException) -> bool:
+    """Report whether the error says the server refuses to accept writes.
+
+    SQLAlchemy wraps the driver error in its own type and keeps the asyncpg
+    exception as ``__cause__``, so both are inspected. Keying on the SQLSTATE
+    rather than on the exception class also covers PostgreSQL-compatible
+    backends that raise an error type of their own.
+    """
+    for candidate in (exc, getattr(exc, "__cause__", None)):
+        if getattr(candidate, "sqlstate", None) == READ_ONLY_SQL_TRANSACTION_SQLSTATE:
+            return True
+    return False
+
+
+def readonly_error_is_disconnect(context):
+    """Report a read-only failure as a lost connection.
+
+    SQLAlchemy does not count SQLSTATE 25006 as a disconnect, and
+    ``pool_pre_ping`` cannot tell the difference either, because a demoted node
+    still answers "SELECT 1". Without this the pool keeps handing back
+    connections to the old primary after a failover and every write fails until
+    the process is restarted. Flagging the error as a disconnect invalidates the
+    whole pool generation, so the next checkout reaches the current primary.
+    """
+    if not is_read_only_transaction_error(context.original_exception):
+        return
+    logger.warning(
+        "Database refused a write with SQLSTATE %s (read-only transaction). "
+        "The server this connection is pinned to no longer accepts writes, "
+        "most likely after a failover; discarding the pooled connections so "
+        "the next query reconnects.",
+        READ_ONLY_SQL_TRANSACTION_SQLSTATE,
+    )
+    context.is_disconnect = True
+
+
+def register_readonly_disconnect_handler(engine: AsyncEngine):
+    """Retire pooled connections whose server stopped accepting writes."""
+    event.listen(engine.sync_engine, "handle_error", readonly_error_is_disconnect)
+
+
 async def init_db_engine(db_url: str):
     connect_args = {}
-    if db_url.startswith("postgresql://"):
+    postgres = db_url.startswith("postgresql://")
+    if postgres:
         # Probe once to see whether we're talking to openGauss — it presents
         # as PostgreSQL but rejects PG's millisecond-scale value for
         # ``idle_in_transaction_session_timeout``. Skip the setting on openGauss.
@@ -113,9 +161,12 @@ async def init_db_engine(db_url: str):
         pool_size=envs.DB_POOL_SIZE,
         max_overflow=envs.DB_MAX_OVERFLOW,
         pool_timeout=envs.DB_POOL_TIMEOUT,
+        pool_recycle=envs.DB_POOL_RECYCLE if envs.DB_POOL_RECYCLE > 0 else -1,
         pool_pre_ping=True,
         connect_args=connect_args,
     )
+    if postgres:
+        register_readonly_disconnect_handler(engine)
     return engine
 
 

--- a/tests/server/test_init_db_failover.py
+++ b/tests/server/test_init_db_failover.py
@@ -1,11 +1,13 @@
 import pytest
 from sqlalchemy import event
+from sqlmodel import SQLModel
 
 from gpustack import envs
 from gpustack.server import init_db as init_db_module
 from gpustack.server.init_db import (
     READ_ONLY_SQL_TRANSACTION_SQLSTATE,
     init_db_engine,
+    listen_events,
     is_read_only_transaction_error,
     flag_readonly_error_as_disconnect,
 )
@@ -30,6 +32,22 @@ class _AsyncpgError(Exception):
 
 async def _not_opengauss(_db_url):
     return False
+
+
+@pytest.fixture
+def contained_listen_events():
+    """Undo the DDL listeners ``listen_events`` leaves on the shared metadata.
+
+    ``listen_events`` registers ``after_create`` listeners on
+    ``SQLModel.metadata``, which is process-global rather than per-engine, and
+    it bakes the calling engine's dialect into the view DDL. Left in place they
+    would accumulate across tests and fire against an unrelated engine.
+    """
+    before = list(SQLModel.metadata.dispatch.after_create)
+    yield
+    for listener in list(SQLModel.metadata.dispatch.after_create):
+        if listener not in before:
+            event.remove(SQLModel.metadata, "after_create", listener)
 
 
 def test_read_only_sqlstate_is_recognised():
@@ -113,10 +131,13 @@ async def test_pool_recycle_can_be_disabled(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_postgres_engine_registers_the_handler(monkeypatch):
+async def test_listen_events_registers_the_handler_on_postgres(
+    monkeypatch, contained_listen_events
+):
     monkeypatch.setattr(init_db_module, "is_opengauss", _not_opengauss)
     engine = await init_db_engine(POSTGRES_URL)
     try:
+        listen_events(engine)
         assert event.contains(
             engine.sync_engine, "handle_error", flag_readonly_error_as_disconnect
         )
@@ -125,12 +146,13 @@ async def test_postgres_engine_registers_the_handler(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_mysql_engine_does_not_register_the_handler():
+async def test_listen_events_skips_the_handler_on_mysql(contained_listen_events):
     """The handler keys on a PostgreSQL SQLSTATE, so it has no business on a
     MySQL engine.
     """
     engine = await init_db_engine(MYSQL_URL)
     try:
+        listen_events(engine)
         assert not event.contains(
             engine.sync_engine, "handle_error", flag_readonly_error_as_disconnect
         )

--- a/tests/server/test_init_db_failover.py
+++ b/tests/server/test_init_db_failover.py
@@ -1,0 +1,126 @@
+import pytest
+from sqlalchemy import event
+
+from gpustack import envs
+from gpustack.server import init_db as init_db_module
+from gpustack.server.init_db import (
+    READ_ONLY_SQL_TRANSACTION_SQLSTATE,
+    init_db_engine,
+    is_read_only_transaction_error,
+    readonly_error_is_disconnect,
+)
+
+POSTGRES_URL = "postgresql://user:pw@db.example.com:5432/gpustack"
+MYSQL_URL = "mysql://user:pw@db.example.com:3306/gpustack"
+
+
+class _FakeContext:
+    """Stand-in for SQLAlchemy's ExceptionContext."""
+
+    def __init__(self, exception):
+        self.original_exception = exception
+        self.is_disconnect = False
+
+
+class _AsyncpgError(Exception):
+    def __init__(self, sqlstate):
+        super().__init__(sqlstate)
+        self.sqlstate = sqlstate
+
+
+async def _not_opengauss(_db_url):
+    return False
+
+
+def test_read_only_sqlstate_is_recognised():
+    """A demoted primary answers pool_pre_ping's SELECT 1 happily, so SQLSTATE
+    25006 is the only signal that the connection is pinned to a node which can
+    no longer be written to.
+    """
+    assert is_read_only_transaction_error(
+        _AsyncpgError(READ_ONLY_SQL_TRANSACTION_SQLSTATE)
+    )
+
+
+def test_read_only_sqlstate_is_recognised_when_wrapped():
+    """SQLAlchemy surfaces the driver error wrapped in its own Error type, with
+    the asyncpg exception as __cause__.
+    """
+    wrapper = Exception("wrapped by SQLAlchemy")
+    wrapper.__cause__ = _AsyncpgError(READ_ONLY_SQL_TRANSACTION_SQLSTATE)
+    assert is_read_only_transaction_error(wrapper)
+
+
+def test_other_database_errors_are_not_read_only_failures():
+    """Only the read-only state means the connection is on the wrong node. A
+    constraint violation must not tear the pool down.
+    """
+    assert not is_read_only_transaction_error(_AsyncpgError("23505"))
+    assert not is_read_only_transaction_error(Exception("no sqlstate at all"))
+
+
+def test_handler_flags_a_read_only_failure_as_a_disconnect():
+    """Unless the error is reported as a disconnect the pool hands the same
+    connection straight back and every following write fails too.
+    """
+    context = _FakeContext(_AsyncpgError(READ_ONLY_SQL_TRANSACTION_SQLSTATE))
+    readonly_error_is_disconnect(context)
+    assert context.is_disconnect is True
+
+
+def test_handler_leaves_unrelated_failures_alone():
+    context = _FakeContext(_AsyncpgError("23505"))
+    readonly_error_is_disconnect(context)
+    assert context.is_disconnect is False
+
+
+@pytest.mark.asyncio
+async def test_engine_bounds_pooled_connection_lifetime(monkeypatch):
+    """Without pool_recycle SQLAlchemy never retires a connection, so a node
+    demoted by a failover is reused for the life of the process.
+    """
+    monkeypatch.setattr(init_db_module, "is_opengauss", _not_opengauss)
+    engine = await init_db_engine(POSTGRES_URL)
+    try:
+        assert engine.pool._recycle == envs.DB_POOL_RECYCLE
+        assert engine.pool._recycle > 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_pool_recycle_can_be_disabled(monkeypatch):
+    """0 means "never recycle", which SQLAlchemy spells -1."""
+    monkeypatch.setattr(init_db_module, "is_opengauss", _not_opengauss)
+    monkeypatch.setattr(envs, "DB_POOL_RECYCLE", 0)
+    engine = await init_db_engine(POSTGRES_URL)
+    try:
+        assert engine.pool._recycle == -1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_postgres_engine_registers_the_handler(monkeypatch):
+    monkeypatch.setattr(init_db_module, "is_opengauss", _not_opengauss)
+    engine = await init_db_engine(POSTGRES_URL)
+    try:
+        assert event.contains(
+            engine.sync_engine, "handle_error", readonly_error_is_disconnect
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_mysql_engine_does_not_register_the_handler():
+    """The handler keys on a PostgreSQL SQLSTATE, so it has no business on a
+    MySQL engine.
+    """
+    engine = await init_db_engine(MYSQL_URL)
+    try:
+        assert not event.contains(
+            engine.sync_engine, "handle_error", readonly_error_is_disconnect
+        )
+    finally:
+        await engine.dispose()

--- a/tests/server/test_init_db_failover.py
+++ b/tests/server/test_init_db_failover.py
@@ -7,7 +7,7 @@ from gpustack.server.init_db import (
     READ_ONLY_SQL_TRANSACTION_SQLSTATE,
     init_db_engine,
     is_read_only_transaction_error,
-    readonly_error_is_disconnect,
+    flag_readonly_error_as_disconnect,
 )
 
 POSTGRES_URL = "postgresql://user:pw@db.example.com:5432/gpustack"
@@ -76,13 +76,13 @@ def test_handler_flags_a_read_only_failure_as_a_disconnect():
     connection straight back and every following write fails too.
     """
     context = _FakeContext(_AsyncpgError(READ_ONLY_SQL_TRANSACTION_SQLSTATE))
-    readonly_error_is_disconnect(context)
+    flag_readonly_error_as_disconnect(context)
     assert context.is_disconnect is True
 
 
 def test_handler_leaves_unrelated_failures_alone():
     context = _FakeContext(_AsyncpgError("23505"))
-    readonly_error_is_disconnect(context)
+    flag_readonly_error_as_disconnect(context)
     assert context.is_disconnect is False
 
 
@@ -118,7 +118,7 @@ async def test_postgres_engine_registers_the_handler(monkeypatch):
     engine = await init_db_engine(POSTGRES_URL)
     try:
         assert event.contains(
-            engine.sync_engine, "handle_error", readonly_error_is_disconnect
+            engine.sync_engine, "handle_error", flag_readonly_error_as_disconnect
         )
     finally:
         await engine.dispose()
@@ -132,7 +132,7 @@ async def test_mysql_engine_does_not_register_the_handler():
     engine = await init_db_engine(MYSQL_URL)
     try:
         assert not event.contains(
-            engine.sync_engine, "handle_error", readonly_error_is_disconnect
+            engine.sync_engine, "handle_error", flag_readonly_error_as_disconnect
         )
     finally:
         await engine.dispose()

--- a/tests/server/test_init_db_failover.py
+++ b/tests/server/test_init_db_failover.py
@@ -51,12 +51,24 @@ def test_read_only_sqlstate_is_recognised_when_wrapped():
     assert is_read_only_transaction_error(wrapper)
 
 
+def test_read_only_sqlstate_is_recognised_through_orig():
+    """Code that catches SQLAlchemy's wrapped DBAPIError sees the driver error
+    as .orig rather than __cause__, so check that shape too.
+    """
+    wrapper = Exception("wrapped by SQLAlchemy")
+    wrapper.orig = _AsyncpgError(READ_ONLY_SQL_TRANSACTION_SQLSTATE)
+    assert is_read_only_transaction_error(wrapper)
+
+
 def test_other_database_errors_are_not_read_only_failures():
     """Only the read-only state means the connection is on the wrong node. A
     constraint violation must not tear the pool down.
     """
     assert not is_read_only_transaction_error(_AsyncpgError("23505"))
     assert not is_read_only_transaction_error(Exception("no sqlstate at all"))
+    unrelated = Exception("wrapped by SQLAlchemy")
+    unrelated.orig = _AsyncpgError("23505")
+    assert not is_read_only_transaction_error(unrelated)
 
 
 def test_handler_flags_a_read_only_failure_as_a_disconnect():

--- a/tests/server/test_init_db_failover.py
+++ b/tests/server/test_init_db_failover.py
@@ -110,10 +110,10 @@ async def test_engine_bounds_pooled_connection_lifetime(monkeypatch):
     demoted by a failover is reused for the life of the process.
     """
     monkeypatch.setattr(init_db_module, "is_opengauss", _not_opengauss)
+    monkeypatch.setattr(envs, "DB_POOL_RECYCLE", 1800)
     engine = await init_db_engine(POSTGRES_URL)
     try:
-        assert engine.pool._recycle == envs.DB_POOL_RECYCLE
-        assert engine.pool._recycle > 0
+        assert engine.pool._recycle == 1800
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
Fixes #6105.

When a failover turns the primary into a hot standby, the connections we already have open to it stay open. That node still answers reads, so nothing looks wrong, but every write fails with SQLSTATE `25006` and keeps failing until someone restarts the pod. Ours ran that way for 3 days and 7 hours.

```
Before the switchover
   gpustack  ──[ open connections ]──▶  node A    primary, writes OK
                                        node B    standby

After the switchover
   gpustack  ──[ same connections ]──▶  node A    now a standby, writes REFUSED
                                        node B    now primary, nobody connects to it
```

Three things have to line up for a connection to stay stuck, and all three do. `pool_pre_ping` sends `SELECT 1`, which a read-only standby answers perfectly well, so the connection looks healthy. SQLAlchemy does not count `25006` as a dead connection, so it goes back in the pool and comes straight back out. And `pool_recycle` is unset, so its default of `-1` applies and nothing retires the connection on age. Nothing crashes either, because the writers all catch and log and `/healthz` never touches the database.

## Changes

- `gpustack/server/init_db.py`: a `handle_error` listener that reports SQLSTATE `25006` as a dead connection, plus `pool_recycle` on the engine.
- `gpustack/envs/__init__.py`: `GPUSTACK_DB_POOL_RECYCLE`, default 1800s. `0` disables it.
- `tests/server/test_init_db_failover.py`: 9 tests covering the SQLSTATE match (bare, wrapped in SQLAlchemy's own error, and unrelated codes), the listener, where it gets registered, and the pool settings.

## Why report it as a dead connection rather than only recycling

Setting `is_disconnect` makes SQLAlchemy throw away the whole pool *generation*, not just the one connection. So a single failed write clears every connection to the old node instead of retiring them one at a time. With 8 stale connections in the pool that is the difference between 1 failed write and 8, and the gap grows with `pool_size`. Every writer already retries on its own tick, so one lost write is the whole cost.

`pool_recycle` is in here as a backstop, not the main fix. A demoted node we never write to never raises `25006`, and nothing else would ever retire that connection. 1800s matches what other pools use for connection lifetime: HikariCP's `maxLifetime` is 30 minutes, PgBouncer's `server_lifetime` is an hour.

The listener is only registered for `postgresql://` URLs, since `25006` is a PostgreSQL SQLSTATE and MySQL reports a read-only server differently.

## Measured

Two PostgreSQL 16 containers behind a small TCP proxy that copies kube-proxy: new connections go to the current endpoint, existing connections are neither moved nor cut. Node A is demoted with `ALTER SYSTEM SET default_transaction_read_only = on`, which gives the same SQLSTATE `25006` on writes while reads keep working. The write loop is a copy of `flush_heartbeats` and the engine comes from the real `init_db_engine()`. Eight connections go into the pool first, then one write per second.

| | failed writes | outcome |
| --- | --- | --- |
| before | 30/30 | never recovers |
| after | 1/30 | recovers on the next tick, writing to the new primary |

One extra check, to be sure the fix is aimed at the right thing: with the proxy set to cut existing connections instead, the unpatched code recovers by itself (0/30 failed). Pre-ping handles a failover fine when the connection actually drops. What breaks is the connection that stays up and goes read-only.

This overlaps with #6106 in `init_db_engine`, so whichever lands second needs a small rebase.
