### PR TITLE
fix(bus): make the id-only event payload a contract consumers can honor

### DIFF
--- a/gpustack/gpu_instances/controllers.py
+++ b/gpustack/gpu_instances/controllers.py
@@ -48,7 +48,7 @@ from gpustack.schemas.clusters import (
     Cluster,
 )
 
-from gpustack.server.bus import Event, EventType
+from gpustack.server.bus import Event, EventType, resolve_event_id
 from gpustack.server.workqueue import WorkEvent, WorkEventType, WorkQueue
 from gpustack import envs
 from gpustack.server.db import async_session
@@ -209,7 +209,11 @@ class GPUInstanceController:
 
     def _enqueue(self, event: Event):
         """Map a bus event onto the work queue (coalescing happens in the queue)."""
-        iid = event.data.id if event.data is not None else event.id
+        # resolve_event_id rather than ``event.data.id``: the latter raises on
+        # an id-only payload (see Event). This topic is not registered for
+        # cross-instance enrichment today, so nothing reaches here in that
+        # shape -- registering it later should not be what discovers that.
+        iid = resolve_event_id(event)
         if iid is None:
             return
         self._queue.add(self._to_work_event(iid, event))
@@ -1039,7 +1043,8 @@ class _PersistentVolumeFinalizeController:
 
     def _enqueue(self, event: Event):
         """Map a bus event onto the work queue (coalescing happens in the queue)."""
-        row_id = event.data.id if event.data is not None else event.id
+        # See the note on GPUInstanceController._enqueue.
+        row_id = resolve_event_id(event)
         if row_id is None:
             return
         self._queue.add(self._to_work_event(row_id, event))

--- a/gpustack/gpu_instances/gateway.py
+++ b/gpustack/gpu_instances/gateway.py
@@ -9,7 +9,7 @@ import logging
 
 from gpustack.gpu_instances import gateway_client
 from gpustack.schemas.clusters import Cluster, ClusterProvider, K8sOptions
-from gpustack.server.bus import Event, EventType
+from gpustack.server.bus import Event, EventType, resolve_event_id
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,24 @@ async def reconcile_gpustack_operator_subscription():
 
 async def _reconcile(event: Event):
     cluster: Cluster = event.data
-    if cluster is None or cluster.provider != ClusterProvider.Kubernetes:
+    if cluster is None:
+        return
+
+    # A cross-instance DELETE arrives carrying nothing but the row id (see
+    # Event): the cluster topic is not preloaded into the change-detector
+    # cache, and by the time the event lands the row is gone. Reading
+    # ``provider`` off that dict would raise, the caller would swallow it, and
+    # this server's operator subprocess would go on proxying a cluster that no
+    # longer exists -- with no further event to recover from. The id is all the
+    # unsubscribe needs, and unsubscribing a cluster that was never subscribed
+    # is a no-op, so do not try to re-derive the provider first.
+    if isinstance(cluster, dict):
+        cluster_id = resolve_event_id(event)
+        if cluster_id is not None:
+            await gateway_client.unsubscribe_worker(str(cluster_id))
+        return
+
+    if cluster.provider != ClusterProvider.Kubernetes:
         return
     # Over the bus the ``k8s_options`` JSON column can arrive as a plain dict
     # (nested pydantic_column_type isn't re-validated on replay), so coerce it

--- a/gpustack/server/bus.py
+++ b/gpustack/server/bus.py
@@ -6,7 +6,12 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 from gpustack.envs import EVENT_BUS_SUBSCRIBER_QUEUE_SIZE
 
 # Re-export from coordinator.base for backward compatibility
-from gpustack.server.coordinator.base import Event, EventType
+from gpustack.server.coordinator.base import (
+    Event,
+    EventType,
+    event_field,
+    resolve_event_id,
+)
 from gpustack.server.coordinator.cache import get_change_detector
 from gpustack.server.coordinator.models import get_model_for_topic
 
@@ -41,6 +46,12 @@ __all__ = [
     'event_bus',
     'set_coordinator',
     'event_decoder',
+    # Payload-shape helpers. Exported here rather than left in
+    # coordinator.base because this is the module consumers -- in-tree and
+    # plugins alike -- already import Event/EventType from, and handling
+    # both shapes is not optional for any of them. See Event's docstring.
+    'event_field',
+    'resolve_event_id',
 ]
 
 
@@ -224,6 +235,9 @@ class EventBus:
         # ``(topic, source, kind, event_type)`` — a bounded label space, so
         # this dict cannot grow without limit.
         self.retired_event_counts: Dict[Tuple[str, str, str, str], int] = {}
+        # Topics already reported as missing from ``_ModelRegistry``, so that
+        # warning fires once each rather than once per dropped event.
+        self._unregistered_topics_warned: Set[str] = set()
 
     def _spawn(self, coro) -> asyncio.Task:
         """``asyncio.create_task`` plus retain-and-discard bookkeeping."""
@@ -309,6 +323,49 @@ class EventBus:
                 f"No running event loop for coordinator event on topic {topic}, skipping"
             )
 
+    def _remember_local_row(self, event: Event, topic: str):
+        """Cache a locally-published row so a later cross-instance DELETE for
+        it can still be enriched.
+
+        Without this the change detector only ever learns about rows from
+        *other* instances, so a row created here is never in our own cache --
+        and when another instance deletes it, the DELETE arrives with nothing
+        but an id and there is no longer a row to re-read. Create on A, delete
+        on B, and A gets a payload it cannot act on. That is the common path,
+        not an edge case, so warm the cache from writes we serve ourselves.
+
+        It does not remove the id-only shape (a restart, a dropped event or an
+        LRU eviction all still produce it) -- consumers must keep handling it.
+        It just stops the most frequent cause.
+
+        Side effect worth knowing about: ``changed_fields`` on a later
+        cross-instance event is now diffed against the last state this
+        instance saw rather than against the startup snapshot, so the handlers
+        gated on it (``"state"``, ``"labels"``, ``"deleted_at"``) see fewer
+        missed transitions.
+
+        Both gates below exist because this cache is only ever *read* from the
+        id-only branch of :meth:`_process_coordinator_event`. Writing entries
+        no reader can reach is not free: it pins up to ``maxsize`` detached
+        rows per topic, and on an append-only table with monotonic ids the
+        LRU never hits at all, so it is pure churn.
+        """
+        # No cross-instance path, so no id-only payload will ever arrive to
+        # be enriched. Single-node is the default deployment; do not make it
+        # pay for a distributed-mode optimisation.
+        if self._coordinator is None or not self._coordinator.is_distributed:
+            return
+        # Unregistered topics return before the lookup in every mode.
+        if get_model_for_topic(topic) is None:
+            return
+        if event.id is None or isinstance(event.data, dict) or event.data is None:
+            return
+        detector = get_change_detector(topic)
+        if event.type == EventType.DELETED:
+            detector.remove(event.id)
+        else:
+            detector.put(event.id, event.data)
+
     async def _process_coordinator_event(self, event: Event, topic: str):
         """
         Process event from coordinator.
@@ -333,6 +390,7 @@ class EventBus:
             logger.trace(
                 f"Routing non-ID-only event for topic {topic}: data type={type(event.data).__name__}, keys={list(event.data.keys()) if isinstance(event.data, dict) else 'N/A'}, id={event.id}"
             )
+            self._remember_local_row(event, topic)
             self._route_event(event, topic)
             return
 
@@ -346,8 +404,23 @@ class EventBus:
         try:
             model_class = get_model_for_topic(topic)
             if model_class is None:
-                # Unknown topic, skip to avoid sending incomplete data
-                logger.debug(f"Skipping event for topic {topic}: no model class found.")
+                # Unregistered topic: every cross-instance event on it is
+                # dropped here, so its subscribers only ever see writes this
+                # instance served. That is a silent, total loss of one topic's
+                # distributed delivery, and the registry is a hand-maintained
+                # allowlist -- the way this goes wrong is a topic gaining a
+                # subscriber without gaining an entry, which debug-level hides.
+                # Once per topic, not per event: the affected topics include
+                # high-frequency ones, and the second line says nothing new.
+                if topic not in self._unregistered_topics_warned:
+                    self._unregistered_topics_warned.add(topic)
+                    logger.warning(
+                        f"Dropping cross-instance events for topic {topic}: not "
+                        f"registered in _ModelRegistry, so they cannot be "
+                        f"enriched. Subscribers on this topic will not see "
+                        f"writes served by other instances. Further drops on "
+                        f"this topic are not logged."
+                    )
                 return
 
             # Use ChangeDetector to detect changes and manage cache

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -90,7 +90,13 @@ from gpustack.schemas.users import (
     User,
     is_default_cluster_principal,
 )
-from gpustack.server.bus import Event, EventType, event_bus
+from gpustack.server.bus import (
+    Event,
+    EventType,
+    event_bus,
+    event_field,
+    resolve_event_id,
+)
 from gpustack.server.cache import delete_cache_by_key
 from gpustack.utils.model_source import get_draft_model_source
 from gpustack import envs
@@ -202,6 +208,15 @@ class ModelController:
         Reconcile the model.
         """
         model: Model = event.data
+        # Unhydrated means a delete whose row is gone (see Event), and every
+        # callee below reads model fields. Leader-only controller, so nothing
+        # else picks it up -- warn rather than drop it quietly.
+        if not isinstance(model, Model):
+            logger.warning(
+                f"Model {resolve_event_id(event)} {event.type} not reconciled: "
+                f"the event carries only an id and the row is gone"
+            )
+            return
         try:
             async with async_session() as session:
                 await sync_replicas(session, model)
@@ -237,22 +252,46 @@ class ModelInstanceController:
         """
 
         model_instance: ModelInstance = event.data
+        # A cross-instance DELETE may carry only the id (see Event), so take
+        # what the payload can give: the id always resolves, model_id only
+        # when the event is hydrated.
+        instance_id = resolve_event_id(event)
+        model_id = event_field(model_instance, "model_id")
         try:
             async with async_session() as session:
                 if event.type == EventType.DELETED and model_instance is not None:
                     # Cover cascade deletes that bypass ModelInstanceService.
+                    #
+                    # Known gap: with an id-only payload model_id is unknown,
+                    # so the get_running_instances entry -- the one that feeds
+                    # routing, and so the more important of the two -- is not
+                    # dropped. Deletes through ModelInstanceService are fine
+                    # (it invalidates itself, and delete_cache_by_key
+                    # broadcasts), but the cascade path this block exists for
+                    # is not, and the controller is leader-only so no other
+                    # process retries it. Closing it needs the deleted row's
+                    # model_id, which no event can carry.
                     instance_service = ModelInstanceService(session)
-                    if model_instance.model_id is not None:
+                    if model_id is not None:
                         await delete_cache_by_key(
                             instance_service.get_running_instances,
-                            model_instance.model_id,
+                            model_id,
                         )
-                    if model_instance.id is not None:
+                    if instance_id is not None:
                         await delete_cache_by_key(
-                            instance_service.get_by_id, model_instance.id
+                            instance_service.get_by_id, instance_id
                         )
 
-                model = await Model.one_by_id(session, model_instance.model_id)
+                # Everything past this point needs the row's fields, and
+                # model_id is the way in. Return explicitly rather than
+                # letting one_by_id take a None primary key: it warns today
+                # ("fully NULL primary key identity cannot load any object")
+                # and SQLAlchemy reserves the right to raise on it later.
+                # Nothing is lost -- the replica sync is level-triggered, and
+                # the deleting instance ran it against the hydrated row.
+                if model_id is None:
+                    return
+                model = await Model.one_by_id(session, model_id)
                 if not model:
                     return
                 model_deleting = model.deleted_at is not None
@@ -293,7 +332,8 @@ class ModelInstanceController:
                     await revoke_model_access_cache(session=session)
         except Exception as e:
             logger.error(
-                f"Failed to reconcile model instance {model_instance.name}: {e}"
+                "Failed to reconcile model instance "
+                f"{event_field(model_instance, 'name', instance_id)}: {e}"
             )
 
 
@@ -1274,6 +1314,17 @@ class WorkerController:
 
         async for event in Worker.subscribe(source="worker_controller"):
             if event.type == EventType.HEARTBEAT:
+                continue
+            # All three handlers below branch on worker fields (state,
+            # cluster_id, name), none of which survive an unhydrated payload
+            # (see Event). Guarding once keeps one the first handler cannot
+            # read from costing the other two as well.
+            if not isinstance(event.data, Worker):
+                logger.warning(
+                    f"Worker {resolve_event_id(event)} {event.type} not "
+                    f"reconciled: the event carries only an id and the row is "
+                    f"gone"
+                )
                 continue
             try:
                 await self._reconcile(event)
@@ -2313,10 +2364,19 @@ class WorkerPoolController:
         """
         Reconcile the worker pool state with the current event.
         """
-        logger.info(f"Reconcile worker pool {event.data.id} with event {event.type}")
+        # Only the id is needed -- the pool is re-read below either way -- so
+        # an id-only payload (see Event) is as good as a hydrated one here.
+        # On a DELETE the row is gone and one_by_id returns None.
+        pool_event_id = resolve_event_id(event)
+        if pool_event_id is None:
+            # No row to reconcile. Return rather than passing None to
+            # one_by_id, which warns ("fully NULL primary key identity cannot
+            # load any object") and may raise in a future SQLAlchemy.
+            return
+        logger.info(f"Reconcile worker pool {pool_event_id} with event {event.type}")
         async with async_session() as session:
             pool = await WorkerPool.one_by_id(
-                session, event.data.id, options=[selectinload(WorkerPool.cluster)]
+                session, pool_event_id, options=[selectinload(WorkerPool.cluster)]
             )
             if pool is None or pool.deleted_at is not None:
                 return
@@ -2692,10 +2752,15 @@ class ClusterController:
         """
         if self._cfg.gateway_mode == GatewayModeEnum.disabled:
             return
-        cluster: Cluster = event.data
+        # This runs on DELETED too -- cleaning up after a deleted cluster is
+        # the point -- and the id is all it needs, so an id-only payload
+        # (see Event) serves it just as well as a hydrated row.
+        cluster_id = resolve_event_id(event)
+        if cluster_id is None:
+            return
         mcp_resource_name = mcp_handler.default_mcp_bridge_name
         desired_registries = []
-        to_delete_prefix = mcp_handler.cluster_worker_prefix(cluster.id)
+        to_delete_prefix = mcp_handler.cluster_worker_prefix(cluster_id)
         try:
             await mcp_handler.ensure_mcp_bridge(
                 client=self._higress_network_api,
@@ -2705,7 +2770,10 @@ class ClusterController:
                 to_delete_prefix=to_delete_prefix,
             )
         except Exception as e:
-            logger.error(f"Failed to ensure MCPBridge for cluster {cluster.name}: {e}")
+            logger.error(
+                "Failed to ensure MCPBridge for cluster "
+                f"{event_field(event.data, 'name', cluster_id)}: {e}"
+            )
             raise
 
 
@@ -2801,26 +2869,32 @@ class ModelProviderController:
         model_provider: ModelProvider,
         event: Event,
     ):
-        provider_registry = mcp_handler.provider_registry(model_provider)
-        registry_to_remove = (
-            provider_registry is None or event.type == EventType.DELETED
+        # On DELETED both desired sets are empty and only the id is read, so
+        # this path works off an id-only payload (see Event) -- which is what
+        # a cross-instance delete carries, and skipping it would strand the
+        # registry and proxy of a provider that no longer exists. Deriving
+        # the two specs first would defeat that: they need a hydrated row and
+        # their values are discarded here anyway.
+        deleted = event.type == EventType.DELETED
+        provider_id = resolve_event_id(event)
+        provider_registry = (
+            None if deleted else mcp_handler.provider_registry(model_provider)
         )
+        registry_to_remove = provider_registry is None or deleted
         # Match by exact name (not prefix) so that deleting provider id "1" does
         # not also drop other providers whose id shares that numeric prefix
         # (e.g. "provider-10", "provider-11").
         to_delete_names = (
-            [mcp_handler.provider_registry_name(model_provider.id)]
+            [mcp_handler.provider_registry_name(provider_id)]
             if registry_to_remove
             else None
         )
         desired_registries = [] if registry_to_remove else [provider_registry]
 
-        provider_proxy = mcp_handler.provider_proxy(model_provider)
-        proxy_to_remove = provider_proxy is None or event.type == EventType.DELETED
+        provider_proxy = None if deleted else mcp_handler.provider_proxy(model_provider)
+        proxy_to_remove = provider_proxy is None or deleted
         to_delete_proxy_names = (
-            [mcp_handler.provider_proxy_name(model_provider.id)]
-            if proxy_to_remove
-            else None
+            [mcp_handler.provider_proxy_name(provider_id)] if proxy_to_remove else None
         )
         desired_proxies = [] if proxy_to_remove else [provider_proxy]
 
@@ -2836,7 +2910,8 @@ class ModelProviderController:
             )
         except Exception as e:
             logger.error(
-                f"Failed to ensure MCPRegistry for model provider {model_provider.name}: {e}"
+                "Failed to ensure MCPRegistry for model provider "
+                f"{event_field(model_provider, 'name', provider_id)}: {e}"
             )
             raise
 
@@ -3064,6 +3139,20 @@ class ModelRouteTargetController:
         target: ModelRouteTarget = event.data
         if not target:
             return
+        # Every branch below keys off target fields (route_name, route_id,
+        # model_id, state), none of which an unhydrated payload has (see
+        # Event). Known gap: this controller exists to cover cascades that
+        # bypass ModelRouteService, and it is leader-only, so nothing else
+        # invalidates the route caches or transfers an orphaned route.
+        # Closing it needs the deleted row's route_name, which no event can
+        # carry, so it belongs in a periodic pass.
+        if not isinstance(target, ModelRouteTarget):
+            logger.warning(
+                f"Model route target {resolve_event_id(event)} {event.type} "
+                f"not reconciled: the event carries only an id and the row is "
+                f"gone; route caches may be stale until the next write"
+            )
+            return
         async with async_session() as session:
             # Cover cascade create/delete that bypass ModelRouteService.
             # UPDATED is skipped — it cannot change the resolved target set.
@@ -3116,12 +3205,10 @@ class ModelRouteController:
         model_route: ModelRoute = event.data
         if not model_route:
             return False
-        # Handle ID-only events from distributed mode
-        model_route_id = (
-            model_route.id
-            if hasattr(model_route, 'id')
-            else model_route.get('id') if isinstance(model_route, dict) else None
-        )
+        # Reached only with a hydrated route -- the caller guards, and a
+        # DELETE returned above -- so this is just the canonical way to read
+        # the id, not id-only handling.
+        model_route_id = resolve_event_id(event)
         if not model_route_id:
             return False
         model_route: ModelRoute = await ModelRoute.one_by_id(
@@ -3161,6 +3248,22 @@ class ModelRouteController:
         """
         model_route: ModelRoute = event.data
         if not model_route:
+            return
+        # sync_gateway and distribute_models_to_user both need the row's
+        # fields (name for the ingress names, model_dump for the per-user
+        # copies), which an unhydrated payload does not have (see Event).
+        # Known gap, not a safe skip: re-reading is not an option either
+        # (ModelRouteService.delete takes the default hard-delete path), and
+        # this controller is leader-only. Deletes through the API are still
+        # covered -- the service drops the route caches itself, and that
+        # invalidation is broadcast -- so what is uncovered is the cascade
+        # path this controller exists for.
+        if not isinstance(model_route, ModelRoute):
+            logger.warning(
+                f"Model route {resolve_event_id(event)} {event.type} not "
+                f"reconciled: the event carries only an id and the row is "
+                f"gone; gateway config for it may be stale"
+            )
             return
         async with async_session() as session:
             # sync targets will update model route record so make sure to do it before other operations

--- a/gpustack/server/coordinator/base.py
+++ b/gpustack/server/coordinator/base.py
@@ -28,6 +28,42 @@ class EventType(Enum):
 
 @dataclass
 class Event:
+    """A change on a topic, as seen by a subscriber.
+
+    ``data`` has **two** shapes and every consumer has to handle both:
+
+    * the hydrated model object, on the local path and whenever the bus
+      could re-read the row from the database, and
+    * the id-only ``{"id": N}`` dict, when it could not.
+
+    The second shape is not a degradation to be fixed -- it is what a
+    cross-instance DELETE genuinely carries. :meth:`to_dict` reduces the
+    payload to an id on the wire (a full row does not fit a NOTIFY payload),
+    and by the time the event lands on another instance the row is gone, so
+    there is nothing left to re-read. ``EventBus._process_coordinator_event``
+    falls back to its ChangeDetector cache, which the bus warms from the
+    startup preload, from cross-instance events, and from writes this
+    instance serves -- but a restart, a dropped event or an LRU eviction all
+    still leave it cold, and then the id is all a subscriber gets.
+
+    **Only DELETE.** CREATED and UPDATED are re-read from the database on
+    arrival and delivered hydrated, or dropped if the row is already gone --
+    they never reach a subscriber id-only. So a handler that needs fields the
+    payload cannot supply is choosing what to do about a *deletion*, and
+    guarding on the shape does not cost it any update. See
+    ``tests/server/test_bus.py`` for the pinned matrix.
+
+    So attribute access on ``data`` is only safe once you have established
+    the shape. Use :func:`event_field` to read a field and
+    :func:`resolve_event_id` to get the id.
+
+    ``id`` is the reliable identifier for a row-backed event: it is derived
+    from ``data`` when the event is constructed locally and carried
+    explicitly over the wire, so it survives both paths. It is ``None`` for
+    an event that stands for no row -- HEARTBEAT, and anything built with
+    ``data=None`` -- so callers still check before using it.
+    """
+
     type: EventType
     data: Any
     changed_fields: Dict[str, Tuple[Any, Any]] = field(default_factory=dict)
@@ -91,6 +127,51 @@ class Event:
         )
 
 
+def event_field(data: Any, name: str, default: Any = None) -> Any:
+    """Read one field off an event payload, whatever shape it arrived in.
+
+    See :class:`Event` for why there is more than one shape.
+
+    ``default`` covers three cases that callers here treat alike: no payload,
+    a field the payload could not carry, and a field carried as ``None``.
+    They all read as "nothing to act on", which is the branch every caller
+    wants, so collapsing them keeps that a single check. It does mean a NULL
+    column is indistinguishable from an absent one -- read ``data`` directly
+    if you ever need to tell those apart.
+
+    Takes the **payload**, not the :class:`Event`. Passing an event would
+    otherwise find no matching attribute and quietly return ``default``, so
+    that mistake raises instead.
+    """
+    if isinstance(data, Event):
+        raise TypeError(
+            "event_field takes Event.data, not the Event; "
+            "use event_field(event.data, ...) or resolve_event_id(event)"
+        )
+    if data is None:
+        return default
+    if isinstance(data, dict):
+        value = data.get(name)
+    else:
+        value = getattr(data, name, None)
+    return default if value is None else value
+
+
+def resolve_event_id(event: "Event") -> Optional[Any]:
+    """Return the primary key an event refers to, for either payload shape.
+
+    Prefer this over ``event.data.id``, which raises ``AttributeError`` on an
+    id-only payload -- the single most common way to get :class:`Event`
+    wrong, and one that only shows up on a replica that did not serve the
+    write.
+
+    ``Event.id`` is populated on both paths: ``__post_init__`` derives it
+    from ``data`` locally, and it is carried explicitly over the wire.
+    ``None`` means the event stands for no row (HEARTBEAT, ``data=None``).
+    """
+    return event.id
+
+
 class Coordinator(ABC):
     """
     Abstract base class for coordinating server instances.
@@ -111,6 +192,18 @@ class Coordinator(ABC):
         self._leader_election_renew_interval = leader_election_renew_interval
         self._subscribers: Dict[str, List[Callable[[Event], Any]]] = {}
         self._is_leader = False
+
+    @property
+    def is_distributed(self) -> bool:
+        """Whether events reach this process from other instances.
+
+        Defaults to True: a coordinator exists to distribute, and the
+        single-node implementation is the exception. Anything keyed on the
+        id-only payload shape should gate on this -- that shape only arises
+        on the cross-instance path, so work done to anticipate it is pure
+        overhead where there is no such path.
+        """
+        return True
 
     @property
     def leader_election_ttl(self) -> int:

--- a/gpustack/server/coordinator/local.py
+++ b/gpustack/server/coordinator/local.py
@@ -28,6 +28,11 @@ class LocalCoordinator(Coordinator):
         super().__init__(config, **kwargs)
         self._started = False
 
+    @property
+    def is_distributed(self) -> bool:
+        """No other instance to receive events from, so no id-only payloads."""
+        return False
+
     async def start(self):
         """Start the local coordinator (no-op)."""
         self._started = True

--- a/gpustack/server/coordinator/models.py
+++ b/gpustack/server/coordinator/models.py
@@ -40,6 +40,14 @@ class _ModelRegistry:
         'modelprovider': lambda: _import_model(
             'gpustack.schemas.model_provider', 'ModelProvider'
         ),
+        # Identity consolidation made ``User`` an alias of ``Principal``, and
+        # ``subscribe()`` keys the topic off ``cls.__name__`` -- so everything
+        # publishes to 'principal' and the 'user' entry below has been dead
+        # since. Without 'principal' registered, every cross-instance
+        # principal event was dropped by _process_coordinator_event. Keep the
+        # stale key as an alias rather than deleting it: it costs nothing and
+        # covers anything still constructing the topic string by hand.
+        'principal': lambda: _import_model('gpustack.schemas.principals', 'Principal'),
         'user': lambda: _import_model('gpustack.schemas.users', 'User'),
         'apikey': lambda: _import_model('gpustack.schemas.api_keys', 'ApiKey'),
         'benchmark': lambda: _import_model('gpustack.schemas.benchmark', 'Benchmark'),

--- a/tests/server/test_bus.py
+++ b/tests/server/test_bus.py
@@ -1,9 +1,18 @@
 import asyncio
 import logging
+from unittest.mock import patch
 
 import pytest
 
-from gpustack.server.bus import Event, EventType, Subscriber
+from gpustack.server.bus import (
+    Event,
+    EventBus,
+    EventType,
+    Subscriber,
+    event_field,
+    resolve_event_id,
+)
+from gpustack.server.coordinator.cache import clear_all_caches, get_change_detector
 
 
 @pytest.mark.asyncio
@@ -285,3 +294,338 @@ async def test_unsubscribe_unwinds_putters_beyond_queue_capacity():
     assert all(t not in bus._pending_tasks for t in blocked_tasks)
     putters = getattr(subscriber.queue, "_putters", None)
     assert putters is None or len(putters) == 0
+
+
+class _Row:
+    """Stand-in for a SQLModel row: attribute access, and an ``id``."""
+
+    def __init__(self, id, name=None, cluster_id=None):
+        self.id = id
+        self.name = name
+        self.cluster_id = cluster_id
+
+
+def _crossed_instances(event: Event) -> Event:
+    """The event as another instance receives it, id-only payload and all.
+
+    Mirrors what a coordinator does: ``to_dict`` on the publishing side,
+    ``from_dict`` on the receiving one.
+    """
+    return Event.from_dict(event.to_dict())
+
+
+def test_cross_instance_delete_payload_is_id_only():
+    """The shape every consumer has to tolerate, pinned.
+
+    A delete crossing instances carries ``{"id": N}``: to_dict strips the row
+    down to its id, and by the time it lands the row is gone, so nothing can
+    re-hydrate it. Attribute access is what breaks, and it breaks only on the
+    replica that did not serve the write -- which is why it survives testing.
+    """
+    received = _crossed_instances(Event(type=EventType.DELETED, data=_Row(42, "r")))
+
+    assert received.data == {"id": 42}
+    with pytest.raises(AttributeError):
+        received.data.id
+
+
+def test_event_id_survives_the_serialization_round_trip():
+    """``resolve_event_id`` can just read ``Event.id`` because both paths fill
+    it: ``__post_init__`` derives it from a hydrated row, and ``to_dict`` /
+    ``from_dict`` carry it explicitly."""
+    hydrated = Event(type=EventType.DELETED, data=_Row(42, "r"))
+
+    assert resolve_event_id(hydrated) == 42
+    assert resolve_event_id(_crossed_instances(hydrated)) == 42
+
+
+def test_resolve_event_id_survives_a_dataless_event():
+    assert resolve_event_id(Event(type=EventType.DELETED, data=None, id=7)) == 7
+    assert resolve_event_id(Event(type=EventType.HEARTBEAT, data=None)) is None
+
+
+def test_event_field_reads_both_shapes_and_falls_back():
+    hydrated = Event(type=EventType.DELETED, data=_Row(42, "r", cluster_id=9))
+    crossed = _crossed_instances(hydrated)
+
+    assert event_field(hydrated.data, "cluster_id") == 9
+    # Gone from the id-only payload: must read as "unknown", not as a value.
+    assert event_field(crossed.data, "cluster_id") is None
+    assert event_field(crossed.data, "cluster_id", "?") == "?"
+    assert event_field(None, "cluster_id", "?") == "?"
+
+
+def test_event_field_treats_an_explicit_none_as_absent():
+    """A null column and a missing key both mean "nothing to act on" -- callers
+    branch on one check, not two."""
+    assert event_field(_Row(1, name=None), "name", "fallback") == "fallback"
+    assert event_field({"id": 1, "name": None}, "name", "fallback") == "fallback"
+
+
+def test_principal_topic_is_registered_for_cross_instance_enrichment():
+    """Identity consolidation renamed the topic out from under the registry.
+
+    ``User is Principal``, and subscribe() keys the topic off ``__name__``, so
+    events publish to 'principal'. While only the stale 'user' key was
+    registered, _process_coordinator_event dropped every cross-instance
+    principal event before it could reach a subscriber.
+    """
+    from gpustack.schemas.users import User
+    from gpustack.server.coordinator.models import get_model_for_topic
+
+    assert User.__name__.lower() == "principal"
+    assert get_model_for_topic("principal") is not None
+
+
+async def _deliver(event_type, warm_cache):
+    """Push a wire-shaped event through the bus and return what a subscriber got.
+
+    Mirrors the receiving side of a cross-instance hop: the coordinator hands
+    _process_coordinator_event an id-only payload, and whatever comes out the
+    other side is what every consumer must be written against.
+    """
+    clear_all_caches()
+    bus = EventBus()
+    subscriber = bus.subscribe("modelroute", source="test")
+
+    with (
+        patch("gpustack.server.bus.get_model_for_topic", return_value=_FakeRow),
+        patch("gpustack.server.db.async_session", _FakeSession),
+    ):
+        if warm_cache:
+            # Only a prior cross-instance non-DELETE warms the detector.
+            await bus._process_coordinator_event(
+                Event(type=EventType.UPDATED, data={"id": 5}, id=5), "modelroute"
+            )
+            await asyncio.sleep(0.05)
+            while not subscriber.queue.empty():
+                subscriber.queue.get_nowait()
+
+        await bus._process_coordinator_event(
+            Event(type=event_type, data={"id": 5}, id=5), "modelroute"
+        )
+        await asyncio.sleep(0.05)
+
+    if subscriber.queue.empty():
+        return None
+    return subscriber.queue.get_nowait().data
+
+
+class _FakeRow:
+    def __init__(self, id):
+        self.id = id
+
+    @classmethod
+    async def one_by_id(cls, session, id, **kwargs):
+        return cls(id)
+
+
+class _FakeSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeDistributedCoordinator:
+    """Stands in for an out-of-tree coordinator: events reach us from peers."""
+
+    is_distributed = True
+
+    def subscribe(self, channel, callback):
+        pass
+
+
+class _FakeLocalCoordinator:
+    """Stands in for LocalCoordinator: nothing reaches us from anywhere else."""
+
+    is_distributed = False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_type", [EventType.CREATED, EventType.UPDATED])
+async def test_non_delete_events_are_always_delivered_hydrated(event_type):
+    """The invariant the consumer guards rest on.
+
+    A CREATED/UPDATED that crosses instances is re-read from the database
+    before delivery, so it never reaches a subscriber id-only. That is why a
+    handler may guard on the payload shape without skipping any update -- the
+    guard can only ever fire for a delete.
+    """
+    delivered = await _deliver(event_type, warm_cache=False)
+
+    assert isinstance(delivered, _FakeRow)
+    assert delivered.id == 5
+
+
+@pytest.mark.asyncio
+async def test_only_a_delete_with_a_cold_cache_is_delivered_id_only():
+    """The one path that produces the dict -- and the one that hides it.
+
+    With the detector warm the delete is enriched from cache and arrives
+    hydrated, which is why this reproduces on some instances and not others.
+    """
+    assert await _deliver(EventType.DELETED, warm_cache=False) == {"id": 5}
+    assert isinstance(await _deliver(EventType.DELETED, warm_cache=True), _FakeRow)
+
+
+@pytest.mark.asyncio
+async def test_locally_published_row_warms_the_change_detector():
+    """A row this instance created must be enrichable when another deletes it.
+
+    The detector used to be warmed only by cross-instance events, so a row
+    created here was never in our own cache -- create on A, delete on B, and
+    A got a payload it could not act on. Publishing locally now warms it, so
+    the later cross-instance DELETE is enriched from cache instead.
+    """
+    clear_all_caches()
+    bus = EventBus()
+    bus.set_coordinator(_FakeDistributedCoordinator())
+    subscriber = bus.subscribe("modelroute", source="test")
+    row = _FakeRow(5)
+
+    with (
+        patch("gpustack.server.bus.get_model_for_topic", return_value=_FakeRow),
+        patch("gpustack.server.db.async_session", _FakeSession),
+    ):
+        # The local publish path: data is the row itself, not an id-only dict.
+        await bus._process_coordinator_event(
+            Event(type=EventType.CREATED, data=row, id=5), "modelroute"
+        )
+        await asyncio.sleep(0.05)
+        while not subscriber.queue.empty():
+            subscriber.queue.get_nowait()
+
+        assert get_change_detector("modelroute").get(5) is row
+
+        # Now the delete arrives from the instance that served it.
+        await bus._process_coordinator_event(
+            Event(type=EventType.DELETED, data={"id": 5}, id=5), "modelroute"
+        )
+        await asyncio.sleep(0.05)
+
+    delivered = subscriber.queue.get_nowait().data
+    assert delivered is row, "delete should have been enriched from the local write"
+
+
+@pytest.mark.asyncio
+async def test_local_delete_forgets_the_row():
+    """The counterpart: a row deleted here must not linger in the cache."""
+    clear_all_caches()
+    bus = EventBus()
+    bus.set_coordinator(_FakeDistributedCoordinator())
+    bus.subscribe("modelroute", source="test")
+    row = _FakeRow(5)
+
+    with (
+        patch("gpustack.server.bus.get_model_for_topic", return_value=_FakeRow),
+        patch("gpustack.server.db.async_session", _FakeSession),
+    ):
+        await bus._process_coordinator_event(
+            Event(type=EventType.CREATED, data=row, id=5), "modelroute"
+        )
+        await asyncio.sleep(0.05)
+        assert get_change_detector("modelroute").get(5) is row
+
+        await bus._process_coordinator_event(
+            Event(type=EventType.DELETED, data=row, id=5), "modelroute"
+        )
+        await asyncio.sleep(0.05)
+
+    assert get_change_detector("modelroute").get(5) is None
+
+
+def test_event_field_rejects_being_handed_the_event():
+    """The asymmetry with resolve_event_id is easy to trip over, and reading a
+    field off an Event would otherwise silently yield the default."""
+    event = Event(type=EventType.DELETED, data=_Row(42, "r"), id=42)
+
+    with pytest.raises(TypeError, match="takes Event.data"):
+        event_field(event, "name")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "coordinator, topic, reason",
+    [
+        (_FakeLocalCoordinator(), "modelroute", "single-node"),
+        (_FakeDistributedCoordinator(), "_unregistered_topic", "unregistered topic"),
+        (None, "modelroute", "no coordinator"),
+    ],
+)
+async def test_local_row_is_not_cached_where_nothing_could_read_it(
+    coordinator, topic, reason
+):
+    """The cache is only ever read from the id-only branch, so writing to it
+    outside the cases that reach that branch is pure cost -- up to maxsize
+    detached rows per topic, and on an append-only table with monotonic ids
+    the LRU never even hits.
+
+    Single-node is the default deployment and has no cross-instance path at
+    all; an unregistered topic returns before the lookup in every mode.
+    """
+    clear_all_caches()
+    bus = EventBus()
+    if coordinator is not None:
+        bus.set_coordinator(coordinator)
+    bus.subscribe(topic, source="test")
+
+    with (
+        patch("gpustack.server.bus.get_model_for_topic", return_value=None),
+        patch("gpustack.server.db.async_session", _FakeSession),
+    ):
+        await bus._process_coordinator_event(
+            Event(type=EventType.CREATED, data=_FakeRow(5), id=5), topic
+        )
+        await asyncio.sleep(0.05)
+
+    assert get_change_detector(topic).get(5) is None, f"cached despite {reason}"
+
+
+@pytest.mark.asyncio
+async def test_local_write_sharpens_changed_fields_of_a_later_remote_event():
+    """Warming the detector locally also moves the diff baseline forward.
+
+    ``changed_fields`` is computed against the last state this instance knew.
+    Before, that was only the startup snapshot or the last cross-instance
+    event, so a locally-served write was invisible to it and the next remote
+    event diffed against a stale baseline. Several handlers gate on this
+    (``"state"``, ``"labels"``, ``"deleted_at"``), so the sharper baseline
+    means fewer missed transitions.
+    """
+    clear_all_caches()
+    bus = EventBus()
+    bus.set_coordinator(_FakeDistributedCoordinator())
+    subscriber = bus.subscribe("worker", source="test")
+
+    served_here = _FakeRow(5)
+    served_here.state = "READY"
+    remote = _FakeRow(5)
+    remote.state = "NOT_READY"
+
+    async def _returns_remote(cls, session, id, **kwargs):
+        return remote
+
+    with (
+        patch("gpustack.server.bus.get_model_for_topic", return_value=_FakeRow),
+        patch("gpustack.server.db.async_session", _FakeSession),
+        patch.object(_FakeRow, "one_by_id", classmethod(_returns_remote)),
+    ):
+        # A write this instance served: state becomes READY.
+        await bus._process_coordinator_event(
+            Event(type=EventType.UPDATED, data=served_here, id=5), "worker"
+        )
+        await asyncio.sleep(0.05)
+        # Drain via receive(), not get_nowait(): UPDATED events coalesce on
+        # latest_by_key, and only receive() pops that.
+        await asyncio.wait_for(subscriber.receive(), timeout=1)
+
+        # Then a peer flips it back, and we learn about it id-only.
+        await bus._process_coordinator_event(
+            Event(type=EventType.UPDATED, data={"id": 5}, id=5), "worker"
+        )
+        await asyncio.sleep(0.05)
+
+    delivered = subscriber.queue.get_nowait()
+    assert delivered.changed_fields.get("state") == ("READY", "NOT_READY")


### PR DESCRIPTION
Refer to PR:
- https://github.com/gpustack/gpustack/pull/6117

Backport of f2ee6a03 from main, adapted to what exists on v2.2-dev.

A cross-instance DELETE carries `{"id": N}` and nothing else -- `to_dict` strips the row to its id, and by the time the event lands the row is gone. The watch API depends on that shape, but `Event.data` was typed `Any` and documented nowhere, so most consumers assumed a hydrated model and raised `AttributeError: 'dict' object has no attribute 'id'`. Only DELETE is affected: CREATED and UPDATED are re-read from the database and delivered hydrated, so guarding on the shape skips no update.

Document the contract on `Event`, and add `event_field(data, name, default)` and `resolve_event_id(event)` to `gpustack.server.bus`. Then fix the consumers -- a drop-in where only the id was ever needed (worker pool, cluster MCP bridge, model provider registry), a skip where the row's fields are genuinely required.

Those skips are a real gap, not a safe no-op: the controllers are leader-only, so the instance that served the delete often runs none of them, and the row is hard-deleted so it cannot be re-read. Service-level deletes stay covered, since their cache invalidation is broadcast; the cascade path these controllers exist for does not. Each skip warns with what may be stale.

To make that rarer, the bus warms the change detector from writes this instance serves, not only from cross-instance events -- "create on A, delete on B" was the common path into an unusable payload. Gated on `Coordinator.is_distributed` and on the topic being registered, since only the id-only branch ever reads that cache.

The operator gateway's cluster reconciler had the same bug in its own shape: reading `provider` off an id-only dict raised, the watcher swallowed it, and this server's operator subprocess went on proxying a cluster that no longer exists, with no further event to recover from. It now unsubscribes by id.

Also: unregistered topics warn once each rather than at debug; `principal` is registered, since identity consolidation left only the dead 'user' key (`User = Principal`, and the topic keys off `__name__`); unresolved ids no longer reach `one_by_id`.

Not carried over from main, since the code does not exist on v2.2-dev: the CacheServiceController worker guard, GPUInstanceTypeController's watcher-leak fix, gpu_instances/settings.py, and folding gateway_auth_reconciler's private `_event_field` into the shared helper.