### PR TITLE
fix(sglang): recognize --tp and --dp in scheduling

### DIFF
--- a/gpustack/policies/candidate_selectors/sglang_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/sglang_resource_fit_selector.py
@@ -101,7 +101,7 @@ class SGLangResourceFitSelector(ScheduleCandidatesSelector):
         model: Model,
     ) -> Tuple[Optional[int], Optional[List[str]]]:
         tp = find_int_parameter(
-            model.backend_parameters, ["tp-size", "tensor-parallel-size"]
+            model.backend_parameters, ["tp-size", "tensor-parallel-size", "tp"]
         )
         pp = find_int_parameter(
             model.backend_parameters, ["pp-size", "pipeline-parallel-size"]
@@ -146,7 +146,7 @@ class SGLangResourceFitSelector(ScheduleCandidatesSelector):
         model = self._model
         self._tp_size = (
             find_int_parameter(
-                model.backend_parameters, ["tp-size", "tensor-parallel-size"]
+                model.backend_parameters, ["tp-size", "tensor-parallel-size", "tp"]
             )
             or 1
         )
@@ -954,7 +954,7 @@ class MemFractionStaticCalculator:
         )
         self._tp_size = (
             find_int_parameter(
-                model.backend_parameters, ["tp-size", "tensor-parallel-size"]
+                model.backend_parameters, ["tp-size", "tensor-parallel-size", "tp"]
             )
             or 1
         )

--- a/gpustack/policies/candidate_selectors/sglang_resource_fit_selector.py
+++ b/gpustack/policies/candidate_selectors/sglang_resource_fit_selector.py
@@ -107,7 +107,7 @@ class SGLangResourceFitSelector(ScheduleCandidatesSelector):
             model.backend_parameters, ["pp-size", "pipeline-parallel-size"]
         )
         dp = find_int_parameter(
-            model.backend_parameters, ["dp-size", "data-parallel-size"]
+            model.backend_parameters, ["dp-size", "data-parallel-size", "dp"]
         )
         dp_attention = find_bool_parameter(
             model.backend_parameters, ["enable-dp-attention"]
@@ -170,7 +170,7 @@ class SGLangResourceFitSelector(ScheduleCandidatesSelector):
         )
         self._dp_size = (
             find_int_parameter(
-                model.backend_parameters, ["dp-size", "data-parallel-size"]
+                model.backend_parameters, ["dp-size", "data-parallel-size", "dp"]
             )
             or 1
         )
@@ -966,7 +966,7 @@ class MemFractionStaticCalculator:
         )
         self._dp_size = (
             find_int_parameter(
-                model.backend_parameters, ["dp-size", "data-parallel-size"]
+                model.backend_parameters, ["dp-size", "data-parallel-size", "dp"]
             )
             or 1
         )

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -733,6 +733,7 @@ def get_auto_parallelism_arguments(
         [
             "tensor-parallel-size",
             "tp-size",
+            "tp",
             "pipeline-parallel-size",
             "pp-size",
             "data-parallel-size",

--- a/gpustack/worker/backends/sglang.py
+++ b/gpustack/worker/backends/sglang.py
@@ -738,6 +738,7 @@ def get_auto_parallelism_arguments(
             "pp-size",
             "data-parallel-size",
             "dp-size",
+            "dp",
         ],
     )
 

--- a/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
@@ -1317,9 +1317,32 @@ def test_sglang_tp_alias_drives_world_size_and_memory_calculation():
     assert calculator._tp_size == 2
 
 
+def test_sglang_dp_alias_drives_world_size_and_memory_calculation():
+    model = new_model(
+        1,
+        "test_name",
+        huggingface_repo_id="Qwen/Qwen2.5-7B-Instruct",
+        backend_parameters=["--dp", "2"],
+    )
+
+    assert SGLangResourceFitSelector.get_world_size_from_backend_parameters(model) == (
+        2,
+        ["dp"],
+    )
+
+    calculator = MemFractionStaticCalculator(
+        model=model,
+        model_instances=[],
+        model_params=SimpleNamespace(),
+        gpu_type="cuda",
+        selected_gpu_indexes_by_gpu_type_and_worker={},
+    )
+    assert calculator._dp_size == 2
+
+
 @pytest.mark.asyncio
 async def test_sglang_data_parallel_size(config):
-    """Test SGLang data parallel size handling"""
+    """The SGLang --dp abbreviation must drive GPUStack scheduling too."""
     workers = [
         linux_nvidia_22_H100_80gx8(),
         linux_nvidia_23_H100_80gx8(),
@@ -1333,7 +1356,7 @@ async def test_sglang_data_parallel_size(config):
         huggingface_repo_id="Qwen/Qwen2.5-7B-Instruct",
         cpu_offloading=False,
         backend_parameters=[
-            "--dp-size=2",
+            "--dp=2",
             "--tp-size=4",
         ],
     )
@@ -1365,8 +1388,8 @@ async def test_sglang_data_parallel_size(config):
         candidates = await resource_fit_selector.select_candidates(workers)
         candidates = await placement_scorer.score(candidates)
 
-        # Should handle data parallel size correctly
-        assert len(candidates) >= 0
+        assert resource_fit_selector._dp_size == 2
+        assert resource_fit_selector._gpu_count == 8
 
 
 @pytest.mark.asyncio

--- a/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
+++ b/tests/policies/candidate_selectors/sglang/test_sglang_resource_fit_selector.py
@@ -6,6 +6,9 @@ from tests.utils.mock import mock_async_session
 
 from tests.utils.model import make_model, new_model, new_model_instance
 from gpustack.policies.candidate_selectors import SGLangResourceFitSelector
+from gpustack.policies.candidate_selectors.sglang_resource_fit_selector import (
+    MemFractionStaticCalculator,
+)
 from gpustack.policies.scorers.placement_scorer import PlacementScorer
 from gpustack.scheduler import scheduler
 from gpustack.schemas.models import (
@@ -1242,12 +1245,11 @@ async def test_sglang_backend_parameters(config):
 
 @pytest.mark.asyncio
 async def test_sglang_tensor_parallel_size(config):
-    """Test SGLang tensor parallel size handling"""
+    """The SGLang --tp abbreviation must drive GPUStack scheduling too."""
     workers = [
         linux_nvidia_4_4080_16gx4(),
     ]
 
-    # Test with tensor parallel size
     m = new_model(
         1,
         "test_name",
@@ -1255,7 +1257,7 @@ async def test_sglang_tensor_parallel_size(config):
         huggingface_repo_id="Qwen/Qwen2.5-7B-Instruct",
         cpu_offloading=False,
         backend_parameters=[
-            "--tp-size=2",
+            "--tp=2",
         ],
     )
 
@@ -1286,10 +1288,33 @@ async def test_sglang_tensor_parallel_size(config):
         candidates = await resource_fit_selector.select_candidates(workers)
         candidates = await placement_scorer.score(candidates)
 
-        # Should handle tensor parallel size correctly
-        if candidates:
-            # If candidates are found, they should respect the tp-size parameter
-            assert len(candidates) >= 0
+        assert resource_fit_selector._tp_size == 2
+        assert resource_fit_selector._gpu_count == 2
+        assert candidates
+        assert all(len(candidate.gpu_indexes) == 2 for candidate in candidates)
+
+
+def test_sglang_tp_alias_drives_world_size_and_memory_calculation():
+    model = new_model(
+        1,
+        "test_name",
+        huggingface_repo_id="Qwen/Qwen2.5-7B-Instruct",
+        backend_parameters=["--tp", "2"],
+    )
+
+    assert SGLangResourceFitSelector.get_world_size_from_backend_parameters(model) == (
+        2,
+        ["tp"],
+    )
+
+    calculator = MemFractionStaticCalculator(
+        model=model,
+        model_instances=[],
+        model_params=SimpleNamespace(),
+        gpu_type="cuda",
+        selected_gpu_indexes_by_gpu_type_and_worker={},
+    )
+    assert calculator._tp_size == 2
 
 
 @pytest.mark.asyncio

--- a/tests/worker/backends/test_backend.py
+++ b/tests/worker/backends/test_backend.py
@@ -757,12 +757,13 @@ def test_sglang_command_args_include_model_and_late_system_flags_as_injected():
     ]
 
 
-def test_sglang_tp_alias_prevents_conflicting_auto_parallelism_arguments():
+@pytest.mark.parametrize("alias", ["tp", "dp"])
+def test_sglang_short_alias_prevents_conflicting_auto_parallelism_arguments(alias):
     model_instance = types.SimpleNamespace(gpu_indexes=[0, 1])
 
     assert (
         get_sglang_auto_parallelism_arguments(
-            ["--tp", "2"], model_instance, is_distributed=False
+            [f"--{alias}", "2"], model_instance, is_distributed=False
         )
         == []
     )

--- a/tests/worker/backends/test_backend.py
+++ b/tests/worker/backends/test_backend.py
@@ -29,6 +29,7 @@ from gpustack.worker.backends.sglang import (
     SGLangServer,
     extend_sglang_mounted_lora_arguments,
     get_access_log_arguments as get_sglang_access_log_arguments,
+    get_auto_parallelism_arguments as get_sglang_auto_parallelism_arguments,
     get_cache_report_arguments as get_sglang_cache_report_arguments,
 )
 from gpustack.worker.backends.vllm import (
@@ -754,6 +755,17 @@ def test_sglang_command_args_include_model_and_late_system_flags_as_injected():
         "--port",
         "4000",
     ]
+
+
+def test_sglang_tp_alias_prevents_conflicting_auto_parallelism_arguments():
+    model_instance = types.SimpleNamespace(gpu_indexes=[0, 1])
+
+    assert (
+        get_sglang_auto_parallelism_arguments(
+            ["--tp", "2"], model_instance, is_distributed=False
+        )
+        == []
+    )
 
 
 def test_vox_box_command_args_return_injected_parameters():


### PR DESCRIPTION
## Summary

- recognize SGLang `--tp` and `--dp` short forms when calculating scheduler world size
- use the short forms in selector validation and memory planning
- avoid adding automatic parallelism arguments when the user already supplied a short form
- add regression coverage for scheduling and worker argument generation

## Problem

SGLang accepts `--tp`, and its argument parser also accepts `--dp` as the unique prefix for `--dp-size`. GPUStack only recognized the longer parameter names. As a result, SGLang could launch with a different parallel world size from the one GPUStack used for placement and resource planning.

## Fix

Add `tp` and `dp` to the existing accepted parameter-name lists in the SGLang selector, memory calculator, and backend auto-parallelism detection. User parameters are left unchanged, and GPUStack automatic output remains canonical.

## Testing

- focused short-alias regression tests: 4 passed
- affected SGLang selector and backend modules: 214 passed
- full suite: 3325 passed, 12 skipped; two remote Hub metadata requests failed, then both failed nodes passed on immediate isolated retry
- `make lint`
- ARM64 CUDA 13 deployment across two NVIDIA GB10 workers with SGLang 0.5.15.post1; both ranks initialized with TP=2 and an OpenAI-compatible chat request completed successfully

Fixes #5966
