### PR TITLE
feat(cluster): add the do.top cloud provider

### DIFF
--- a/gpustack/cloud_providers/abstract.py
+++ b/gpustack/cloud_providers/abstract.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 from abc import ABC, abstractmethod
 from enum import Enum
 from gpustack.schemas.clusters import Volume
@@ -12,7 +12,21 @@ class InstanceState(str, Enum):
     STOPPING = "stopping"
     STOPPED = "stopped"
     TERMINATED = "terminated"
+    # Provisioning failed on the provider side. Terminal: unlike CREATED it
+    # will never become RUNNING, so waiters must give up instead of polling to
+    # their timeout.
+    FAILED = "failed"
     UNKNOWN = "unknown"
+
+
+class InstanceProvisioningFailed(Exception):
+    """
+    The provider gave up creating the instance.
+
+    Distinct from a timeout: waiting longer or polling again cannot help, so
+    callers should surface it instead of retrying. The provisioning controller
+    treats it as terminal and moves the worker to ERROR.
+    """
 
 
 @dataclass
@@ -21,9 +35,15 @@ class CloudInstanceCreate:
     image: str
     type: str
     region: str
-    ssh_key_id: str
+    # None when the provider has no SSH key API, i.e. create_ssh_key
+    # registered nothing to attach by id.
+    ssh_key_id: Optional[str] = None
     user_data: Optional[str] = None
     labels: Optional[Dict[str, str]] = None
+    # Token identifying one attempt at creating this instance, for providers
+    # that offer replay protection. Stable across retries of the same attempt,
+    # different for a later one. See construct_cloud_instance.
+    idempotency_key: Optional[str] = None
 
 
 @dataclass
@@ -33,6 +53,12 @@ class CloudInstance(CloudInstanceCreate):
     ip_address: Optional[str] = None
     ssh_key_id: Optional[str] = None
     volume_ids: Optional[List[str]] = None
+    # ``(host, port)`` SSH actually answers on, when that is not
+    # ``ip_address:22``. Providers that publish instances behind a shared
+    # address with mapped ports need it, and it is the only way a caller can
+    # build a working connection hint. None means use ip_address:22.
+    ssh_endpoint: Optional[Tuple[str, int]] = None
+    ssh_user: Optional[str] = None
 
 
 class ProviderClientBase(ABC):
@@ -72,7 +98,16 @@ class ProviderClientBase(ABC):
         pass
 
     @abstractmethod
-    async def create_ssh_key(self, worker_name: str, public_key: str) -> str:
+    async def create_ssh_key(self, worker_name: str, public_key: str) -> Optional[str]:
+        """
+        Register the public key with the provider and return its id, which the
+        caller records on ``Credential.external_id``.
+
+        Return None when there is nothing to register, i.e. the provider has no
+        SSH key API and the key travels inside the user data instead (see
+        :meth:`construct_user_data`). The caller then leaves ``external_id``
+        NULL and skips :meth:`delete_ssh_key` on teardown.
+        """
         pass
 
     @abstractmethod
@@ -97,7 +132,19 @@ class ProviderClientBase(ABC):
         os_image: str,
         worker_name: str,
         secret_configs: Dict[str, Any] = {},
+        ssh_public_key: Optional[str] = None,
     ) -> UserDataTemplate:
+        """
+        Build the cloud-init document for a worker.
+
+        ``ssh_public_key`` is the key created by :meth:`create_ssh_key`, handed
+        over so each provider can decide how the instance ends up trusting it.
+        The base implementation ignores it: providers with an SSH key API
+        (DigitalOcean) pass the key's id on ``CloudInstanceCreate.ssh_key_id``
+        and let the API inject it. A provider without such an API overrides
+        this and calls ``user_data.add_ssh_authorized_keys(ssh_public_key)``,
+        so the key travels inside the user data instead.
+        """
         user_data = UserDataTemplate(
             server_url=server_url,
             token=token,

--- a/gpustack/cloud_providers/common.py
+++ b/gpustack/cloud_providers/common.py
@@ -1,7 +1,10 @@
 import base64
-from typing import Dict, Tuple, Type, Callable
+import hashlib
+from datetime import timezone
+from typing import Dict, Optional, Tuple, Type, Callable
 from .abstract import ProviderClientBase, CloudInstanceCreate
 from .digital_ocean import DigitalOceanClient
+from .shuihua import ShuihuaProviderClient
 from gpustack.schemas.clusters import ClusterProvider, CloudCredential, Credential
 from gpustack.schemas.workers import Worker
 from cryptography.hazmat.primitives import serialization
@@ -16,7 +19,27 @@ factory: Dict[
         DigitalOceanClient,
         lambda credential: DigitalOceanClient(token=credential.secret),
     ),
+    ClusterProvider.Shuihua: (
+        ShuihuaProviderClient,
+        lambda credential: ShuihuaProviderClient(api_key=credential.secret),
+    ),
 }
+
+
+def get_provider_api_endpoint(provider: ClusterProvider) -> Optional[str]:
+    """
+    The API base URL a cloud provider will talk to, or None when it has none.
+
+    A provider whose API has no single well-known host takes its URL from a
+    server start-up option, so until that is set there is nowhere to send
+    requests. Returning None lets the cluster and credential routes say so up
+    front instead of letting provisioning fail later against a URL that was
+    never configured.
+    """
+    type_factory = factory.get(provider, None)
+    if type_factory is None:
+        return None
+    return type_factory[0].get_api_endpoint() or None
 
 
 def get_client_from_provider(
@@ -28,6 +51,48 @@ def get_client_from_provider(
         raise ValueError(f"Unsupported provider: {provider}")
     f = type_factory[1]
     return f(credential)
+
+
+def creation_idempotency_key(worker: Worker) -> str:
+    """
+    A token identifying one attempt at creating this worker's instance.
+
+    Providers offering replay protection (Shuihua requires a key) send this, so
+    that retrying a create whose outcome was never learned returns the first
+    instance instead of provisioning — and charging for — a second one. The
+    live case is the server being killed mid-provision: nothing records the
+    failure, so the worker is still PROVISIONING and gets picked up again on
+    restart.
+
+    ``updated_at`` supplies the stability. The provisioning state machine
+    commits once per step, so the value read here was persisted by the
+    *previous* step and survives this one rolling back, while any later write
+    that re-drives the worker (resetting it out of ERROR) necessarily bumps it
+    and so mints a new token. This holds only because the controller re-reads
+    the worker from the database on every reconcile — caching it across steps
+    would break it.
+
+    Whole seconds: MySQL stores TIMESTAMP without fractional digits while
+    PostgreSQL keeps microseconds, so the key stays the same either way.
+
+    The limit of anchoring on ``updated_at`` is that only failures leaving no
+    trace are covered. Any failure the reconcile loop records -- it writes
+    ``state=ERROR`` on every exception, including a timeout on a create the
+    provider had already accepted and charged for -- bumps the column, so a
+    fresh attempt would mint a new key and pay for a second instance. That is
+    survivable today because nothing re-drives an ERROR worker: recovery means
+    deleting it, and the replacement is a different row that *should* get its
+    own key. Adding an in-place retry would make it real, and would mean
+    persisting the key instead (in ``worker.provider_config``, committed in the
+    state-machine step *before* the create, or the crash window reopens).
+    """
+    updated_at = worker.updated_at
+    if updated_at is not None and updated_at.tzinfo is None:
+        # The column holds naive UTC; reading it as local time would shift it.
+        updated_at = updated_at.replace(tzinfo=timezone.utc)
+    attempt = int(updated_at.timestamp()) if updated_at is not None else 0
+    identity = f"{worker.cluster_id}/{worker.id}/{worker.name}/{attempt}"
+    return f"gpustack-{hashlib.sha256(identity.encode()).hexdigest()[:32]}"
 
 
 def construct_cloud_instance(
@@ -53,6 +118,7 @@ def construct_cloud_instance(
             "worker_id": worker.id,
             **labels,
         },
+        idempotency_key=creation_idempotency_key(worker),
     )
 
 

--- a/gpustack/cloud_providers/digital_ocean.py
+++ b/gpustack/cloud_providers/digital_ocean.py
@@ -197,7 +197,11 @@ class DigitalOceanClient(ProviderClientBase):
         os_image,
         worker_name,
         secret_configs: Dict[str, Any] = {},
+        ssh_public_key: Optional[str] = None,
     ) -> UserDataTemplate:
+        # ssh_public_key is unused on purpose: the key is registered through
+        # the ssh_keys API and attached by id in create_instance, so it must
+        # not also be written into the user data.
         image_info = await self.client.images.get(os_image)
         distribution = image_info.get('image', {}).get('distribution', '').lower()
         image_slug = image_info.get('image', {}).get('slug', '').lower()
@@ -214,7 +218,13 @@ class DigitalOceanClient(ProviderClientBase):
             install_driver = ManufacturerEnum.NVIDIA
             setup_driver = ManufacturerEnum.NVIDIA
         user_data = await super().construct_user_data(
-            server_url, token, image_name, os_image, worker_name, secret_configs
+            server_url,
+            token,
+            image_name,
+            os_image,
+            worker_name,
+            secret_configs,
+            ssh_public_key,
         )
         user_data.distribution = distribution
         user_data.setup_driver = setup_driver

--- a/gpustack/cloud_providers/shuihua.py
+++ b/gpustack/cloud_providers/shuihua.py
@@ -1,0 +1,738 @@
+"""
+Async SDK for the Shuihua open API (基于 API key 认证的开放接口, v1.4.0).
+
+Generated from ``open-api.openapi_v5.json``. The API wraps every successful
+response in ``{"data": ...}`` (list endpoints add ``{"meta": ...}``) and every
+failure in ``{"error": {"code": ..., "message": ...}}``; this client unwraps
+both and raises :class:`ShuihuaAPIError` on failure.
+
+Creation is asynchronous: ``create_vm`` returns as soon as the lease is
+accepted (HTTP 202, ``status=creating``) and the caller polls
+:meth:`ShuihuaClient.get_vm` until the status reaches ``active`` or ``failed``.
+
+Usage::
+
+    async with ShuihuaClient(api_key="amp_live_xxx") as client:
+        specs = await client.list_gpu_instances()
+        images = await client.list_images()
+        vm = await client.create_vm(
+            template_id=specs[0].template_id,
+            image_id=images[0].image_uuid,
+            idempotency_key="my-stable-token",
+            user_data="#cloud-config\\npackages:\\n  - htop",
+        )
+        while vm.status in PENDING_STATUSES:
+            vm = await client.get_vm(vm.id)
+        await client.terminate_vm(vm.id)
+"""
+
+import asyncio
+import hashlib
+import logging
+from contextlib import asynccontextmanager
+from datetime import datetime
+from enum import Enum
+from typing import Any, AsyncGenerator, AsyncIterator, Dict, List, Optional, Tuple
+
+import httpx
+from pydantic import BaseModel, Field, field_validator
+from gpustack_runtime.detector import ManufacturerEnum
+
+from gpustack.config.config import get_global_config
+from gpustack.schemas.clusters import Volume
+from gpustack.cloud_providers.user_data import UserDataTemplate
+from .abstract import (
+    CloudInstance,
+    CloudInstanceCreate,
+    InstanceProvisioningFailed,
+    InstanceState,
+    ProviderClientBase,
+)
+
+logger = logging.getLogger(__name__)
+
+API_PREFIX = "/api/v1/open"
+
+# Default read timeout for normal calls. Creation only has to be accepted, not
+# completed, so it needs no timeout of its own.
+DEFAULT_TIMEOUT = 30
+# cloud-init user data is capped at 64KB by the server.
+MAX_USER_DATA_SIZE = 65536
+# Internal port the API defaults to when an instance has no port mapping.
+DEFAULT_SSH_PORT = 22
+# The API caps the idempotency key and the instance name at 64 characters.
+MAX_IDEMPOTENCY_KEY_SIZE = 64
+MAX_INSTANCE_NAME_SIZE = 64
+
+
+class VMStatus(str, Enum):
+    CREATING = "creating"
+    PROCESSING = "processing"
+    ACTIVE = "active"
+    FAILED = "failed"
+    EXPIRED = "expired"
+    TERMINATED = "terminated"
+
+
+# Statuses a VM passes through before it is either usable or lost.
+PENDING_STATUSES = frozenset({VMStatus.CREATING, VMStatus.PROCESSING})
+
+# A lease that expired is powered off but still exists, unlike a terminated one.
+status_mapping = {
+    # creating = queued for a backend worker to claim, processing = the flint
+    # instance is being built. Both are on their way to active.
+    VMStatus.CREATING: InstanceState.CREATED,
+    VMStatus.PROCESSING: InstanceState.CREATED,
+    VMStatus.ACTIVE: InstanceState.RUNNING,
+    VMStatus.FAILED: InstanceState.FAILED,
+    VMStatus.EXPIRED: InstanceState.STOPPED,
+    VMStatus.TERMINATED: InstanceState.TERMINATED,
+}
+
+
+class GpuInstance(BaseModel):
+    """An orderable spec template: GPU model, hourly price and remaining stock."""
+
+    template_id: Optional[int] = None
+    name: Optional[str] = None
+    gpu_model: Optional[str] = None
+    price_per_hour: Optional[float] = Field(
+        default=None, description="Hourly price in CNY"
+    )
+    remaining: Optional[int] = Field(default=None, description="Remaining available")
+
+
+class Image(BaseModel):
+    id: Optional[int] = None
+    image_uuid: Optional[str] = Field(
+        default=None, description="Pass as image_id when creating a VM"
+    )
+    name: Optional[str] = None
+    os_distro: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class PortMapping(BaseModel):
+    """One public endpoint mapped onto an internal port of the instance."""
+
+    public_ip: Optional[str] = None
+    public_port: Optional[int] = None
+    internal_port: Optional[int] = Field(
+        default=None, description="Internal port, e.g. 22 for SSH or 80 for HTTP"
+    )
+
+
+class VMSummary(BaseModel):
+    id: Optional[int] = None
+    template_id: Optional[int] = None
+    template_name: Optional[str] = None
+    gpu_model: Optional[str] = None
+    instance_id: Optional[str] = None
+    instance_name: Optional[str] = None
+    ip_address: Optional[str] = Field(default=None, description="Instance IP")
+    port_mappings: Optional[List[PortMapping]] = Field(
+        default=None,
+        description=(
+            "Port mappings; one internal IP may expose several public ports. "
+            "Absent when the instance has no mapping."
+        ),
+    )
+    internal_port: Optional[int] = Field(
+        default=None,
+        description=(
+            "Default internal port (22), only returned when there is no port "
+            "mapping. See port_mappings otherwise."
+        ),
+    )
+    status: Optional[VMStatus] = None
+    start_time: Optional[datetime] = None
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _tolerate_unknown_status(cls, value):
+        """Degrade an unrecognised status to None instead of failing the parse.
+
+        The status set grew by three values between API 1.3.0 and 1.4.0, and a
+        strict enum would turn the next addition into a hard error — not just
+        for that VM but for the whole ``list_vms`` page it appears on, taking
+        every worker on the credential down with it. None maps to
+        ``InstanceState.UNKNOWN``, so callers keep polling and the warning says
+        why.
+        """
+        if value is None or isinstance(value, VMStatus):
+            return value
+        try:
+            return VMStatus(value)
+        except ValueError:
+            logger.warning(f"Ignoring unknown Shuihua VM status {value!r}")
+            return None
+
+    def public_endpoint(
+        self, internal_port: int = DEFAULT_SSH_PORT
+    ) -> Optional[Tuple[str, int]]:
+        """Resolve ``(public_ip, public_port)`` for an internal port.
+
+        Returns ``None`` when the instance has no mapping for that port, in which
+        case reach it directly on ``ip_address``.
+        """
+        for mapping in self.port_mappings or []:
+            if mapping.internal_port == internal_port:
+                if mapping.public_ip and mapping.public_port:
+                    return mapping.public_ip, mapping.public_port
+                return None
+        return None
+
+
+class VMDetail(VMSummary):
+    ssh_user: Optional[str] = None
+    ssh_private_key: Optional[str] = Field(
+        default=None,
+        description=(
+            "PEM private key, only returned for VMs created without user_data. "
+            "Empty in self-contained (user_data) mode."
+        ),
+    )
+    end_time: Optional[datetime] = Field(default=None, description="Lease end time")
+
+
+class PaginationMeta(BaseModel):
+    total: Optional[int] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+    total_pages: Optional[int] = None
+
+
+class ShuihuaAPIError(Exception):
+    """Raised when the API returns a non-2xx response or an error envelope."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: Optional[int] = None,
+        code: Optional[str] = None,
+        payload: Optional[Any] = None,
+    ):
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.payload = payload
+        super().__init__(
+            f"Shuihua API error (status={status_code}, code={code}): {message}"
+        )
+
+
+class ShuihuaClient:
+    """Async client for the Shuihua open API.
+
+    Authentication is a bearer API key (``amp_live_`` prefixed).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str,
+        timeout: float = DEFAULT_TIMEOUT,
+        client: Optional[httpx.AsyncClient] = None,
+    ):
+        """``client`` lets the caller inject a shared/mocked ``AsyncClient``; it is
+        not closed by this class and every request carries an absolute URL, so its
+        own ``base_url`` and headers are irrelevant."""
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=timeout,
+        )
+
+    async def __aenter__(self) -> "ShuihuaClient":
+        return self
+
+    async def __aexit__(self, *_exc_info):
+        await self.aclose()
+
+    async def aclose(self):
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Tuple[Any, Optional[PaginationMeta]]:
+        """Send a request and unwrap the ``data`` / ``meta`` envelope."""
+        url = f"{self._base_url}{API_PREFIX}{path}"
+        try:
+            response = await self._client.request(
+                method,
+                url,
+                params=params,
+                json=json,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=timeout if timeout is not None else httpx.USE_CLIENT_DEFAULT,
+            )
+        except httpx.HTTPError as e:
+            raise ShuihuaAPIError(f"Request to {method} {url} failed: {e}") from e
+
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+
+        if isinstance(body, dict) and isinstance(body.get("error"), dict):
+            error = body["error"]
+            raise ShuihuaAPIError(
+                error.get("message", "unknown error"),
+                status_code=response.status_code,
+                code=error.get("code"),
+                payload=body,
+            )
+
+        if response.is_error:
+            raise ShuihuaAPIError(
+                body if isinstance(body, str) else response.text,
+                status_code=response.status_code,
+                payload=body,
+            )
+
+        if not isinstance(body, dict):
+            raise ShuihuaAPIError(
+                f"Unexpected response body from {method} {url}: {response.text}",
+                status_code=response.status_code,
+                payload=body,
+            )
+
+        meta = body.get("meta")
+        return body.get("data"), PaginationMeta(**meta) if meta else None
+
+    async def list_gpu_instances(self) -> List[GpuInstance]:
+        """List spec templates with GPU model, hourly price and remaining stock."""
+        data, _ = await self._request("GET", "/gpu-instances")
+        return [GpuInstance(**item) for item in data or []]
+
+    async def list_images(self) -> List[Image]:
+        """List available OS images. Use ``image_uuid`` as ``image_id`` on create."""
+        data, _ = await self._request("GET", "/images")
+        return [Image(**item) for item in data or []]
+
+    async def create_vm(
+        self,
+        template_id: int,
+        image_id: str,
+        idempotency_key: str,
+        user_data: Optional[str] = None,
+        instance_name: Optional[str] = None,
+    ) -> VMDetail:
+        """Accept a VM for creation and start billing (first hour is pre-charged).
+
+        Asynchronous: returns as soon as the lease is accepted (HTTP 202) with
+        ``status=creating``. Poll :meth:`get_vm` until the status leaves
+        :data:`PENDING_STATUSES` — ``active`` means ready, ``failed`` means the
+        creation gave up.
+
+        ``idempotency_key`` is required and guards against replays: the same
+        key from the same user returns the lease from the first request instead
+        of creating (and charging for) a second one. It must therefore be
+        derived from something stable across retries. A creation that ended in
+        ``failed`` can only be retried under a *new* key.
+
+        Passing ``user_data`` switches the VM to self-contained mode: no SSH key
+        is injected or generated, so ``ssh_private_key`` comes back empty and the
+        public key must be embedded in the cloud-init script.
+        """
+        if not idempotency_key:
+            raise ValueError("idempotency_key is required")
+        if len(idempotency_key) > MAX_IDEMPOTENCY_KEY_SIZE:
+            raise ValueError(
+                f"idempotency_key exceeds the {MAX_IDEMPOTENCY_KEY_SIZE} "
+                "characters limit"
+            )
+        body: Dict[str, Any] = {
+            "template_id": template_id,
+            # The image list has been observed to hand back uuids with
+            # surrounding whitespace, which travels through the worker pool's
+            # os_image untouched; strip it rather than posting an unknown image.
+            "image_id": (image_id or "").strip(),
+            "idempotency_key": idempotency_key,
+        }
+        if user_data is not None:
+            if not user_data.startswith("#cloud-config"):
+                raise ValueError("user_data must start with '#cloud-config'")
+            if len(user_data.encode()) > MAX_USER_DATA_SIZE:
+                raise ValueError(
+                    f"user_data exceeds the {MAX_USER_DATA_SIZE} bytes limit"
+                )
+            body["user_data"] = user_data
+        if instance_name:
+            if len(instance_name) > MAX_INSTANCE_NAME_SIZE:
+                raise ValueError(
+                    f"instance_name exceeds the {MAX_INSTANCE_NAME_SIZE} "
+                    "characters limit"
+                )
+            body["instance_name"] = instance_name
+
+        logger.info(
+            f"Creating Shuihua VM with template {template_id} and image {image_id}"
+        )
+        data, _ = await self._request("POST", "/vms", json=body)
+        return VMDetail(**(data or {}))
+
+    async def list_vms(
+        self, page: int = 1, page_size: int = 20
+    ) -> Tuple[List[VMSummary], PaginationMeta]:
+        """List the VMs created by the current API key, one page at a time."""
+        data, meta = await self._request(
+            "GET", "/vms", params={"page": page, "page_size": page_size}
+        )
+        return [VMSummary(**item) for item in data or []], meta or PaginationMeta()
+
+    async def iter_vms(self, page_size: int = 20) -> AsyncIterator[VMSummary]:
+        """Iterate over every VM of the current API key, following pagination."""
+        page = 1
+        while True:
+            items, meta = await self.list_vms(page=page, page_size=page_size)
+            for item in items:
+                yield item
+            # total_pages is optional, so it cannot be the only stop condition:
+            # coercing a missing one to 0 would end the walk after page 1. A
+            # short page means the last one either way.
+            total_pages = meta.total_pages
+            if (
+                not items
+                or len(items) < page_size
+                or (total_pages is not None and page >= total_pages)
+            ):
+                return
+            page += 1
+
+    async def get_vm(self, id: int) -> VMDetail:
+        """Get a VM owned by the current API key.
+
+        VMs created without ``user_data`` also return their SSH private key.
+        """
+        data, _ = await self._request("GET", f"/vms/{id}")
+        return VMDetail(**(data or {}))
+
+    async def start_vm(self, id: int) -> str:
+        """Power on a VM. Returns the server message."""
+        logger.info(f"Starting Shuihua VM {id}")
+        return await self._vm_action(id, "start")
+
+    async def stop_vm(self, id: int) -> str:
+        """Power off a VM. Returns the server message."""
+        logger.info(f"Stopping Shuihua VM {id}")
+        return await self._vm_action(id, "stop")
+
+    async def terminate_vm(self, id: int) -> str:
+        """Destroy a VM, settle billing by the minute and end the lease."""
+        logger.info(f"Terminating Shuihua VM {id}")
+        return await self._vm_action(id, "terminate")
+
+    async def _vm_action(self, id: int, action: str) -> str:
+        data, _ = await self._request("POST", f"/vms/{id}/{action}")
+        return (data or {}).get("message", "")
+
+
+def get_endpoint() -> str:
+    """Base URL of the Shuihua API, from the server's ``shuihua_api_base_url``.
+
+    There is deliberately no default: the integration and production
+    environments live on different hosts, so a built-in guess would point
+    provisioning at the wrong account while looking like it worked. Returns
+    ``""`` when unconfigured, which the cluster and credential routes reject up
+    front.
+    """
+    cfg = get_global_config()
+    base_url = cfg.shuihua_api_base_url if cfg is not None else None
+    return (base_url or "").rstrip("/")
+
+
+class ShuihuaProviderClient(ProviderClientBase):
+    """Adapts :class:`ShuihuaClient` to the cloud provider lifecycle.
+
+    Two API-level differences from a full IaaS provider shape the mapping:
+
+    * There is no SSH key API, so there is nothing to register and
+      ``create_ssh_key`` returns None. The key reaches the instance through
+      ``construct_user_data``, which writes it into the cloud-config as an
+      authorized key — every instance runs in Shuihua's self-contained mode.
+    * There is no block storage API, so volumes are rejected rather than
+      silently dropped.
+
+    ``CloudInstanceCreate.type`` carries the ``template_id`` (a numeric spec
+    template) and ``image`` the ``image_uuid``; ``name`` becomes the instance
+    name and ``labels`` anchor the idempotency key, while ``region`` has no
+    counterpart in the API and is ignored.
+    """
+
+    def __init__(self, api_key: str, base_url: Optional[str] = None):
+        self._api_key = api_key
+        self._base_url = base_url or get_endpoint()
+        if not self._base_url:
+            raise ValueError(
+                "No API base URL configured for the Shuihua provider; start the "
+                "server with --shuihua-api-base-url"
+            )
+
+    @asynccontextmanager
+    async def _api(self) -> AsyncGenerator[ShuihuaClient, None]:
+        """One short-lived HTTP client per call.
+
+        Provider clients are rebuilt on every reconcile, so holding an open
+        connection pool on the instance would leak sockets.
+        """
+        client = ShuihuaClient(api_key=self._api_key, base_url=self._base_url)
+        try:
+            yield client
+        finally:
+            await client.aclose()
+
+    async def create_instance(self, instance: CloudInstanceCreate) -> str:
+        try:
+            template_id = int(instance.type)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"Shuihua instance type must be a numeric template_id, got {instance.type!r}"
+            )
+        if not instance.user_data:
+            raise ValueError("Shuihua requires user_data to bootstrap the worker")
+        async with self._api() as client:
+            vm = await client.create_vm(
+                template_id=template_id,
+                image_id=instance.image,
+                idempotency_key=_idempotency_key(instance),
+                user_data=instance.user_data,
+                instance_name=(instance.name or "")[:MAX_INSTANCE_NAME_SIZE] or None,
+            )
+        if vm.id is None:
+            raise RuntimeError(
+                f"Shuihua returned no VM id when creating instance {instance.name}"
+            )
+        if status_mapping.get(vm.status) in TERMINAL_STATES:
+            # Not a fresh lease: replaying the key of one that already ended
+            # hands that same dead lease back, and only a new key can start
+            # over, so there is nothing here to wait for.
+            raise InstanceProvisioningFailed(
+                f"Shuihua answered the create for {instance.name} with VM "
+                f"{vm.id} already {vm.status.value if vm.status else None}; "
+                "recreate the worker to retry under a new idempotency key"
+            )
+        # Creation is asynchronous, so the lease usually comes back as
+        # 'creating' here; wait_for_started polls it to completion. An
+        # unrecognised status also falls through to that poll rather than
+        # failing outright.
+        return str(vm.id)
+
+    async def delete_instance(self, external_id: str):
+        vm_id = _parse_vm_id(external_id)
+        if vm_id is None:
+            # Nothing to terminate, and raising would block the worker's
+            # deletion on an id that can never resolve to a VM.
+            return
+        async with self._api() as client:
+            try:
+                await client.terminate_vm(vm_id)
+            except ShuihuaAPIError as e:
+                # Only 404. Terminating an already-terminated lease answers 200
+                # ("terminated"), so 400 never means "already gone" — it is any
+                # bad request, plausibly "cannot terminate while creating", and
+                # swallowing it would delete the worker row while a live,
+                # billing VM stays up with nothing pointing at it.
+                if e.status_code == 404:
+                    logger.info(
+                        f"Shuihua VM {external_id} no longer exists, skipping delete: {e}"
+                    )
+                    return
+                raise
+
+    async def get_instance(self, external_id: str) -> Optional[CloudInstance]:
+        vm_id = _parse_vm_id(external_id)
+        if vm_id is None:
+            return None
+        async with self._api() as client:
+            try:
+                vm = await client.get_vm(vm_id)
+            except ShuihuaAPIError as e:
+                if e.status_code == 404:
+                    return None
+                raise
+        return _to_cloud_instance(vm)
+
+    async def wait_for_started(
+        self, external_id: str, backoff: int = 15, limit: int = 20
+    ) -> CloudInstance:
+        for _ in range(limit):
+            instance = await self.get_instance(external_id)
+            if instance and instance.status == InstanceState.RUNNING:
+                return instance
+            _raise_if_terminal(external_id, instance)
+            await asyncio.sleep(backoff)
+        raise TimeoutError(
+            f"Shuihua VM {external_id} did not start within {limit} retries"
+        )
+
+    async def wait_for_public_ip(
+        self, external_id: str, backoff: int = 15, limit: int = 20
+    ) -> CloudInstance:
+        for _ in range(limit):
+            instance = await self.get_instance(external_id)
+            if instance and instance.ip_address:
+                return instance
+            _raise_if_terminal(external_id, instance)
+            await asyncio.sleep(backoff)
+        raise TimeoutError(
+            f"Shuihua VM {external_id} did not acquire an IP within {limit} retries"
+        )
+
+    async def create_ssh_key(self, worker_name: str, public_key: str) -> Optional[str]:
+        """No key API upstream, so there is nothing to register.
+
+        The key reaches the instance through :meth:`construct_user_data`
+        instead, so no external id exists and the caller leaves
+        ``Credential.external_id`` NULL.
+        """
+        return None
+
+    async def delete_ssh_key(self, id: str):
+        """Unreachable: with no external id recorded, teardown skips this."""
+        return
+
+    async def create_volumes_and_attach(
+        self, worker_id: int, external_id: str, region: str, *volumes: Volume
+    ) -> List[str]:
+        if volumes:
+            raise NotImplementedError(
+                "Shuihua has no block storage API; remove the worker pool's volumes"
+            )
+        return []
+
+    async def construct_user_data(
+        self,
+        server_url,
+        token,
+        image_name,
+        os_image,
+        worker_name,
+        secret_configs: Dict[str, Any] = {},
+        ssh_public_key: Optional[str] = None,
+    ) -> UserDataTemplate:
+        user_data = await super().construct_user_data(
+            server_url,
+            token,
+            image_name,
+            os_image,
+            worker_name,
+            secret_configs,
+            ssh_public_key,
+        )
+        # Shuihua only offers GPU images that already carry both the NVIDIA
+        # driver and the container toolkit (checked on a live instance: nvidia-ctk
+        # is on PATH), so setup only has to point Docker at the runtime -- there
+        # is nothing to install. Were the toolkit ever missing, this would fail
+        # quietly: cloud-init keeps going past a failed runcmd, so the worker
+        # would register normally and simply report no GPUs.
+        user_data.distribution = "ubuntu"
+        user_data.setup_driver = ManufacturerEnum.NVIDIA
+        user_data.install_driver = None
+        user_data.insert_runcmd("mkdir -p /var/lib/gpustack")
+        # Passing user_data puts the VM in self-contained mode, where Shuihua
+        # injects no key of its own, so the worker's key has to ride along here.
+        if ssh_public_key:
+            user_data.add_ssh_authorized_keys(ssh_public_key)
+        return user_data
+
+    @classmethod
+    def get_api_endpoint(cls) -> str:
+        return get_endpoint()
+
+    @classmethod
+    def process_header(cls, ak: str, sk: str, options: dict, headers: dict) -> dict:
+        headers["Authorization"] = f"Bearer {sk}"
+        return headers
+
+
+def _parse_vm_id(external_id: str) -> Optional[int]:
+    """The VM id an external_id names, or None when it names none.
+
+    Every id this client hands out is a stringified integer, so a value that
+    isn't one cannot match a VM. Callers treat None as "no such instance"
+    rather than letting a ValueError escape into the provisioning controller,
+    where it would strand the worker over an id that can never resolve.
+    """
+    try:
+        return int(external_id)
+    except (TypeError, ValueError):
+        logger.warning(f"Ignoring malformed Shuihua VM id {external_id!r}")
+        return None
+
+
+def _idempotency_key(instance: CloudInstanceCreate) -> str:
+    """The replay-guard token to send, which Shuihua requires on every create.
+
+    Normally supplied by ``construct_cloud_instance``, which anchors it to the
+    worker row so that it stays put across retries of one attempt and turns
+    over for the next. The fallback only covers a hand-built
+    ``CloudInstanceCreate``: it is stable, but has no notion of attempts, so
+    the same worker can never get a second VM under it.
+    """
+    if instance.idempotency_key:
+        return instance.idempotency_key
+    labels = instance.labels or {}
+    identity = "/".join(str(labels.get(key, "")) for key in ("cluster_id", "worker_id"))
+    digest = hashlib.sha256(f"{identity}/{instance.name}".encode()).hexdigest()
+    return f"gpustack-{digest[:32]}"
+
+
+# Statuses a lease can no longer leave for 'active'. EXPIRED is left out: it is
+# only powered off, and the API does offer a start endpoint, so it is not
+# provably dead.
+TERMINAL_STATES = (InstanceState.FAILED, InstanceState.TERMINATED)
+
+
+def _raise_if_terminal(external_id: str, instance: Optional[CloudInstance]) -> None:
+    """Give up on a lease that can no longer start, instead of polling it.
+
+    Replaying the key of a lease that already ended hands back that same dead
+    lease rather than creating a VM, so without this the wait spins to its
+    timeout and the next reconcile starts the same wait over again.
+    """
+    if instance and instance.status in TERMINAL_STATES:
+        raise InstanceProvisioningFailed(
+            f"Shuihua VM {external_id} is {instance.status.value} and will not "
+            "start; recreate the worker to retry under a new idempotency key"
+        )
+
+
+def _to_cloud_instance(vm: VMDetail) -> CloudInstance:
+    # The instance's own address, deliberately not the public IP of its port
+    # mapping: one public IP fronts every instance in the account, differing
+    # only by port, so it identifies nothing and cannot serve as an advertise
+    # address. Only ports 22 and 80 are mapped anyway — never the worker's own
+    # port — so these workers are reached through the tunnel rather than
+    # inbound, and the private address is what identifies them. Callers that
+    # do need to connect (SSH) get the mapped endpoint below instead.
+    ip_address = vm.ip_address
+    return CloudInstance(
+        external_id=str(vm.id),
+        name=vm.instance_name or "",
+        image="",
+        type=str(vm.template_id) if vm.template_id is not None else "",
+        region="",
+        # SSH is only reachable through the mapping, on the shared public IP at
+        # an instance-specific port — port 22 of ip_address answers nothing.
+        ssh_endpoint=vm.public_endpoint(DEFAULT_SSH_PORT),
+        ssh_user=vm.ssh_user or None,
+        ssh_key_id=None,
+        volume_ids=[],
+        user_data=None,
+        status=status_mapping.get(vm.status, InstanceState.UNKNOWN),
+        ip_address=ip_address,
+    )

--- a/gpustack/cloud_providers/user_data.py
+++ b/gpustack/cloud_providers/user_data.py
@@ -124,13 +124,35 @@ class UserDataTemplate:
         for idx, command in enumerate(commands):
             command_list.insert(idx, command)
 
+    def add_ssh_authorized_keys(self, *public_keys: Optional[str]):
+        """
+        Trust the given public keys on first boot via cloud-init's
+        ``ssh_authorized_keys``.
+
+        Only for providers whose API has no way to attach a key to the
+        instance; the ones that do (DigitalOcean's ``ssh_keys``) let the API
+        inject it and never call this. The list is created on first key, so a
+        provider that doesn't call this renders exactly the same document as
+        before.
+        """
+        keys: List[str] = self._data.setdefault('ssh_authorized_keys', [])
+        for public_key in public_keys:
+            public_key = (public_key or "").strip()
+            if public_key and public_key not in keys:
+                keys.append(public_key)
+        if not keys:
+            # Don't leave an empty key behind for a caller that passed nothing.
+            self._data.pop('ssh_authorized_keys')
+
     def _process_install_driver(self) -> bool:
         """
         process_install_driver handles the installation of the GPU drivers.
         Returns True if a reboot is required after installation.
         """
+        # Refresh the apt lists either way — the packages below are installed on
+        # first boot and a stale cache makes that fail — but stop short of
+        # upgrading.
         self._data['package_update'] = True
-        self._data['package_upgrade'] = True
         packages: List[str] = self._data.get('packages')
         write_files: List[Dict[str, Any]] = self._data.get('write_files')
         # only supports nvidia and debian/ubuntu for now
@@ -139,6 +161,14 @@ class UserDataTemplate:
             "ubuntu",
         ]:
             return False
+        # A full upgrade only pays for itself when a driver is about to be
+        # built: linux-headers-generic tracks the newest kernel in the repo, so
+        # the running kernel is brought up to match it before DKMS compiles
+        # against it, and this path reboots into that kernel anyway. On an image
+        # that already ships a driver it would just cost minutes of boot time —
+        # and risk pulling in a kernel the prebuilt driver has no DKMS setup to
+        # rebuild for.
+        self._data['package_upgrade'] = True
         driver_name = debian_driver_map.get(self.distribution, "nvidia-driver-570")
         nvidia_toolkit_version = "1.17.8-1"
         packages.extend(

--- a/gpustack/cmd/start.py
+++ b/gpustack/cmd/start.py
@@ -302,6 +302,12 @@ def start_cmd_options(parser_server: argparse.ArgumentParser):
         help=argparse.SUPPRESS,
         default=get_gpustack_env("GATEWAY_INGRESS_CLASS"),
     )
+    server_group.add_argument(
+        "--shuihua-api-base-url",
+        type=str,
+        help=argparse.SUPPRESS,
+        default=get_gpustack_env("SHUIHUA_API_BASE_URL"),
+    )
 
     # Observability settings
     server_group.add_argument(
@@ -879,6 +885,7 @@ def set_server_options(args, config_data: dict):
         "gateway_concurrency",
         "gateway_plugin_server_url",
         "gateway_ingress_class",
+        "shuihua_api_base_url",
         "disable_builtin_observability",
         "builtin_prometheus_port",
         "builtin_grafana_port",

--- a/gpustack/config/config.py
+++ b/gpustack/config/config.py
@@ -174,6 +174,8 @@ class Config(WorkerConfig, BaseSettings):
         grafana_model_dashboard_uid: Grafana dashboard UID for model dashboard.
         grafana_cache_service_dashboard_uid: Grafana dashboard UID for cache service dashboard.
         gateway_plugin_server_url: URL to fetch gateway plugin manifest for embedded gateway.
+        shuihua_api_base_url: Base URL of the Shuihua API. Has no default; Shuihua clusters
+                            and credentials cannot be created until it is set.
     """
 
     # Server options
@@ -295,6 +297,14 @@ class Config(WorkerConfig, BaseSettings):
     # ``ai-statistics`` vs ``gpustack-ai-statistics``, ...). See
     # ``gpustack.gateway.plugins.plugin_spec_overrides``.
     gateway_plugin: Dict[str, GatewayPluginEntry] = {}
+
+    # Base URL of the Shuihua API. Deliberately no default: that provider serves
+    # its integration and production environments from different hosts, so a
+    # built-in guess would point provisioning at the wrong account while looking
+    # like it worked. Creating a Shuihua cluster or credential is rejected until
+    # this is set.
+    shuihua_api_base_url: Optional[str] = None
+
     disable_builtin_observability: bool = False
     builtin_prometheus_port: int = 19090
     builtin_grafana_port: int = 13000

--- a/gpustack/migrations/versions/2026_08_19_1600-b7e2c4d15a80_add_shuihua_cluster_provider.py
+++ b/gpustack/migrations/versions/2026_08_19_1600-b7e2c4d15a80_add_shuihua_cluster_provider.py
@@ -1,0 +1,107 @@
+"""add Shuihua cluster provider
+
+Adds the ``Shuihua`` value to the ``clusterprovider`` enum so cloud credentials,
+clusters and workers can be created against the Shuihua open API.
+
+Revision ID: b7e2c4d15a80
+Revises: d5e8f0a1b2c3
+Create Date: 2026-08-19 16:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+import gpustack.utils.sql_enum as sql_enum
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7e2c4d15a80'
+down_revision: Union[str, None] = 'd5e8f0a1b2c3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+cluster_provider_enum = sa.Enum(
+    'Docker',
+    'Kubernetes',
+    'DigitalOcean',
+    name='clusterprovider',
+)
+
+cluster_provider_to_add = ['Shuihua']
+
+# Every table carrying the enum. PostgreSQL alters the shared type once and
+# ignores this; MySQL inlines the enum per column, so each one is rewritten.
+cluster_provider_table_columns = {
+    'cloud_credentials': 'provider',
+    'clusters': 'provider',
+    'workers': 'provider',
+}
+
+
+def upgrade() -> None:
+    sql_enum.add_enum_values(
+        cluster_provider_table_columns,
+        cluster_provider_enum,
+        *cluster_provider_to_add,
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Move the data off Shuihua first. This is the load-bearing half: the older
+    # code's ClusterProvider has no Shuihua member, so any row still carrying it
+    # raises LookupError on load, while an unused label left in the DB type
+    # would be harmless. Relabelling to Docker is what
+    # sql_enum.remove_enum_values does for the single-column case.
+    #
+    # The cloud instances behind these workers are NOT reclaimed: a migration
+    # cannot call the Shuihua API, so the VMs leak either way. Relabelling keeps
+    # the rows (and their external_id) around so they can still be found.
+    conn.execute(
+        sa.text(
+            "UPDATE clusters SET provider = 'Docker', credential_id = NULL "
+            "WHERE provider = 'Shuihua'"
+        )
+    )
+    conn.execute(
+        sa.text("UPDATE workers SET provider = 'Docker' WHERE provider = 'Shuihua'")
+    )
+    # A cloud credential has no meaning under Docker — routes/cloud_credentials
+    # rejects that provider outright — so these are deleted rather than
+    # relabelled. The UPDATE above cleared clusters.credential_id, the only FK
+    # pointing at them.
+    conn.execute(sa.text("DELETE FROM cloud_credentials WHERE provider = 'Shuihua'"))
+
+    # Then narrow the enum, so that re-running upgrade() afterwards still
+    # works: add_enum_values issues a bare ADD VALUE on PostgreSQL, which
+    # errors if the label is already there.
+    if conn.dialect.name == 'postgresql':
+        # Recreate the type and convert all three columns in one pass, rather
+        # than sql_enum.remove_enum_values: that recreates per (table, column),
+        # so its first DROP TYPE would fail while the other two columns still
+        # reference clusterprovider. Same shape as
+        # _consolidate_access_policy_enum in the multi-tenancy migration, minus
+        # the DROP/SET DEFAULT dance — these columns were created with a
+        # Python-side default only, so there is no server DEFAULT to restore.
+        conn.execute(
+            sa.text(
+                "CREATE TYPE clusterprovidertmp AS ENUM "
+                "('Docker', 'Kubernetes', 'DigitalOcean')"
+            )
+        )
+        for table, column in cluster_provider_table_columns.items():
+            conn.execute(
+                sa.text(
+                    f"ALTER TABLE {table} ALTER COLUMN {column} TYPE "
+                    f"clusterprovidertmp USING {column}::text::clusterprovidertmp"
+                )
+            )
+        conn.execute(sa.text("DROP TYPE clusterprovider"))
+        conn.execute(sa.text("ALTER TYPE clusterprovidertmp RENAME TO clusterprovider"))
+    elif conn.dialect.name == 'mysql':
+        for table, column in cluster_provider_table_columns.items():
+            sql_enum.modify_mysql_table_column_enum(
+                conn, table, column, [], cluster_provider_to_add
+            )

--- a/gpustack/routes/cloud_credentials.py
+++ b/gpustack/routes/cloud_credentials.py
@@ -26,11 +26,31 @@ from gpustack.schemas.clusters import (
     CloudCredential,
     ClusterProvider,
 )
-from gpustack.cloud_providers.common import factory
+from gpustack.cloud_providers.common import factory, get_provider_api_endpoint
 from gpustack.routes.proxy import proxy_to
 from gpustack.schemas.principals import platform_principal_id
 
 router = APIRouter()
+
+
+def check_provider_api_endpoint(provider: ClusterProvider):
+    """
+    Reject a credential for a provider the server cannot reach.
+
+    A provider whose API has no well-known host takes its base URL from
+    a server start-up option; without it the credential could neither be
+    proxied nor used to provision, so saying so at create time beats storing a
+    secret that cannot be used. Docker and Kubernetes have no cloud API at all.
+    """
+    if provider in [ClusterProvider.Docker, ClusterProvider.Kubernetes]:
+        return
+    if not get_provider_api_endpoint(provider):
+        raise BadRequestException(
+            message=(
+                f"No API base URL is configured for provider {provider.value}. "
+                "Start the server with the provider's API base URL configured."
+            )
+        )
 
 
 @router.get("", response_model=CloudCredentialsPublic)
@@ -104,6 +124,7 @@ async def create(
         raise AlreadyExistsException(
             message=f"Cloud credential with name '{input.name}' already exists."
         )
+    check_provider_api_endpoint(input.provider)
 
     try:
         return await CloudCredential.create(session, input)
@@ -124,6 +145,8 @@ async def update(
     if not existing or existing.deleted_at is not None:
         raise NotFoundException(message=f"cloud credential {id} not found")
     assert_org_owned_writable(ctx, existing, resource_label="cloud credential")
+    if "provider" in input.model_fields_set:
+        check_provider_api_endpoint(input.provider)
 
     try:
         await CloudCredential.update(existing, session=session, source=input)
@@ -175,6 +198,16 @@ async def proxy_cluster_provider_api(
     if provider is None:
         raise NotFoundException(message=f"Provider {credential.provider} not found")
     endpoint = provider[0].get_api_endpoint()
+    if not endpoint:
+        # Without a base URL there is no host to join the path onto; failing
+        # here beats sending the credential's secret to a malformed URL.
+        raise BadRequestException(
+            message=(
+                f"No API base URL is configured for provider "
+                f"{credential.provider.value}. Start the server with "
+                "the provider's API base URL configured."
+            )
+        )
     # The request carries the credential's auth header, so it must stay on
     # the provider host. Require a strictly relative path first: an
     # absolute, scheme-relative, or backslash-bearing path can be parsed

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -24,7 +24,11 @@ from gpustack.api.exceptions import (
 from gpustack.api.responses import StreamingResponseWithStatusCode
 from gpustack.schemas import Principal
 from gpustack.schemas.common import PaginatedList, Pagination
-from gpustack.schemas.config import parse_base_model_to_env_vars
+from gpustack.schemas.config import (
+    ModelInstanceProxyModeEnum,
+    PredefinedConfigNoDefaults,
+    parse_base_model_to_env_vars,
+)
 from gpustack.api.tenant import (
     TenantContext,
     bypass_tenant_filter,
@@ -78,6 +82,7 @@ from gpustack.gpu_instances.cluster_apis_util import (
     get_namespace_name,
 )
 from gpustack.k8s.manifest_template import TemplateConfig
+from gpustack.cloud_providers.common import get_provider_api_endpoint
 from gpustack.config.config import (
     get_global_config,
     get_cluster_image_name,
@@ -328,8 +333,154 @@ async def get_cluster(session: SessionDep, ctx: TenantContextDep, id: int):
     return cluster
 
 
+DOCKER_HUB_REGISTRY_HOSTS = {
+    "docker.io",
+    "index.docker.io",
+    "registry-1.docker.io",
+    "registry.hub.docker.com",
+}
+
+
+def image_ref_registry(image_ref: str) -> Optional[str]:
+    """
+    The registry host of an image reference, or None when it is implicit.
+
+    An implicit registry means Docker Hub: ``gpustack/gpustack:v1`` carries no
+    host, while ``my-registry.cn/gpustack:v1`` does. A first segment holding a
+    dot, a port, or the literal ``localhost`` is a host.
+    """
+    if "/" not in image_ref:
+        # A bare name like "gpustack:v1" has no host at all. Splitting anyway
+        # would hand back "gpustack:v1", whose tag colon reads as a port and
+        # would pass for a registry.
+        return None
+    first = image_ref.split("/")[0]
+    if "." in first or ":" in first or first == "localhost":
+        return first
+    return None
+
+
+def is_docker_hub_registry(registry: str) -> bool:
+    return registry.split("/")[0].lower() in DOCKER_HUB_REGISTRY_HOSTS
+
+
+def apply_shuihua_defaults(
+    input: Union[ClusterCreate, ClusterUpdate], existing: Optional[Cluster] = None
+):
+    """
+    Default the Shuihua settings the caller left empty.
+
+    ``proxy_mode`` defaults to tunnel because a Shuihua instance normally sits
+    behind NAT with server-assigned port mappings, and nothing in the create
+    API lets us request a mapping for the worker's own port — so the gateway
+    cannot reach it directly. It is a default rather than a requirement: an
+    operator running the server inside a network with direct routing to the
+    instances can legitimately choose WORKER or DIRECT, and only they know
+    that. Whatever the caller sets explicitly is left alone.
+
+    On update a missing ``worker_config`` is left alone: ``Cluster.update``
+    applies ``model_fields_set``, and assigning here would add
+    ``worker_config`` to that set, overwriting the cluster's stored config with
+    this bare default. When the caller does send one, the value already stored
+    wins over the tunnel default -- sending worker_config replaces it wholesale,
+    so defaulting blindly would silently flip a cluster the operator had put on
+    WORKER or DIRECT.
+    """
+    stored = existing.worker_config if existing is not None else None
+    fallback = (
+        stored.proxy_mode
+        if stored is not None and stored.proxy_mode is not None
+        else ModelInstanceProxyModeEnum.TUNNEL
+    )
+    if input.worker_config is None:
+        if not isinstance(input, ClusterCreate):
+            return
+        input.worker_config = PredefinedConfigNoDefaults(proxy_mode=fallback)
+        return
+    if input.worker_config.proxy_mode is None:
+        input.worker_config.proxy_mode = fallback
+
+
+def check_shuihua_requirements(
+    input: Union[ClusterCreate, ClusterUpdate], existing: Optional[Cluster] = None
+):
+    """
+    Require a registry the Shuihua instances can actually pull from.
+
+    ``determine_default_registry`` probes Docker Hub *from the server*, so a
+    reachable server yields no registry prefix and the instance is told to pull
+    ``gpustack/gpustack`` straight from Docker Hub. The cluster may inherit the
+    registry from the server-level setting instead of carrying its own.
+
+    On update only the parts the caller actually sends are checked: Cluster
+    updates apply ``model_fields_set`` alone, so demanding these fields on
+    every PUT would block unrelated edits such as a rename.
+    """
+    is_create = isinstance(input, ClusterCreate)
+    worker_config = input.worker_config
+    sends_worker_config = "worker_config" in input.model_fields_set
+    sends_registry = "system_default_container_registry" in input.model_fields_set
+
+    if not (is_create or sends_worker_config or sends_registry):
+        return
+
+    # A full image override wins over the registry column in
+    # get_cluster_image_name, so validate whichever one actually decides where
+    # the instance pulls from.
+    override = worker_config.image_name_override if worker_config else None
+    if override:
+        registry = image_ref_registry(override)
+        source = f"worker_config.image_name_override '{override}'"
+        missing_message = (
+            f"{source} carries no registry host, so it resolves to Docker Hub, "
+            f"which {ClusterProvider.Shuihua.value} instances cannot reach."
+        )
+    else:
+        # Mirror get_cluster_image_name's resolution order, which falls back to
+        # the server-level setting — rejecting a cluster that would in fact
+        # pull from a reachable registry would be a false alarm.
+        # Mirrors get_cluster_image_name, plus the value already on the
+        # cluster: a partial PUT need not resend it, and Cluster.update keeps
+        # what it doesn't touch, so ignoring the stored one would reject an
+        # update to a cluster that is in fact configured.
+        registry = (
+            input.system_default_container_registry
+            or (
+                worker_config.system_default_container_registry
+                if worker_config
+                else None
+            )
+            or (
+                existing.system_default_container_registry
+                if existing is not None
+                else None
+            )
+            or get_global_config().system_default_container_registry
+        )
+        source = "system_default_container_registry"
+        missing_message = (
+            f"{source} is required for provider {ClusterProvider.Shuihua.value}: "
+            "its instances cannot reach Docker Hub, so the registry to pull the "
+            "worker image from has to be set on the cluster or as the server's "
+            "default."
+        )
+
+    if not registry:
+        raise InvalidException(message=missing_message)
+    if is_docker_hub_registry(registry):
+        raise InvalidException(
+            message=(
+                f"{source} points at Docker Hub ('{registry}'), which "
+                f"{ClusterProvider.Shuihua.value} instances cannot reach. Use a "
+                "mirror or a private registry."
+            )
+        )
+
+
 def create_update_check(
-    provider: ClusterProvider, input: Union[ClusterCreate, ClusterUpdate]
+    provider: ClusterProvider,
+    input: Union[ClusterCreate, ClusterUpdate],
+    existing: Optional[Cluster] = None,
 ):
     cfg = get_global_config()
     is_cloud_provider = provider not in [
@@ -349,6 +500,16 @@ def create_update_check(
         raise InvalidException(
             message=f"server_url is required for provider {provider}"
         )
+    if is_cloud_provider and not get_provider_api_endpoint(provider):
+        raise InvalidException(
+            message=(
+                f"No API base URL is configured for provider {provider.value}. "
+                "Start the server with the provider's API base URL configured."
+            )
+        )
+    if provider == ClusterProvider.Shuihua:
+        apply_shuihua_defaults(input, existing)
+        check_shuihua_requirements(input, existing)
     if provider == ClusterProvider.Kubernetes:
         # check for volume mounts (now nested under k8s_options)
         volume_mounts = (
@@ -579,7 +740,7 @@ async def update_cluster(
         raise NotFoundException(message=f"cluster {id} not found")
     assert_cluster_writable(ctx, cluster)
 
-    create_update_check(cluster.provider, input)
+    create_update_check(cluster.provider, input, existing=cluster)
     if cluster.provider == ClusterProvider.Kubernetes:
         enforce_data_dir_mounts(input)
         await check_cluster_purpose_switch(session, cluster, input)

--- a/gpustack/routes/workers.py
+++ b/gpustack/routes/workers.py
@@ -56,7 +56,12 @@ from gpustack.server.worker_allocated_cache import (
     get_worker_allocated,
     vram_allocated_for_index,
 )
-from gpustack.schemas.clusters import Cluster, Credential, ClusterStateEnum
+from gpustack.schemas.clusters import (
+    Cluster,
+    ClusterProvider,
+    Credential,
+    ClusterStateEnum,
+)
 from gpustack.schemas.principals import Principal, PrincipalType
 from gpustack.schemas.api_keys import ApiKey
 from gpustack.schemas.config import (
@@ -323,6 +328,24 @@ def update_worker_data(
             and existing.maintenance is not None
         ):
             incoming_data["maintenance"] = existing.maintenance
+
+        # A worker reports external_id by reading $data_dir/external_id, which
+        # its cloud-init writes from the instance metadata service. Shuihua has
+        # no such service, so its workers always report None and this full-dump
+        # merge would erase the id provisioning recorded — after which deleting
+        # the worker takes the hard-delete path, never tells the provider, and
+        # leaks the instance.
+        #
+        # Scoped to this one provider deliberately: everywhere else the
+        # reported value stays authoritative, which is what stops a worker
+        # booted from a cloned OS image from inheriting another worker's
+        # identity.
+        if (
+            cluster is not None
+            and cluster.provider == ClusterProvider.Shuihua
+            and incoming_data.get("external_id") is None
+        ):
+            incoming_data["external_id"] = existing.external_id
 
         to_create_worker = Worker.model_validate(
             {

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -458,6 +458,7 @@ class ClusterProvider(Enum):
     Docker = "Docker"
     Kubernetes = "Kubernetes"
     DigitalOcean = "DigitalOcean"
+    Shuihua = "Shuihua"
 
 
 class CloudCredentialBase(SQLModel):

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -141,6 +141,7 @@ from gpustack.cloud_providers.common import (
 from gpustack.cloud_providers.abstract import (
     ProviderClientBase,
     CloudInstance,
+    InstanceProvisioningFailed,
     InstanceState,
 )
 from kubernetes_asyncio import client as k8s_client
@@ -2893,6 +2894,32 @@ class WorkerPoolController:
             )
 
 
+def _record_ssh_endpoint(
+    provider_config: Dict[str, Any], instance: Optional[CloudInstance]
+) -> bool:
+    """Note where SSH answers, when the provider doesn't serve it on the
+    instance's own address. Returns whether anything was written.
+
+    Only providers that publish instances behind a mapped address report one;
+    for the rest ``advertise_address:22`` is the answer and nothing is stored.
+    Already-recorded endpoints are left alone so a later poll that happens to
+    come back without the mapping can't erase it.
+    """
+    if instance is None or not instance.ssh_endpoint:
+        return False
+    if "ssh_endpoint" in provider_config:
+        return False
+    host, port = instance.ssh_endpoint
+    ssh_endpoint: Dict[str, Any] = {"host": host, "port": port}
+    # Omit an unknown user rather than storing "": the provider only fills it
+    # in once the instance is up, and a consumer shouldn't have to tell an
+    # empty string apart from an absent key.
+    if instance.ssh_user:
+        ssh_endpoint["user"] = instance.ssh_user
+    provider_config["ssh_endpoint"] = ssh_endpoint
+    return True
+
+
 class WorkerProvisioningController:
     def __init__(self, cfg: Config):
         self._cfg = cfg
@@ -2921,7 +2948,10 @@ class WorkerProvisioningController:
             ),
         )
         ssh_key_id = await client.create_ssh_key(worker.name, public_key)
-        ssh_key.external_id = str(ssh_key_id)
+        # None means the provider registered nothing (no SSH key API); leave
+        # external_id NULL rather than storing the string "None", so teardown
+        # knows there is no upstream key to delete.
+        ssh_key.external_id = str(ssh_key_id) if ssh_key_id is not None else None
         ssh_key_rtn = await Credential.create(session, ssh_key, auto_commit=False)
         return ssh_key_rtn.id
 
@@ -2939,6 +2969,9 @@ class WorkerProvisioningController:
             if worker.cluster.worker_config
             else {}
         )
+        ssh_key = await Credential.one_by_id(session, worker.ssh_key_id)
+        if ssh_key is None:
+            raise ValueError(f"SSH key {worker.ssh_key_id} not found")
         user_data = await client.construct_user_data(
             server_url=worker.cluster.server_url or cfg.server_external_url,
             token=worker.cluster.registration_token,
@@ -2949,10 +2982,10 @@ class WorkerProvisioningController:
             os_image=worker.worker_pool.os_image,
             secret_configs=secret_configs,
             worker_name=worker.name,
+            # Providers with no SSH key API embed this in the cloud-config;
+            # the ones that have one attach it by id instead and ignore it.
+            ssh_public_key=ssh_key.public_key,
         )
-        ssh_key = await Credential.one_by_id(session, worker.ssh_key_id)
-        if ssh_key is None:
-            raise ValueError(f"SSH key {worker.ssh_key_id} not found")
         to_create = construct_cloud_instance(worker, ssh_key, user_data.format())
         logger.info(f"Creating cloud instance for worker {worker.name}")
         logger.debug(f"Cloud instance configuration: {to_create}")
@@ -2967,11 +3000,23 @@ class WorkerProvisioningController:
         instance: CloudInstance,
     ) -> bool:
         changed = True
-        provider_config = worker.provider_config or {}
+        # Copy rather than alias: provider_config is a plain JSON column, so
+        # SQLAlchemy only notices a write when the attribute is set to a
+        # different object. Mutating the loaded dict in place and assigning it
+        # back would leave the change unsaved.
+        provider_config = dict(worker.provider_config or {})
         volumes = list(
             (getattr(worker.worker_pool.cloud_options, "volumes", None) or [])
         )
         volume_ids = provider_config.get("volume_ids", [])
+        # Backfill a mapping that wasn't published yet the first time round.
+        # wait_for_public_ip returns as soon as an address appears, which for a
+        # provider that maps SSH elsewhere can be before the mapping exists —
+        # and the branch below only runs while advertise_address is still
+        # empty, so without this the hint would stay missing for good.
+        backfilled = _record_ssh_endpoint(provider_config, instance)
+        if backfilled:
+            worker.provider_config = provider_config
         if worker.advertise_address is None or worker.advertise_address == "":
             try:
                 instance = await client.wait_for_public_ip(worker.external_id)
@@ -2979,6 +3024,13 @@ class WorkerProvisioningController:
                     instance.ip_address if instance.ip_address else ""
                 )
                 worker.state_message = "Waiting for volumes to attach"
+                # Last in the branch on purpose: this is a display aid, and
+                # failing to read it must not hold back the state machine.
+                if _record_ssh_endpoint(provider_config, instance):
+                    worker.provider_config = provider_config
+            except InstanceProvisioningFailed:
+                # Terminal on the provider side; see _provisioning_before_started.
+                raise
             except Exception as e:
                 logger.warning(
                     f"Failed to wait for instance {worker.external_id} to get public ip: {e}"
@@ -2993,7 +3045,11 @@ class WorkerProvisioningController:
             len(volumes) == len(volume_ids)
             and worker.state == WorkerStateEnum.PROVISIONING
         ):
-            if not hasattr(provider_config, "volume_ids"):
+            # Membership, not hasattr: provider_config is a dict, so hasattr
+            # was always False and this overwrote the ids of volumes that had
+            # just been created -- losing the only record of them, so teardown
+            # could never find the volumes to delete.
+            if "volume_ids" not in provider_config:
                 provider_config["volume_ids"] = []
             worker.provider_config = provider_config
             worker.state = WorkerStateEnum.INITIALIZING
@@ -3002,7 +3058,7 @@ class WorkerProvisioningController:
                 await worker.cluster.update(session=session, auto_commit=False)
             worker.state_message = "Initializing: installing required drivers and software. The worker will start automatically after setup."
         else:
-            changed = False
+            changed = backfilled
         return changed
 
     @classmethod
@@ -3040,6 +3096,11 @@ class WorkerProvisioningController:
                 # depress the timeout exception
                 instance = await client.wait_for_started(worker.external_id)
                 worker.state_message = "Waiting for instance's public ip"
+            except InstanceProvisioningFailed:
+                # The provider gave up on the instance, so polling it again on
+                # the next reconcile would spin forever. Let it through to the
+                # caller, which parks the worker in ERROR.
+                raise
             except Exception as e:
                 logger.warning(
                     f"Failed to wait for instance {worker.external_id} to start: {e}"

--- a/gpustack/utils/sql_enum.py
+++ b/gpustack/utils/sql_enum.py
@@ -45,17 +45,21 @@ def modify_mysql_table_column_enum(
     to_add_values: List[str],
     to_remove_values: List[str],
 ):
-    result = conn.execute(
+    definition = conn.execute(
         sa.text(
             f"""
-            SELECT COLUMN_TYPE
+            SELECT COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT
             FROM information_schema.COLUMNS
             WHERE TABLE_NAME = '{table_name}'
             AND COLUMN_NAME = '{column_name}'
             AND TABLE_SCHEMA = DATABASE()
         """
         )
-    ).scalar()
+    ).first()
+    if definition is None:
+        # No such table/column in this database; nothing to rewrite.
+        return
+    result, is_nullable, default = definition
 
     existing_values = []
     if result:
@@ -67,9 +71,16 @@ def modify_mysql_table_column_enum(
     if set(new_values) != set(existing_values):
         new_enum_str = "enum('" + "','".join(new_values) + "')"
 
+        # MODIFY COLUMN restates the column in full, so NOT NULL and DEFAULT
+        # have to be carried over explicitly or MySQL silently drops them.
+        constraints = "" if is_nullable == 'YES' else " NOT NULL"
+        if default is not None:
+            constraints += f" DEFAULT '{default}'"
+
         # Construct new ALTER TABLE statement
         alter_sql = (
-            f"ALTER TABLE {table_name} MODIFY COLUMN {column_name} {new_enum_str};"
+            f"ALTER TABLE {table_name} MODIFY COLUMN {column_name} "
+            f"{new_enum_str}{constraints};"
         )
 
         # Execute modification

--- a/tests/cloud_providers/test_shuihua.py
+++ b/tests/cloud_providers/test_shuihua.py
@@ -1,0 +1,531 @@
+"""Offline tests for the Shuihua provider.
+
+Nothing here touches the network: the pure helpers take plain inputs, and the
+few cases that must exercise a request path inject an ``httpx.MockTransport``,
+which answers in-process. Response bodies are the shapes the live API was
+observed to return.
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from gpustack.cloud_providers.abstract import (
+    CloudInstanceCreate,
+    InstanceProvisioningFailed,
+    InstanceState,
+)
+from gpustack.cloud_providers.common import creation_idempotency_key
+from gpustack.cloud_providers.shuihua import (
+    MAX_IDEMPOTENCY_KEY_SIZE,
+    MAX_INSTANCE_NAME_SIZE,
+    MAX_USER_DATA_SIZE,
+    PENDING_STATUSES,
+    TERMINAL_STATES,
+    ShuihuaAPIError,
+    ShuihuaClient,
+    ShuihuaProviderClient,
+    VMDetail,
+    VMStatus,
+    _idempotency_key,
+    _parse_vm_id,
+    _raise_if_terminal,
+    _to_cloud_instance,
+    status_mapping,
+)
+
+# The body GET /vms/{id} returned for an active instance created with
+# user_data, mapping only SSH and HTTP.
+ACTIVE_VM = {
+    "id": 33,
+    "template_id": 1,
+    "template_name": "RTX4090-16C60G",
+    "instance_id": "49a1d649-9053-4fca-a746-1cb7ce348701",
+    "instance_name": "pool-3-abc",
+    "ip_address": "172.16.46.22",
+    "port_mappings": [
+        {"public_ip": "125.67.215.17", "public_port": 33004, "internal_port": 22},
+        {"public_ip": "125.67.215.17", "public_port": 33005, "internal_port": 80},
+    ],
+    "status": "active",
+    "ssh_user": "ubuntu",
+    "ssh_private_key": "",
+}
+
+
+def transport(handler):
+    """A client whose requests are answered in-process."""
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def responder(status, body, capture=None):
+    def handle(request):
+        if capture is not None:
+            capture["body"] = json.loads(request.content) if request.content else None
+            capture["url"] = str(request.url)
+        return httpx.Response(status, json=body)
+
+    return handle
+
+
+def provider(handler):
+    """A provider client wired to an in-process transport."""
+    client = ShuihuaClient(
+        api_key="k", base_url="https://api.test", client=transport(handler)
+    )
+    p = ShuihuaProviderClient(api_key="k", base_url="https://api.test")
+    p._api = lambda: _as_ctx(client)
+    return p
+
+
+class _as_ctx:
+    def __init__(self, client):
+        self._client = client
+
+    async def __aenter__(self):
+        return self._client
+
+    async def __aexit__(self, *_):
+        return False
+
+
+# --------------------------------------------------------------------------
+# instance mapping
+# --------------------------------------------------------------------------
+
+
+def test_to_cloud_instance_advertises_the_private_address():
+    """One public IP fronts every instance, so it cannot identify one.
+
+    Only ports 22 and 80 are mapped and never the worker's own, so nothing
+    reaches these workers inbound anyway; the per-instance private address is
+    what distinguishes them.
+    """
+    instance = _to_cloud_instance(VMDetail(**ACTIVE_VM))
+
+    assert instance.ip_address == "172.16.46.22"
+    assert instance.ssh_endpoint == ("125.67.215.17", 33004)
+    assert instance.ssh_user == "ubuntu"
+    assert instance.status == InstanceState.RUNNING
+    assert instance.external_id == "33"
+
+
+def test_to_cloud_instance_without_a_mapping():
+    """An instance the API reports no mapping for yields no SSH endpoint."""
+    vm = VMDetail(
+        **{
+            "id": 29,
+            "ip_address": "172.16.46.11",
+            "internal_port": 22,
+            "status": "active",
+        }
+    )
+    instance = _to_cloud_instance(vm)
+
+    assert instance.ip_address == "172.16.46.11"
+    assert instance.ssh_endpoint is None
+    assert instance.ssh_user is None
+
+
+def test_public_endpoint_resolves_only_mapped_ports():
+    vm = VMDetail(**ACTIVE_VM)
+
+    assert vm.public_endpoint(22) == ("125.67.215.17", 33004)
+    assert vm.public_endpoint(80) == ("125.67.215.17", 33005)
+    # The worker's own port is never mapped, which is why these clusters can
+    # only be reached through the tunnel.
+    assert vm.public_endpoint(10150) is None
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        ("creating", InstanceState.CREATED),
+        ("processing", InstanceState.CREATED),
+        ("active", InstanceState.RUNNING),
+        ("failed", InstanceState.FAILED),
+        ("expired", InstanceState.STOPPED),
+        ("terminated", InstanceState.TERMINATED),
+    ],
+)
+def test_status_mapping_is_total(status, expected):
+    assert status_mapping[VMStatus(status)] is expected
+
+
+def test_pending_and_terminal_sets_do_not_overlap():
+    pending = {status_mapping[s] for s in PENDING_STATUSES}
+    assert not pending & set(TERMINAL_STATES)
+
+
+def test_unknown_status_degrades_instead_of_failing_the_parse():
+    """The status set grew by three values between API 1.3.0 and 1.4.0.
+
+    A strict enum would turn the next addition into a hard error for the whole
+    list_vms page the value appears on, taking every worker on the credential
+    with it.
+    """
+    vm = VMDetail(**{"id": 1, "status": "some-new-status"})
+
+    assert vm.status is None
+    assert _to_cloud_instance(vm).status is InstanceState.UNKNOWN
+
+
+# --------------------------------------------------------------------------
+# terminal-lease guards
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["failed", "terminated"])
+def test_raise_if_terminal_gives_up_on_a_dead_lease(status):
+    """Replaying a spent key returns the dead lease, so waiting is futile."""
+    instance = _to_cloud_instance(VMDetail(**{"id": 7, "status": status}))
+
+    with pytest.raises(InstanceProvisioningFailed):
+        _raise_if_terminal("7", instance)
+
+
+@pytest.mark.parametrize("status", ["creating", "processing", "active", "expired"])
+def test_raise_if_terminal_keeps_waiting_otherwise(status):
+    # expired is only powered off and the API offers a start endpoint, so it is
+    # not provably dead.
+    instance = _to_cloud_instance(VMDetail(**{"id": 7, "status": status}))
+
+    _raise_if_terminal("7", instance)
+
+
+def test_raise_if_terminal_tolerates_a_missing_instance():
+    _raise_if_terminal("7", None)
+
+
+@pytest.mark.parametrize("value", ["", "abc", "12x", None])
+def test_parse_vm_id_rejects_what_cannot_name_a_vm(value):
+    """Every id handed out is a stringified int, so anything else matches none.
+
+    Returning None keeps a ValueError from escaping into the provisioning
+    controller, where it would strand the worker on an id that can never
+    resolve.
+    """
+    assert _parse_vm_id(value) is None
+
+
+def test_parse_vm_id_accepts_an_integer_string():
+    assert _parse_vm_id("33") == 33
+
+
+# --------------------------------------------------------------------------
+# idempotency key
+# --------------------------------------------------------------------------
+
+
+def _worker(updated_at, worker_id=42, name="pool-3-abc", cluster_id=3):
+    worker = MagicMock()
+    worker.id = worker_id
+    worker.name = name
+    worker.cluster_id = cluster_id
+    worker.updated_at = updated_at
+    return worker
+
+
+PG_PRECISION = datetime(2026, 8, 21, 3, 7, 51, 138582, tzinfo=timezone.utc)
+MYSQL_PRECISION = datetime(2026, 8, 21, 3, 7, 51, tzinfo=timezone.utc)
+NAIVE_UTC = datetime(2026, 8, 21, 3, 7, 51)
+LATER = datetime(2026, 8, 21, 3, 9, 0, tzinfo=timezone.utc)
+
+
+def test_idempotency_key_is_stable_across_reads():
+    """Two reads of the same row must agree, or a retry provisions a second VM."""
+    assert creation_idempotency_key(_worker(PG_PRECISION)) == creation_idempotency_key(
+        _worker(PG_PRECISION)
+    )
+
+
+def test_idempotency_key_ignores_timestamp_precision():
+    """MySQL stores TIMESTAMP without fractional digits, PostgreSQL keeps them."""
+    assert creation_idempotency_key(_worker(PG_PRECISION)) == creation_idempotency_key(
+        _worker(MYSQL_PRECISION)
+    )
+
+
+def test_idempotency_key_reads_a_naive_timestamp_as_utc():
+    """The column holds naive UTC; reading it as local time would shift it."""
+    assert creation_idempotency_key(_worker(NAIVE_UTC)) == creation_idempotency_key(
+        _worker(PG_PRECISION)
+    )
+
+
+def test_idempotency_key_turns_over_when_the_row_is_rewritten():
+    """A write that re-drives the worker has to mint a new key."""
+    assert creation_idempotency_key(_worker(PG_PRECISION)) != creation_idempotency_key(
+        _worker(LATER)
+    )
+
+
+def test_idempotency_key_is_per_worker():
+    assert creation_idempotency_key(_worker(PG_PRECISION)) != creation_idempotency_key(
+        _worker(PG_PRECISION, worker_id=43)
+    )
+
+
+def test_idempotency_key_fits_the_api_limit():
+    key = creation_idempotency_key(_worker(PG_PRECISION))
+
+    assert 0 < len(key) <= MAX_IDEMPOTENCY_KEY_SIZE
+
+
+def test_idempotency_key_survives_a_worker_without_a_timestamp():
+    assert creation_idempotency_key(_worker(None))
+
+
+def _create(**kwargs):
+    defaults = {
+        "name": "pool-3-abc",
+        "image": "img-uuid",
+        "type": "1",
+        "region": "",
+        "user_data": "#cloud-config\nruncmd: []\n",
+        "labels": {"cluster_id": 3, "worker_id": 42},
+    }
+    return CloudInstanceCreate(**{**defaults, **kwargs})
+
+
+def test_provider_prefers_the_caller_supplied_key():
+    assert _idempotency_key(_create(idempotency_key="from-the-worker-row")) == (
+        "from-the-worker-row"
+    )
+
+
+def test_provider_derives_a_key_when_none_was_supplied():
+    """Only a hand-built CloudInstanceCreate hits this; the API demands a key."""
+    key = _idempotency_key(_create())
+
+    assert key and len(key) <= MAX_IDEMPOTENCY_KEY_SIZE
+    assert key == _idempotency_key(_create())
+
+
+# --------------------------------------------------------------------------
+# request path (in-process transport)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_unwraps_the_data_envelope():
+    client = ShuihuaClient(
+        api_key="k",
+        base_url="https://api.test",
+        client=transport(
+            responder(200, {"data": [{"template_id": 1, "gpu_model": "RTX4090"}]})
+        ),
+    )
+
+    specs = await client.list_gpu_instances()
+
+    assert [s.template_id for s in specs] == [1]
+    assert specs[0].gpu_model == "RTX4090"
+
+
+@pytest.mark.asyncio
+async def test_request_raises_on_the_error_envelope():
+    client = ShuihuaClient(
+        api_key="k",
+        base_url="https://api.test",
+        client=transport(
+            responder(404, {"error": {"code": "NOT_FOUND", "message": "虚拟机不存在"}})
+        ),
+    )
+
+    with pytest.raises(ShuihuaAPIError) as exc:
+        await client.get_vm(999)
+
+    assert exc.value.status_code == 404
+    assert exc.value.code == "NOT_FOUND"
+    assert exc.value.message == "虚拟机不存在"
+
+
+@pytest.mark.asyncio
+async def test_get_instance_maps_a_missing_vm_to_none():
+    p = provider(responder(404, {"error": {"code": "NOT_FOUND", "message": "gone"}}))
+
+    assert await p.get_instance("33") is None
+
+
+@pytest.mark.asyncio
+async def test_get_instance_skips_the_call_for_an_unusable_id():
+    def explode(request):  # pragma: no cover - must not be reached
+        raise AssertionError("no request should be sent")
+
+    assert await provider(explode).get_instance("not-an-id") is None
+
+
+@pytest.mark.asyncio
+async def test_iter_vms_walks_past_the_first_page_without_total_pages():
+    """total_pages is optional, so it cannot be the only stop condition.
+
+    Coercing a missing one to 0 ended the walk after page 1, hiding every VM
+    but the first page's.
+    """
+    pages = {
+        1: {"data": [{"id": 1}, {"id": 2}], "meta": {}},
+        2: {"data": [{"id": 3}], "meta": {}},
+    }
+
+    def handle(request):
+        page = int(dict(request.url.params)["page"])
+        return httpx.Response(200, json=pages[page])
+
+    client = ShuihuaClient(
+        api_key="k", base_url="https://api.test", client=transport(handle)
+    )
+
+    assert [vm.id async for vm in client.iter_vms(page_size=2)] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_iter_vms_stops_on_the_page_count_when_given_one():
+    def handle(request):
+        page = int(dict(request.url.params)["page"])
+        assert page == 1, "should not ask for a page beyond total_pages"
+        return httpx.Response(
+            200, json={"data": [{"id": 1}], "meta": {"total_pages": 1}}
+        )
+
+    client = ShuihuaClient(
+        api_key="k", base_url="https://api.test", client=transport(handle)
+    )
+
+    assert [vm.id async for vm in client.iter_vms(page_size=1)] == [1]
+
+
+@pytest.mark.asyncio
+async def test_create_vm_sends_the_replay_guard_and_trims_the_image_id():
+    """The image list has been seen handing back uuids with surrounding space."""
+    captured = {}
+    client = ShuihuaClient(
+        api_key="k",
+        base_url="https://api.test",
+        client=transport(
+            responder(202, {"data": {"id": 29, "status": "creating"}}, captured)
+        ),
+    )
+
+    vm = await client.create_vm(
+        template_id=1,
+        image_id="  img-uuid  ",
+        idempotency_key="token",
+        user_data="#cloud-config\n",
+        instance_name="pool-3-abc",
+    )
+
+    assert captured["body"] == {
+        "template_id": 1,
+        "image_id": "img-uuid",
+        "idempotency_key": "token",
+        "user_data": "#cloud-config\n",
+        "instance_name": "pool-3-abc",
+    }
+    # Creation is asynchronous: accepted now, polled to completion later.
+    assert vm.status is VMStatus.CREATING
+    assert vm.status in PENDING_STATUSES
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"idempotency_key": ""},
+        {"idempotency_key": "x" * (MAX_IDEMPOTENCY_KEY_SIZE + 1)},
+        {"user_data": "not-cloud-config"},
+        {"user_data": "#cloud-config\n" + "x" * MAX_USER_DATA_SIZE},
+        {"instance_name": "n" * (MAX_INSTANCE_NAME_SIZE + 1)},
+    ],
+)
+async def test_create_vm_validates_before_spending_money(kwargs):
+    """Creation is billed on acceptance, so bad input must not reach the API."""
+
+    def explode(request):  # pragma: no cover - must not be reached
+        raise AssertionError("no request should be sent")
+
+    client = ShuihuaClient(
+        api_key="k", base_url="https://api.test", client=transport(explode)
+    )
+    call = {
+        "template_id": 1,
+        "image_id": "img",
+        "idempotency_key": "token",
+        "user_data": "#cloud-config\n",
+        **kwargs,
+    }
+
+    with pytest.raises(ValueError):
+        await client.create_vm(**call)
+
+
+@pytest.mark.asyncio
+async def test_create_instance_returns_the_accepted_lease_id():
+    p = provider(responder(202, {"data": {"id": 29, "status": "creating"}}))
+
+    assert await p.create_instance(_create(idempotency_key="token")) == "29"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["terminated", "failed"])
+async def test_create_instance_rejects_a_replayed_dead_lease(status):
+    """Replaying a spent key hands back that lease rather than making a VM.
+
+    Only a new key can start over, so there is nothing here to wait for.
+    """
+    p = provider(responder(202, {"data": {"id": 29, "status": status}}))
+
+    with pytest.raises(InstanceProvisioningFailed):
+        await p.create_instance(_create(idempotency_key="spent"))
+
+
+@pytest.mark.asyncio
+async def test_create_instance_requires_user_data():
+    def explode(request):  # pragma: no cover - must not be reached
+        raise AssertionError("no request should be sent")
+
+    with pytest.raises(ValueError):
+        await provider(explode).create_instance(_create(user_data=None))
+
+
+@pytest.mark.asyncio
+async def test_create_instance_requires_a_numeric_template():
+    def explode(request):  # pragma: no cover - must not be reached
+        raise AssertionError("no request should be sent")
+
+    with pytest.raises(ValueError):
+        await provider(explode).create_instance(_create(type="not-a-template"))
+
+
+@pytest.mark.asyncio
+async def test_delete_instance_tolerates_a_vanished_vm():
+    p = provider(responder(404, {"error": {"code": "NOT_FOUND", "message": "gone"}}))
+
+    await p.delete_instance("33")
+
+
+@pytest.mark.asyncio
+async def test_delete_instance_surfaces_other_failures():
+    """400 is any bad request, plausibly "cannot terminate while creating".
+
+    Swallowing it would delete the worker row while a live, billing VM stays up
+    with nothing left pointing at it.
+    """
+    p = provider(responder(400, {"error": {"code": "BAD_STATE", "message": "busy"}}))
+
+    with pytest.raises(ShuihuaAPIError):
+        await p.delete_instance("33")
+
+
+@pytest.mark.asyncio
+async def test_volumes_are_rejected_rather_than_dropped():
+    """There is no block storage API, so a configured volume cannot be honoured."""
+    p = provider(responder(200, {"data": {}}))
+
+    with pytest.raises(NotImplementedError):
+        await p.create_volumes_and_attach(1, "33", "", MagicMock())
+
+    assert await p.create_volumes_and_attach(1, "33", "") == []

--- a/tests/cloud_providers/test_user_data_template.py
+++ b/tests/cloud_providers/test_user_data_template.py
@@ -95,6 +95,41 @@ def test_userdata_template_setup_driver():
     assert any("nvidia-ctk runtime configure" in cmd for cmd in data["runcmd"])
 
 
+def test_userdata_template_ssh_authorized_keys():
+    template = UserDataTemplate(
+        server_url="http://test-server",
+        token="test-token",
+        image_name="gpustack/test:latest",
+        worker_name="test-worker",
+    )
+    template.distribution = "ubuntu"
+    template.add_ssh_authorized_keys("ssh-ed25519 AAAA first")
+    # Duplicates and blanks are dropped, new keys are appended.
+    template.add_ssh_authorized_keys(
+        "ssh-ed25519 AAAA first", "", "ssh-ed25519 BBBB second"
+    )
+    data = yaml.safe_load(template.format())
+    assert data["ssh_authorized_keys"] == [
+        "ssh-ed25519 AAAA first",
+        "ssh-ed25519 BBBB second",
+    ]
+
+
+def test_userdata_template_no_ssh_authorized_keys():
+    template = UserDataTemplate(
+        server_url="http://test-server",
+        token="test-token",
+        image_name="gpustack/test:latest",
+        worker_name="test-worker",
+    )
+    template.distribution = "ubuntu"
+    # Providers that let their API attach the key never add one here, and must
+    # not get an empty ssh_authorized_keys in the rendered document.
+    template.add_ssh_authorized_keys(None)
+    data = yaml.safe_load(template.format())
+    assert "ssh_authorized_keys" not in data
+
+
 def test_userdata_template_secret_configs():
     template = UserDataTemplate(
         server_url="http://test-server",

--- a/tests/controller/test_provisioning.py
+++ b/tests/controller/test_provisioning.py
@@ -10,7 +10,7 @@ from gpustack.schemas.clusters import (
     CloudOptions,
 )
 from gpustack.server.controllers import WorkerProvisioningController
-from gpustack.cloud_providers.abstract import InstanceState, Volume
+from gpustack.cloud_providers.abstract import CloudInstance, InstanceState, Volume
 
 
 @pytest.mark.asyncio
@@ -115,12 +115,15 @@ async def test_provisioning_flow(monkeypatch):
     mock_instance.id = "instance-id"
     mock_instance.ip_address = "1.2.3.4"
     mock_instance.status = InstanceState.RUNNING
+    # A provider that serves SSH on the instance itself reports no mapping.
+    mock_instance.ssh_endpoint = None
     client.get_instance.return_value = mock_instance
     client.wait_for_public_ip.return_value = mock_instance
     await WorkerProvisioningController._provisioning_instance(
         session, client, worker, cfg
     )
     assert worker.state_message == "Waiting for volumes to attach"
+    assert "ssh_endpoint" not in (worker.provider_config or {})
 
     # Sixth call, should create and attach volumes
     client.create_volumes_and_attach.return_value = ["vol-1", "vol-2"]
@@ -135,6 +138,132 @@ async def test_provisioning_flow(monkeypatch):
         session, client, worker, cfg
     )
     assert worker.state == WorkerStateEnum.INITIALIZING
+
+
+@pytest.mark.asyncio
+async def test_provisioning_records_mapped_ssh_endpoint():
+    """A provider that maps SSH elsewhere gets that recorded for the UI.
+
+    Shuihua publishes every instance behind one shared IP on an
+    instance-specific port, so advertise_address:22 answers nothing and the
+    mapping is the only way to reach the host.
+    """
+    session = AsyncMock()
+    client = AsyncMock()
+    worker = Worker(
+        id=1,
+        name="w",
+        hostname="h",
+        ip="",
+        advertise_address="",
+        external_id="33",
+        state=WorkerStateEnum.PROVISIONING,
+        provider_config={"volume_ids": []},
+    )
+    worker.worker_pool = WorkerPool(id=1, cloud_options=CloudOptions())
+    instance = CloudInstance(
+        name="w",
+        image="",
+        type="",
+        region="",
+        ip_address="172.16.46.22",
+        status=InstanceState.RUNNING,
+        ssh_endpoint=("125.67.215.17", 33004),
+        ssh_user="ubuntu",
+    )
+    client.wait_for_public_ip = AsyncMock(return_value=instance)
+
+    changed = await WorkerProvisioningController._provisioning_started(
+        session, client, worker, instance
+    )
+
+    assert changed
+    # The private per-instance address stays the identity, the mapping is only
+    # a connection hint.
+    assert worker.advertise_address == "172.16.46.22"
+    assert worker.provider_config["ssh_endpoint"] == {
+        "host": "125.67.215.17",
+        "port": 33004,
+        "user": "ubuntu",
+    }
+    # Pre-existing keys survive the write.
+    assert worker.provider_config["volume_ids"] == []
+
+    # An unreported user is left out rather than stored as "".
+    worker.provider_config = {"volume_ids": []}
+    worker.advertise_address = ""
+    instance.ssh_user = None
+    await WorkerProvisioningController._provisioning_started(
+        session, client, worker, instance
+    )
+    assert worker.provider_config["ssh_endpoint"] == {
+        "host": "125.67.215.17",
+        "port": 33004,
+    }
+
+
+@pytest.mark.asyncio
+async def test_provisioning_backfills_late_ssh_endpoint():
+    """A mapping published after the address appears still gets recorded.
+
+    wait_for_public_ip returns as soon as an address exists, which can be
+    before the provider has published the port mapping. That branch only runs
+    while advertise_address is empty, so the endpoint has to be picked up on a
+    later pass or it would stay missing for good.
+    """
+    session = AsyncMock()
+    client = AsyncMock()
+    worker = Worker(
+        id=1,
+        name="w",
+        hostname="h",
+        ip="",
+        advertise_address="",
+        external_id="33",
+        state=WorkerStateEnum.PROVISIONING,
+        provider_config={},
+    )
+    worker.worker_pool = WorkerPool(id=1, cloud_options=CloudOptions())
+    worker.cluster = Cluster(id=1, name="c", state=ClusterStateEnum.PROVISIONED)
+
+    def instance(ssh_endpoint):
+        return CloudInstance(
+            name="w",
+            image="",
+            type="",
+            region="",
+            ip_address="172.16.46.22",
+            status=InstanceState.RUNNING,
+            ssh_endpoint=ssh_endpoint,
+            ssh_user="ubuntu",
+        )
+
+    # First pass: an address but no mapping yet.
+    client.wait_for_public_ip = AsyncMock(return_value=instance(None))
+    await WorkerProvisioningController._provisioning_started(
+        session, client, worker, instance(None)
+    )
+    assert worker.advertise_address == "172.16.46.22"
+    assert "ssh_endpoint" not in worker.provider_config
+
+    # Later pass: the mapping is published, and advertise_address is set by now.
+    worker.state = WorkerStateEnum.PROVISIONING
+    changed = await WorkerProvisioningController._provisioning_started(
+        session, client, worker, instance(("125.67.215.17", 33004))
+    )
+    assert changed
+    assert worker.provider_config["ssh_endpoint"] == {
+        "host": "125.67.215.17",
+        "port": 33004,
+        "user": "ubuntu",
+    }
+
+    # A later poll without the mapping must not erase what was recorded.
+    worker.state = WorkerStateEnum.PROVISIONING
+    await WorkerProvisioningController._provisioning_started(
+        session, client, worker, instance(None)
+    )
+    assert worker.provider_config["ssh_endpoint"]["port"] == 33004
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_shuihua_cluster_checks.py
+++ b/tests/routes/test_shuihua_cluster_checks.py
@@ -1,0 +1,335 @@
+"""Offline tests for the Shuihua cluster create/update rules.
+
+No database and no network: the checks operate on the request models plus the
+cluster row the caller is editing, with the server config stubbed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import gpustack.routes.clusters as clusters
+from gpustack.api.exceptions import InvalidException
+from gpustack.routes.clusters import (
+    apply_shuihua_defaults,
+    check_shuihua_requirements,
+    create_update_check,
+    image_ref_registry,
+    is_docker_hub_registry,
+)
+from gpustack.schemas.clusters import (
+    Cluster,
+    ClusterCreate,
+    ClusterProvider,
+    ClusterUpdate,
+)
+from gpustack.schemas.config import (
+    ModelInstanceProxyModeEnum,
+    PredefinedConfigNoDefaults,
+)
+
+PRIVATE_REGISTRY = "swr.cn-south-1.myhuaweicloud.com"
+
+
+@pytest.fixture
+def server_config(monkeypatch):
+    """Server-level settings the checks read, with nothing configured."""
+    cfg = MagicMock()
+    cfg.server_external_url = "https://gpustack.test"
+    cfg.system_default_container_registry = None
+    cfg.shuihua_api_base_url = "https://api.test"
+    monkeypatch.setattr(clusters, "get_global_config", lambda: cfg)
+    monkeypatch.setattr(
+        clusters, "get_provider_api_endpoint", lambda provider: "https://api.test"
+    )
+    return cfg
+
+
+# --------------------------------------------------------------------------
+# image reference parsing
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "image_ref, expected",
+    [
+        # No slash at all: a bare name, so the registry is implicit. The tag
+        # colon must not be mistaken for a port.
+        ("gpustack:v1", None),
+        ("gpustack", None),
+        # A single path segment before the name is a Docker Hub namespace.
+        ("gpustack/gpustack:v1", None),
+        # A dot, a port or localhost in the first segment makes it a host.
+        ("reg.cn/gpustack:v1", "reg.cn"),
+        (
+            "swr.cn-south-1.myhuaweicloud.com/gpustack/gpustack:v1",
+            "swr.cn-south-1.myhuaweicloud.com",
+        ),
+        ("localhost:5000/gpustack:v1", "localhost:5000"),
+        ("localhost/gpustack:v1", "localhost"),
+    ],
+)
+def test_image_ref_registry(image_ref, expected):
+    assert image_ref_registry(image_ref) == expected
+
+
+@pytest.mark.parametrize(
+    "registry, expected",
+    [
+        ("docker.io", True),
+        ("index.docker.io", True),
+        ("registry-1.docker.io", True),
+        ("registry.hub.docker.com", True),
+        ("DOCKER.IO", True),
+        ("docker.io/gpustack", True),
+        ("reg.cn", False),
+        ("mydocker.io.cn", False),
+    ],
+)
+def test_is_docker_hub_registry(registry, expected):
+    assert is_docker_hub_registry(registry) is expected
+
+
+# --------------------------------------------------------------------------
+# proxy mode defaulting
+# --------------------------------------------------------------------------
+
+
+def test_create_defaults_proxy_mode_to_tunnel():
+    """Instances sit behind NAT with no mapping for the worker's own port."""
+    request = ClusterCreate(name="c", provider=ClusterProvider.Shuihua, credential_id=1)
+
+    apply_shuihua_defaults(request)
+
+    assert request.worker_config.proxy_mode is ModelInstanceProxyModeEnum.TUNNEL
+
+
+def test_create_fills_only_an_empty_proxy_mode():
+    """An operator whose network routes to the instances may pick another mode."""
+    request = ClusterCreate(
+        name="c",
+        provider=ClusterProvider.Shuihua,
+        credential_id=1,
+        worker_config={"proxy_mode": "direct"},
+    )
+
+    apply_shuihua_defaults(request)
+
+    assert request.worker_config.proxy_mode is ModelInstanceProxyModeEnum.DIRECT
+
+
+def test_update_without_worker_config_is_left_alone():
+    """Cluster.update applies model_fields_set only.
+
+    Assigning a worker_config here would add it to that set and overwrite the
+    cluster's stored config with a bare default.
+    """
+    request = ClusterUpdate(name="renamed")
+
+    apply_shuihua_defaults(request, existing=Cluster(name="c"))
+
+    assert request.worker_config is None
+    assert "worker_config" not in request.model_fields_set
+
+
+def test_update_keeps_the_stored_proxy_mode():
+    """Sending worker_config replaces it wholesale.
+
+    Defaulting blindly would silently move a cluster the operator had put on
+    WORKER over to the tunnel.
+    """
+    stored = Cluster(
+        name="c",
+        worker_config=PredefinedConfigNoDefaults(
+            proxy_mode=ModelInstanceProxyModeEnum.WORKER
+        ),
+    )
+    request = ClusterUpdate(name="c", worker_config={"debug": True})
+
+    apply_shuihua_defaults(request, existing=stored)
+
+    assert request.worker_config.proxy_mode is ModelInstanceProxyModeEnum.WORKER
+
+
+def test_update_still_honours_an_explicit_proxy_mode():
+    stored = Cluster(
+        name="c",
+        worker_config=PredefinedConfigNoDefaults(
+            proxy_mode=ModelInstanceProxyModeEnum.WORKER
+        ),
+    )
+    request = ClusterUpdate(name="c", worker_config={"proxy_mode": "direct"})
+
+    apply_shuihua_defaults(request, existing=stored)
+
+    assert request.worker_config.proxy_mode is ModelInstanceProxyModeEnum.DIRECT
+
+
+# --------------------------------------------------------------------------
+# registry requirement
+# --------------------------------------------------------------------------
+
+
+def test_create_requires_a_registry(server_config):
+    """The instances cannot reach Docker Hub, and the server has no default."""
+    request = ClusterCreate(name="c", provider=ClusterProvider.Shuihua, credential_id=1)
+
+    with pytest.raises(InvalidException):
+        check_shuihua_requirements(request)
+
+
+def test_create_accepts_a_registry_on_the_cluster(server_config):
+    request = ClusterCreate(
+        name="c",
+        provider=ClusterProvider.Shuihua,
+        credential_id=1,
+        system_default_container_registry=PRIVATE_REGISTRY,
+    )
+
+    check_shuihua_requirements(request)
+
+
+def test_create_accepts_the_server_level_registry(server_config):
+    """get_cluster_image_name falls back to it, so rejecting would be a false alarm."""
+    server_config.system_default_container_registry = PRIVATE_REGISTRY
+    request = ClusterCreate(name="c", provider=ClusterProvider.Shuihua, credential_id=1)
+
+    check_shuihua_requirements(request)
+
+
+@pytest.mark.parametrize("registry", ["docker.io", "index.docker.io"])
+def test_create_rejects_docker_hub(server_config, registry):
+    request = ClusterCreate(
+        name="c",
+        provider=ClusterProvider.Shuihua,
+        credential_id=1,
+        system_default_container_registry=registry,
+    )
+
+    with pytest.raises(InvalidException):
+        check_shuihua_requirements(request)
+
+
+@pytest.mark.parametrize(
+    "override, rejected",
+    [
+        # A full override decides where the pull comes from, so it is what gets
+        # checked -- and one with no host resolves to Docker Hub.
+        ("gpustack/gpustack:v1", True),
+        ("gpustack:v1", True),
+        ("docker.io/gpustack/gpustack:v1", True),
+        (f"{PRIVATE_REGISTRY}/gpustack/gpustack:v1", False),
+    ],
+)
+def test_create_checks_an_image_override_over_the_registry(
+    server_config, override, rejected
+):
+    server_config.system_default_container_registry = PRIVATE_REGISTRY
+    request = ClusterCreate(
+        name="c",
+        provider=ClusterProvider.Shuihua,
+        credential_id=1,
+        worker_config={"image_name_override": override},
+    )
+
+    if rejected:
+        with pytest.raises(InvalidException):
+            check_shuihua_requirements(request)
+    else:
+        check_shuihua_requirements(request)
+
+
+def test_update_accepts_the_registry_already_on_the_cluster(server_config):
+    """A partial PUT need not resend it, and Cluster.update keeps what it
+    doesn't touch, so ignoring the stored value rejected a configured cluster."""
+    stored = Cluster(name="c", system_default_container_registry=PRIVATE_REGISTRY)
+    request = ClusterUpdate(name="c", worker_config={"debug": True})
+
+    check_shuihua_requirements(request, existing=stored)
+
+
+def test_update_untouched_by_the_registry_rule(server_config):
+    """A rename sends neither worker_config nor the registry, so nothing to check."""
+    check_shuihua_requirements(
+        ClusterUpdate(name="renamed"), existing=Cluster(name="c")
+    )
+
+
+def test_update_rejects_switching_to_docker_hub(server_config):
+    stored = Cluster(name="c", system_default_container_registry=PRIVATE_REGISTRY)
+    request = ClusterUpdate(name="c", system_default_container_registry="docker.io")
+
+    with pytest.raises(InvalidException):
+        check_shuihua_requirements(request, existing=stored)
+
+
+# --------------------------------------------------------------------------
+# the whole check, as the routes call it
+# --------------------------------------------------------------------------
+
+
+def test_create_update_check_rejects_an_unconfigured_provider(
+    server_config, monkeypatch
+):
+    """Without a base URL there is nowhere to send requests."""
+    monkeypatch.setattr(clusters, "get_provider_api_endpoint", lambda provider: None)
+    request = ClusterCreate(
+        name="c",
+        provider=ClusterProvider.Shuihua,
+        credential_id=1,
+        system_default_container_registry=PRIVATE_REGISTRY,
+    )
+
+    with pytest.raises(InvalidException):
+        create_update_check(ClusterProvider.Shuihua, request)
+
+
+def test_create_update_check_requires_a_credential(server_config):
+    request = ClusterCreate(
+        name="c",
+        provider=ClusterProvider.Shuihua,
+        system_default_container_registry=PRIVATE_REGISTRY,
+    )
+
+    with pytest.raises(InvalidException):
+        create_update_check(ClusterProvider.Shuihua, request)
+
+
+def test_create_update_check_passes_a_complete_request(server_config):
+    request = ClusterCreate(
+        name="c",
+        provider=ClusterProvider.Shuihua,
+        credential_id=1,
+        system_default_container_registry=PRIVATE_REGISTRY,
+    )
+
+    create_update_check(ClusterProvider.Shuihua, request)
+
+    assert request.worker_config.proxy_mode is ModelInstanceProxyModeEnum.TUNNEL
+
+
+def test_create_update_check_allows_editing_a_configured_cluster(server_config):
+    """The regression: a PUT carrying worker_config used to 400 unless the
+    caller resent the registry, because the check never saw the cluster row."""
+    stored = Cluster(
+        name="c",
+        provider=ClusterProvider.Shuihua,
+        system_default_container_registry=PRIVATE_REGISTRY,
+        worker_config=PredefinedConfigNoDefaults(
+            proxy_mode=ModelInstanceProxyModeEnum.TUNNEL
+        ),
+    )
+    request = ClusterUpdate(name="c", worker_config={"debug": True})
+
+    create_update_check(ClusterProvider.Shuihua, request, existing=stored)
+
+
+@pytest.mark.parametrize(
+    "provider", [ClusterProvider.Docker, ClusterProvider.DigitalOcean]
+)
+def test_other_providers_are_untouched(server_config, provider):
+    request = ClusterCreate(name="c", provider=provider, credential_id=1)
+
+    create_update_check(provider, request)
+
+    assert request.worker_config is None


### PR DESCRIPTION
- SDK and provider client for the Shuihua open API (v1.4.0): async create
  (202 + poll), a required idempotency key derived from the worker row, and
  terminal statuses that stop a dead lease being polled forever.
- Keys reach instances through cloud-init, so UserDataTemplate grows
  add_ssh_authorized_keys and construct_user_data takes the public key;
  create_ssh_key may return None when there is nothing to register.
- Cluster creation defaults proxy_mode to tunnel and requires a registry
  other than Docker Hub, which the instances cannot reach.
- The API base URL comes from --shuihua-api-base-url; without it, creating a
  Shuihua cluster or credential is rejected.
- Registration no longer erases a Shuihua worker's external_id, which had
  left deleted workers' instances running.
- The mapped SSH endpoint is recorded in provider_config for the UI.
- Fixes: sql_enum kept NOT NULL/DEFAULT when widening a MySQL enum;
  package_upgrade limited to the driver-install path.