### PR TITLE
[Backport] fix(benchmark): let the container verify a private-CA server

### DIFF
--- a/docs/user-guide/benchmarking.md
+++ b/docs/user-guide/benchmarking.md
@@ -40,3 +40,9 @@ GPUStack can run benchmarks against running model instances. Benchmarks are exec
 2. Find the benchmark you want to delete.
 3. Click the `Delete` button in the `Operations` column.
 4. Confirm the deletion.
+
+## Benchmarks on an HTTPS Server with a Private CA
+
+The benchmark container reports its progress back to the GPUStack server over the server URL, so on an HTTPS deployment it has to verify the server's certificate. The benchmark runs in a separate image and does not import CAs on its own, so the worker hands it the CA bundle the worker itself trusts — including any private CA mounted under `/usr/local/share/ca-certificates/` (see [Additional Trusted CAs](../installation/installation.md#additional-trusted-cas)). No extra configuration is needed as long as that CA is available on the worker.
+
+If verification still fails, the benchmark itself is unaffected — the load is generated against the model instance over plain HTTP — but progress stays at 0% until the run completes, and the worker log records why. Import the server's CA on the worker to resolve it.

--- a/gpustack/__init__.py
+++ b/gpustack/__init__.py
@@ -1,4 +1,4 @@
 __version__ = '0.0.0'
 __git_commit__ = 'HEAD'
-__benchmark_runner_version__ = 'v0.0.4'
+__benchmark_runner_version__ = 'v0.0.4.post1'
 __operator_version__ = 'v0.5.4'

--- a/gpustack/utils/command.py
+++ b/gpustack/utils/command.py
@@ -3,14 +3,56 @@ import sys
 import sysconfig
 from os.path import dirname, abspath, join
 import shutil
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Any, List, Literal, Optional, Sequence, Tuple, Union
 import shlex
 
 from gpustack_runtime.deployer.__utils__ import compare_versions
 
-
 _TRUTHY_VALUES = frozenset({"1", "true", "yes", "on", "t", "y"})
 _FALSY_VALUES = frozenset({"0", "false", "no", "off", "f", "n"})
+
+REDACTED = "***"
+
+# Flags whose value is a credential GPUStack injects itself, rather than
+# something an operator typed. Only these are redacted: blanket-matching on
+# substrings like "token" would also hit knobs whose value is a number an
+# operator needs to see in the log (``--token-timeout``, ``--max-tokens``).
+_SENSITIVE_PARAMETER_KEYS = frozenset({"--progress-auth"})
+
+
+def sanitize_args(args: Sequence[Any]) -> List[str]:
+    """Redact credential values in an argv list so it can be logged.
+
+    The counterpart of ``sanitize_env``: same reason -- a log line that anyone
+    who can read worker logs can read must not carry a secret -- for the other
+    carrier. ``--progress-auth`` is the worker token, so the container command
+    line printed at workload creation would otherwise hand it out verbatim.
+
+    Handles both ``--flag value`` and ``--flag=value``. Elements are stringified
+    on the way out, since ``_build_command_args`` does not stringify every value
+    it appends. This only covers the log;
+    the container still receives the real value, and it remains visible in the
+    workload spec (``docker inspect`` / ``kubectl describe``).
+    """
+    sanitized: List[str] = []
+    redact_next = False
+    for arg in args:
+        text = str(arg)
+        if redact_next:
+            sanitized.append(REDACTED)
+            redact_next = False
+            continue
+        key, sep, _ = text.partition("=")
+        if key in _SENSITIVE_PARAMETER_KEYS:
+            if sep:
+                sanitized.append(f"{key}={REDACTED}")
+            else:
+                # Value is the next element; redact it on the following pass.
+                sanitized.append(text)
+                redact_next = True
+            continue
+        sanitized.append(text)
+    return sanitized
 
 
 def is_command_available(command_name):

--- a/gpustack/worker/benchmark/runner.py
+++ b/gpustack/worker/benchmark/runner.py
@@ -3,12 +3,14 @@ import logging
 import os
 import sys
 from typing import Dict, List, Optional
+from urllib.parse import urlparse
 
 from gpustack.client.generated_clientset import ClientSet
 from gpustack.config.config import Config, set_global_config
 from gpustack.config.registration import read_worker_token
 from gpustack.envs import BENCHMARK_DATASET_SHAREGPT_PATH, BENCHMARK_REQUEST_TIMEOUT
 from gpustack.logging import setup_logging
+from gpustack.ssl_context import resolve_ca_bundle
 from gpustack.schemas.benchmark import (
     DATASET_RANDOM,
     DATASET_SHAREGPT,
@@ -17,12 +19,12 @@ from gpustack.schemas.benchmark import (
     BenchmarkStateEnum,
     ModelInstanceSnapshot,
 )
-from gpustack.utils.command import find_bool_parameter
+from gpustack.utils.command import find_bool_parameter, sanitize_args
 from gpustack.utils.config import apply_registry_override_to_image
-from gpustack.utils.envs import filter_env_vars, sanitize_env
+from gpustack.utils.envs import filter_env_vars, get_gpustack_env_bool, sanitize_env
 from gpustack_runtime.logging import setup_logging as setup_runtime_logging
 from gpustack_runtime import envs as runtime_envs
-from gpustack_runtime.deployer import ContainerMount
+from gpustack_runtime.deployer import ContainerFile, ContainerMount
 
 from gpustack_runtime.deployer import (
     Container,
@@ -39,6 +41,32 @@ from gpustack.utils.runtime import transform_workload_plan
 
 logger = logging.getLogger(__name__)
 
+# Where the CA bundle lands inside the benchmark container. It is injected as
+# file content by the runtime (see BenchmarkRunner._progress_ca_file), so this
+# path only has to make sense in the container -- nothing is written on the host.
+PROGRESS_CA_BUNDLE_PATH = "/etc/gpustack/progress-ca-bundle.crt"
+
+
+def resolve_progress_insecure_tls() -> bool:
+    """Whether the benchmark container should skip TLS verification on progress.
+
+    Driven by ``GPUSTACK_INSECURE_TLS`` alone, which a worker started with the
+    enterprise plugin's ``--insecure-tls`` sets (operators without that plugin
+    can set the variable directly). It means "this worker cannot verify the
+    server's certificate", and progress reporting is exactly the worker talking
+    to the server, so it already covers this case -- a benchmark-only switch
+    would let benchmarks skip verification while the worker's own connection to
+    the same server could not, which is not a distinction worth configuring.
+
+    It has to be read here because it cannot propagate on its own: the
+    enterprise shim carries it into spawned *interpreters* via
+    ``PYTHONPATH``/``sitecustomize``, which a separate benchmark image does not
+    have, and ``filter_env_vars`` strips ``GPUSTACK_*`` before the container env
+    is built. So this process (a spawn child, which does inherit the variable) is
+    the last place that can act on it.
+    """
+    return bool(get_gpustack_env_bool("INSECURE_TLS"))
+
 
 class BenchmarkRunner:
     _clientset: ClientSet
@@ -50,6 +78,7 @@ class BenchmarkRunner:
     _api_url: str
     _api_key: str
     _benchmark_dir: Optional[str]
+    _progress_insecure_skip_tls_verify: bool
     _fallback_registry: Optional[str] = None
     """The fallback container registry to use if needed."""
 
@@ -120,6 +149,7 @@ class BenchmarkRunner:
             self._api_url = (
                 f"{_server_url.rstrip('/')}/v2/benchmarks/{self._benchmark.id}/state"
             )
+            self._progress_insecure_skip_tls_verify = resolve_progress_insecure_tls()
 
         except Exception as e:
             error_message = f"Failed to initialize: {e}"
@@ -142,13 +172,102 @@ class BenchmarkRunner:
         env = {}
         if not runtime_envs.GPUSTACK_RUNTIME_DEPLOY_MIRRORED_DEPLOYMENT:
             env = filter_env_vars(os.environ)
+            self._drop_worker_ca_env(env)
 
-        command_args = self._build_command_args()
+        # Resolved before the args so the two agree: --progress-ca-cert is only
+        # forwarded when the file it names is actually going to be there.
+        ca_file = self._progress_ca_file()
+        command_args = self._build_command_args(with_ca_cert=ca_file is not None)
         self._create_workload(
             deployment_metadata=deployment_metadata,
             command=["benchmark-runner"],
             command_args=command_args,
             env=env,
+            files=[ca_file] if ca_file is not None else None,
+        )
+
+    @property
+    def _progress_is_https(self) -> bool:
+        """Whether progress reporting has to verify anything at all.
+
+        Read from two places that must agree -- the env/bundle handling and the
+        flag forwarding -- so it lives in one place rather than as two copies of
+        the same urlparse.
+        """
+        return urlparse(self._api_url).scheme == "https"
+
+    def _drop_worker_ca_env(self, env: Dict[str, str]) -> None:
+        """Strip CA-bundle variables inherited from the worker.
+
+        They name paths in the WORKER's filesystem, which the benchmark image
+        does not have, and none of them fall back on their own when the file is
+        missing: ``SSL_CERT_FILE`` makes OpenSSL load ZERO certificates, and
+        ``REQUESTS_CA_BUNDLE`` makes requests raise OSError outright rather than
+        verify against anything. Passing them through is worse than dropping
+        them, since the container's own trust store is at least coherent.
+
+        ``SSL_CERT_DIR`` is deliberately left alone: a missing capath is simply
+        ignored, and the value IS valid in the container when it names a standard
+        path both images have.
+        """
+        for stale in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+            env.pop(stale, None)
+
+    def _progress_ca_file(self) -> Optional[ContainerFile]:
+        """The CA bundle to hand the container, injected as file content.
+
+        The progress endpoint is the server's own URL, so on an HTTPS deployment
+        fronted by a private CA the container has to verify a certificate the
+        worker already trusts -- and it cannot. The benchmark image is a separate
+        ``gpustack/benchmark-runner`` image whose entrypoint is the runner CLI, so
+        it never runs ``gpustack-prerun.sh`` and never sees the CAs an operator
+        dropped into ``/usr/local/share/ca-certificates/``. Every progress PATCH
+        then dies with CERTIFICATE_VERIFY_FAILED.
+
+        So hand it the bundle the worker itself verifies against -- private CAs
+        already merged in by ``update-ca-certificates``. It travels as container
+        file content rather than through a shared directory: the runtime writes
+        it into the container itself (a tar upload before start on Docker, a
+        ConfigMap on Kubernetes), so nothing is written anywhere the container
+        can reach beforehand, nothing outlives the run, and the path inside the
+        container is ours to choose rather than one that has to exist identically
+        on the host.
+
+        Returns None when there is nothing to verify (plain HTTP), when
+        verification is switched off, or when the bundle cannot be read -- the
+        last of which warns rather than raising, since the measurement only needs
+        the model endpoint and a run must not be lost over progress telemetry.
+        """
+        if not self._progress_is_https:
+            # Progress goes out over plain HTTP; no trust store is consulted.
+            return None
+
+        if self._progress_insecure_skip_tls_verify:
+            # Verification is off; a bundle would not be consulted. The warning
+            # that explains this lives next to the flag in _build_command_args,
+            # which is reached under a mirrored deployment too -- this is not.
+            return None
+
+        try:
+            source = resolve_ca_bundle()
+            with open(source, "r", encoding="utf-8") as bundle:
+                content = bundle.read()
+        except OSError as e:
+            logger.warning(
+                f"Failed to read the CA bundle for benchmark progress reporting: "
+                f"{e}. Progress updates to {self._api_url} may fail TLS "
+                "verification; the benchmark itself is unaffected."
+            )
+            return None
+
+        logger.debug(
+            f"Handing CA bundle {source} to the benchmark container at "
+            f"{PROGRESS_CA_BUNDLE_PATH}."
+        )
+        return ContainerFile(
+            path=PROGRESS_CA_BUNDLE_PATH,
+            content=content,
+            mode=0o644,
         )
 
     def _create_workload(
@@ -157,6 +276,7 @@ class BenchmarkRunner:
         command: Optional[List[str]],
         command_args: List[str],
         env: Dict[str, str],
+        files: Optional[List[ContainerFile]] = None,
     ):
         image = apply_registry_override_to_image(
             self._config, self._config.benchmark_image_repo, self._fallback_registry
@@ -183,6 +303,7 @@ class BenchmarkRunner:
                 for name, value in env.items()
             ],
             mounts=mounts,
+            files=files or [],
         )
 
         logger.info(
@@ -191,7 +312,7 @@ class BenchmarkRunner:
         logger.info(
             f"With image: {image}, "
             f"command: [{' '.join(command) if command else ''}], "
-            f"arguments: [{' '.join(str(arg) for arg in command_args)}], "
+            f"arguments: [{' '.join(sanitize_args(command_args))}], "
             f"envs(inconsistent input items mean unchangeable):{os.linesep}"
             f"{os.linesep.join(f'{k}={v}' for k, v in sorted(sanitize_env(env).items()))}"
         )
@@ -211,7 +332,7 @@ class BenchmarkRunner:
 
         logger.info(f"Created benchmark container workload: {deployment_metadata.name}")
 
-    def _build_command_args(self) -> List[str]:
+    def _build_command_args(self, with_ca_cert: bool = False) -> List[str]:
         backend_kwargs = {
             "timeout": BENCHMARK_REQUEST_TIMEOUT,
             "response_handlers": {
@@ -245,6 +366,34 @@ class BenchmarkRunner:
             "--backend",
             "openai_http_error_detail",
         ]
+
+        # Points the runner at the bundle the caller is injecting as file content.
+        # Scoped to the progress channel on purpose: SSL_CERT_FILE would replace
+        # the trust store for every TLS call the container makes, so a bundle
+        # holding only a private CA would leave the runner unable to verify
+        # anything else.
+        if with_ca_cert:
+            command_args.extend(["--progress-ca-cert", PROGRESS_CA_BUNDLE_PATH])
+
+        # Only forwarded for an HTTPS progress endpoint: on plain HTTP the flag is
+        # a no-op the runner would still have to recognize, and an operator who
+        # left the setting on while pinning an older --benchmark-image-repo gets
+        # an unknown-option failure at most where it could have mattered.
+        #
+        # The warning belongs here rather than with the rest of the TLS handling:
+        # that runs only outside a mirrored deployment, while this append does
+        # not, so an operator hitting exactly the failure described below would
+        # otherwise get no log line pointing at its cause.
+        if self._progress_insecure_skip_tls_verify and self._progress_is_https:
+            logger.warning(
+                "GPUSTACK_INSECURE_TLS is set: TLS verification is disabled for "
+                f"benchmark progress reporting to {self._api_url}. Prefer "
+                "importing the server's CA into /usr/local/share/ca-certificates/ "
+                "on this worker. Note the benchmark image must support "
+                "--progress-insecure-skip-tls-verify; an older pinned image fails "
+                "to start on the unknown option."
+            )
+            command_args.append("--progress-insecure-skip-tls-verify")
 
         if find_bool_parameter(self._model_backend_parameters, ["trust-remote-code"]):
             command_args.extend(

--- a/tests/utils/test_command.py
+++ b/tests/utils/test_command.py
@@ -2,6 +2,7 @@ import shutil
 import pytest
 
 from gpustack.utils.command import (
+    REDACTED,
     is_command_available,
     find_parameter,
     find_bool_parameter,
@@ -11,6 +12,7 @@ from gpustack.utils.command import (
     format_backend_parameters,
     is_parameter_key,
     safe_split,
+    sanitize_args,
 )
 
 
@@ -415,3 +417,45 @@ def test_find_bool_parameter_argv_stream():
         ['--tp 8 --max-model-len 1024'],
         ['enable-expert-parallel'],
     )
+
+
+class TestSanitizeArgs:
+    """Credential redaction for logged command lines.
+
+    ``--progress-auth`` carries the worker token, so the container command line
+    printed at workload creation would otherwise hand it to anyone who can read
+    the worker log.
+    """
+
+    def test_the_value_after_the_flag_is_redacted(self):
+        args = ['benchmark', 'run', '--progress-auth', 'sk-worker-token', '--rate', '4']
+        assert sanitize_args(args) == [
+            'benchmark',
+            'run',
+            '--progress-auth',
+            REDACTED,
+            '--rate',
+            '4',
+        ]
+
+    def test_the_inline_form_is_redacted(self):
+        assert sanitize_args(['--progress-auth=sk-worker-token']) == [
+            f'--progress-auth={REDACTED}'
+        ]
+
+    def test_everything_else_is_left_alone(self):
+        # Only GPUStack-injected credentials are redacted. A blanket match on
+        # "token" would also swallow values an operator needs to read.
+        args = ['--token-timeout', '60', '--max-tokens', '128', '--target', 'http://x']
+        assert sanitize_args(args) == args
+
+    def test_a_trailing_flag_without_a_value_does_not_crash(self):
+        assert sanitize_args(['--rate', '4', '--progress-auth']) == [
+            '--rate',
+            '4',
+            '--progress-auth',
+        ]
+
+    def test_non_string_elements_survive(self):
+        # _build_command_args stringifies most values, but not all of them.
+        assert sanitize_args(['--rate', 4]) == ['--rate', '4']

--- a/tests/worker/test_benchmark_tls.py
+++ b/tests/worker/test_benchmark_tls.py
@@ -1,0 +1,316 @@
+"""TLS trust for the benchmark container's progress reporting.
+
+The benchmark container is a separate ``gpustack/benchmark-runner`` image whose
+entrypoint is the runner CLI, so it never runs ``gpustack-prerun.sh`` and never
+sees a private CA an operator imported on the worker. Nothing about the worker's
+trust store reaches it by itself.
+
+So the worker's own CA bundle is handed over as container file content, and the
+runner is pointed at it with ``--progress-ca-cert``. Both halves matter:
+
+* As *content*, the runtime writes it into the container itself. Nothing is
+  written to a directory the container can reach beforehand, so there is no
+  destination for it to hijack, and nothing outlives the run.
+* As a *progress-scoped option* rather than ``SSL_CERT_FILE``, it leaves the
+  rest of the container's TLS alone -- a bundle holding only a private CA would
+  otherwise strip the public roots the runner needs elsewhere.
+"""
+
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+import gpustack.worker.benchmark.runner as bm_runner
+from gpustack.worker.benchmark.runner import BenchmarkRunner
+
+
+class TestProgressCAFile:
+    """What gets handed to the container, and when."""
+
+    def _runner(self, api_url, *, insecure=False):
+        return SimpleNamespace(
+            _api_url=api_url,
+            _progress_insecure_skip_tls_verify=insecure,
+            _progress_is_https=urlparse(api_url).scheme == "https",
+        )
+
+    def _bundle(self, tmp_path, body="-----BEGIN CERTIFICATE-----\n"):
+        source = tmp_path / "worker-ca-bundle.crt"
+        source.write_text(body)
+        return source
+
+    def test_https_hands_over_the_worker_bundle(self, tmp_path, monkeypatch):
+        source = self._bundle(tmp_path)
+        monkeypatch.setattr(bm_runner, "resolve_ca_bundle", lambda: str(source))
+
+        ca_file = BenchmarkRunner._progress_ca_file(
+            self._runner("https://gpustack.internal/v2/benchmarks/1/state")
+        )
+
+        assert ca_file is not None
+        # Content, not a host path: the runtime writes this into the container.
+        assert ca_file.content == source.read_text()
+        assert ca_file.path == bm_runner.PROGRESS_CA_BUNDLE_PATH
+        assert ca_file.mode == 0o644
+
+    def test_nothing_is_written_on_the_host(self, tmp_path, monkeypatch):
+        """The property that removes the whole hijack surface.
+
+        The previous design copied the bundle into benchmark_dir, which is
+        mounted ReadWriteMany into a container running as root -- so that
+        container could plant a symlink at the destination and have the next
+        run, also root, follow it.
+        """
+        source = self._bundle(tmp_path)
+        monkeypatch.setattr(bm_runner, "resolve_ca_bundle", lambda: str(source))
+        before = set(tmp_path.iterdir())
+
+        BenchmarkRunner._progress_ca_file(
+            self._runner("https://gpustack.internal/v2/benchmarks/1/state")
+        )
+
+        assert set(tmp_path.iterdir()) == before
+
+    def test_plain_http_hands_over_nothing(self, tmp_path, monkeypatch):
+        import pytest
+
+        monkeypatch.setattr(
+            bm_runner,
+            "resolve_ca_bundle",
+            lambda: pytest.fail("must not resolve a bundle for http://"),
+        )
+
+        assert (
+            BenchmarkRunner._progress_ca_file(
+                self._runner("http://127.0.0.1:80/v2/benchmarks/1/state")
+            )
+            is None
+        )
+
+    def test_insecure_mode_hands_over_nothing(self, tmp_path, monkeypatch):
+        import pytest
+
+        monkeypatch.setattr(
+            bm_runner,
+            "resolve_ca_bundle",
+            lambda: pytest.fail("verification is off; no bundle is consulted"),
+        )
+
+        assert (
+            BenchmarkRunner._progress_ca_file(
+                self._runner(
+                    "https://gpustack.internal/v2/benchmarks/1/state", insecure=True
+                )
+            )
+            is None
+        )
+
+    def test_an_unreadable_bundle_is_not_fatal(self, tmp_path, monkeypatch):
+        """The measurement only needs the model endpoint, which is plain HTTP.
+
+        A run must not be lost over progress telemetry, so this warns and the
+        caller simply does not forward --progress-ca-cert.
+        """
+        monkeypatch.setattr(
+            bm_runner, "resolve_ca_bundle", lambda: str(tmp_path / "does-not-exist")
+        )
+
+        assert (
+            BenchmarkRunner._progress_ca_file(
+                self._runner("https://gpustack.internal/v2/benchmarks/1/state")
+            )
+            is None
+        )
+
+
+class TestWorkerCAEnvIsDropped:
+    """Inherited CA variables name paths in the WORKER's filesystem.
+
+    filter_env_vars has no reason to know that, so it passes them through. None
+    of them fall back when the file is missing: SSL_CERT_FILE loads zero
+    certificates, and requests raises OSError outright.
+    """
+
+    def test_the_bundle_variables_are_dropped(self):
+        env = {
+            "SSL_CERT_FILE": "/worker/only/ca.crt",
+            "REQUESTS_CA_BUNDLE": "/worker/only/ca.crt",
+            "CURL_CA_BUNDLE": "/worker/only/ca.crt",
+            "HF_TOKEN": "keep-me",
+        }
+
+        BenchmarkRunner._drop_worker_ca_env(SimpleNamespace(), env)
+
+        assert "SSL_CERT_FILE" not in env
+        assert "REQUESTS_CA_BUNDLE" not in env
+        assert "CURL_CA_BUNDLE" not in env
+        assert env["HF_TOKEN"] == "keep-me"
+
+    def test_the_cert_dir_is_kept(self):
+        """SSL_CERT_DIR is not the same hazard: a missing capath is ignored, and
+        the value IS valid in the container when it names a standard path."""
+        env = {"SSL_CERT_DIR": "/etc/ssl/certs"}
+
+        BenchmarkRunner._drop_worker_ca_env(SimpleNamespace(), env)
+
+        assert env["SSL_CERT_DIR"] == "/etc/ssl/certs"
+
+
+class TestInsecureFlagForwarding:
+    """Whether the runner is told to skip verification.
+
+    This gating decides whether a container starts at all: the option only exists
+    on runner images from v0.0.4.post1 on, so forwarding it to an older pinned
+    image is a hard startup failure (unknown option, exit 2). It is also the one
+    piece of TLS handling that runs under a mirrored deployment, where the rest
+    of it is skipped.
+    """
+
+    def _runner(self, api_url, *, insecure):
+        benchmark = SimpleNamespace(
+            id=1,
+            auto_tune=False,
+            stages=None,
+            load_type="fixed_rate",
+            request_rate=10,
+            total_requests=None,
+            max_seconds=None,
+            dataset_name="Random",
+            dataset_input_tokens=128,
+            dataset_output_tokens=128,
+            dataset_input_stdev=None,
+            dataset_input_min=None,
+            dataset_input_max=None,
+            dataset_output_stdev=None,
+            dataset_output_min=None,
+            dataset_output_max=None,
+            dataset_seed=42,
+            dataset_seed_increment=True,
+            prefix_buckets=None,
+            turns=None,
+            warmup=None,
+            cooldown=None,
+            max_errors=None,
+            max_error_rate=None,
+            stop_on_saturation=None,
+        )
+        return SimpleNamespace(
+            _benchmark=benchmark,
+            _model_endpoint="http://127.0.0.1:8000",
+            _model_path="/models/qwen3-0.6b",
+            _model_backend_parameters=None,
+            _benchmark_dir="/var/lib/gpustack/benchmarks",
+            _api_url=api_url,
+            _api_key="token",
+            _progress_insecure_skip_tls_verify=insecure,
+            _progress_is_https=urlparse(api_url).scheme == "https",
+        )
+
+    def test_the_ca_cert_points_at_the_injected_file(self):
+        """Its value is the in-container path, which only the injection defines.
+
+        The two are decided together in start(), so they cannot disagree about
+        whether the file is there.
+        """
+        args = BenchmarkRunner._build_command_args(
+            self._runner(
+                "https://gpustack.internal/v2/benchmarks/1/state", insecure=False
+            ),
+            with_ca_cert=True,
+        )
+
+        assert (
+            args[args.index("--progress-ca-cert") + 1]
+            == bm_runner.PROGRESS_CA_BUNDLE_PATH
+        )
+
+    def test_no_ca_cert_when_nothing_was_injected(self):
+        args = BenchmarkRunner._build_command_args(
+            self._runner(
+                "https://gpustack.internal/v2/benchmarks/1/state", insecure=False
+            ),
+            with_ca_cert=False,
+        )
+
+        assert "--progress-ca-cert" not in args
+
+    def test_forwarded_for_https(self):
+        args = BenchmarkRunner._build_command_args(
+            self._runner(
+                "https://gpustack.internal/v2/benchmarks/1/state", insecure=True
+            )
+        )
+        assert "--progress-insecure-skip-tls-verify" in args
+
+    def test_omitted_for_plain_http(self):
+        # Nothing to skip, and forwarding it over HTTP would risk the
+        # unknown-option failure for no gain.
+        args = BenchmarkRunner._build_command_args(
+            self._runner("http://127.0.0.1:80/v2/benchmarks/1/state", insecure=True)
+        )
+        assert "--progress-insecure-skip-tls-verify" not in args
+
+    def test_omitted_when_disabled(self):
+        args = BenchmarkRunner._build_command_args(
+            self._runner(
+                "https://gpustack.internal/v2/benchmarks/1/state", insecure=False
+            )
+        )
+        assert "--progress-insecure-skip-tls-verify" not in args
+
+    def test_the_warning_travels_with_the_flag(self, caplog):
+        """The log line naming the cause must be emitted wherever the flag is.
+
+        It used to live with the rest of the TLS handling, which a mirrored
+        deployment skips -- so exactly the operator whose container died on the
+        unknown option got no explanation.
+        """
+        with caplog.at_level("WARNING"):
+            BenchmarkRunner._build_command_args(
+                self._runner(
+                    "https://gpustack.internal/v2/benchmarks/1/state", insecure=True
+                )
+            )
+
+        assert "GPUSTACK_INSECURE_TLS is set" in caplog.text
+        assert "--progress-insecure-skip-tls-verify" in caplog.text
+
+    def test_the_worker_token_is_passed_to_the_container(self):
+        # The container needs the real credential; only the LOG of it is redacted.
+        args = BenchmarkRunner._build_command_args(
+            self._runner(
+                "https://gpustack.internal/v2/benchmarks/1/state", insecure=False
+            )
+        )
+        assert args[args.index("--progress-auth") + 1] == "token"
+
+
+class TestResolveProgressInsecureTLS:
+    """What puts the progress channel into insecure mode.
+
+    Only GPUSTACK_INSECURE_TLS, which a worker started with the enterprise
+    plugin's --insecure-tls sets. There is deliberately no benchmark-only switch:
+    it would let benchmarks skip verification while the worker's own connection
+    to the same server could not. The variable cannot reach the benchmark
+    container on its own (stripped by filter_env_vars, and the enterprise
+    sitecustomize shim lives in the gpustack image), so it is read here.
+    """
+
+    def test_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("GPUSTACK_INSECURE_TLS", raising=False)
+        assert bm_runner.resolve_progress_insecure_tls() is False
+
+    def test_the_worker_wide_env_enables_it(self, monkeypatch):
+        monkeypatch.setenv("GPUSTACK_INSECURE_TLS", "1")
+        assert bm_runner.resolve_progress_insecure_tls() is True
+
+    def test_true_also_enables_it(self, monkeypatch):
+        # get_gpustack_env_bool accepts "1" and "true" only -- not "yes"/"on",
+        # which the backend-parameter parser does accept.
+        monkeypatch.setenv("GPUSTACK_INSECURE_TLS", "true")
+        assert bm_runner.resolve_progress_insecure_tls() is True
+
+    def test_a_falsy_env_value_does_not_enable_it(self, monkeypatch):
+        # get_gpustack_env_bool reads "true"/"1"; anything else is off, so an
+        # operator who explicitly disabled it is not overridden by its presence.
+        monkeypatch.setenv("GPUSTACK_INSECURE_TLS", "false")
+        assert bm_runner.resolve_progress_insecure_tls() is False


### PR DESCRIPTION
Benchmark progress is reported to the server's own URL, so on an HTTPS deployment the container has to verify a certificate the worker already trusts -- and it could not. The benchmark image is a separate gpustack/benchmark-runner image whose entrypoint is the runner CLI, so it never runs gpustack-prerun.sh and never sees the CAs an operator dropped into /usr/local/share/ca-certificates/. Its only mounts are the model dir and benchmark_dir. Nothing about the worker's trust store reached it, and every progress PATCH died with CERTIFICATE_VERIFY_FAILED -- fatally so on runner images before this fix, which raised instead of warning.

The worker now copies the bundle it verifies against itself -- private CAs already merged in by update-ca-certificates -- into benchmark_dir, the one directory both writable here and mounted into the container, and points SSL_CERT_FILE at the copy. aiohttp builds its default context with ssl.create_default_context(), which honors that variable.

An inherited SSL_CERT_FILE is dropped first. It names a path in the worker's filesystem, and a missing SSL_CERT_FILE does not fall back to the system bundle -- OpenSSL loads zero certificates -- so leaving a stale one behind when staging fails would be worse than not setting it at all. SSL_CERT_DIR needs no such handling: a missing capath is simply ignored.

A worker that cannot verify the server at all is covered too. The enterprise plugin's --insecure-tls sets GPUSTACK_INSECURE_TLS, which reaches this process but not the container: filter_env_vars strips GPUSTACK_*, and the shim that re-applies the ssl patch in spawned interpreters lives in the gpustack image, not the benchmark one. So it is read here and forwarded as the runner's own --progress-insecure-skip-tls-verify. There is deliberately no benchmark-only switch -- benchmarks skipping verification while the worker's own connection to the same server could not is not a distinction worth configuring.

Also keeps the worker token out of the workload log. --progress-auth is the token itself, and the log joined command_args verbatim, so every benchmark start wrote the credential into the worker log while the env on the next line was already going through sanitize_env. sanitize_args redacts the values of flags carrying a credential GPUStack injects itself; only those, since matching on substrings like "token" would also swallow --token-timeout and --max-tokens. The container still receives the real value, and it remains visible in the workload spec.

The runner option requires the image bump to v0.0.4.post1.