### PR TITLE
Fix the embedded gateway never listening on :80, plus three fixes found alongside

### DIFF
--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -868,6 +868,20 @@ def initialize_gateway(cfg: Config, timeout: int = 60, interval: int = 5):
                     namespace=cfg.gateway_namespace,
                     spec_diff=spec_diff_func,
                 )
+            # Envoy starts loading these the moment Higress pushes the ECDS
+            # resource, which is now -- and where a module is fetched over
+            # HTTP, that is while the server serving it is still several
+            # startup steps from binding its port. Logging the URLs is what
+            # makes that visible at all; verify_published_plugin_modules
+            # checks them once the API is up.
+            logger.info(
+                "Published %d WasmPlugin resources in namespace %s: %s",
+                len(plugin_list),
+                cfg.gateway_namespace,
+                ", ".join(
+                    f"{name}={spec.url}" for name, spec in plugin_list if spec.url
+                ),
+            )
 
         try:
             asyncio.run(prepare())

--- a/gpustack/gateway/plugins.py
+++ b/gpustack/gateway/plugins.py
@@ -1,13 +1,27 @@
+import asyncio
 import json
+import logging
+import time
 from dataclasses import dataclass
-from urllib.parse import quote
+from pathlib import Path
+from urllib.parse import quote, urlparse
+from urllib.request import url2pathname
 from importlib.resources import files
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional, List, Tuple
+
+import aiohttp
+
 from gpustack.config.config import Config, GatewayPluginEntry
+from gpustack.schemas.config import GatewayModeEnum
 from gpustack_higress_plugins.server import router as higress_plugins_router
+
+logger = logging.getLogger(__name__)
 
 # Reuse the same prefix as the plugin server router
 http_path_prefix = higress_plugins_router.prefix.removeprefix("/")
+
+# Where the plugin package keeps the module bytes it also serves over HTTP.
+_plugins_dir = Path(str(files("gpustack_higress_plugins").joinpath("plugins")))
 
 
 @dataclass
@@ -20,6 +34,10 @@ class HigressPlugin:
             [quote(self.name, safe=""), quote(self.version, safe=""), "plugin.wasm"]
         )
         return f"{get_plugin_url_prefix(cfg)}/{path}"
+
+    def get_local_path(self) -> Path:
+        """Where this module sits on disk, served or not."""
+        return _plugins_dir / self.name / self.version / "plugin.wasm"
 
 
 def _load_plugins_from_manifest() -> List[HigressPlugin]:
@@ -56,6 +74,10 @@ def get_plugin_url_with_name_and_version(
     Pass a version only where following the package silently is the worse
     failure.
     """
+    return resolve_plugin(name, version).get_path(cfg)
+
+
+def resolve_plugin(name: str, version: Optional[str] = None) -> HigressPlugin:
     target = next(
         (
             p
@@ -67,7 +89,7 @@ def get_plugin_url_with_name_and_version(
     if target is None:
         wanted = name if version is None else f"{name} with version {version}"
         raise ValueError(f"Plugin {wanted} is not supported.")
-    return target.get_path(cfg)
+    return target
 
 
 def get_plugin_url_prefix(cfg: Optional[Config] = None) -> str:
@@ -96,6 +118,42 @@ def get_plugin_url_prefix(cfg: Optional[Config] = None) -> str:
     return f"{base_url}/{http_path_prefix}"
 
 
+def get_local_plugin_url(name: str, version: Optional[str] = None) -> Optional[str]:
+    """A ``file://`` URL for a module Envoy can read off its own filesystem,
+    or None when it cannot.
+
+    Only meaningful where Envoy and this process share a filesystem, which is
+    the embedded gateway and nothing else -- see
+    :func:`use_local_plugin_modules`. There the module bytes are already
+    present, shipped inside ``gpustack_higress_plugins``, so serving them over
+    HTTP only to fetch them back over loopback buys nothing and costs the one
+    thing that actually broke: a dependency on this server being able to
+    answer at the moment Envoy warms its listeners.
+
+    ``Path.as_uri`` rather than an f-string, so a path needing escaping
+    produces a URL Go's ``url.Parse`` reads back as the same path.
+
+    Returns None if the file is absent, which lets the caller fall back to
+    HTTP instead of publishing a CR Envoy can only fail on.
+    """
+    path = resolve_plugin(name, version).get_local_path()
+    if not path.is_file():
+        return None
+    return path.resolve().as_uri()
+
+
+def use_local_plugin_modules(cfg: Optional[Config] = None) -> bool:
+    """Whether Envoy reads the modules from disk instead of fetching them.
+
+    Embedded only, and that is not a policy choice -- it is the only mode
+    where Envoy runs in the same container as this process, so it is the only
+    mode where a local path means the same thing on both sides. In
+    ``external`` and ``incluster`` the gateway is a different pod with a
+    different filesystem and a ``file://`` URL would resolve to nothing.
+    """
+    return cfg is not None and cfg.gateway_mode == GatewayModeEnum.embedded
+
+
 def plugin_entry(name: str, cfg: Optional[Config]) -> Optional[GatewayPluginEntry]:
     """The operator's overrides for one plugin, keyed by its *manifest* name.
 
@@ -121,10 +179,19 @@ def plugin_spec_overrides(
     the same way. Overriding the URL without the matching ``sha256`` is
     accepted -- Envoy simply does not verify the module then -- but the pair is
     what an operator pointing at a private registry normally wants.
+
+    Three sources, in descending order of how specific they are: an operator's
+    explicit URL, the module on Envoy's own filesystem where there is one, and
+    otherwise this server over HTTP.
     """
     entry = plugin_entry(name, cfg)
+    local_url = (
+        get_local_plugin_url(name, version) if use_local_plugin_modules(cfg) else None
+    )
     if entry is not None and entry.url:
         spec: Dict[str, Any] = {"url": entry.url}
+    elif local_url is not None:
+        spec = {"url": local_url}
     else:
         spec = {"url": get_plugin_url_with_name_and_version(name, version, cfg)}
     if entry is not None and entry.sha256:
@@ -132,3 +199,107 @@ def plugin_spec_overrides(
     if entry is not None and entry.image_pull_policy:
         spec["imagePullPolicy"] = entry.image_pull_policy
     return spec
+
+
+def published_plugin_urls(cfg: Optional[Config] = None) -> List[Tuple[str, str]]:
+    """Every module URL the WasmPlugin CRs carry, as ``(plugin name, url)``.
+
+    Derived from ``cfg`` rather than recorded while publishing: the same
+    ``cfg`` produces the same URLs, so there is nothing to keep in sync and no
+    state to carry between ``initialize_gateway`` and whoever wants to check
+    its work.
+
+    Covers every plugin in the manifest, including any the current
+    configuration does not deploy. One extra URL checked is cheap; keeping
+    this in step with the deployment list in ``initialize_gateway`` -- which
+    varies by server role -- is not.
+    """
+    return [
+        (plugin.name, plugin_spec_overrides(plugin.name, cfg=cfg).get("url", ""))
+        for plugin in supported_plugins
+    ]
+
+
+async def verify_published_plugin_modules(
+    cfg: Optional[Config] = None, timeout: float = 10.0
+) -> bool:
+    """Check that every published module URL resolves, and log what it found.
+
+    Worth doing because a module Envoy cannot load is not a degradation: the
+    filter is discovered over ECDS with ``initial_fetch_timeout: 0`` and no
+    default config, so an unresolved one leaves the listener warming and its
+    port unbound, and ``failStrategy: FAIL_OPEN`` does not cover it. Silence
+    from the gateway is the only other symptom.
+
+    ``file://`` URLs are stat'd -- under the embedded gateway that is every
+    module, on the filesystem Envoy itself reads, so an existing readable file
+    is as much proof as a fetch would be. HTTP URLs are fetched with a
+    one-byte ``Range``, since the modules run to megabytes. Anything else is
+    reported unverified rather than broken: a plugin pointed at an OCI
+    registry cannot be reached from here and does not depend on this server.
+
+    An HTTP pass proves the URL is servable from *here*. Where the gateway is
+    a different pod it leaves routing and firewalling between there and this
+    address unproven, which is why the URL is logged verbatim -- enough for an
+    operator to curl it from the gateway itself.
+
+    Returns True when nothing was found broken.
+    """
+    plugin_urls = published_plugin_urls(cfg)
+    if not plugin_urls:
+        return True
+
+    def probe_local(name: str, url: str) -> Tuple[bool, str]:
+        path = Path(url2pathname(urlparse(url).path))
+        try:
+            return True, f"{name}=local {path.stat().st_size} bytes"
+        except OSError as e:
+            return False, f"{name}=UNREADABLE {path}: {type(e).__name__}: {e}"
+
+    async def probe_http(
+        session: aiohttp.ClientSession, name: str, url: str
+    ) -> Tuple[bool, str]:
+        started = time.monotonic()
+        try:
+            async with session.get(url, headers={"Range": "bytes=0-0"}) as resp:
+                elapsed = time.monotonic() - started
+                length = resp.headers.get("Content-Range") or resp.headers.get(
+                    "Content-Length", "?"
+                )
+                return resp.status in (200, 206), (
+                    f"{name}={resp.status} ({length}) in {elapsed:.2f}s"
+                )
+        except Exception as e:
+            elapsed = time.monotonic() - started
+            return (
+                False,
+                f"{name}=FAILED after {elapsed:.2f}s: {type(e).__name__}: {e}",
+            )
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=timeout)
+    ) as session:
+
+        async def probe(name: str, url: str) -> Tuple[bool, str]:
+            if url.startswith(("http://", "https://")):
+                return await probe_http(session, name, url)
+            if url.startswith("file://"):
+                return probe_local(name, url)
+            return True, f"{name}=unverified ({urlparse(url).scheme or 'no'} scheme)"
+
+        results = await asyncio.gather(*(probe(name, url) for name, url in plugin_urls))
+
+    broken = [text for ok, text in results if not ok]
+    message = "Gateway plugin modules (%d): %s" % (
+        len(plugin_urls),
+        "; ".join(text for _, text in results),
+    )
+    if broken:
+        logger.error(
+            "%s -- Envoy cannot load these; the gateway listener will stay in "
+            "warming and its port will not be bound.",
+            message,
+        )
+        return False
+    logger.info(message)
+    return True

--- a/gpustack/gpu_instances/gateway.py
+++ b/gpustack/gpu_instances/gateway.py
@@ -170,6 +170,8 @@ class OperatorSubscriptionReconciler:
                     logger.error(f"Failed to retry subscribing {cluster_id}: {e}")
 
     async def _reconcile_worker(self, event: Event):
+        if event.type == EventType.HEARTBEAT:
+            return
         worker: Worker = event.data
         # Same id-only payload as the cluster path above, for the same reason
         # (see :func:`deleted_cluster_id`) -- but here the id is not enough:

--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -87,6 +87,12 @@ def send_post_commit_events(session: AsyncSession):
             # Detach from the SQLAlchemy session so subscribers don't see
             # lazy loads or further mutations on the same row.
             bus_event.data = bus_event.data.model_copy(deep=True)
+            # ``CommitEvent`` builds the Event when the write is queued, which
+            # for a CREATED event is before the INSERT assigns the primary
+            # key -- so it snapshotted ``id=None`` while ``data.id`` is now
+            # correct. Derive after the copy, so ``id`` can never disagree
+            # with the payload subscribers are handed.
+            bus_event.refresh_id()
             asyncio.create_task(event_bus.publish(event.name, bus_event))
         except Exception as e:
             logger.exception(f"Failed to publish events: {e}")

--- a/gpustack/server/coordinator/base.py
+++ b/gpustack/server/coordinator/base.py
@@ -62,6 +62,12 @@ class Event:
     explicitly over the wire, so it survives both paths. It is ``None`` for
     an event that stands for no row -- HEARTBEAT, and anything built with
     ``data=None`` -- so callers still check before using it.
+
+    Deriving at construction is not always enough. A CREATED event is built
+    before the INSERT that assigns the primary key, so its ``data`` has no id
+    yet; the commit hook that publishes it calls :meth:`refresh_id` once the
+    key is settled. Anywhere else, construction is the only chance and the
+    row already has its id.
     """
 
     type: EventType
@@ -73,6 +79,17 @@ class Event:
         if isinstance(self.type, int):
             self.type = EventType(self.type)
 
+        self.refresh_id()
+
+    def refresh_id(self) -> None:
+        """Fill ``id`` from ``data`` if it is not set yet.
+
+        Only fills a gap, never overwrites: an id that came in explicitly is
+        authoritative -- over the wire it is all that survives, and ``data``
+        there is a stripped ``{"id": N}`` at best. A primary key does not
+        change once assigned, so for a locally built event the two sources
+        agree wherever both exist.
+        """
         if self.id is None:
             self.id = self._derive_id_from_data()
 

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -118,6 +118,7 @@ from gpustack.gateway.utils import (
     resolve_instance_address_from_model_header,
 )
 from gpustack.gateway import get_async_k8s_config
+from gpustack.gateway.plugins import verify_published_plugin_modules
 from gpustack.envs import (
     GATEWAY_PORT_CHECK_INTERVAL,
     GATEWAY_PORT_CHECK_RETRY_COUNT,
@@ -357,7 +358,7 @@ class Server:
         await asyncio.gather(*self._async_tasks)
 
     async def _check_gateway_startup(self, server: uvicorn.Server):
-        """Confirm the gateway actually came up.
+        """Confirm the gateway can load its modules and did come up.
 
         Reports, never raises: this runs alongside a server that is already
         serving and must not be the reason one fails to start. What it finds
@@ -367,14 +368,15 @@ class Server:
         if self._config.gateway_mode == GatewayModeEnum.disabled:
             return
         try:
-            # Wait until uvicorn is accepting, so a gateway still waiting on
-            # this server is not reported as broken. ``started`` never flips if
-            # the bind fails, so give the loop its own way out rather than
-            # leaving it to the cancellation that follows.
+            # ``server.started`` flips once uvicorn is accepting, which is
+            # when a module served by this process becomes fetchable. It never
+            # flips if the bind fails, so give the loop its own way out rather
+            # than leaving it to the cancellation that follows.
             while not server.started:
                 if server.should_exit:
                     return
                 await asyncio.sleep(0.05)
+            await verify_published_plugin_modules(self._config)
             await self._wait_for_gateway_ready()
         except asyncio.CancelledError:
             raise

--- a/gpustack/server/server.py
+++ b/gpustack/server/server.py
@@ -352,8 +352,34 @@ class Server:
 
         server = uvicorn.Server(config)
         self._create_async_task(server.serve())
+        self._create_async_task(self._check_gateway_startup(server))
 
         await asyncio.gather(*self._async_tasks)
+
+    async def _check_gateway_startup(self, server: uvicorn.Server):
+        """Confirm the gateway actually came up.
+
+        Reports, never raises: this runs alongside a server that is already
+        serving and must not be the reason one fails to start. What it finds
+        is a gateway problem, and the log is the only place it surfaces --
+        Envoy failing this way is silent.
+        """
+        if self._config.gateway_mode == GatewayModeEnum.disabled:
+            return
+        try:
+            # Wait until uvicorn is accepting, so a gateway still waiting on
+            # this server is not reported as broken. ``started`` never flips if
+            # the bind fails, so give the loop its own way out rather than
+            # leaving it to the cancellation that follows.
+            while not server.started:
+                if server.should_exit:
+                    return
+                await asyncio.sleep(0.05)
+            await self._wait_for_gateway_ready()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"Gateway startup check failed to complete: {e}")
 
     def _start_default_registry_checker(self):
         registration.determine_default_registry(
@@ -752,6 +778,17 @@ class Server:
         self._create_async_task(wait_and_start_after_healthy())
 
     async def _wait_for_gateway_ready(self):
+        """Wait for the gateway to actually be listening, and say so if it is not.
+
+        Only ``embedded`` can be observed from here -- that is the one mode
+        where Envoy shares this network namespace.
+
+        Failure is reported, never raised: a gateway that never binds its port
+        is a total outage, but killing the server on top of it removes the
+        only process still able to explain why. Envoy gives no other signal --
+        a listener stuck warming just never appears -- so without this the
+        whole product is unreachable and nothing says so.
+        """
         if self._config.gateway_mode != GatewayModeEnum.embedded:
             return
         # http port is always started
@@ -759,8 +796,20 @@ class Server:
         if self._config.get_tls_secret_name() is not None:
             ports.append(self._config.tls_port)
         logger.info(f"Waiting for ports {ports} of GPUStack to be ready...")
-        # wait for gateway ready for about 60s
-        await self._check_ports_ready(*ports)
+        try:
+            # wait for gateway ready for about 60s
+            await self._check_ports_ready(*ports)
+        except Exception as e:
+            logger.error(
+                "Gateway port(s) %s never became ready after %ss: %s. Inspect "
+                "Envoy on the gateway: a listener reported in `warming_state` "
+                "by `curl localhost:15000/config_dump?resource=dynamic_"
+                "listeners` is waiting on a Wasm module it could not load.",
+                ports,
+                GATEWAY_PORT_CHECK_RETRY_COUNT * GATEWAY_PORT_CHECK_INTERVAL,
+                e,
+            )
+            return
         logger.info("GPUStack Server is ready.")
 
     @tenacity.retry(

--- a/pack/rootfs/etc/s6-overlay/s6-rc.d/gateway/run
+++ b/pack/rootfs/etc/s6-overlay/s6-rc.d/gateway/run
@@ -44,7 +44,16 @@ if [ -n "$LITE_METRICS" ]; then
 fi
 # end copied
 
+# Envoy no longer needs the API to load its Wasm modules -- it reads them off
+# this container's filesystem -- but it does need it to serve a request, so the
+# wait stays. The timings are what is new: a bound port is not a server that
+# can answer, and on a first boot the gap between the two was seven seconds.
+# Without these lines the log could not tell "Envoy started too early" from
+# "Envoy started late enough and still failed".
+echo "[INFO] Waiting for the GPUStack API on 127.0.0.1:${GPUSTACK_API_PORT} before starting Envoy."
+GATEWAY_WAIT_START=$(date +%s)
 readinessCheck "GPUStack API server" "$GPUSTACK_API_PORT"
+echo "[INFO] Starting Envoy $(($(date +%s) - GATEWAY_WAIT_START))s after the wait began."
 
 cd /
 

--- a/tests/gateway/test_gateway_plugins.py
+++ b/tests/gateway/test_gateway_plugins.py
@@ -1,5 +1,8 @@
 import pytest
 import logging
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 from unittest.mock import MagicMock, patch
 from gpustack.gateway.plugins import (
     HigressPlugin,
@@ -7,8 +10,13 @@ from gpustack.gateway.plugins import (
     get_plugin_url_with_name_and_version,
     supported_plugins,
     http_path_prefix,
+    plugin_spec_overrides,
+    get_local_plugin_url,
+    published_plugin_urls,
+    verify_published_plugin_modules,
 )
 from gpustack.config.config import GatewayPluginEntry
+from gpustack.schemas.config import GatewayModeEnum
 from gpustack.api.auth import (
     GATEWAY_ASSERTED_ACCESS_KEY_HEADER,
     GATEWAY_ASSERTED_KEY_REF_HEADER,
@@ -30,9 +38,17 @@ def _manifest_suffix(name: str) -> str:
     return f"/{name}/{version}/plugin.wasm"
 
 
-def make_cfg(plugin_server_url: str, gateway_plugin=None):
+def make_cfg(
+    plugin_server_url: str,
+    gateway_plugin=None,
+    gateway_mode=GatewayModeEnum.external,
+):
     cfg = MagicMock()
     cfg.gateway_plugin_server_url = plugin_server_url
+    # Explicit, because the mode decides whether modules are fetched over HTTP
+    # or read off Envoy's own filesystem. A MagicMock here would compare
+    # unequal to every mode and silently pick HTTP.
+    cfg.gateway_mode = gateway_mode
     # Real entries, not raw dicts: a live Config validates this section into
     # GatewayPluginEntry, so a dict here would exercise a shape production
     # never sees -- and would skip the extra="forbid" on url / sha256.
@@ -59,6 +75,120 @@ class TestGetPluginUrlPrefix:
     def test_cfg_with_https_url(self):
         cfg = make_cfg("https://example.com")
         assert get_plugin_url_prefix(cfg) == f"https://example.com/{http_path_prefix}"
+
+
+class TestLocalPluginModules:
+    """Embedded reads modules off Envoy's own filesystem instead of fetching
+    them from this server -- the one mode where the two share one."""
+
+    def test_embedded_publishes_file_urls(self):
+        cfg = make_cfg("http://127.0.0.1:30080", gateway_mode=GatewayModeEnum.embedded)
+        url = plugin_spec_overrides("transformer", cfg=cfg)["url"]
+        assert url.startswith("file:///")
+        assert url.endswith(_manifest_suffix("transformer"))
+
+    def test_the_file_url_points_at_a_real_module(self):
+        cfg = make_cfg("http://127.0.0.1:30080", gateway_mode=GatewayModeEnum.embedded)
+        for plugin in supported_plugins:
+            url = plugin_spec_overrides(plugin.name, cfg=cfg)["url"]
+            assert Path(url2pathname(urlparse(url).path)).is_file()
+
+    @pytest.mark.parametrize(
+        "mode",
+        [GatewayModeEnum.external, GatewayModeEnum.incluster],
+    )
+    def test_other_modes_keep_fetching_over_http(self, mode):
+        # Envoy is a different pod there, so a local path would resolve to
+        # nothing on its side.
+        cfg = make_cfg("http://192.168.1.1:8080", gateway_mode=mode)
+        url = plugin_spec_overrides("transformer", cfg=cfg)["url"]
+        assert url.startswith("http://192.168.1.1:8080/")
+
+    def test_no_cfg_keeps_fetching_over_http(self):
+        assert plugin_spec_overrides("transformer")["url"].startswith("http://")
+
+    def test_an_operator_url_still_wins_over_the_local_module(self):
+        cfg = make_cfg(
+            "http://127.0.0.1:30080",
+            {"transformer": {"url": "oci://registry.example/transformer:2.0.0"}},
+            gateway_mode=GatewayModeEnum.embedded,
+        )
+        assert (
+            plugin_spec_overrides("transformer", cfg=cfg)["url"]
+            == "oci://registry.example/transformer:2.0.0"
+        )
+
+    def test_missing_module_falls_back_to_http_rather_than_publishing_a_dead_path(self):
+        cfg = make_cfg("http://127.0.0.1:30080", gateway_mode=GatewayModeEnum.embedded)
+        with patch(
+            "gpustack.gateway.plugins.get_local_plugin_url", return_value=None
+        ) as _:
+            url = plugin_spec_overrides("transformer", cfg=cfg)["url"]
+        assert url.startswith("http://127.0.0.1:30080/")
+
+    def test_unknown_plugin_still_raises(self):
+        with pytest.raises(ValueError, match="not supported"):
+            get_local_plugin_url("nonexistent-plugin")
+
+
+class TestPublishedPluginUrls:
+    def test_pairs_every_manifest_plugin_with_the_url_in_its_cr(self):
+        cfg = make_cfg("http://127.0.0.1:30080")
+        pairs = published_plugin_urls(cfg)
+        assert len(pairs) == len(supported_plugins)
+        for name, url in pairs:
+            assert url == plugin_spec_overrides(name, cfg=cfg)["url"]
+
+
+class TestVerifyPublishedPluginModules:
+    """A module Envoy cannot load takes the listener down silently, so the
+    check has to distinguish "broken" from "cannot be checked from here"."""
+
+    @pytest.mark.asyncio
+    async def test_local_modules_pass_without_any_fetch(self, caplog):
+        # The embedded default. aiohttp cannot open a file:// URL, so treating
+        # these as HTTP would report every module broken on every start.
+        cfg = make_cfg("http://127.0.0.1:30080", gateway_mode=GatewayModeEnum.embedded)
+        with caplog.at_level(logging.INFO, logger="gpustack.gateway.plugins"):
+            assert await verify_published_plugin_modules(cfg) is True
+        assert "transformer=local" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_missing_local_module_is_reported_broken(self, caplog):
+        cfg = make_cfg(
+            "http://127.0.0.1:30080",
+            {"transformer": {"url": "file:///nonexistent/plugin.wasm"}},
+            gateway_mode=GatewayModeEnum.embedded,
+        )
+        with caplog.at_level(logging.INFO, logger="gpustack.gateway.plugins"):
+            assert await verify_published_plugin_modules(cfg) is False
+        assert "transformer=UNREADABLE" in caplog.text
+        assert "will not be bound" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_registry_reference_is_unverified_not_broken(self, caplog):
+        # Nothing here can reach a registry, and a registry does not depend on
+        # this server -- reporting it broken would be a standing false alarm.
+        cfg = make_cfg(
+            "http://127.0.0.1:30080",
+            {"transformer": {"url": "oci://registry.example/transformer:2.0.0"}},
+            gateway_mode=GatewayModeEnum.embedded,
+        )
+        with caplog.at_level(logging.INFO, logger="gpustack.gateway.plugins"):
+            assert await verify_published_plugin_modules(cfg) is True
+        assert "transformer=unverified (oci scheme)" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_http_module_is_reported_broken(self, caplog):
+        # Port 1 on loopback: refused fast, no network needed.
+        cfg = make_cfg(
+            "http://127.0.0.1:30080",
+            {"transformer": {"url": "http://127.0.0.1:1/plugin.wasm"}},
+            gateway_mode=GatewayModeEnum.embedded,
+        )
+        with caplog.at_level(logging.INFO, logger="gpustack.gateway.plugins"):
+            assert await verify_published_plugin_modules(cfg) is False
+        assert "transformer=FAILED" in caplog.text
 
 
 class TestHigressPluginGetPath:

--- a/tests/gateway/test_operator_subscription.py
+++ b/tests/gateway/test_operator_subscription.py
@@ -10,6 +10,7 @@ the gateway pushes Instance change events for the downstream watcher.
 """
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -437,3 +438,47 @@ async def test_non_kubernetes_cluster_is_ignored(harness):
 
     harness.subscribe.assert_not_awaited()
     harness.unsubscribe.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_worker_heartbeat_is_dropped_before_it_reads_the_payload(harness, caplog):
+    """A heartbeat carries ``data=None``, so every field read off it is unknown.
+
+    Falling through instead put the id-only warning on the heartbeat cadence,
+    once every 15s forever, for an event that had nothing to reconcile in the
+    first place. The cluster path has its own heartbeat branch (the retry
+    sweep); the worker path has no work to do.
+    """
+    harness.ready_workers = 1
+    await harness.reconciler._reconcile_cluster(
+        Event(type=EventType.CREATED, data=_cluster())
+    )
+    harness.queries = 0
+    harness.subscribe.reset_mock()
+
+    with caplog.at_level(logging.WARNING, logger=gateway.logger.name):
+        await harness.reconciler._reconcile_worker(
+            Event(type=EventType.HEARTBEAT, data=None)
+        )
+
+    assert caplog.records == []
+    assert harness.queries == 0
+    harness.subscribe.assert_not_awaited()
+    harness.unsubscribe.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_id_only_worker_delete_still_warns(harness, caplog):
+    """What the warning was written for, and what the heartbeat was drowning.
+
+    This reconciler is keyed on the worker's cluster, which a deleted row can
+    no longer name, so the subscription may be left in place -- worth a warning
+    precisely because nothing else recovers it.
+    """
+    with caplog.at_level(logging.WARNING, logger=gateway.logger.name):
+        await harness.reconciler._reconcile_worker(
+            Event(type=EventType.DELETED, data={"id": 5}, id=5)
+        )
+
+    assert "not reconciled" in caplog.text
+    assert "its cluster is unknown" in caplog.text

--- a/tests/server/test_bus.py
+++ b/tests/server/test_bus.py
@@ -1,8 +1,13 @@
 import asyncio
 import logging
+from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
+from sqlmodel import SQLModel
+
+from gpustack.mixins.active_record import CommitEvent, send_post_commit_events
 
 from gpustack.server.bus import (
     Event,
@@ -296,6 +301,13 @@ async def test_unsubscribe_unwinds_putters_beyond_queue_capacity():
     assert putters is None or len(putters) == 0
 
 
+class _PersistedRow(SQLModel):
+    """A real model, for the paths that ``model_copy`` the payload."""
+
+    id: Optional[int] = None
+    name: Optional[str] = None
+
+
 class _Row:
     """Stand-in for a SQLModel row: attribute access, and an ``id``."""
 
@@ -337,6 +349,63 @@ def test_event_id_survives_the_serialization_round_trip():
 
     assert resolve_event_id(hydrated) == 42
     assert resolve_event_id(_crossed_instances(hydrated)) == 42
+
+
+def test_a_created_event_has_no_id_until_the_insert_assigns_one():
+    """Why :meth:`Event.refresh_id` exists.
+
+    ``ActiveRecordMixin.create`` queues the event and *then* calls ``save``,
+    so the Event is built while the row's primary key is still None. Deriving
+    at construction is all ``__post_init__`` can do, and for a create it
+    derives nothing.
+    """
+    pre_insert = Event(type=EventType.CREATED, data=_Row(None, "r"))
+    assert resolve_event_id(pre_insert) is None
+
+    pre_insert.data.id = 42  # the INSERT
+    pre_insert.refresh_id()
+
+    assert resolve_event_id(pre_insert) == 42
+
+
+def test_refresh_id_does_not_overwrite_an_id_that_arrived_explicitly():
+    """Over the wire the id is all that survives and ``data`` is stripped, so
+    an explicit id outranks whatever can be read back off the payload."""
+    crossed = Event(type=EventType.DELETED, data={"id": 42}, id=42)
+    crossed.data = {}
+    crossed.refresh_id()
+
+    assert resolve_event_id(crossed) == 42
+
+
+@pytest.mark.asyncio
+async def test_the_commit_hook_publishes_a_created_event_with_its_id():
+    """The gap this closes: every consumer reading ``Event.id`` rather than
+    ``data.id`` saw None on every create, so anything that returned early on a
+    missing id silently did nothing until a restart replayed the row."""
+    row = _PersistedRow(id=None, name="r")
+    commit_event = CommitEvent(name="modelroute", type=EventType.CREATED, data=row)
+    assert commit_event.event.id is None, "built before the flush"
+
+    row.id = 42  # the INSERT, during save()
+
+    published = []
+
+    class _RecordingBus:
+        async def publish(self, name, event):
+            published.append((name, event))
+
+    session = SimpleNamespace(info={"pending_events": [commit_event]})
+    with patch("gpustack.mixins.active_record.event_bus", _RecordingBus()):
+        send_post_commit_events(session)
+        await asyncio.sleep(0)
+
+    assert len(published) == 1
+    name, event = published[0]
+    assert name == "modelroute"
+    assert resolve_event_id(event) == 42
+    # Derived after the detaching copy, so the two can never disagree.
+    assert event.id == event.data.id
 
 
 def test_resolve_event_id_survives_a_dataless_event():


### PR DESCRIPTION
Four independent fixes, found while chasing one symptom: on a fresh embedded
deployment the gateway never started listening on `:80`, and nothing said why.

Each commit stands alone and can be reverted alone.

Refer to issues:
- #6132
- #6133
- #6134

## Background

The reported symptom was a first boot where `:80` was never bound. The server
log looked entirely healthy; Envoy's listener was sitting in `warming_state`,
and only restarting the container recovered it.

That turned out to be two problems stacked on each other, and chasing them
surfaced two more that are unrelated to the gateway.

**The wait before Envoy starts proved the wrong thing.** The s6 `gateway`
service already waited for the GPUStack API — with `nc -z`, which proves a
socket is bound, not that the server behind it can answer. On one first boot
the API accepted TCP 28s in and did not answer `/healthz` for another 7. Envoy
was released into that window, where it fetches nine ~6 MB Wasm modules from
the API at once, gets connections but no responses, and exhausts istio-agent's
bounded retries.

That failure does not degrade and does not heal. A WasmPlugin becomes an HTTP
filter discovered over ECDS with `initial_fetch_timeout: 0` and no default
config, so an unresolved resource leaves the listener warming permanently —
the listener never appears at all. `failStrategy: FAIL_OPEN` governs VM
failures at request time, not downloads. Nothing retries until the next xDS
push.

**Nothing was checking whether the gateway came up.**
`Server._wait_for_gateway_ready` existed but had no caller anywhere, so the one
failure that makes the whole product unreachable produced no log line.

While verifying the fix, two more turned up: every locally published `CREATED`
event carried `Event.id` as `None`, which silently broke three reconcilers; and
worker heartbeats were logging a warning every 15 seconds.

## What each commit does

**`fix(server)` — run the readiness check that had no caller.** Invoked from a
startup task once uvicorn is accepting, so a gateway still waiting on this
server is not reported as broken. Reports rather than raises: killing the
server on top of a dead gateway removes the only process able to say so.

**`fix(gateway)` — read the modules off disk in the embedded gateway.**
Embedded runs Envoy in the same container as the server, so the fetch is
avoidable entirely: the modules already ship inside `gpustack_higress_plugins`
on the filesystem Envoy reads, and a WasmPlugin accepts a `file://` URL. That
removes the dependency rather than timing it — no serving, no readiness, no
window. Falls back to HTTP when the file is absent, rather than publishing a
path Envoy can only fail on, and an operator's `gateway_plugin.<name>.url`
still wins over both.

Now that a module URL has three possible schemes, the published URLs go into
the log and `verify_published_plugin_modules` checks each one after the API is
up — `stat` for `file://`, a one-byte ranged `GET` for HTTP, and a registry
reference reported unverified rather than broken. Envoy loading a module it
cannot read is otherwise silent.

The wait before Envoy starts keeps its TCP check, since Envoy still needs the
API to serve a request even though it no longer needs it to warm a listener,
and gains the timings that made this diagnosable at all.

**`fix(bus)` — give a `CREATED` event the id its row got from the INSERT.**
`create` queues the event before `save`, so `CommitEvent` built the `Event`
while the primary key was still `None`; the commit hook then copied `data`
without revisiting `id`. Consumers moved onto `resolve_event_id` read
`Event.id`, and three returned early without one — a provider-backed route's
`ready_targets` stuck at 0, a new worker pool unreconciled, a new cluster's
mcpbridge registry unsynced. A restart hid all three, because the replay
snapshot reads rows that do have ids.

**`fix(operator-subscription)` — drop worker heartbeats before reading the
payload.** A heartbeat carries `data=None`, so the reconciler fell through and
warned once every 15s about an event with nothing to reconcile — drowning the
same warning's legitimate case, an id-only `DELETE` that cannot name the
worker's cluster.

## Testing

- Verified on a rebuilt all-in-one image: embedded now publishes `file://` URLs
  and Envoy loads them off disk. Higress accepts the scheme, and `:80` comes up
  on a first boot against an empty database.
- Verified that a provider-backed route's ready targets are correct immediately,
  with no restart.
- Unit tests cover the three URL schemes, the embedded/external mode split,
  the operator URL override taking precedence, the missing-file fallback, and
  `Event.id` on the local `CREATED` path.

## Not addressed

**External mode keeps the window.** Envoy is already running in another
cluster there and its start cannot be sequenced from the server, so the
`file://` fix does not apply. A module it cannot fetch is now reported by
`verify_published_plugin_modules` instead of failing silently, but it is
reported, not prevented. This is a decision, not an oversight.

**No preventive gate for a plugin pointed back at this server over HTTP in
embedded mode.** An earlier revision waited on each such module before starting
Envoy; it was removed because the s6 gateway service only runs in embedded
mode, where every module is now local, so the probe list was empty in every
supported configuration. That configuration is still covered diagnostically, by
the same two checks above.

**The stall itself is unexplained.** The ~7s gap between the port accepting TCP
and the API answering is caused by the event loop blocking for over 5s right
after uvicorn binds — the server's own in-process work had completed in 0.28s
moments earlier. That affects every client during startup, not just Envoy, and
this PR only keeps Envoy out of the window rather than closing it. A blocking
call in a startup task is the shape of it; it needs its own investigation.
