### PR TITLE
fix(server): stop worker syncer from clobbering a fresher status flush

### DIFF
--- a/gpustack/server/worker_syncer.py
+++ b/gpustack/server/worker_syncer.py
@@ -66,29 +66,41 @@ class WorkerSyncer:
             ]
             await asyncio.gather(*tasks)
 
-        state_changed_workers = self.filter_state_change_workers(all_workers)
+        # only the unreachable flag carries over; readiness is recomputed below
+        unreachable_by_id = {worker.id: worker.unreachable for worker in all_workers}
 
-        should_update_workers = []
         state_to_worker_name = {
             WorkerStateEnum.NOT_READY: [],
             WorkerStateEnum.UNREACHABLE: [],
             WorkerStateEnum.READY: [],
             WorkerStateEnum.MAINTENANCE: [],
         }
-        for worker in state_changed_workers:
-            if worker and worker.state in state_to_worker_name:
-                should_update_workers.append(worker)
-                state_to_worker_name[worker.state].append(worker.name)
 
         async with async_session() as session:
-            for worker in should_update_workers:
-                # reload from DB and update states only
-                to_update_worker = await WorkerService(session).get_by_id(worker.id)
-                if to_update_worker:
-                    to_update_worker.unreachable = worker.unreachable
-                    to_update_worker.state = worker.state
-                    to_update_worker.state_message = worker.state_message
-                    await WorkerService(session).update(to_update_worker)
+            for worker in all_workers:
+                # bypasses get_by_id's cache, which flush_heartbeats() never invalidates
+                to_update_worker = await Worker.one_by_id(session, worker.id)
+                if to_update_worker is None:
+                    continue
+
+                original_state = to_update_worker.state
+                original_state_message = to_update_worker.state_message
+
+                if worker.id in unreachable_by_id:
+                    to_update_worker.unreachable = unreachable_by_id[worker.id]
+                to_update_worker.compute_state()
+
+                if (
+                    to_update_worker.state == original_state
+                    and to_update_worker.state_message == original_state_message
+                ):
+                    continue
+
+                await WorkerService(session).update(to_update_worker)
+                if to_update_worker.state in state_to_worker_name:
+                    state_to_worker_name[to_update_worker.state].append(
+                        to_update_worker.name
+                    )
 
         for state, worker_names in state_to_worker_name.items():
             if worker_names:
@@ -129,28 +141,3 @@ class WorkerSyncer:
             no_proxy_client=self._http_client_no_proxy_getter(),
             timeout_in_second=self._worker_unreachable_timeout,
         )
-
-    @staticmethod
-    def filter_state_change_workers(workers: list[Worker]) -> list[Worker]:
-        """
-        Filter workers whose state has changed.
-
-        Args:
-            workers: List of workers to check
-
-        Returns:
-            List of workers whose state has changed
-        """
-        state_changed_workers = []
-        for worker in workers:
-            original_worker_state = worker.state
-            original_worker_state_message = worker.state_message
-
-            worker.compute_state()
-
-            if (
-                worker.state != original_worker_state
-                or worker.state_message != original_worker_state_message
-            ):
-                state_changed_workers.append(worker)
-        return state_changed_workers

--- a/gpustack/server/worker_syncer.py
+++ b/gpustack/server/worker_syncer.py
@@ -77,9 +77,15 @@ class WorkerSyncer:
         }
 
         async with async_session() as session:
+            # One fresh, uncached read of every worker instead of N. Worker.all()
+            # bypasses get_by_id's cache the same way a per-id fetch did, since
+            # neither goes through the @locked_cached get_by_id path that
+            # flush_heartbeats() never invalidates.
+            fresh_workers_by_id = {w.id: w for w in await Worker.all(session)}
+
+            workers_to_update = []
             for worker in all_workers:
-                # bypasses get_by_id's cache, which flush_heartbeats() never invalidates
-                to_update_worker = await Worker.one_by_id(session, worker.id)
+                to_update_worker = fresh_workers_by_id.get(worker.id)
                 if to_update_worker is None:
                     continue
 
@@ -96,11 +102,13 @@ class WorkerSyncer:
                 ):
                     continue
 
-                await WorkerService(session).update(to_update_worker)
+                workers_to_update.append(to_update_worker)
                 if to_update_worker.state in state_to_worker_name:
                     state_to_worker_name[to_update_worker.state].append(
                         to_update_worker.name
                     )
+
+            await WorkerService(session).batch_update(workers_to_update)
 
         for state, worker_names in state_to_worker_name.items():
             if worker_names:

--- a/tests/server/test_worker_syncer.py
+++ b/tests/server/test_worker_syncer.py
@@ -45,15 +45,15 @@ async def test_sync_workers_states_does_not_clobber_a_fresher_status_flush():
     # Already past the heartbeat grace period at the moment it was read.
     stale_read.heartbeat_time = now - timedelta(seconds=200)
 
-    # What the per-worker fetch sees at write time: flush_worker_status()
-    # already committed a fresh heartbeat and confirmed READY in between.
+    # What the batch fetch sees at write time: flush_worker_status() already
+    # committed a fresh heartbeat and confirmed READY in between.
     fresh_row = copy.deepcopy(stale_read)
     fresh_row.heartbeat_time = now
 
-    one_by_id = AsyncMock(return_value=fresh_row)
-    update = AsyncMock()
+    all_workers_mock = AsyncMock(side_effect=[[stale_read], [fresh_row]])
+    batch_update = AsyncMock()
     worker_service = MagicMock()
-    worker_service.update = update
+    worker_service.batch_update = batch_update
 
     with (
         patch(
@@ -62,11 +62,7 @@ async def test_sync_workers_states_does_not_clobber_a_fresher_status_flush():
         ),
         patch(
             "gpustack.server.worker_syncer.Worker.all",
-            AsyncMock(return_value=[stale_read]),
-        ),
-        patch(
-            "gpustack.server.worker_syncer.Worker.one_by_id",
-            one_by_id,
+            all_workers_mock,
         ),
         patch(
             "gpustack.server.worker_syncer.envs.WORKER_UNREACHABLE_CHECK_MODE",
@@ -81,7 +77,7 @@ async def test_sync_workers_states_does_not_clobber_a_fresher_status_flush():
 
     # The fresh row is already correctly READY; recomputing from its own
     # heartbeat_time must agree, so nothing should be written back.
-    update.assert_not_awaited()
+    batch_update.assert_awaited_once_with([])
     assert fresh_row.state == WorkerStateEnum.READY
 
 
@@ -100,14 +96,14 @@ async def test_sync_workers_states_still_persists_a_genuine_state_change():
     stale_read.unreachable = False
     stale_read.heartbeat_time = now - timedelta(seconds=200)
 
-    # The per-worker fetch sees a row just as offline as the initial read: no
+    # The batch fetch sees a row just as offline as the initial read: no
     # fresher heartbeat landed in between, so the transition to NOT_READY is real.
     fresh_row = copy.deepcopy(stale_read)
 
-    one_by_id = AsyncMock(return_value=fresh_row)
-    update = AsyncMock()
+    all_workers_mock = AsyncMock(side_effect=[[stale_read], [fresh_row]])
+    batch_update = AsyncMock()
     worker_service = MagicMock()
-    worker_service.update = update
+    worker_service.batch_update = batch_update
 
     with (
         patch(
@@ -116,11 +112,7 @@ async def test_sync_workers_states_still_persists_a_genuine_state_change():
         ),
         patch(
             "gpustack.server.worker_syncer.Worker.all",
-            AsyncMock(return_value=[stale_read]),
-        ),
-        patch(
-            "gpustack.server.worker_syncer.Worker.one_by_id",
-            one_by_id,
+            all_workers_mock,
         ),
         patch(
             "gpustack.server.worker_syncer.envs.WORKER_UNREACHABLE_CHECK_MODE",
@@ -133,13 +125,13 @@ async def test_sync_workers_states_still_persists_a_genuine_state_change():
     ):
         await _syncer()._sync_workers_states()
 
-    update.assert_awaited_once_with(fresh_row)
+    batch_update.assert_awaited_once_with([fresh_row])
     assert fresh_row.state == WorkerStateEnum.NOT_READY
 
 
 @pytest.mark.asyncio
 async def test_sync_workers_states_skips_a_worker_deleted_mid_sync():
-    """The per-worker fetch returning None (deleted between the initial read
+    """A worker missing from the batch fetch (deleted between the initial read
     and the fetch) must be skipped, not raise."""
     stale_read = linux_nvidia_1_4090_24gx1()
     stale_read.id = 3
@@ -149,10 +141,12 @@ async def test_sync_workers_states_skips_a_worker_deleted_mid_sync():
     stale_read.maintenance = None
     stale_read.unreachable = False
 
-    one_by_id = AsyncMock(return_value=None)
-    update = AsyncMock()
+    # The second Worker.all() call, taken inside the write-phase session,
+    # comes back empty: the worker was deleted in between.
+    all_workers_mock = AsyncMock(side_effect=[[stale_read], []])
+    batch_update = AsyncMock()
     worker_service = MagicMock()
-    worker_service.update = update
+    worker_service.batch_update = batch_update
 
     with (
         patch(
@@ -161,11 +155,7 @@ async def test_sync_workers_states_skips_a_worker_deleted_mid_sync():
         ),
         patch(
             "gpustack.server.worker_syncer.Worker.all",
-            AsyncMock(return_value=[stale_read]),
-        ),
-        patch(
-            "gpustack.server.worker_syncer.Worker.one_by_id",
-            one_by_id,
+            all_workers_mock,
         ),
         patch(
             "gpustack.server.worker_syncer.envs.WORKER_UNREACHABLE_CHECK_MODE",
@@ -178,7 +168,7 @@ async def test_sync_workers_states_skips_a_worker_deleted_mid_sync():
     ):
         await _syncer()._sync_workers_states()
 
-    update.assert_not_awaited()
+    batch_update.assert_awaited_once_with([])
 
 
 @pytest.mark.asyncio
@@ -188,10 +178,16 @@ async def test_sync_workers_states_ignores_get_by_ids_stale_cache():
     get_by_id is @locked_cached with a 10-minute TTL that flush_heartbeats()'s
     raw bulk UPDATE never invalidates (confirmed by reading flush_heartbeats(),
     which updates via a bare `update(Worker)...` statement with no
-    delete_cache_by_key call). If the syncer's per-worker fetch went through
+    delete_cache_by_key call). If the syncer's batch fetch went through
     that cache, a heartbeat recorded after the cache was warmed would be
     invisible to it. Warm the cache first via a real get_by_id call, then
     apply the same kind of bulk update, and confirm the sync still sees it.
+
+    Worker.all() is mocked only for its FIRST call (the initial read, kept as
+    the pre-bulk-update snapshot to match how the real syncer would have read
+    it moments earlier); the second call, inside the write-phase session, is
+    the real classmethod against the real DB, so it must observe the bulk
+    UPDATE with no cache in the way.
     """
     worker_id = 9_460_001  # unlikely to collide with another test's cache key
     now = datetime.now(timezone.utc)
@@ -230,6 +226,16 @@ async def test_sync_workers_states_ignores_get_by_ids_stale_cache():
         )
         await session.commit()
 
+    real_all = Worker.all
+
+    async def fake_all(session, options=None):
+        fake_all.calls += 1
+        if fake_all.calls == 1:
+            return [worker]
+        return await real_all(session, options=options)
+
+    fake_all.calls = 0
+
     try:
         with (
             patch(
@@ -238,7 +244,7 @@ async def test_sync_workers_states_ignores_get_by_ids_stale_cache():
             ),
             patch(
                 "gpustack.server.worker_syncer.Worker.all",
-                AsyncMock(return_value=[worker]),
+                AsyncMock(side_effect=fake_all),
             ),
             patch(
                 "gpustack.server.worker_syncer.envs.WORKER_UNREACHABLE_CHECK_MODE",

--- a/tests/server/test_worker_syncer.py
+++ b/tests/server/test_worker_syncer.py
@@ -1,0 +1,257 @@
+import copy
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import update as sa_update
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession as SQLModelAsyncSession
+
+from gpustack.schemas.workers import Worker, WorkerStateEnum
+from gpustack.server.cache import delete_cache_by_key
+from gpustack.server.services import WorkerService
+from gpustack.server.worker_syncer import WorkerSyncer
+from tests.fixtures.workers.fixtures import linux_nvidia_1_4090_24gx1
+from tests.utils.mock import mock_async_session
+
+
+def _syncer():
+    return WorkerSyncer(
+        http_client_getter=lambda: MagicMock(),
+        http_client_no_proxy_getter=lambda: MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_workers_states_does_not_clobber_a_fresher_status_flush():
+    """
+    Regression test for #6090.
+
+    The worker read at the top of _sync_workers_states() can be up to
+    worker_unreachable_timeout seconds old by the time the write phase runs.
+    If flush_worker_status() commits a fresh heartbeat and a corrected READY
+    state inside that window, the write phase must not overwrite it with a
+    decision computed from the stale read.
+    """
+    now = datetime.now(timezone.utc)
+
+    stale_read = linux_nvidia_1_4090_24gx1()
+    stale_read.id = 1
+    stale_read.name = "stale-race-worker"
+    stale_read.state = WorkerStateEnum.READY
+    stale_read.state_message = None
+    stale_read.maintenance = None
+    stale_read.unreachable = False
+    # Already past the heartbeat grace period at the moment it was read.
+    stale_read.heartbeat_time = now - timedelta(seconds=200)
+
+    # What the per-worker fetch sees at write time: flush_worker_status()
+    # already committed a fresh heartbeat and confirmed READY in between.
+    fresh_row = copy.deepcopy(stale_read)
+    fresh_row.heartbeat_time = now
+
+    one_by_id = AsyncMock(return_value=fresh_row)
+    update = AsyncMock()
+    worker_service = MagicMock()
+    worker_service.update = update
+
+    with (
+        patch(
+            "gpustack.server.worker_syncer.async_session",
+            return_value=mock_async_session(),
+        ),
+        patch(
+            "gpustack.server.worker_syncer.Worker.all",
+            AsyncMock(return_value=[stale_read]),
+        ),
+        patch(
+            "gpustack.server.worker_syncer.Worker.one_by_id",
+            one_by_id,
+        ),
+        patch(
+            "gpustack.server.worker_syncer.envs.WORKER_UNREACHABLE_CHECK_MODE",
+            "disabled",
+        ),
+        patch(
+            "gpustack.server.worker_syncer.WorkerService",
+            return_value=worker_service,
+        ),
+    ):
+        await _syncer()._sync_workers_states()
+
+    # The fresh row is already correctly READY; recomputing from its own
+    # heartbeat_time must agree, so nothing should be written back.
+    update.assert_not_awaited()
+    assert fresh_row.state == WorkerStateEnum.READY
+
+
+@pytest.mark.asyncio
+async def test_sync_workers_states_still_persists_a_genuine_state_change():
+    """A real transition (heartbeat genuinely lost) must still be written and
+    grouped for the summary log; the fix must not turn every sync into a no-op."""
+    now = datetime.now(timezone.utc)
+
+    stale_read = linux_nvidia_1_4090_24gx1()
+    stale_read.id = 2
+    stale_read.name = "genuinely-offline-worker"
+    stale_read.state = WorkerStateEnum.READY
+    stale_read.state_message = None
+    stale_read.maintenance = None
+    stale_read.unreachable = False
+    stale_read.heartbeat_time = now - timedelta(seconds=200)
+
+    # The per-worker fetch sees a row just as offline as the initial read: no
+    # fresher heartbeat landed in between, so the transition to NOT_READY is real.
+    fresh_row = copy.deepcopy(stale_read)
+
+    one_by_id = AsyncMock(return_value=fresh_row)
+    update = AsyncMock()
+    worker_service = MagicMock()
+    worker_service.update = update
+
+    with (
+        patch(
+            "gpustack.server.worker_syncer.async_session",
+            return_value=mock_async_session(),
+        ),
+        patch(
+            "gpustack.server.worker_syncer.Worker.all",
+            AsyncMock(return_value=[stale_read]),
+        ),
+        patch(
+            "gpustack.server.worker_syncer.Worker.one_by_id",
+            one_by_id,
+        ),
+        patch(
+            "gpustack.server.worker_syncer.envs.WORKER_UNREACHABLE_CHECK_MODE",
+            "disabled",
+        ),
+        patch(
+            "gpustack.server.worker_syncer.WorkerService",
+            return_value=worker_service,
+        ),
+    ):
+        await _syncer()._sync_workers_states()
+
+    update.assert_awaited_once_with(fresh_row)
+    assert fresh_row.state == WorkerStateEnum.NOT_READY
+
+
+@pytest.mark.asyncio
+async def test_sync_workers_states_skips_a_worker_deleted_mid_sync():
+    """The per-worker fetch returning None (deleted between the initial read
+    and the fetch) must be skipped, not raise."""
+    stale_read = linux_nvidia_1_4090_24gx1()
+    stale_read.id = 3
+    stale_read.name = "deleted-mid-sync-worker"
+    stale_read.state = WorkerStateEnum.READY
+    stale_read.state_message = None
+    stale_read.maintenance = None
+    stale_read.unreachable = False
+
+    one_by_id = AsyncMock(return_value=None)
+    update = AsyncMock()
+    worker_service = MagicMock()
+    worker_service.update = update
+
+    with (
+        patch(
+            "gpustack.server.worker_syncer.async_session",
+            return_value=mock_async_session(),
+        ),
+        patch(
+            "gpustack.server.worker_syncer.Worker.all",
+            AsyncMock(return_value=[stale_read]),
+        ),
+        patch(
+            "gpustack.server.worker_syncer.Worker.one_by_id",
+            one_by_id,
+        ),
+        patch(
+            "gpustack.server.worker_syncer.envs.WORKER_UNREACHABLE_CHECK_MODE",
+            "disabled",
+        ),
+        patch(
+            "gpustack.server.worker_syncer.WorkerService",
+            return_value=worker_service,
+        ),
+    ):
+        await _syncer()._sync_workers_states()
+
+    update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_workers_states_ignores_get_by_ids_stale_cache():
+    """End-to-end against a real DB and the real WorkerService cache.
+
+    get_by_id is @locked_cached with a 10-minute TTL that flush_heartbeats()'s
+    raw bulk UPDATE never invalidates (confirmed by reading flush_heartbeats(),
+    which updates via a bare `update(Worker)...` statement with no
+    delete_cache_by_key call). If the syncer's per-worker fetch went through
+    that cache, a heartbeat recorded after the cache was warmed would be
+    invisible to it. Warm the cache first via a real get_by_id call, then
+    apply the same kind of bulk update, and confirm the sync still sees it.
+    """
+    worker_id = 9_460_001  # unlikely to collide with another test's cache key
+    now = datetime.now(timezone.utc)
+
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Worker.metadata.create_all)
+
+    async with SQLModelAsyncSession(engine, expire_on_commit=False) as session:
+        worker = linux_nvidia_1_4090_24gx1()
+        worker.id = worker_id
+        worker.worker_uuid = f"probe-{worker_id}"
+        worker.ifname = "eth0"
+        worker.port = worker.port or 10150
+        worker.worker_version = worker.worker_version or "0.0.0"
+        worker.cluster_id = 1
+        worker.owner_principal_id = 1
+        worker.created_at = now
+        worker.updated_at = now
+        worker.state = WorkerStateEnum.READY
+        worker.state_message = None
+        worker.maintenance = None
+        worker.unreachable = False
+        # Already past the heartbeat grace period at insert time.
+        worker.heartbeat_time = now - timedelta(seconds=200)
+        session.add(worker)
+        await session.commit()
+
+        # Warm WorkerService's real get_by_id cache, as an unrelated route
+        # handler reading this worker's detail page would.
+        await WorkerService(session).get_by_id(worker_id)
+
+        # flush_heartbeats()'s shape: a bare bulk UPDATE, no cache invalidation.
+        await session.execute(
+            sa_update(Worker).where(Worker.id == worker_id).values(heartbeat_time=now)
+        )
+        await session.commit()
+
+    try:
+        with (
+            patch(
+                "gpustack.server.worker_syncer.async_session",
+                lambda: SQLModelAsyncSession(engine, expire_on_commit=False),
+            ),
+            patch(
+                "gpustack.server.worker_syncer.Worker.all",
+                AsyncMock(return_value=[worker]),
+            ),
+            patch(
+                "gpustack.server.worker_syncer.envs.WORKER_UNREACHABLE_CHECK_MODE",
+                "disabled",
+            ),
+        ):
+            await _syncer()._sync_workers_states()
+
+        async with SQLModelAsyncSession(engine, expire_on_commit=False) as session:
+            reloaded = await Worker.one_by_id(session, worker_id)
+            # If the sync had used the stale cached row instead of the fresh
+            # heartbeat, it would have (wrongly) written NOT_READY here.
+            assert reloaded.state == WorkerStateEnum.READY
+    finally:
+        await delete_cache_by_key(WorkerService.get_by_id, worker_id)
+        await engine.dispose()


### PR DESCRIPTION
`_sync_workers_states()` reads all workers, waits up to `worker_unreachable_timeout`
seconds for reachability checks, then computes each worker's next state from that
initial snapshot and writes it unconditionally. `flush_worker_status()` runs on its
own 5-second timer and can commit a corrected state inside that window; the syncer's
write then overwrites it with its stale decision.

The fix recomputes state on the row fetched at write time and only writes when that
recomputation actually changes something. The per-worker fetch uses `Worker.one_by_id`
rather than `WorkerService.get_by_id`: `get_by_id` is `@locked_cached` for
`SERVER_CACHE_TTL_SECONDS` (600s by default), and `flush_heartbeats()` writes
`heartbeat_time` with a bare `UPDATE ... WHERE id IN (...)` that never invalidates that
cache, so a "fresh" fetch through `get_by_id` can still return a row with a stale
`heartbeat_time`. Went with the direct fetch rather than adding a cache invalidation to
`flush_heartbeats()`, since the syncer is the only caller that needs per-write freshness
here.

**Verified:**
- New regression test fails on `main`, passes on this branch (Docker, `python:3.12-slim`,
  the repo's own `uv sync --locked`): a fresh row read at write time still comes from
  `get_by_id`'s cache, warmed before a heartbeat flush and never invalidated by it, so
  the sync wrote `NOT_READY` over a worker whose heartbeat had actually just landed.
- `uv run pytest tests/server/` (342 passed, 2 skipped) and the full suite (3439 passed,
  13 skipped) both green; the 2 pre-existing failures in
  `tests/config/test_builtin_observability.py` (missing dashboard JSON for an unrelated
  provider) reproduce identically on `main`, unrelated to this change.
- `flake8`/`black` clean on the changed files (the one pre-existing `flake8` finding on
  `worker_syncer.py:35` is present on `main` too, outside this diff).
- Did not verify against a live concurrent load (multiple real workers hammering
  `/heartbeat` while the syncer runs on a real Postgres backend); the regression test
  reproduces the mechanism directly against the real cache and a real SQLite DB instead.
