### PR TITLE
fix: decide shared-cache node-locality at scheduling, not validation

### DIFF
--- a/gpustack/assets/cache-providers.yaml
+++ b/gpustack/assets/cache-providers.yaml
@@ -39,6 +39,9 @@
   # own cache server instance and engines attach to the one on their
   # node, so managed deployments follow the cluster's workers.
   topology: per_node
+  # The MP connector's zero-copy path is CUDA IPC: engines can only
+  # attach the cache server on their own node.
+  attach_locality: node_local
   default_version: "v0.5.2"
   # A service may pin a user-supplied image ("custom" version); it runs
   # with the default version's run command and env templates, so the image
@@ -373,6 +376,9 @@
     - { label: Product Page, url: "https://www.xsky.com" }
   supported_modes: [managed]
   topology: per_node
+  # The MP connector's zero-copy path is CUDA IPC: engines can only
+  # attach the cache server on their own node.
+  attach_locality: node_local
   default_version: "v0.5.2"
   custom_version: true
   versions:

--- a/gpustack/routes/models.py
+++ b/gpustack/routes/models.py
@@ -815,19 +815,6 @@ async def validate_shared_kv_cache(
             message="The cache service must be in the same cluster as the model."
         )
 
-    # The MP-style connectors share KV node-locally (CUDA IPC has no
-    # cross-host path) and the resolver attaches node-local only, while a
-    # multi-worker distributed instance runs one engine across several
-    # nodes with a single snapshot — its subordinate workers would face a
-    # remote server on the node-local contract. Reject the combination.
-    if model_in.distributed_inference_across_workers:
-        raise BadRequestException(
-            message=(
-                "Shared KV cache attaches node-locally and does not "
-                "support instances distributed across workers."
-            )
-        )
-
     provider = get_cache_provider(cache_service.provider_name)
     backend = model_in.backend or BackendEnum.VLLM.value
     if provider is None or provider.integration_for(backend) is None:

--- a/gpustack/scheduler/scheduler.py
+++ b/gpustack/scheduler/scheduler.py
@@ -406,7 +406,10 @@ class Scheduler:
                     # instance's node.
                     model_instance.cache_config = (
                         await resolve_instance_cache_config_safe(
-                            session, model, worker=candidate.worker
+                            session,
+                            model,
+                            worker=candidate.worker,
+                            spans_workers=model_instance.spans_workers,
                         )
                     )
 

--- a/gpustack/schemas/cache_providers.py
+++ b/gpustack/schemas/cache_providers.py
@@ -297,6 +297,16 @@ class CacheProvider(BaseModel):
     per active worker of the service's cluster, following workers as they
     join and leave."""
 
+    attach_locality: str = "cluster"
+    """Where an engine may attach from: "node_local" means the connector
+    only works against a cache server on the engine's own node (e.g.
+    LMCache MP's CUDA-IPC transport), so remote fallback and multi-worker
+    instances degrade; "cluster" (default) means the endpoint is
+    network-reachable from any worker. Deliberately separate from
+    ``topology``: placement and attach contract only coincide for
+    LMCache-style providers — a distributed pool may run per-node data
+    components while engines attach its cluster-wide endpoint."""
+
     default_version: Optional[str] = None
     versions: Dict[str, CacheProviderVersionConfig] = {}
 

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -798,6 +798,15 @@ class ModelInstanceBase(SQLModel, ModelSource):
         sa_column=Column(pydantic_column_type(List[LoraListEntry]), nullable=True),
     )
 
+    @property
+    def spans_workers(self) -> bool:
+        """Whether this instance is actually placed across several
+        workers (subordinate workers assigned at scheduling) — the
+        placement fact, as opposed to the model's
+        distributed_inference_across_workers permission flag."""
+        dservers = self.distributed_servers
+        return bool(dservers and dservers.subordinate_workers)
+
     def get_deployment_metadata(
         self,
         worker_id: int,

--- a/gpustack/server/cache_services.py
+++ b/gpustack/server/cache_services.py
@@ -137,13 +137,13 @@ async def _resolve_managed_endpoint(
     ("node_local" | "remote"); provider declarations map it to their own
     connector vocabulary via injection.locality_params.
 
-    per_node topologies attach node-local only: measured remote transfer
-    (the engine-driven copy path) is slower than running without the
-    cache at all, and falling back would also funnel every uncovered
-    engine onto a single instance — so an engine on a worker without a
-    RUNNING cache instance starts degraded instead. singleton topologies
-    serve the whole cluster from their one instance, where remote attach
-    is inherent. Returns (None, reason) when no instance is usable.
+    Providers declaring attach_locality node_local attach node-local
+    only: measured remote transfer (the engine-driven copy path) is
+    slower than running without the cache at all, and falling back would
+    also funnel every uncovered engine onto a single instance — so an
+    engine on a worker without a RUNNING cache instance starts degraded
+    instead. Cluster-attachable providers serve any worker from any
+    instance. Returns (None, reason) when no instance is usable.
     """
     instances = await CacheServiceInstance.all_by_fields(
         session, {"cache_service_id": service.id}
@@ -170,7 +170,7 @@ async def _resolve_managed_endpoint(
         )
     node_local = target is not None
     if target is None:
-        if provider.topology == "per_node":
+        if provider.attach_locality == "node_local":
             if worker is None:
                 return None, (
                     "Cache endpoint resolves with the instance's worker "
@@ -205,7 +205,10 @@ async def _resolve_managed_endpoint(
 
 
 async def resolve_instance_cache_config(
-    session: AsyncSession, model: Model, worker: Optional[Worker] = None
+    session: AsyncSession,
+    model: Model,
+    worker: Optional[Worker] = None,
+    spans_workers: bool = False,
 ) -> Optional[CacheConfigSnapshot]:
     """
     Resolve the shared-cache connection snapshot for an instance of the
@@ -216,6 +219,13 @@ async def resolve_instance_cache_config(
     ``worker`` is the instance's assigned worker. Node-local external
     endpoints resolve to it, so calls made before scheduling yield an
     explicit pending snapshot for such services.
+
+    ``spans_workers`` marks an instance actually placed across several
+    workers (subordinate workers assigned at scheduling). The
+    distributed_inference_across_workers model flag is only a
+    permission — most single-node placements carry it — so the
+    node-local incompatibility is decided here, where the real
+    placement is known, not at model validation.
     """
     ext = model.extended_kv_cache
     if not ext or not ext.is_shared():
@@ -258,6 +268,26 @@ async def resolve_instance_cache_config(
             reason=(
                 f"Unknown cache provider '{service.provider_name}'; "
                 "instance starts without shared KV cache"
+            ),
+        )
+
+    if spans_workers and provider.attach_locality == "node_local":
+        # Declared attach contract, the same predicate
+        # _resolve_managed_endpoint keys its no-remote-fallback rule on:
+        # node_local connectors (MP-style, CUDA IPC) have no cross-host
+        # path, so every subordinate worker of a spanning instance would
+        # face a remote server. Cluster-attachable providers (e.g.
+        # Mooncake's distributed pool) serve spanning instances by
+        # design and pass through — with a known calibration caveat: the
+        # snapshot renders once with the main worker, so subordinate
+        # workers see its local_hostname.
+        return CacheConfigSnapshot(
+            **snapshot_base,
+            injected=False,
+            reason=(
+                f"Cache provider '{provider.name}' attaches node-locally; "
+                "this instance spans multiple workers and starts without "
+                "the shared KV cache"
             ),
         )
 
@@ -420,7 +450,10 @@ async def resolve_instance_cache_config(
 
 
 async def resolve_instance_cache_config_safe(
-    session: AsyncSession, model: Model, worker: Optional[Worker] = None
+    session: AsyncSession,
+    model: Model,
+    worker: Optional[Worker] = None,
+    spans_workers: bool = False,
 ) -> Optional[CacheConfigSnapshot]:
     """
     resolve_instance_cache_config that degrades instead of raising: an
@@ -428,7 +461,9 @@ async def resolve_instance_cache_config_safe(
     callers on critical paths (e.g. the scheduler) keep going.
     """
     try:
-        return await resolve_instance_cache_config(session, model, worker)
+        return await resolve_instance_cache_config(
+            session, model, worker=worker, spans_workers=spans_workers
+        )
     except Exception as e:
         logger.error(
             f"Failed to resolve shared cache config for model {model.name}: {e}"

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -515,7 +515,10 @@ class CacheServiceController:
                 if not (refreshable or running):
                     continue
                 snapshot = await resolve_instance_cache_config_safe(
-                    session, model, workers_by_id.get(mi.worker_id)
+                    session,
+                    model,
+                    workers_by_id.get(mi.worker_id),
+                    spans_workers=mi.spans_workers,
                 )
                 if snapshot is None:
                     continue

--- a/tests/routes/test_model_kv_cache_validation.py
+++ b/tests/routes/test_model_kv_cache_validation.py
@@ -194,20 +194,18 @@ async def test_shared_skips_cluster_check_without_effective_cluster(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_shared_rejects_distributed_across_workers(monkeypatch):
-    """Shared cache attaches node-locally; a multi-worker distributed
-    instance would leave subordinate workers facing a remote server on
-    the node-local contract."""
+async def test_shared_allows_distributed_permission_flag(monkeypatch):
+    """distributed_inference_across_workers defaults to True for vLLM and
+    SGLang as a permission, not a placement plan — creation must not
+    reject it; the node-local incompatibility is decided at scheduling,
+    where the real placement is known (see the injection resolver)."""
     _patch_lookups(monkeypatch, _service())
-    with pytest.raises(BadRequestException) as exc_info:
-        await models_route.validate_shared_kv_cache(
-            MagicMock(),
-            _model_in(_shared_ext(), distributed=True),
-            OWNER_PRINCIPAL,
-            1,
-        )
-
-    assert "distributed across workers" in exc_info.value.message
+    await models_route.validate_shared_kv_cache(
+        MagicMock(),
+        _model_in(_shared_ext(), distributed=True),
+        OWNER_PRINCIPAL,
+        1,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/scheduler/test_scheduler_cache_config.py
+++ b/tests/scheduler/test_scheduler_cache_config.py
@@ -49,6 +49,9 @@ def _shared_cache_model():
 
 
 def _instance():
+    # the scheduler assigns distributed_servers then reads the real
+    # ModelInstance.spans_workers property; the fake mirrors the
+    # single-worker placement (_candidate has no subordinate workers)
     return SimpleNamespace(
         id=11,
         name="m-1",
@@ -56,6 +59,7 @@ def _instance():
         state=ModelInstanceStateEnum.PENDING,
         state_message="",
         worker_id=None,
+        spans_workers=False,
         cache_config="unchanged-sentinel",
     )
 

--- a/tests/server/test_cache_provider_catalog.py
+++ b/tests/server/test_cache_provider_catalog.py
@@ -26,8 +26,13 @@ def test_lmcache_provider_declaration():
     # itself; reference-only distributed caches are what external is for.
     assert provider.supported_modes == [CacheServiceModeEnum.MANAGED.value]
     # The MP server keeps KV transfers node-local, so managed deployments
-    # run one instance per worker of the cluster.
+    # run one instance per worker of the cluster; attach_locality is the
+    # declared contract the resolver's node-local rules key on —
+    # deliberately separate from topology (a distributed pool may run
+    # per-node data components while engines attach its cluster-wide
+    # endpoint).
     assert provider.topology == "per_node"
+    assert provider.attach_locality == "node_local"
     # /healthcheck verifies engine readiness (503 until initialized) and
     # lives on the HTTP frontend — the metrics port in our port model.
     assert provider.health_check.scheme == "http"
@@ -181,6 +186,9 @@ def test_mooncake_provider_declaration():
     # Shipped and supported as part of the GPUStack catalog, like LMCache;
     # "partner" is reserved for vendor-branded providers.
     assert provider.source.value == "built_in"
+    # A distributed pool is network-attachable from any worker — spanning
+    # (multi-worker) instances attach by design.
+    assert provider.attach_locality == "cluster"
     assert provider.icon == "/static/catalog_icons/mooncake.png"
     # Mooncake is a self-deployed distributed store; GPUStack only references
     # it, so it is external-only and runs no managed container.

--- a/tests/server/test_cache_service_controller.py
+++ b/tests/server/test_cache_service_controller.py
@@ -553,6 +553,7 @@ def _model_instance(state, injected=False, reason="not ready", worker_id=5):
         model_id=3,
         worker_id=worker_id,
         state=state,
+        spans_workers=False,
         cache_config=CacheConfigSnapshot(
             cache_service_id=9, injected=injected, reason=reason
         ),
@@ -718,6 +719,7 @@ async def test_refresh_tracks_endpoint_liveness_on_running_instance():
         model_id=3,
         worker_id=5,
         state=ModelInstanceStateEnum.RUNNING,
+        spans_workers=False,
         cache_config=CacheConfigSnapshot(
             cache_service_id=9,
             injected=True,

--- a/tests/server/test_cache_service_injection.py
+++ b/tests/server/test_cache_service_injection.py
@@ -323,6 +323,27 @@ async def test_resolve_degrades_when_engine_version_below_floor():
 
 
 @pytest.mark.asyncio
+async def test_resolve_degrades_when_instance_spans_workers():
+    """The distributed permission flag rides on most vLLM/SGLang models;
+    only an instance actually placed across workers conflicts with the
+    per_node providers' node-local contract — decided here with the real
+    placement, and degrading keeps the engine running without the
+    cache."""
+    model = shared_cache_model()
+    with patch_lookups(managed_cache_service()):
+        snapshot = await resolve_instance_cache_config(
+            MagicMock(),
+            model,
+            worker=SimpleNamespace(id=2, ip="10.0.0.5", deleted_at=None),
+            spans_workers=True,
+        )
+
+    assert snapshot.injected is False
+    assert "spans multiple workers" in snapshot.reason
+    assert not snapshot.args
+
+
+@pytest.mark.asyncio
 async def test_resolve_per_node_degrades_without_node_local_instance():
     """per_node never attaches across nodes: the engine-driven copy path
     measures slower than running without the cache, and a silent
@@ -469,6 +490,26 @@ async def test_resolve_external_mooncake_injects_store_connector():
     assert config["metadata_server"] == "P2PHANDSHAKE"
     assert config["protocol"] == "tcp"
     assert config["local_buffer_size"] == "1GB"
+    assert '"kv_connector":"MooncakeStoreConnector"' in snapshot.args[1]
+
+
+@pytest.mark.asyncio
+async def test_resolve_external_provider_attaches_spanning_instances():
+    """Node-locality is the per_node providers' contract, not a
+    shared-cache property: a cross-host pool (Mooncake, external mode,
+    singleton topology) serves multi-worker instances by design — every
+    subordinate worker's engine reaches the master over the network."""
+    model = shared_cache_model()
+    instance_worker = SimpleNamespace(id=7, ip="10.0.0.7", deleted_at=None)
+    with patch_lookups(mooncake_cache_service(), worker=None, instances=[]):
+        snapshot = await resolve_instance_cache_config(
+            MagicMock(),
+            model,
+            worker=instance_worker,
+            spans_workers=True,
+        )
+
+    assert snapshot.injected is True
     assert '"kv_connector":"MooncakeStoreConnector"' in snapshot.args[1]
 
 


### PR DESCRIPTION
distributed_inference_across_workers defaults to true for vLLM and SGLang as a permission, not a placement plan, so rejecting it at model validation blocked every default-configured deployment from attaching a shared cache. Whether an instance actually spans workers is only known once scheduling assigns subordinate workers.

Move the node-local incompatibility there: the injection resolver takes the real placement and degrades a multi-worker instance to a plain start with an explicit reason (subordinate workers would face a remote server on the node-local contract), instead of failing the whole model up front. The snapshot refresher passes the same fact so convergence never flips a spanning instance to attached.