### PR TITLE
refactor(benchmark): name the latency targets SLO, not SLA

### DIFF
--- a/gpustack/__init__.py
+++ b/gpustack/__init__.py
@@ -1,12 +1,16 @@
 __version__ = '0.0.0'
 __git_commit__ = 'HEAD'
-# Requires the auto-tune/stages CLI (--auto-tune, --axis, --stages, --sla-*,
+# Requires the auto-tune/stages CLI (--auto-tune, --axis, --stages, --slo-*,
 # --seed-increment, --detect-saturation) and the guidellm 0.7.1 backend that takes
 # path-keyed `request_handlers`. v0.0.4 has neither, and the backend kwarg is sent
 # on EVERY run, so pointing at an older image breaks single-rate runs too.
 #
 # Also needs --progress-ca-cert / --progress-insecure-skip-tls-verify, which the
-# benchmark container is given when the server sits behind a private CA. Not yet
-# released on this line -- bump once a v0.0.5-based image carries them.
-__benchmark_runner_version__ = 'v0.0.5'
+# benchmark container is given when the server sits behind a private CA.
+#
+# v0.0.7 is the floor, not a preference: it renamed the latency-target flags
+# --sla-* -> --slo-* and the `sla_failed` stop reason to `slo_failed`. An older
+# image rejects every flag this server sends for an SLO run, and would report a
+# stop reason the detail page has no text for.
+__benchmark_runner_version__ = 'v0.0.7'
 __operator_version__ = 'v0.8.5'

--- a/gpustack/assets/profiles_config/profiles_config.yaml
+++ b/gpustack/assets/profiles_config/profiles_config.yaml
@@ -27,13 +27,30 @@ profiles:
     # then uses seed + point_index.
     dataset_seed_increment: true # increment the seed per point
     # Auto-tune budget — written explicitly so the effective values are visible /
-    # editable in the form instead of being silently applied by the runner (kept
-    # in sync with benchmark-runner RampConfig, design §4.5). multiplier/min_requests
-    # stay internal (no form field).
+    # editable in the form instead of being silently applied by the runner.
+    # multiplier/min_requests stay internal (no form field).
+    #
+    # The two presets deliberately budget DIFFERENTLY, because their answers are
+    # different shapes. This one reports the argmax over measured points, which
+    # Phase 1 already finds: it needs the doubling to walk one point PAST the knee
+    # and nothing more. Phase 2 only narrows an interval that never enters the
+    # answer, so points beyond that buy nothing — simulated over 7 deployment
+    # sizes, the peak was already exact at 8 points and unchanged at 16 while the
+    # run took twice as long.
     lower_bound: 4 # knob floor (ramp start; skip low-info 1,2 points)
-    upper_bound: 1024 # knob ceiling (rate axis)
-    max_points: 12 # max measured ramp points
-    max_total_seconds: 3600 # whole-run cap (1h)
+    # Ceiling, not a target: Phase 1 stops on capacity_plateau long before it, so
+    # raising this costs nothing on small deployments (measured: identical point
+    # count and wall clock at 1024/2048/4096/8192 for everything up to a 1024-
+    # concurrency peak). Too LOW is what costs — a run that ends on `upper_bound`
+    # reports the range end as its peak, which is a number nobody measured. At
+    # 1024 every deployment peaking at or above it did exactly that.
+    upper_bound: 8192 # knob ceiling (rate axis)
+    # 15 covers the longest Phase 1 actually measured (11 points, on a peak near
+    # 2048 concurrency — the doubling stops on saturation, so it does not walk the
+    # full 12 steps up to the ceiling) plus the peak-seeking probes that let the
+    # smaller sizes finish on `converged` instead of `budget_points`.
+    max_points: 15 # max measured ramp points
+    max_total_seconds: 3600 # whole-run cap (1h; the slowest size measured 51m)
 
   - name: Meet Latency SLO
     # Kept in sync with benchmark.form.profile.latencySlo.tips (see above).
@@ -48,8 +65,24 @@ profiles:
     dataset_seed_increment: true # increment the seed per point (see note above)
     slo_avg_ttft_ms: 500
     slo_avg_tpot_ms: 50
-    # Auto-tune budget (see Max Throughput note above).
+    # Auto-tune budget (see Max Throughput note above for what the knobs are).
+    #
+    # This preset budgets HIGHER than Max Throughput because here the interval IS
+    # the answer: every bisection step halves it, so points buy precision directly.
+    # The cost also grows with the deployment — reaching the boundary takes
+    # Phase 1's doublings plus log2(bracket width), so a 2048-concurrency peak
+    # needs ~8 more points than a 32-concurrency one.
     lower_bound: 4 # knob floor (ramp start; skip low-info 1,2 points)
-    upper_bound: 1024 # knob ceiling (concurrency axis)
-    max_points: 12
-    max_total_seconds: 3600
+    upper_bound: 8192 # knob ceiling (concurrency axis)
+    # 18, not 12 and not 22. Simulated across 8 deployment sizes with ±8% per-point
+    # noise, the reported boundary lands within ~2% of the truth and stays there:
+    # that is a NOISE floor, not a budget one, so more points cannot beat it (22
+    # points measured the same 2.0% as 18). 12 leaves the largest sizes at 4-27%
+    # off — a real error, since the bisection had not closed. 18 is where every
+    # size reaches the floor; 20 and 22 buy ~0.5pp for 8-15 minutes more.
+    max_points: 18
+    # 5400, not 3600: the largest sizes need 64-73 min at 18 points. The cap is not
+    # merely a stop signal — it is also handed to each point as max_seconds, so a
+    # too-tight budget silently SHORTENS the last few measurements instead of
+    # dropping them, and stop_reason still says `budget_points`.
+    max_total_seconds: 5400

--- a/gpustack/assets/profiles_config/profiles_config.yaml
+++ b/gpustack/assets/profiles_config/profiles_config.yaml
@@ -6,8 +6,8 @@
 # `name` is stored on the benchmark's `profile` column as a soft label for list
 # display / filtering. `load_type` (fixed_rate / concurrency) is the load axis;
 # `auto_tune` toggles the adaptive ramp engine (geometric bracket + binary
-# search) which auto-detects the answer. The latency-SLA scenario is just
-# load_type=concurrency + auto_tune + sla_avg_ttft_ms / sla_avg_tpot_ms.
+# search) which auto-detects the answer. The latency-SLO scenario is just
+# load_type=concurrency + auto_tune + slo_avg_ttft_ms / slo_avg_tpot_ms.
 profiles:
   - name: Max Throughput
     # Kept in sync with the UI blurb (benchmark.form.profile.maxThroughput.tips):
@@ -16,7 +16,7 @@ profiles:
     description: >
       Finds peak throughput. The usual baseline for comparing GPUs and models.
     load_type: fixed_rate # rate axis (open-loop constant)
-    auto_tune: true # adaptive ramp; target = throughput saturation (no SLA)
+    auto_tune: true # adaptive ramp; target = throughput saturation (no SLO)
     dataset_name: Random
     dataset_input_tokens: 1024 # vLLM Random default https://github.com/vllm-project/vllm/blob/17b17c068453e6dc6af79240bb94857ae175cc51/vllm/benchmarks/datasets.py#L457
     dataset_output_tokens: 128
@@ -35,19 +35,19 @@ profiles:
     max_points: 12 # max measured ramp points
     max_total_seconds: 3600 # whole-run cap (1h)
 
-  - name: Latency SLA
-    # Kept in sync with benchmark.form.profile.latencySla.tips (see above).
+  - name: Meet Latency SLO
+    # Kept in sync with benchmark.form.profile.latencySlo.tips (see above).
     description: >
       Finds the most load that still meets your TTFT/TPOT targets. For capacity
       planning.
     load_type: concurrency # concurrency axis (closed-loop)
-    auto_tune: true # adaptive ramp; target = SLA boundary (sla_* set)
+    auto_tune: true # adaptive ramp; target = SLO boundary (slo_* set)
     dataset_name: Random
     dataset_input_tokens: 128
     dataset_output_tokens: 128
     dataset_seed_increment: true # increment the seed per point (see note above)
-    sla_avg_ttft_ms: 500
-    sla_avg_tpot_ms: 50
+    slo_avg_ttft_ms: 500
+    slo_avg_tpot_ms: 50
     # Auto-tune budget (see Max Throughput note above).
     lower_bound: 4 # knob floor (ramp start; skip low-info 1,2 points)
     upper_bound: 1024 # knob ceiling (concurrency axis)

--- a/gpustack/migrations/versions/2026_07_15_1600-367a3982fcde_v2_3_0_database_changes.py
+++ b/gpustack/migrations/versions/2026_07_15_1600-367a3982fcde_v2_3_0_database_changes.py
@@ -37,7 +37,7 @@ Bundles the pre-release schema changes for v2.3.0:
    
 5. Benchmark load curves: a ``benchmark_results`` child table holding one row
    per measured point, and the ``benchmarks`` config/result columns behind it
-   (load axis, adaptive auto-tune budget, the nine latency-SLA thresholds, the
+   (load axis, adaptive auto-tune budget, the nine latency-SLO thresholds, the
    token-length distribution, seed policy, stop conditions, and the computed
    best operating points). The parent's flat ``*_mean`` columns stay as the
    representative (throughput-peak) point, so this is an additive change.
@@ -144,7 +144,7 @@ _METRIC_INT_COLS = [
     'request_errored',
     'request_incomplete',
 ]
-# Measured percentiles of the SLA-relevant latency metrics. Both aggregations
+# Measured percentiles of the SLO-relevant latency metrics. Both aggregations
 # are stored because a threshold can only be evaluated against its own
 # percentile. NOT backfilled: rows written before this revision have neither,
 # and simply never match a p95/p99 threshold.
@@ -152,7 +152,7 @@ _METRIC_PCT_COLS = [
     'time_to_first_token_p95',
     'time_to_first_token_p99',
     # Decode-only per-token time (guidellm's inter_token_latency): the industry
-    # TPOT, and what the `sla_*_tpot_ms` thresholds are evaluated against.
+    # TPOT, and what the `slo_*_tpot_ms` thresholds are evaluated against.
     'inter_token_latency_p95',
     'inter_token_latency_p99',
     # The includes-TTFT variant. Still recorded, no longer judged on.
@@ -166,22 +166,22 @@ _METRIC_PCT_COLS = [
 _BENCHMARK_COLUMNS = [
     # Load axis: fixed_rate (open-loop req/s) or concurrency (closed-loop).
     ('load_type', sqlmodel.sql.sqltypes.AutoString(), None),
-    # Latency-SLA targets: 3 metrics x 3 aggregations, every one an optional
-    # "<= ms" threshold. A point meets the SLA when every threshold that was
+    # Latency-SLO targets: 3 metrics x 3 aggregations, every one an optional
+    # "<= ms" threshold. A point meets the SLO when every threshold that was
     # set holds AND its success rate clears the floor.
-    ('sla_avg_ttft_ms', sa.Float(), None),
-    ('sla_p95_ttft_ms', sa.Float(), None),
-    ('sla_p99_ttft_ms', sa.Float(), None),
-    ('sla_avg_tpot_ms', sa.Float(), None),
-    ('sla_p95_tpot_ms', sa.Float(), None),
-    ('sla_p99_tpot_ms', sa.Float(), None),
-    ('sla_avg_latency_ms', sa.Float(), None),
-    ('sla_p95_latency_ms', sa.Float(), None),
-    ('sla_p99_latency_ms', sa.Float(), None),
+    ('slo_avg_ttft_ms', sa.Float(), None),
+    ('slo_p95_ttft_ms', sa.Float(), None),
+    ('slo_p99_ttft_ms', sa.Float(), None),
+    ('slo_avg_tpot_ms', sa.Float(), None),
+    ('slo_p95_tpot_ms', sa.Float(), None),
+    ('slo_p99_tpot_ms', sa.Float(), None),
+    ('slo_avg_latency_ms', sa.Float(), None),
+    ('slo_p95_latency_ms', sa.Float(), None),
+    ('slo_p99_latency_ms', sa.Float(), None),
     # Measured percentiles of the representative point (mirrors the sub-table).
     *[(c, sa.Float(), None) for c in _METRIC_PCT_COLS],
     # Computed conclusions + run constraints + multi-turn.
-    ('sla_met_rate', sa.Float(), None),
+    ('slo_met_rate', sa.Float(), None),
     ('recommended_rate', sa.Float(), None),
     ('peak_rate', sa.Float(), None),
     ('validity', JSON(), None),

--- a/gpustack/routes/benchmarks.py
+++ b/gpustack/routes/benchmarks.py
@@ -70,9 +70,9 @@ from sqlalchemy.orm import defer
 
 MAX_EXPORT_RECORDS = 20
 # Upper bound on the per-point grid a single benchmark may upload. The ramp's own
-# budget is max_points (12 by default) and a manual stage list is user-sized, so
-# this is far above any real curve — it exists so a malformed upload is rejected at
-# the boundary instead of turning into an unbounded write.
+# budget is max_points and a manual stage list is user-sized, so this sits far
+# above any real curve — it exists so a malformed upload is rejected at the
+# boundary instead of turning into an unbounded write.
 MAX_BENCHMARK_RESULT_POINTS = 500
 BENCHMARK_EXPORT_FIELD_ORDER = [
     "name",

--- a/gpustack/routes/benchmarks.py
+++ b/gpustack/routes/benchmarks.py
@@ -37,7 +37,7 @@ from gpustack.schemas.benchmark import (
     DATASET_SEED_MAX,
     DATASET_SEED_MIN,
     DATASET_SHAREGPT,
-    SLA_THRESHOLDS,
+    SLO_THRESHOLDS,
     Benchmark,
     BenchmarkCreate,
     BenchmarkFullPublic,
@@ -370,10 +370,10 @@ def _validate_search_range(benchmark_in: BenchmarkCreate) -> None:
 
 
 def _validate_positive_knobs(benchmark_in: BenchmarkCreate) -> None:
-    """Budgets and SLA thresholds are all "<= N"-style quantities: 0 or less is not
+    """Budgets and SLO thresholds are all "<= N"-style quantities: 0 or less is not
     a stricter setting, it is a value the runner cannot act on."""
     fields = ["max_points", "max_total_seconds", "max_seconds", "turns"]
-    fields += [t.attr for t in SLA_THRESHOLDS]
+    fields += [t.attr for t in SLO_THRESHOLDS]
     for field in fields:
         value = getattr(benchmark_in, field, None)
         if value is not None and value <= 0:

--- a/gpustack/schemas/benchmark.py
+++ b/gpustack/schemas/benchmark.py
@@ -101,15 +101,15 @@ def benchmark_load_axis(benchmark) -> str:
 
 
 @dataclass(frozen=True)
-class SLAThreshold:
+class SLOThreshold:
     r"""
-    One optional latency SLA target ("this metric must stay <= N ms").
+    One optional latency SLO target ("this metric must stay <= N ms").
 
     Single source of truth for the 3 metrics x 3 aggregations grid, consumed by
     everything that has to walk it:
 
     - the runner, to forward the threshold to benchmark-runner (`flag`);
-    - the analysis, to decide whether a measured point meets the SLA and how much
+    - the analysis, to decide whether a measured point meets the SLO and how much
       of its budget the point used (`metric`, `scale`).
 
     Each of those used to carry its own hand-written copy of the nine rows, so
@@ -128,19 +128,19 @@ class SLAThreshold:
     scale: float
     flag: str
     # Second column to read when `metric` was not measured on a point (absent or
-    # non-positive). Only the TPOT rows need one — see SLA_THRESHOLDS.
+    # non-positive). Only the TPOT rows need one — see SLO_THRESHOLDS.
     fallback: Optional[str] = None
 
 
-SLA_THRESHOLDS: List[SLAThreshold] = [
-    SLAThreshold(
-        "sla_avg_ttft_ms", "time_to_first_token_mean", 1.0, "--sla-avg-ttft-ms"
+SLO_THRESHOLDS: List[SLOThreshold] = [
+    SLOThreshold(
+        "slo_avg_ttft_ms", "time_to_first_token_mean", 1.0, "--slo-avg-ttft-ms"
     ),
-    SLAThreshold(
-        "sla_p95_ttft_ms", "time_to_first_token_p95", 1.0, "--sla-p95-ttft-ms"
+    SLOThreshold(
+        "slo_p95_ttft_ms", "time_to_first_token_p95", 1.0, "--slo-p95-ttft-ms"
     ),
-    SLAThreshold(
-        "sla_p99_ttft_ms", "time_to_first_token_p99", 1.0, "--sla-p99-ttft-ms"
+    SLOThreshold(
+        "slo_p99_ttft_ms", "time_to_first_token_p99", 1.0, "--slo-p99-ttft-ms"
     ),
     # TPOT thresholds bound the DECODE-ONLY per-token time, which guidellm files
     # under `inter_token_latency_ms` — (last_token - first_token) / (tokens - 1),
@@ -150,7 +150,7 @@ SLA_THRESHOLDS: List[SLAThreshold] = [
     # per-token metric: (last_token - request_start) / tokens, i.e. TTFT folded
     # into the decode average. That charged prefill and queue wait to the decode
     # loop; the error is TTFT / (n * TPOT), so ~5% on a 128-token run and ~40% at
-    # 16 output tokens, and it grew with load exactly where the SLA decides
+    # 16 output tokens, and it grew with load exactly where the SLO decides
     # capacity.
     #
     # It stays as the FALLBACK because the decode-only metric is not always
@@ -162,35 +162,35 @@ SLA_THRESHOLDS: List[SLAThreshold] = [
     # judged instead of failing it (a threshold that fails wherever the server
     # batched its stream would bracket the ramp on its first point) and without
     # waiving it (0 ms would clear every budget).
-    SLAThreshold(
-        "sla_avg_tpot_ms",
+    SLOThreshold(
+        "slo_avg_tpot_ms",
         "inter_token_latency_mean",
         1.0,
-        "--sla-avg-tpot-ms",
+        "--slo-avg-tpot-ms",
         fallback="time_per_output_token_mean",
     ),
-    SLAThreshold(
-        "sla_p95_tpot_ms",
+    SLOThreshold(
+        "slo_p95_tpot_ms",
         "inter_token_latency_p95",
         1.0,
-        "--sla-p95-tpot-ms",
+        "--slo-p95-tpot-ms",
         fallback="time_per_output_token_p95",
     ),
-    SLAThreshold(
-        "sla_p99_tpot_ms",
+    SLOThreshold(
+        "slo_p99_tpot_ms",
         "inter_token_latency_p99",
         1.0,
-        "--sla-p99-tpot-ms",
+        "--slo-p99-tpot-ms",
         fallback="time_per_output_token_p99",
     ),
-    SLAThreshold(
-        "sla_avg_latency_ms", "request_latency_mean", 1000.0, "--sla-avg-latency-ms"
+    SLOThreshold(
+        "slo_avg_latency_ms", "request_latency_mean", 1000.0, "--slo-avg-latency-ms"
     ),
-    SLAThreshold(
-        "sla_p95_latency_ms", "request_latency_p95", 1000.0, "--sla-p95-latency-ms"
+    SLOThreshold(
+        "slo_p95_latency_ms", "request_latency_p95", 1000.0, "--slo-p95-latency-ms"
     ),
-    SLAThreshold(
-        "sla_p99_latency_ms", "request_latency_p99", 1000.0, "--sla-p99-latency-ms"
+    SLOThreshold(
+        "slo_p99_latency_ms", "request_latency_p99", 1000.0, "--slo-p99-latency-ms"
     ),
 ]
 
@@ -345,8 +345,8 @@ class BenchmarkBase(SQLModel):
     # (throughput / custom-sweep). Stage runs carry max_seconds per stage instead.
     max_seconds: Optional[float] = Field(default=None)
 
-    # The load axis (knob) — see BenchmarkLoadTypeEnum. The latency-SLA scenario
-    # is concurrency + any sla_* threshold set.
+    # The load axis (knob) — see BenchmarkLoadTypeEnum. The latency-SLO scenario
+    # is concurrency + any slo_* threshold set.
     #
     # Typed as the enum so an unknown value is a 422 at the API boundary instead
     # of silently falling through to the rate axis, but stored as a plain string
@@ -365,7 +365,7 @@ class BenchmarkBase(SQLModel):
     # Auto-tune (adaptive ramp): when true, the runner ramps the load_type axis
     # (fixed_rate=req/s, concurrency=streams) with a geometric bracket + binary
     # search instead of running user-specified stages, and auto-detects the
-    # answer. Target is derived: sla_* set -> SLA boundary (max knob meeting SLA);
+    # answer. Target is derived: slo_* set -> SLO boundary (max knob meeting SLO);
     # otherwise -> throughput saturation (peak output tok/s). Replaces the old
     # guidellm `sweep` profile (removed).
     auto_tune: Optional[bool] = Field(default=None)
@@ -379,32 +379,32 @@ class BenchmarkBase(SQLModel):
     max_points: Optional[int] = Field(default=None)  # max measured points (12)
     max_total_seconds: Optional[float] = Field(default=None)  # whole-run cap (3600)
 
-    # Latency SLA: optional "<= threshold" targets used to pick the max load that
-    # still meets the SLA. Each is independent; a point meets the SLA when every
-    # SET threshold holds (AND) and success >= 95%. `sla_avg_ttft_ms` / `sla_avg_tpot_ms`
+    # Latency SLO: optional "<= threshold" targets used to pick the max load that
+    # still meets the SLO. Each is independent; a point meets the SLO when every
+    # SET threshold holds (AND) and success >= 95%. `slo_avg_ttft_ms` / `slo_avg_tpot_ms`
     # are the average TTFT / TPOT (kept from the original 2-field model); the p95 /
     # p99 and end-to-end latency targets extend it (EvalScope-style latency metrics),
     # giving 3 metrics x 3 aggregations = 9 optional thresholds.
     #
     # The columns are declared individually (they are queryable/sortable scalars),
-    # but everything that WALKS the grid — the runner's CLI forwarding, the SLA
-    # evaluation, the budget-utilization check — reads SLA_THRESHOLDS instead of
+    # but everything that WALKS the grid — the runner's CLI forwarding, the SLO
+    # evaluation, the budget-utilization check — reads SLO_THRESHOLDS instead of
     # repeating these nine names. Adding an aggregation means one row there plus
     # the column here and in a migration.
     #
     # "TPOT" here means the DECODE-ONLY per-token time (guidellm's
     # inter_token_latency), matching the industry definition and what the report
-    # shows. SLA_THRESHOLDS carries the mapping; the threshold names stay
+    # shows. SLO_THRESHOLDS carries the mapping; the threshold names stay
     # `*_tpot_ms` because that is what the CLI, the API and the form call them.
-    sla_avg_ttft_ms: Optional[float] = Field(default=None)  # avg TTFT (ms)
-    sla_avg_tpot_ms: Optional[float] = Field(default=None)  # avg TPOT (ms)
-    sla_p95_ttft_ms: Optional[float] = Field(default=None)  # p95 TTFT (ms)
-    sla_p95_tpot_ms: Optional[float] = Field(default=None)  # p95 TPOT (ms)
-    sla_p99_ttft_ms: Optional[float] = Field(default=None)  # p99 TTFT (ms)
-    sla_p99_tpot_ms: Optional[float] = Field(default=None)  # p99 TPOT (ms)
-    sla_avg_latency_ms: Optional[float] = Field(default=None)  # avg e2e latency (ms)
-    sla_p95_latency_ms: Optional[float] = Field(default=None)  # p95 e2e latency (ms)
-    sla_p99_latency_ms: Optional[float] = Field(default=None)  # p99 e2e latency (ms)
+    slo_avg_ttft_ms: Optional[float] = Field(default=None)  # avg TTFT (ms)
+    slo_avg_tpot_ms: Optional[float] = Field(default=None)  # avg TPOT (ms)
+    slo_p95_ttft_ms: Optional[float] = Field(default=None)  # p95 TTFT (ms)
+    slo_p95_tpot_ms: Optional[float] = Field(default=None)  # p95 TPOT (ms)
+    slo_p99_ttft_ms: Optional[float] = Field(default=None)  # p99 TTFT (ms)
+    slo_p99_tpot_ms: Optional[float] = Field(default=None)  # p99 TPOT (ms)
+    slo_avg_latency_ms: Optional[float] = Field(default=None)  # avg e2e latency (ms)
+    slo_p95_latency_ms: Optional[float] = Field(default=None)  # p95 e2e latency (ms)
+    slo_p99_latency_ms: Optional[float] = Field(default=None)  # p99 e2e latency (ms)
 
     # Shared prefix: guidellm prefix_buckets — a list of buckets, each
     # {prefix_tokens, prefix_count, bucket_weight}. A common prompt prefix shared
@@ -468,7 +468,7 @@ class BenchmarkMetricsLite(SQLModel):
     #
     #   inter_token_latency_ms   = (last_token - first_token) / (tokens - 1)
     #     Decode only. This IS the industry's TPOT (vLLM, genai-perf). It is what
-    #     the report displays as "TPOT" and what the tpot SLA thresholds bound.
+    #     the report displays as "TPOT" and what the tpot SLO thresholds bound.
     #   time_per_output_token_ms = (last_token - request_start) / tokens
     #     Includes TTFT, so it bills prefill + queue wait to the decode loop. No
     #     standard name. Recorded for completeness; not displayed, not judged on.
@@ -490,8 +490,8 @@ class BenchmarkMetricsLite(SQLModel):
     time_to_first_token_mean: Optional[float] = Field(
         default=None, description="Mean time to first token (unit: ms)"
     )
-    # P95 / P99 percentiles for the SLA-relevant latency metrics (populated from
-    # guidellm's per-point percentiles). Used to evaluate tail SLA thresholds.
+    # P95 / P99 percentiles for the SLO-relevant latency metrics (populated from
+    # guidellm's per-point percentiles). Used to evaluate tail SLO thresholds.
     time_to_first_token_p95: Optional[float] = Field(
         default=None, description="P95 time to first token (unit: ms)"
     )
@@ -499,7 +499,7 @@ class BenchmarkMetricsLite(SQLModel):
         default=None, description="P95 decode-only time per output token (unit: ms)"
     )
     # Kept because it is cheap and already collected, but nothing reads it: the
-    # tpot SLA thresholds moved to the decode-only metric above.
+    # tpot SLO thresholds moved to the decode-only metric above.
     time_per_output_token_p95: Optional[float] = Field(
         default=None,
         description="P95 per-output-token time including the first token (unit: ms)",
@@ -661,8 +661,8 @@ class BenchmarkRuntime(SQLModel):
     progress: Optional[float] = Field(default=None)
     pid: Optional[int] = Field(default=None)
 
-    # Max rate that still meets the SLA targets (computed by the worker).
-    sla_met_rate: Optional[float] = Field(default=None)
+    # Max rate that still meets the SLO targets (computed by the worker).
+    slo_met_rate: Optional[float] = Field(default=None)
     # Recommended concurrency from over-saturation detection.
     recommended_rate: Optional[float] = Field(default=None)
     # Best operating points (computed by the worker from the stage grid).
@@ -747,7 +747,7 @@ class BenchmarkStateUpdate(SQLModel):
     # Best operating points (computed by the worker from the stage grid; only
     # the explicitly-set ones are persisted via model_fields_set).
     peak_rate: Optional[float] = None
-    sla_met_rate: Optional[float] = None
+    slo_met_rate: Optional[float] = None
     recommended_rate: Optional[float] = None
     validity: Optional[Dict[str, Any]] = None
 

--- a/gpustack/schemas/benchmark.py
+++ b/gpustack/schemas/benchmark.py
@@ -370,14 +370,17 @@ class BenchmarkBase(SQLModel):
     # guidellm `sweep` profile (removed).
     auto_tune: Optional[bool] = Field(default=None)
     # Auto-tune budget / bounds (used when auto_tune=true). None -> runner default.
-    lower_bound: Optional[float] = Field(default=None)  # knob floor (default 4)
+    # The values themselves are deliberately NOT named here: the runner's
+    # AutoTuneConfig owns them, the shipped presets in profiles_config.yaml
+    # override them per goal, and a copy in this comment would be a second
+    # source of truth that drifts the moment either is retuned.
+    lower_bound: Optional[float] = Field(default=None)  # knob floor
     upper_bound: Optional[float] = Field(default=None)  # knob ceiling (anti-runaway)
     # Per-point requests = max(min_requests, round(knob * multiplier)) is computed
-    # by the runner's ramp engine with its own defaults (multiplier 10 conc / 30
-    # rate, min_requests 100 — a percentile floor, see the runner's AutoTuneConfig);
-    # not surfaced or stored here.
-    max_points: Optional[int] = Field(default=None)  # max measured points (12)
-    max_total_seconds: Optional[float] = Field(default=None)  # whole-run cap (3600)
+    # by the runner's ramp engine from its own defaults (see AutoTuneConfig);
+    # neither knob is surfaced or stored here.
+    max_points: Optional[int] = Field(default=None)  # max measured points
+    max_total_seconds: Optional[float] = Field(default=None)  # whole-run cap
 
     # Latency SLO: optional "<= threshold" targets used to pick the max load that
     # still meets the SLO. Each is independent; a point meets the SLO when every

--- a/gpustack/worker/benchmark/analysis.py
+++ b/gpustack/worker/benchmark/analysis.py
@@ -11,7 +11,7 @@ Two kinds of input, deliberately kept apart:
 
 * **facts** — benchmark-runner's ``{id}__ramp.json`` sidecar says WHY the search
   stopped. Several terminations leave identical grids (``capacity_plateau`` and a
-  threshold breaking at the top both end with "the highest knob met the SLA";
+  threshold breaking at the top both end with "the highest knob met the SLO";
   ``budget_seconds`` and a self-directed stop both end with "fewer points than the
   range allows"), so this cannot be re-derived downstream in general.
 * **the grid** — what the remaining verdicts are about: is the answer
@@ -26,8 +26,9 @@ import logging
 from typing import Optional
 
 from gpustack.schemas.benchmark import (
-    SLA_THRESHOLDS,
+    SLO_THRESHOLDS,
     BenchmarkLoadTypeEnum,
+    SLOThreshold,
 )
 from gpustack.worker.benchmark.artifacts import ramp_facts_path
 
@@ -42,11 +43,11 @@ MIN_SUCCESS_RATE = 0.95
 # saturation at the top (don't).
 PEAK_PLATEAU_TOLERANCE = 0.05
 
-# Fraction of its tightest SLA budget a point may consume and still count as "the
+# Fraction of its tightest SLO budget a point may consume and still count as "the
 # thresholds never came into play". A sweep that ended on 31% of its TTFT budget
-# was not stopped by latency, whatever the SLA-capacity number says. Used to
+# was not stopped by latency, whatever the SLO-capacity number says. Used to
 # phrase the message, and as the fallback discriminator when no ramp facts exist.
-SLA_HEADROOM_RATIO = 0.7
+SLO_HEADROOM_RATIO = 0.7
 
 # Achieved rps below this fraction of the OFFERED rate = the server plainly cannot
 # keep up. Deliberately loose: a finite max_requests leaves achieved a few percent
@@ -86,8 +87,8 @@ def read_ramp_facts(benchmark_dir: str, benchmark) -> Optional[dict]:
     return facts if isinstance(facts, dict) else None
 
 
-# ── SLA evaluation ────────────────────────────────────────────────────────────
-# The thresholds themselves live in SLA_THRESHOLDS (one row per metric x
+# ── SLO evaluation ────────────────────────────────────────────────────────────
+# The thresholds themselves live in SLO_THRESHOLDS (one row per metric x
 # aggregation) so the runner's CLI forwarding and the checks below cannot drift.
 
 
@@ -114,13 +115,13 @@ def measured_stages(results: list) -> list:
     return [r for r in results if r.get("rate") is not None]
 
 
-def has_sla(benchmark) -> bool:
+def has_slo(benchmark) -> bool:
     """True when any latency threshold is set on this benchmark."""
-    return any(getattr(benchmark, t.attr, None) for t in SLA_THRESHOLDS)
+    return any(getattr(benchmark, t.attr, None) for t in SLO_THRESHOLDS)
 
 
-def _sla_value(r: dict, t) -> Optional[float]:
-    """The point's value for one SLA threshold, or None when it was not measured.
+def _slo_value(r: dict, t: SLOThreshold) -> Optional[float]:
+    """The point's value for one SLO threshold, or None when it was not measured.
 
     Non-positive counts as not measured, not as "0 ms, passes everything". No
     latency here can really be zero, and one of them reaches zero routinely: the
@@ -128,14 +129,14 @@ def _sla_value(r: dict, t) -> Optional[float]:
     single chunk (the whole output at once — common at low load, and the only shape
     a single-token output can have) collapses it to 0.0. Treating that as a pass
     would let such a run climb to the upper bound and report the ceiling as
-    SLA-approved.
+    SLO-approved.
 
     `t.fallback` covers exactly that case for the TPOT rows: total-time-over-tokens
     is the only per-token number a non-incremental response leaves behind. Failing
     the point instead would bracket the ramp wherever the server batched its
     stream.
     """
-    for metric in (t.metric, getattr(t, "fallback", None)):
+    for metric in (t.metric, t.fallback):
         if not metric:
             continue
         val = r.get(metric)
@@ -144,37 +145,37 @@ def _sla_value(r: dict, t) -> Optional[float]:
     return None
 
 
-def meets_sla(benchmark, r: dict) -> bool:
-    """True iff every SET SLA threshold holds for this point (AND).
+def meets_slo(benchmark, r: dict) -> bool:
+    """True iff every SET SLO threshold holds for this point (AND).
 
     A point that does not carry the metric a threshold is set on never meets it —
     rows written before that percentile was collected have nothing to compare.
     """
-    for t in SLA_THRESHOLDS:
+    for t in SLO_THRESHOLDS:
         thr = getattr(benchmark, t.attr, None)
         if thr is None:
             continue
-        val = _sla_value(r, t)
+        val = _slo_value(r, t)
         if val is None or val * t.scale > thr:
             return False
     return True
 
 
-def sla_utilization(benchmark, r: dict) -> Optional[float]:
-    """How close this point came to its TIGHTEST set SLA threshold.
+def slo_utilization(benchmark, r: dict) -> Optional[float]:
+    """How close this point came to its TIGHTEST set SLO threshold.
 
     1.0 = sitting exactly on a threshold; 0.3 = using 30% of the strictest budget.
     None when no threshold is set, or the point carries none of the metrics one is
-    set on. Tells an SLA that genuinely binds at the throughput peak from one that
+    set on. Tells an SLO that genuinely binds at the throughput peak from one that
     never mattered — the rates alone cannot: both end up with
-    sla_met_rate == peak_rate == the top knob measured.
+    slo_met_rate == peak_rate == the top knob measured.
     """
     worst = None
-    for t in SLA_THRESHOLDS:
+    for t in SLO_THRESHOLDS:
         thr = getattr(benchmark, t.attr, None)
         if thr is None or thr <= 0:
             continue
-        val = _sla_value(r, t)
+        val = _slo_value(r, t)
         if val is None:
             continue
         used = val * t.scale / thr
@@ -189,39 +190,39 @@ def success_ok(r: dict) -> bool:
     return (r.get("request_successful") or 0) / total >= MIN_SUCCESS_RATE
 
 
-def sla_boundary_located(
+def slo_boundary_located(
     benchmark, rate_points: list, best_points: dict, ramp: Optional[dict]
 ) -> bool:
-    """Is ``sla_met_rate`` an EDGE, or merely a FLOOR?
+    """Is ``slo_met_rate`` an EDGE, or merely a FLOOR?
 
-    The number itself cannot say. "The max measured load meeting the SLA" is true
+    The number itself cannot say. "The max measured load meeting the SLO" is true
     either way, but it means two different things:
 
-    * EDGE — a load just above it was measured BREACHING the SLA, so this is the
+    * EDGE — a load just above it was measured BREACHING the SLO, so this is the
       boundary: "257 breaks it".
     * FLOOR — nothing above it was ever measured failing, because the search ended
       first (capacity plateau, budget, range ceiling). The honest reading is
       ">= 256", and treating it as an edge invents a limit nobody measured.
       Capacity planning off a fabricated ceiling is the failure this prevents.
 
-    With ramp facts this is a lookup: ``sla_bracket = (last_pass, first_fail)`` and
+    With ramp facts this is a lookup: ``slo_bracket = (last_pass, first_fail)`` and
     ``first_fail is None`` IS "no boundary located". Without them, the same
     evidence is read off the grid — a measured point above the answer that fails it
     — using the same pass definition :func:`compute_best_points` used to pick the
-    answer (SLA thresholds AND the success floor), so the two cannot drift.
+    answer (SLO thresholds AND the success floor), so the two cannot drift.
     """
-    sla_rate = best_points.get("sla_met_rate")
-    if sla_rate is None:
+    slo_rate = best_points.get("slo_met_rate")
+    if slo_rate is None:
         return False
 
-    bracket = (ramp or {}).get("sla_bracket")
+    bracket = (ramp or {}).get("slo_bracket")
     if isinstance(bracket, (list, tuple)) and len(bracket) == 2:
         return bracket[1] is not None
 
     # Reaching the top of the range with everything passing is deliberately NOT a
     # located boundary: the range ran out, so the edge is somewhere above it.
     return any(
-        r["rate"] > sla_rate and not (meets_sla(benchmark, r) and success_ok(r))
+        r["rate"] > slo_rate and not (meets_slo(benchmark, r) and success_ok(r))
         for r in measured_stages(rate_points)
     )
 
@@ -234,24 +235,24 @@ def compute_best_points(benchmark, results: list) -> dict:
 
     - peak_rate: the true throughput argmax — the rate with the highest measured
       throughput (ties resolve to the lowest rate). Exactly what the name says.
-    - sla_met_rate: when SLA targets are set, the max rate whose latency metrics
-      all stay within the SLA thresholds (ms). The literal answer to "how much
-      load still meets the SLA", reported as measured.
+    - slo_met_rate: when SLO targets are set, the max rate whose latency metrics
+      all stay within the SLO thresholds (ms). The literal answer to "how much
+      load still meets the SLO", reported as measured.
     - recommended_rate: the load to actually RUN at.
-      * No SLA => the throughput peak (the user asked to maximise throughput).
-      * SLA    => min(sla_met_rate, peak_rate). Capped at the PEAK, not below: up
-        to the peak more load buys more throughput, so if it meets the SLA
+      * No SLO => the throughput peak (the user asked to maximise throughput).
+      * SLO    => min(slo_met_rate, peak_rate). Capped at the PEAK, not below: up
+        to the peak more load buys more throughput, so if it meets the SLO
         recommend it (bm93: a real 500ms TTFT target held at concurrency 256 — the
         throughput peak — at 155ms, so 256 is the answer, NOT some lower-latency
         point below it). The cap only bites past the peak, where throughput
-        DECLINES and a higher SLA-meeting rate is strictly worse (bm74: the loose
+        DECLINES and a higher SLO-meeting rate is strictly worse (bm74: the loose
         10s target held to 1024, which delivered LESS throughput than 256 — so
-        recommend 256, and _edge_warnings flags the gap via `sla_not_binding`).
+        recommend 256, and _edge_warnings flags the gap via `slo_not_binding`).
 
       An earlier version capped recommended at a "knee" (lowest rate within 5% of
-      peak throughput). That under-delivered on real SLAs: it treated a healthy
+      peak throughput). That under-delivered on real SLOs: it treated a healthy
       near-peak point (bm93's 256) the same as an over-saturated one and
-      recommended a lower load than the SLA actually allowed.
+      recommended a lower load than the SLO actually allowed.
     """
     points = [
         r
@@ -269,12 +270,12 @@ def compute_best_points(benchmark, results: list) -> dict:
     peak_rate = float(peak["rate"])
     out["peak_rate"] = peak_rate
 
-    if has_sla(benchmark):
-        met = [r for r in points if meets_sla(benchmark, r) and success_ok(r)]
+    if has_slo(benchmark):
+        met = [r for r in points if meets_slo(benchmark, r) and success_ok(r)]
         if met:
-            sla_rate = float(max(met, key=lambda r: r["rate"])["rate"])
-            out["sla_met_rate"] = sla_rate
-            out["recommended_rate"] = min(sla_rate, peak_rate)
+            slo_rate = float(max(met, key=lambda r: r["rate"])["rate"])
+            out["slo_met_rate"] = slo_rate
+            out["recommended_rate"] = min(slo_rate, peak_rate)
     else:
         out["recommended_rate"] = peak_rate
 
@@ -290,12 +291,12 @@ def compute_validity(
     """Judge whether the sweep explored enough to trust the result.
 
     Returns ``{"sufficient": bool, "warnings": [...]}`` plus, when the facts are
-    available, ``stop_reason`` / ``stopped_at`` / ``sla_boundary_located`` and the
+    available, ``stop_reason`` / ``stopped_at`` / ``slo_boundary_located`` and the
     saturation probe's ``probe_ceiling`` / ``probe_bound`` / ``probe_relaxed``.
 
     Codes (rendered/localized by the UI):
-    - ``sla_never_met``: SLA targets set but no measured point meets them -> the
-      server is too slow for this SLA; no usable capacity.
+    - ``slo_never_met``: SLO targets set but no measured point meets them -> the
+      server is too slow for this SLO; no usable capacity.
     - ``not_saturated``: the best point is the highest one measured and the user's
       own search range is what stopped the sweep -> raise upper_bound.
     - ``budget_exhausted``: same situation, but the measurement budget ran out
@@ -307,7 +308,7 @@ def compute_validity(
       measured sustained rps as ``params.ceiling`` so the advice is a number, not
       a direction. Supersedes the top-edge codes, whose advice ("raise the upper
       bound") would point the opposite way.
-    - ``sla_not_binding``: SLA targets set, but they held at the HIGHEST load
+    - ``slo_not_binding``: SLO targets set, but they held at the HIGHEST load
       measured while throughput had already turned over -> capacity, not the
       latency budget, is what limited this run; the thresholds are too loose to
       locate a boundary. Carries the throughput peak as ``params.rate``.
@@ -315,7 +316,7 @@ def compute_validity(
       may be below the search range; lower lower_bound.
     - ``point_high_error``: some point's success rate < 95% -> overloaded /
       unreliable at that load (already flagged red in the table).
-    - ``few_points``: too few measured points (< 3, no SLA) to trust the curve.
+    - ``few_points``: too few measured points (< 3, no SLO) to trust the curve.
 
     ``not_saturated`` and ``budget_exhausted`` are the same observation ("we never
     saw the curve turn over") split by WHAT limited the sweep, because the two need
@@ -328,7 +329,7 @@ def compute_validity(
     warnings: list = []
 
     rate_points = measured_stages(results)
-    sla_set = has_sla(benchmark)
+    slo_set = has_slo(benchmark)
 
     # Any measured point that overloaded (low success rate).
     overloaded_any = False
@@ -348,13 +349,13 @@ def compute_validity(
             {"code": "point_high_error", "params": {"rate": round(worst_ok * 100)}}
         )
 
-    if sla_set and best_points.get("sla_met_rate") is None:
-        # SLA set but nothing met it — even the lowest load is too slow.
-        warnings.append({"code": "sla_never_met", "params": {}})
+    if slo_set and best_points.get("slo_met_rate") is None:
+        # SLO set but nothing met it — even the lowest load is too slow.
+        warnings.append({"code": "slo_never_met", "params": {}})
 
     warnings.extend(
         _edge_warnings(
-            benchmark, rate_points, best_points, overloaded_any, sla_set, ramp
+            benchmark, rate_points, best_points, overloaded_any, slo_set, ramp
         )
     )
 
@@ -363,16 +364,16 @@ def compute_validity(
     # `saturated_at_lower_bound` or `peak_at_floor` doesn't need "and also, few
     # points" tacked on — it dilutes the primary cause the user should act on
     # (observed alongside those codes in rounds 5/6).
-    if not sla_set and 0 < len(rate_points) < 3 and not warnings:
+    if not slo_set and 0 < len(rate_points) < 3 and not warnings:
         warnings.append({"code": "few_points", "params": {}})
 
     out = {"sufficient": len(warnings) == 0, "warnings": warnings}
-    if sla_set and best_points.get("sla_met_rate") is not None:
-        # Whether `sla_met_rate` is a measured boundary or a floor. Rides in
+    if slo_set and best_points.get("slo_met_rate") is not None:
+        # Whether `slo_met_rate` is a measured boundary or a floor. Rides in
         # `validity` for the same two reasons as the stop reason: no migration
         # (JSON column), and it IS a coverage statement — "did we actually observe
-        # where the SLA breaks?".
-        out["sla_boundary_located"] = sla_boundary_located(
+        # where the SLO breaks?".
+        out["slo_boundary_located"] = slo_boundary_located(
             benchmark, rate_points, best_points, ramp
         )
     out.update(_ramp_facts_for_ui(ramp))
@@ -428,7 +429,7 @@ def _edge_warnings(
     rate_points: list,
     best_points: dict,
     overloaded_any: bool,
-    sla_set: bool,
+    slo_set: bool,
     ramp: Optional[dict] = None,
 ) -> list:
     """Warnings for a best point sitting at an EDGE of the measured range.
@@ -459,34 +460,34 @@ def _edge_warnings(
 
     top_point = max(rate_points, key=lambda r: r["rate"])
     top_rate = top_point["rate"]
-    sla_rate = best_points.get("sla_met_rate")
+    slo_rate = best_points.get("slo_met_rate")
     peak_rate = best_points.get("peak_rate")
     if (
-        sla_set
-        and sla_rate is not None
+        slo_set
+        and slo_rate is not None
         and peak_rate is not None
-        and sla_rate >= top_rate
+        and slo_rate >= top_rate
     ):
-        # The SLA held at the highest load measured. Two different runs land here,
+        # The SLO held at the highest load measured. Two different runs land here,
         # and only the second one has a real latency boundary:
         #
         # (a) throughput PEAKED strictly below the top — the thresholds have
         #     headroom the throughput does not.
         # (b) the sweep STOPPED on the throughput plateau with the thresholds
-        #     barely touched. The ramp's SLA branch breaks out on capacity
+        #     barely touched. The ramp's SLO branch breaks out on capacity
         #     saturation (past it, more load buys only queueing), so the sweep ends
-        #     mid-range with peak == sla == top and every rate comparison comes out
+        #     mid-range with peak == slo == top and every rate comparison comes out
         #     equal. bm102: stopped at concurrency 256 of a 4..1024 range after 7 of
-        #     12 points, reporting "max within SLA = 256" — while TTFT there was
+        #     12 points, reporting "max within SLO = 256" — while TTFT there was
         #     156ms of a 500ms budget (31%) and TPOT 1.2ms of 50ms. Judging this on
         #     rates alone said "sufficient, no warnings": a capacity ceiling wearing
-        #     an SLA label, with nothing to tell the user why the run ended there.
+        #     an SLO label, with nothing to tell the user why the run ended there.
         #
         # Either way the advice is "tighten the thresholds", NOT the top-edge codes'
         # "raise the upper bound", which would only buy points past the peak. A
-        # threshold actually pressed against at the peak (bm93) is a binding SLA and
+        # threshold actually pressed against at the peak (bm93) is a binding SLO and
         # still reports nothing: its recommendation IS the peak.
-        used = sla_utilization(benchmark, top_point)
+        used = slo_utilization(benchmark, top_point)
         bracket = (ramp or {}).get("bracket_reason")
         if bracket is not None:
             # FACT: the ramp says capacity is what ended the bracket.
@@ -495,16 +496,16 @@ def _edge_warnings(
             # No facts (stage / legacy / pre-sidecar run): fall back to the grid.
             # `used <= ratio` + a flattened top step is the closest observable
             # proxy, and the reason this cannot be the primary signal is that a
-            # binding SLA at the peak produces the same rates.
+            # binding SLO at the peak produces the same rates.
             capacity_bound = (
                 used is not None
-                and used <= SLA_HEADROOM_RATIO
+                and used <= SLO_HEADROOM_RATIO
                 and _plateaued_at_top(rate_points)
             )
-        if peak_rate < sla_rate or capacity_bound:
+        if peak_rate < slo_rate or capacity_bound:
             out.append(
                 {
-                    "code": "sla_not_binding",
+                    "code": "slo_not_binding",
                     "params": {
                         "rate": peak_rate,
                         # Percent of the strictest budget the top point used, so the
@@ -525,7 +526,7 @@ def _edge_warnings(
     # axis this is the only signal available (the knob counts streams, so there is
     # no achieved-vs-offered comparison to make).
     if (
-        not sla_set
+        not slo_set
         and len(rate_points) > 1
         and rec == min(r["rate"] for r in rate_points)
     ):
@@ -570,7 +571,7 @@ def _limit_warnings(
             which = "seconds" if bracket == RAMP_STOP_BUDGET_SECONDS else "points"
             return [{"code": "budget_exhausted", "params": {"which": which}}]
         # Any other reason means either the search had its answer
-        # (capacity_plateau, sla_failed, ...) or the limit was one the user cannot
+        # (capacity_plateau, slo_failed, ...) or the limit was one the user cannot
         # act on: `probe_bound` is the saturation probe's own soft cap, and raising
         # upper_bound does not move a cap the probe re-derives from a fresh
         # measurement on every run. Either way: no limit to report.

--- a/gpustack/worker/benchmark/runner.py
+++ b/gpustack/worker/benchmark/runner.py
@@ -14,7 +14,7 @@ from gpustack.ssl_context import resolve_ca_bundle
 from gpustack.schemas.benchmark import (
     DATASET_RANDOM,
     DATASET_SHAREGPT,
-    SLA_THRESHOLDS,
+    SLO_THRESHOLDS,
     Benchmark,
     BenchmarkDeploymentMetadata,
     BenchmarkLoadModeEnum,
@@ -360,7 +360,7 @@ class BenchmarkRunner:
         # collection and the ready-file count read the same function):
         #   1. auto_tune  -> benchmark-runner's adaptive ramp engine (geometric
         #      bracket + binary search) over the load axis. Replaces the old
-        #      guidellm `sweep` profile. Target derived: sla_* set -> SLA boundary,
+        #      guidellm `sweep` profile. Target derived: slo_* set -> SLO boundary,
         #      else throughput saturation.
         #   2. stages     -> one single-rate guidellm run per stage (Custom manual
         #      mode; each stage carries its own max_requests / max_seconds).
@@ -382,11 +382,11 @@ class BenchmarkRunner:
                 value = getattr(b, attr, None)
                 if value is not None:
                     profile_args += [flag, str(value)]
-            # SLA targets ("<=" ms). Any one set -> target is the SLA boundary; a
-            # point meets the SLA when every set threshold holds (AND). Walked from
-            # SLA_THRESHOLDS so a threshold added there is forwarded here without a
+            # SLO targets ("<=" ms). Any one set -> target is the SLO boundary; a
+            # point meets the SLO when every set threshold holds (AND). Walked from
+            # SLO_THRESHOLDS so a threshold added there is forwarded here without a
             # second list to remember (it used to be silently dropped).
-            for t in SLA_THRESHOLDS:
+            for t in SLO_THRESHOLDS:
                 value = getattr(b, t.attr, None)
                 if value is not None:
                     profile_args += [t.flag, str(value)]

--- a/gpustack/worker/benchmark_manager.py
+++ b/gpustack/worker/benchmark_manager.py
@@ -1019,7 +1019,7 @@ class BenchmarkManager:
         `attempts=1` for partial syncs — a transient blip just retries on the next
         poll instead of blocking it with backoff.
         """
-        # Best operating points: peak throughput / max rate meeting the SLA.
+        # Best operating points: peak throughput / max rate meeting the SLO.
         # Computed from the per-point grid and persisted on the parent row for
         # the detail page's "Best Operating Points" cards.
         best_points = analysis.compute_best_points(benchmark, results)
@@ -1046,7 +1046,7 @@ class BenchmarkManager:
             # values are overwritten, not left stale.
             best_points = {
                 "peak_rate": None,
-                "sla_met_rate": None,
+                "slo_met_rate": None,
                 "recommended_rate": None,
             }
         if in_progress:
@@ -1071,11 +1071,11 @@ class BenchmarkManager:
         # as a stale number next to a validity that contradicts it.
         patch = {
             "peak_rate": best_points.get("peak_rate"),
-            "sla_met_rate": best_points.get("sla_met_rate"),
+            "slo_met_rate": best_points.get("slo_met_rate"),
             "recommended_rate": best_points.get("recommended_rate"),
             "validity": validity,
         }
-        # This write carries the whole conclusion of the run (peak / SLA
+        # This write carries the whole conclusion of the run (peak / SLO
         # capacity / coverage). Losing it leaves a benchmark that reads as
         # "completed" with every conclusion field null and no hint why, so retry a
         # few times and, if it still fails, say so on state_message rather than

--- a/gpustack/worker/schemas/benchmark_runner.py
+++ b/gpustack/worker/schemas/benchmark_runner.py
@@ -108,7 +108,7 @@ class Percentiles(BaseModel):
     emits p001/p01/p05/p10/p25/p50/p75/p90/p95/p99/p999; p25 and p75 are the IQR
     band of the latency-distribution charts (a robust spread signal — "the band
     widens" only means divergence when it comes from real quantiles, never from
-    mean x a constant factor), and p90/p95/p99 carry the tail / SLA thresholds.
+    mean x a constant factor), and p90/p95/p99 carry the tail / SLO thresholds.
     """
 
     # All optional, and none of them defaulted to 0. Two reasons, and the second is
@@ -150,7 +150,7 @@ class DistributionSummary(BaseModel):
     min: float = Field(description="Minimum value")
     max: float = Field(description="Maximum value")
     # Sample size of this distribution. A point with few samples has p99 == max, so
-    # the report greys out its tail percentiles instead of reading them as an SLA
+    # the report greys out its tail percentiles instead of reading them as an SLO
     # conclusion. Optional for the same backward-compatibility reason as p25/p75.
     count: Optional[int] = Field(default=None, description="Number of observations")
     std_dev: Optional[float] = Field(default=None, description="Standard deviation")
@@ -223,7 +223,7 @@ class GenerativeMetrics(BaseModel):
     #     -> includes TTFT. No standard name. Recorded, not judged on, not shown.
     #   inter_token_latency_ms   = (last_token - first_token) / (tokens - 1)
     #     -> decode only. THIS is the industry TPOT, and what the report shows and
-    #        the `sla_*_tpot_ms` thresholds bound.
+    #        the `slo_*_tpot_ms` thresholds bound.
     # Both are per-REQUEST values whose distribution is token-weighted, so their
     # percentiles rank requests by their own average decode speed; neither can
     # show a single-token stall (guidellm keeps only the first/last token
@@ -273,7 +273,7 @@ class RequestTimings(BaseModel):
 
     Provides comprehensive timing data for distributed request processing, capturing
     key timestamps from initial targeting through final completion. Essential for
-    performance analysis, SLA monitoring, and debugging request processing bottlenecks
+    performance analysis, SLO monitoring, and debugging request processing bottlenecks
     across scheduler workers and backend systems.
     """
 
@@ -592,9 +592,9 @@ class GenerativeBenchmarksReport(BaseModel):
             time_per_output_token_mean=m.time_per_output_token_ms.successful.mean,
             inter_token_latency_mean=m.inter_token_latency_ms.successful.mean,
             time_to_first_token_mean=m.time_to_first_token_ms.successful.mean,
-            # p95 / p99 percentiles for the SLA-relevant latency metrics. The tpot
+            # p95 / p99 percentiles for the SLO-relevant latency metrics. The tpot
             # thresholds are evaluated on inter_token_latency_* (decode only);
-            # time_per_output_token_* is kept for reference — see SLA_THRESHOLDS.
+            # time_per_output_token_* is kept for reference — see SLO_THRESHOLDS.
             time_to_first_token_p95=(
                 m.time_to_first_token_ms.successful.percentiles.p95
             ),

--- a/tests/routers/test_benchmarks.py
+++ b/tests/routers/test_benchmarks.py
@@ -15,7 +15,7 @@ from gpustack.routes.benchmarks import (
 from gpustack.schemas.benchmark import (
     DATASET_SEED_MAX,
     DATASET_SEED_MIN,
-    SLA_THRESHOLDS,
+    SLO_THRESHOLDS,
     Benchmark,
     BenchmarkCreate,
     BenchmarkFullPublic,
@@ -188,8 +188,8 @@ class TestValidateLoadConfig:
             _validate_load_config(_create(stages=stages))
         assert "stages" in str(e.value.message)
 
-    @pytest.mark.parametrize("t", SLA_THRESHOLDS, ids=lambda t: t.attr)
-    def test_every_sla_threshold_must_be_positive(self, t):
+    @pytest.mark.parametrize("t", SLO_THRESHOLDS, ids=lambda t: t.attr)
+    def test_every_slo_threshold_must_be_positive(self, t):
         # Parametrized off the single source of truth, so a threshold added there is
         # covered here without editing this test.
         with pytest.raises(BadRequestException) as e:
@@ -453,7 +453,7 @@ class TestCreateCannotFabricateAConclusion:
         "progress",
         "pid",
         "peak_rate",
-        "sla_met_rate",
+        "slo_met_rate",
         "recommended_rate",
         "validity",
     )
@@ -468,14 +468,14 @@ class TestCreateCannotFabricateAConclusion:
             state=BenchmarkStateEnum.COMPLETED,
             progress=100,
             peak_rate=9999,
-            sla_met_rate=9999,
+            slo_met_rate=9999,
             recommended_rate=9999,
             validity={"sufficient": True, "warnings": []},
         )
         assert not set(forged.model_dump()) & set(self.RUNTIME_FIELDS)
         row = Benchmark(**forged.model_dump())
         assert row.state is BenchmarkStateEnum.PENDING
-        assert (row.peak_rate, row.sla_met_rate, row.recommended_rate) == (
+        assert (row.peak_rate, row.slo_met_rate, row.recommended_rate) == (
             None,
             None,
             None,
@@ -500,11 +500,11 @@ class TestCreateCannotFabricateAConclusion:
         # PATCH /{id}/state is the one door in, and it stays open.
         for field in ("state", "state_message", "progress", "pid"):
             assert field in BenchmarkStateUpdate.model_fields
-        for field in ("peak_rate", "sla_met_rate", "recommended_rate", "validity"):
+        for field in ("peak_rate", "slo_met_rate", "recommended_rate", "validity"):
             assert field in BenchmarkStateUpdate.model_fields
 
     def test_the_config_fields_are_untouched(self):
         # Sanity guard on the split: what the client legitimately configures has to
         # stay on the create body.
-        for field in ("auto_tune", "lower_bound", "max_points", "sla_avg_ttft_ms"):
+        for field in ("auto_tune", "lower_bound", "max_points", "slo_avg_ttft_ms"):
             assert field in BenchmarkCreate.model_fields

--- a/tests/worker/test_benchmark_manager.py
+++ b/tests/worker/test_benchmark_manager.py
@@ -25,8 +25,8 @@ def _point(rate, tps, tpot, *, total=100, ok=None, **extra):
     """One row of the per-point result grid, as uploaded to benchmark_results.
 
     `tpot` lands on `inter_token_latency_mean`, which is where the decode-only
-    per-token time lives (guidellm's naming) and what `sla_avg_tpot_ms` is
-    evaluated against — see SLA_THRESHOLDS.
+    per-token time lives (guidellm's naming) and what `slo_avg_tpot_ms` is
+    evaluated against — see SLO_THRESHOLDS.
     """
     return {
         "rate": rate,
@@ -55,13 +55,13 @@ _SWEEP = [
 
 
 class TestComputeBestPoints:
-    def test_peak_and_recommendation_without_sla(self):
+    def test_peak_and_recommendation_without_slo(self):
         benchmark = SimpleNamespace()
         out = analysis.compute_best_points(benchmark, _SWEEP)
         assert out["peak_rate"] == 31
-        # No SLA => recommend the throughput peak, and report no SLA capacity.
+        # No SLO => recommend the throughput peak, and report no SLO capacity.
         assert out["recommended_rate"] == 31
-        assert "sla_met_rate" not in out
+        assert "slo_met_rate" not in out
 
     def test_p95_threshold_is_evaluated(self):
         points = [
@@ -69,19 +69,19 @@ class TestComputeBestPoints:
             _point(8, 9100, 0.35, time_to_first_token_p95=480.0),
             _point(16, 17800, 0.62, time_to_first_token_p95=900.0),
         ]
-        benchmark = SimpleNamespace(sla_p95_ttft_ms=500.0)
+        benchmark = SimpleNamespace(slo_p95_ttft_ms=500.0)
         out = analysis.compute_best_points(benchmark, points)
         # rate 16 breaches the p95 budget, so capacity tops out at 8.
-        assert out["sla_met_rate"] == 8
+        assert out["slo_met_rate"] == 8
         assert out["recommended_rate"] == 8
 
     def test_point_missing_the_p95_metric_never_meets_a_p95_threshold(self):
-        benchmark = SimpleNamespace(sla_p95_tpot_ms=50.0)
+        benchmark = SimpleNamespace(slo_p95_tpot_ms=50.0)
         # Rows written before p95 was collected have no value to compare.
-        assert not analysis.meets_sla(benchmark, _point(4, 4600, 0.16))
+        assert not analysis.meets_slo(benchmark, _point(4, 4600, 0.16))
 
 
-# Benchmark 74 (qwen3-0.6b, concurrency axis, SLA avg TTFT <= 10s / TPOT <= 1s):
+# Benchmark 74 (qwen3-0.6b, concurrency axis, SLO avg TTFT <= 10s / TPOT <= 1s):
 # throughput peaks at 256 streams and then declines, while a threshold that loose
 # is never violated anywhere in [4, 1024].
 _BM74 = [
@@ -101,15 +101,15 @@ _BM74_BENCHMARK = dict(
     lower_bound=4,
     upper_bound=1024,
     max_points=12,
-    sla_avg_ttft_ms=10000.0,
-    sla_avg_tpot_ms=1000.0,
+    slo_avg_ttft_ms=10000.0,
+    slo_avg_tpot_ms=1000.0,
 )
 
 
-class TestLooseSlaFallsBackToThePeak:
+class TestLooseSloFallsBackToThePeak:
     """A threshold too loose to ever break must not hand back the top of the range.
 
-    Benchmark 74 reported concurrency 1024 as the SLA capacity: 6% LESS throughput
+    Benchmark 74 reported concurrency 1024 as the SLO capacity: 6% LESS throughput
     than 256 at 5809ms TTFT instead of 142ms — a load nobody would choose to run at.
     Past saturation more load buys only queueing, so the operating point is capped
     at the throughput peak and the reason is stated instead of being implied.
@@ -119,17 +119,17 @@ class TestLooseSlaFallsBackToThePeak:
         benchmark = SimpleNamespace(**_BM74_BENCHMARK)
         out = analysis.compute_best_points(benchmark, _BM74)
         assert out["peak_rate"] == 256
-        # The literal SLA answer is kept as measured...
-        assert out["sla_met_rate"] == 1024
+        # The literal SLO answer is kept as measured...
+        assert out["slo_met_rate"] == 1024
         # ...but the point to actually run at is the peak.
         assert out["recommended_rate"] == 256
 
-    def test_a_binding_sla_below_the_peak_is_left_alone(self):
+    def test_a_binding_slo_below_the_peak_is_left_alone(self):
         # Tight TTFT budget: the boundary is at 128, well under the 256 peak, so the
         # cap must not move it.
-        benchmark = SimpleNamespace(**{**_BM74_BENCHMARK, "sla_avg_ttft_ms": 100.0})
+        benchmark = SimpleNamespace(**{**_BM74_BENCHMARK, "slo_avg_ttft_ms": 100.0})
         out = analysis.compute_best_points(benchmark, _BM74)
-        assert out["sla_met_rate"] == 128
+        assert out["slo_met_rate"] == 128
         assert out["recommended_rate"] == 128
 
     def test_verdict_says_tighten_the_thresholds_not_raise_the_bound(self):
@@ -137,15 +137,15 @@ class TestLooseSlaFallsBackToThePeak:
         best = analysis.compute_best_points(benchmark, _BM74)
         v = analysis.compute_validity(benchmark, _BM74, best)
         codes = [w["code"] for w in v["warnings"]]
-        assert codes == ["sla_not_binding"]
+        assert codes == ["slo_not_binding"]
         # "Raise the upper bound" would only buy more points past the peak.
         assert "not_saturated" not in codes
         # The advice carries the peak, so the message can name a load.
         w = v["warnings"][0]
         assert w["params"]["rate"] == 256
 
-    def test_sla_holding_at_the_top_of_a_still_climbing_curve_is_not_flagged(self):
-        # Same loose SLA, but throughput never turned over: here "raise the upper
+    def test_slo_holding_at_the_top_of_a_still_climbing_curve_is_not_flagged(self):
+        # Same loose SLO, but throughput never turned over: here "raise the upper
         # bound" IS the right advice, so the top-edge code must still win.
         points = [
             _point(r, r * 1000.0, 0.5, time_to_first_token_mean=50.0)
@@ -340,7 +340,7 @@ class TestBuildCommandArgs:
         )
         assert "--max-requests" not in args
 
-    def test_auto_tune_passes_p95_sla_thresholds(self):
+    def test_auto_tune_passes_p95_slo_thresholds(self):
         args = BenchmarkRunner._build_command_args(
             self._runner(
                 auto_tune=True,
@@ -349,18 +349,18 @@ class TestBuildCommandArgs:
                 upper_bound=64,
                 max_points=6,
                 max_total_seconds=300,
-                sla_p95_ttft_ms=500.0,
-                sla_p95_tpot_ms=None,
-                sla_avg_ttft_ms=None,
-                sla_avg_tpot_ms=None,
-                sla_p99_ttft_ms=None,
-                sla_p99_tpot_ms=None,
-                sla_avg_latency_ms=None,
-                sla_p95_latency_ms=None,
-                sla_p99_latency_ms=None,
+                slo_p95_ttft_ms=500.0,
+                slo_p95_tpot_ms=None,
+                slo_avg_ttft_ms=None,
+                slo_avg_tpot_ms=None,
+                slo_p99_ttft_ms=None,
+                slo_p99_tpot_ms=None,
+                slo_avg_latency_ms=None,
+                slo_p95_latency_ms=None,
+                slo_p99_latency_ms=None,
             )
         )
-        assert args[args.index("--sla-p95-ttft-ms") + 1] == "500.0"
+        assert args[args.index("--slo-p95-ttft-ms") + 1] == "500.0"
 
     def test_max_error_rate_is_forwarded_only_when_guidellm_accepts_it(self):
         # guidellm's MaxErrorRateConstraint takes a fraction in (0, 1) and rejects
@@ -622,14 +622,14 @@ class TestWriteBestPointsAndValidity:
         assert "in_progress" not in captured["validity"]
 
     def test_every_conclusion_field_is_sent_so_none_goes_stale(self, monkeypatch):
-        # A partial sync may have written an sla_met_rate that the final read no
+        # A partial sync may have written an slo_met_rate that the final read no
         # longer supports. Omitting the key would leave that number on the row next
         # to a validity that contradicts it, so all three are always patched.
         captured = {}
         mgr = self._mgr(captured, monkeypatch)
         mgr._write_best_points_and_validity(SimpleNamespace(id=1, name="x"), [])
         assert captured["peak_rate"] == 5
-        assert captured["sla_met_rate"] is None
+        assert captured["slo_met_rate"] is None
         assert captured["recommended_rate"] is None
 
     def _mgr_with_warnings(self, captured, monkeypatch, warnings):
@@ -1058,9 +1058,9 @@ class TestSaturatedAtLowerBoundClearsBestPoints:
         assert "saturated_at_lower_bound" in codes
 
 
-# Benchmark 86 (round 7): loose SLA (10s TTFT / 1s TPOT), concurrency axis. The
+# Benchmark 86 (round 7): loose SLO (10s TTFT / 1s TPOT), concurrency axis. The
 # ramp stops at 512 on the <5% plateau; 512 is the throughput argmax and meets the
-# loose SLA, so it is both the peak and the recommendation. The <5% top step keeps
+# loose SLO, so it is both the peak and the recommendation. The <5% top step keeps
 # the run from being mislabeled range-limited.
 _BM86 = [
     _point(4, 1738.7, 0.15, time_to_first_token_mean=19.1),
@@ -1073,9 +1073,9 @@ _BM86 = [
     _point(512, 17427.6, 14.98, time_to_first_token_mean=1917.2),  # +1.4% plateau
 ]
 
-# Benchmark 93 (round 7 follow-up): a REAL latency SLA (500ms TTFT / 50ms TPOT),
+# Benchmark 93 (round 7 follow-up): a REAL latency SLO (500ms TTFT / 50ms TPOT),
 # concurrency axis. Every point meets it and throughput is still climbing at the
-# top (256 = argmax, TTFT 155ms << 500ms). The answer to "max load within my SLA"
+# top (256 = argmax, TTFT 155ms << 500ms). The answer to "max load within my SLO"
 # is 256 — the knee cap wrongly returned 128.
 _BM93 = [
     _point(4, 3536.0, 0.17, time_to_first_token_mean=22.1),
@@ -1092,8 +1092,8 @@ _BM93_BENCHMARK = dict(
     load_type="concurrency",
     upper_bound=1024,
     max_points=12,
-    sla_avg_ttft_ms=500.0,
-    sla_avg_tpot_ms=50.0,
+    slo_avg_ttft_ms=500.0,
+    slo_avg_tpot_ms=50.0,
 )
 
 
@@ -1106,8 +1106,8 @@ class TestRampFactsBeatInference:
     * `budget_seconds` vs a self-directed stop — both leave "fewer points than the
       range allows". The grid path reported `not_saturated` ("raise the upper
       bound") for a run the clock ended.
-    * `capacity_plateau` vs an SLA binding at the peak — both leave "the highest
-      knob measured met the SLA".
+    * `capacity_plateau` vs an SLO binding at the peak — both leave "the highest
+      knob measured met the SLO".
     """
 
     def _facts(self, bracket, **kw):
@@ -1158,9 +1158,9 @@ class TestRampFactsBeatInference:
         v = analysis.compute_validity(
             benchmark, _BM93, best, self._facts("capacity_plateau", stopped_at=256.0)
         )
-        assert [w["code"] for w in v["warnings"]] == ["sla_not_binding"]
+        assert [w["code"] for w in v["warnings"]] == ["slo_not_binding"]
 
-    def test_an_sla_boundary_reported_by_the_ramp_is_not_flagged(self):
+    def test_an_slo_boundary_reported_by_the_ramp_is_not_flagged(self):
         # Same grid, same loose-looking rates — but the ramp says a THRESHOLD ended
         # the bracket, so this is a real latency boundary and there is nothing to
         # report. The grid alone would still call it capacity-bound (31% headroom
@@ -1168,7 +1168,7 @@ class TestRampFactsBeatInference:
         benchmark = SimpleNamespace(**_BM93_BENCHMARK)
         best = analysis.compute_best_points(benchmark, _BM93)
         v = analysis.compute_validity(
-            benchmark, _BM93, best, self._facts("sla_failed", stopped_at=256.0)
+            benchmark, _BM93, best, self._facts("slo_failed", stopped_at=256.0)
         )
         assert v["warnings"] == []
         assert v["sufficient"] is True
@@ -1202,7 +1202,7 @@ class TestRampFactsBeatInference:
         assert v["bracket_reason"] == "capacity_plateau"
         # The verdict still keys off the BRACKET reason — capacity is what bounded
         # the answer, whatever Phase 2 went on to do.
-        assert [w["code"] for w in v["warnings"]] == ["sla_not_binding"]
+        assert [w["code"] for w in v["warnings"]] == ["slo_not_binding"]
 
     def test_a_legacy_sidecar_without_a_stop_reason_falls_back_to_the_bracket(self):
         benchmark = SimpleNamespace(upper_bound=1024, max_points=12)
@@ -1329,21 +1329,21 @@ class TestProbeCapFactsAreCarriedThrough:
         assert "probe_relaxed" not in v
 
 
-class TestSlaBoundaryLocated:
-    """`sla_met_rate` is an EDGE only when something above it was measured failing.
+class TestSloBoundaryLocated:
+    """`slo_met_rate` is an EDGE only when something above it was measured failing.
 
-    Same number, two meanings: "257 breaks the SLA" vs ">= 256, we stopped looking".
+    Same number, two meanings: "257 breaks the SLO" vs ">= 256, we stopped looking".
     Reporting the second as the first invents a ceiling nobody measured — which is
     what capacity planning would then be done against.
     """
 
     def test_a_measured_breach_above_the_answer_is_an_edge(self):
         # 512 breaches the loose budget, so 256 is where it actually breaks.
-        benchmark = SimpleNamespace(**{**_BM74_BENCHMARK, "sla_avg_ttft_ms": 200.0})
+        benchmark = SimpleNamespace(**{**_BM74_BENCHMARK, "slo_avg_ttft_ms": 200.0})
         best = analysis.compute_best_points(benchmark, _BM74)
-        assert best["sla_met_rate"] == 256
+        assert best["slo_met_rate"] == 256
         v = analysis.compute_validity(benchmark, _BM74, best)
-        assert v["sla_boundary_located"] is True
+        assert v["slo_boundary_located"] is True
 
     def test_stopping_before_anything_failed_is_a_floor(self):
         # bm102: the ramp stopped on the plateau at 256 with the budget 31% used.
@@ -1351,7 +1351,7 @@ class TestSlaBoundaryLocated:
         benchmark = SimpleNamespace(**_BM93_BENCHMARK)
         best = analysis.compute_best_points(benchmark, _BM93)
         v = analysis.compute_validity(benchmark, _BM93, best)
-        assert v["sla_boundary_located"] is False
+        assert v["slo_boundary_located"] is False
 
     def test_reaching_the_range_ceiling_is_not_a_located_boundary(self):
         # Everything passed all the way to upper_bound: the RANGE ran out, so the
@@ -1363,7 +1363,7 @@ class TestSlaBoundaryLocated:
         benchmark = SimpleNamespace(**{**_BM74_BENCHMARK, "upper_bound": 32})
         best = analysis.compute_best_points(benchmark, points)
         v = analysis.compute_validity(benchmark, points, best)
-        assert v["sla_boundary_located"] is False
+        assert v["slo_boundary_located"] is False
 
     def test_the_ramp_bracket_answers_it_directly(self):
         # With facts it is a lookup, not a scan: first_fail is the knob that
@@ -1372,14 +1372,14 @@ class TestSlaBoundaryLocated:
         best = analysis.compute_best_points(benchmark, _BM93)
 
         floor = analysis.compute_validity(
-            benchmark, _BM93, best, {"sla_bracket": [256.0, None]}
+            benchmark, _BM93, best, {"slo_bracket": [256.0, None]}
         )
-        assert floor["sla_boundary_located"] is False
+        assert floor["slo_boundary_located"] is False
 
         edge = analysis.compute_validity(
-            benchmark, _BM93, best, {"sla_bracket": [256.0, 257.0]}
+            benchmark, _BM93, best, {"slo_bracket": [256.0, 257.0]}
         )
-        assert edge["sla_boundary_located"] is True
+        assert edge["slo_boundary_located"] is True
 
     def test_the_grid_fallback_uses_the_same_pass_rule_as_the_answer(self):
         # A point above the answer that fails only the SUCCESS floor (its latency is
@@ -1393,16 +1393,16 @@ class TestSlaBoundaryLocated:
         ]
         benchmark = SimpleNamespace(**{**_BM74_BENCHMARK, "upper_bound": 1024})
         best = analysis.compute_best_points(benchmark, points)
-        assert best["sla_met_rate"] == 8  # 16 excluded by the success floor
+        assert best["slo_met_rate"] == 8  # 16 excluded by the success floor
         v = analysis.compute_validity(benchmark, points, best)
-        assert v["sla_boundary_located"] is True
+        assert v["slo_boundary_located"] is True
 
-    def test_a_run_without_an_sla_has_no_such_key(self):
+    def test_a_run_without_an_slo_has_no_such_key(self):
         # Meaningless without thresholds — absent, not False.
         benchmark = SimpleNamespace(upper_bound=1024, max_points=12)
         best = analysis.compute_best_points(benchmark, _SWEEP)
         v = analysis.compute_validity(benchmark, _SWEEP, best)
-        assert "sla_boundary_located" not in v
+        assert "slo_boundary_located" not in v
 
 
 class TestReadRampFacts:
@@ -1447,12 +1447,12 @@ class TestReadRampFacts:
 
 class TestPeakAndRecommendation:
     """peak_rate is the true throughput argmax; recommended_rate is the peak, or
-    (with an SLA) the SLA boundary capped at the peak — never a lower "knee". The
+    (with an SLO) the SLO boundary capped at the peak — never a lower "knee". The
     plateau guard keeps a saturated top from being mislabeled range-limited."""
 
     def test_bm92_peak_is_the_argmax(self):
         # rate 31 has the highest throughput (0 errors) but was returned as
-        # peak_rate=30. peak_rate and the no-SLA recommendation are both the argmax.
+        # peak_rate=30. peak_rate and the no-SLO recommendation are both the argmax.
         bm92 = [
             _point(4, 4679.8, 0.14),
             _point(8, 9322.6, 0.18),
@@ -1474,12 +1474,12 @@ class TestPeakAndRecommendation:
         v = analysis.compute_validity(benchmark, bm92, out)
         assert v["warnings"] == []  # curve turned over cleanly; nothing to warn
 
-    def test_bm93_real_sla_recommends_the_max_within_the_sla(self):
+    def test_bm93_real_slo_recommends_the_max_within_the_slo(self):
         benchmark = SimpleNamespace(**_BM93_BENCHMARK)
         out = analysis.compute_best_points(benchmark, _BM93)
-        # 256 is the argmax AND meets the SLA => it is peak, sla_met, and the answer.
+        # 256 is the argmax AND meets the SLO => it is peak, slo_met, and the answer.
         assert out["peak_rate"] == 256
-        assert out["sla_met_rate"] == 256
+        assert out["slo_met_rate"] == 256
         assert out["recommended_rate"] == 256  # NOT a lower knee (was 128)
         v = analysis.compute_validity(benchmark, _BM93, out)
         codes = [w["code"] for w in v["warnings"]]
@@ -1488,45 +1488,45 @@ class TestPeakAndRecommendation:
         # 500ms budget was only 31% used there (155ms) — so 256 is a capacity
         # ceiling, not the latency boundary the profile set out to find. Re-observed
         # live as bm102, which reported "sufficient, no warnings" for a 7-point run.
-        assert codes == ["sla_not_binding"]
+        assert codes == ["slo_not_binding"]
         assert v["warnings"][0]["params"] == {"rate": 256, "used": 31}
         # Still not the reversed advice: raising the bound only buys plateau points.
         assert "not_saturated" not in codes
 
-    def test_bm86_loose_sla_recommends_the_peak_without_a_reversed_warning(self):
+    def test_bm86_loose_slo_recommends_the_peak_without_a_reversed_warning(self):
         benchmark = SimpleNamespace(
             load_type="concurrency",
             upper_bound=1024,
             max_points=12,
-            sla_avg_ttft_ms=10000.0,
-            sla_avg_tpot_ms=1000.0,
+            slo_avg_ttft_ms=10000.0,
+            slo_avg_tpot_ms=1000.0,
         )
         out = analysis.compute_best_points(benchmark, _BM86)
         assert out["peak_rate"] == 512
-        assert out["sla_met_rate"] == 512
-        assert out["recommended_rate"] == 512  # meets the loose SLA, max throughput
+        assert out["slo_met_rate"] == 512
+        assert out["recommended_rate"] == 512  # meets the loose SLO, max throughput
         v = analysis.compute_validity(benchmark, _BM86, out)
         codes = [w["code"] for w in v["warnings"]]
         # Plateaued at the top => never "raise the bound". But a 10s TTFT budget
         # that the top point used 19% of (1917ms) did not shape this answer, and
         # saying so is the whole point of the code.
-        assert codes == ["sla_not_binding"]
+        assert codes == ["slo_not_binding"]
         assert v["warnings"][0]["params"]["used"] == 19
         assert "not_saturated" not in codes
 
-    def test_an_sla_pressed_against_at_the_peak_stays_silent(self):
+    def test_an_slo_pressed_against_at_the_peak_stays_silent(self):
         # Same curve and range as bm93, but a budget the top point nearly spends
-        # (155ms of 160ms = 97%): here the SLA genuinely bound the answer, so there
-        # is nothing to report. This is the case _SLA_HEADROOM_RATIO protects — the
+        # (155ms of 160ms = 97%): here the SLO genuinely bound the answer, so there
+        # is nothing to report. This is the case _SLO_HEADROOM_RATIO protects — the
         # headroom test, not the rates, is what separates it from bm93.
         benchmark = SimpleNamespace(
             load_type="concurrency",
             upper_bound=1024,
             max_points=12,
-            sla_avg_ttft_ms=160.0,
+            slo_avg_ttft_ms=160.0,
         )
         out = analysis.compute_best_points(benchmark, _BM93)
-        assert out["sla_met_rate"] == 256
+        assert out["slo_met_rate"] == 256
         assert out["recommended_rate"] == 256
         v = analysis.compute_validity(benchmark, _BM93, out)
         assert v["warnings"] == []
@@ -1535,19 +1535,19 @@ class TestPeakAndRecommendation:
     def test_the_tightest_threshold_decides_the_headroom(self):
         # TTFT is loose (31%) but TPOT is nearly spent (1.21 of 1.3ms = 93%): the
         # run WAS shaped by a latency budget, just not by the one with slack. Taking
-        # the loosest (or an average) would flag a binding SLA as irrelevant.
+        # the loosest (or an average) would flag a binding SLO as irrelevant.
         benchmark = SimpleNamespace(
             load_type="concurrency",
             upper_bound=1024,
             max_points=12,
-            sla_avg_ttft_ms=500.0,
-            sla_avg_tpot_ms=1.3,
+            slo_avg_ttft_ms=500.0,
+            slo_avg_tpot_ms=1.3,
         )
         out = analysis.compute_best_points(benchmark, _BM93)
         v = analysis.compute_validity(benchmark, _BM93, out)
         assert v["warnings"] == []
 
-    def test_no_sla_plateau_does_not_say_raise_the_bound(self):
+    def test_no_slo_plateau_does_not_say_raise_the_bound(self):
         benchmark = SimpleNamespace(upper_bound=1024, max_points=12)
         out = analysis.compute_best_points(benchmark, _BM86)
         assert out["peak_rate"] == 512
@@ -1820,8 +1820,8 @@ class TestTerminalSyncReportsLostPoints:
         )
 
 
-class TestAllSlaThresholdsReachTheRunner:
-    """SLA_THRESHOLDS is the single source of truth. The runner used to keep its own
+class TestAllSloThresholdsReachTheRunner:
+    """SLO_THRESHOLDS is the single source of truth. The runner used to keep its own
     hand-written copy of the nine flags, so a threshold added to the model but not to
     that list was accepted by the API and silently never forwarded."""
 
@@ -1829,21 +1829,21 @@ class TestAllSlaThresholdsReachTheRunner:
         runner = TestBuildCommandArgs()._runner(
             auto_tune=True,
             load_type="concurrency",
-            **{t.attr: float(i + 1) for i, t in enumerate(bm_schemas.SLA_THRESHOLDS)},
+            **{t.attr: float(i + 1) for i, t in enumerate(bm_schemas.SLO_THRESHOLDS)},
         )
         args = BenchmarkRunner._build_command_args(runner)
-        for i, t in enumerate(bm_schemas.SLA_THRESHOLDS):
+        for i, t in enumerate(bm_schemas.SLO_THRESHOLDS):
             assert t.flag in args, f"{t.attr} was not forwarded"
             assert args[args.index(t.flag) + 1] == str(float(i + 1))
 
     def test_the_flags_are_distinct(self):
-        flags = [t.flag for t in bm_schemas.SLA_THRESHOLDS]
+        flags = [t.flag for t in bm_schemas.SLO_THRESHOLDS]
         assert len(set(flags)) == len(flags)
 
     def test_each_row_points_at_a_real_column_and_a_real_metric(self):
         from gpustack.schemas.benchmark import BenchmarkBase, BenchmarkMetricsLite
 
-        for t in bm_schemas.SLA_THRESHOLDS:
+        for t in bm_schemas.SLO_THRESHOLDS:
             assert t.attr in BenchmarkBase.model_fields
             assert t.metric in BenchmarkMetricsLite.model_fields
 
@@ -1958,8 +1958,8 @@ class TestUnreadableResultsAreReported:
         ]
 
 
-class TestTpotSlaIsDecodeOnly:
-    """A `sla_*_tpot_ms` threshold bounds the DECODE-ONLY per-token time.
+class TestTpotSloIsDecodeOnly:
+    """A `slo_*_tpot_ms` threshold bounds the DECODE-ONLY per-token time.
 
     guidellm reports two per-output-token latencies under names that are the
     reverse of the industry's: `inter_token_latency_ms` is
@@ -1968,36 +1968,36 @@ class TestTpotSlaIsDecodeOnly:
     the average. The thresholds used to be judged on the second one, which billed
     prefill and queue wait to the decode loop: the error is TTFT / (n * TPOT), so
     ~5% at 128 output tokens and ~40% at 16, and it grew with load exactly where
-    the SLA decides capacity.
+    the SLO decides capacity.
     """
 
     def test_the_thresholds_read_the_decode_only_columns(self):
-        by_attr = {t.attr: t.metric for t in bm_schemas.SLA_THRESHOLDS}
-        assert by_attr["sla_avg_tpot_ms"] == "inter_token_latency_mean"
-        assert by_attr["sla_p95_tpot_ms"] == "inter_token_latency_p95"
-        assert by_attr["sla_p99_tpot_ms"] == "inter_token_latency_p99"
+        by_attr = {t.attr: t.metric for t in bm_schemas.SLO_THRESHOLDS}
+        assert by_attr["slo_avg_tpot_ms"] == "inter_token_latency_mean"
+        assert by_attr["slo_p95_tpot_ms"] == "inter_token_latency_p95"
+        assert by_attr["slo_p99_tpot_ms"] == "inter_token_latency_p99"
 
     def test_the_includes_ttft_metric_is_only_the_fallback(self):
-        metrics = {t.metric for t in bm_schemas.SLA_THRESHOLDS}
+        metrics = {t.metric for t in bm_schemas.SLO_THRESHOLDS}
         assert "time_per_output_token_mean" not in metrics
         assert "time_per_output_token_p95" not in metrics
         assert "time_per_output_token_p99" not in metrics
-        by_attr = {t.attr: t.fallback for t in bm_schemas.SLA_THRESHOLDS}
-        assert by_attr["sla_avg_tpot_ms"] == "time_per_output_token_mean"
-        assert by_attr["sla_p95_tpot_ms"] == "time_per_output_token_p95"
-        assert by_attr["sla_p99_tpot_ms"] == "time_per_output_token_p99"
+        by_attr = {t.attr: t.fallback for t in bm_schemas.SLO_THRESHOLDS}
+        assert by_attr["slo_avg_tpot_ms"] == "time_per_output_token_mean"
+        assert by_attr["slo_p95_tpot_ms"] == "time_per_output_token_p95"
+        assert by_attr["slo_p99_tpot_ms"] == "time_per_output_token_p99"
 
     def test_only_the_tpot_rows_have_a_fallback(self):
         # TTFT and end-to-end latency are always measurable; giving them a second
         # column to try would only hide a missing percentile.
-        for t in bm_schemas.SLA_THRESHOLDS:
+        for t in bm_schemas.SLO_THRESHOLDS:
             if "tpot" not in t.attr:
                 assert t.fallback is None, t.attr
 
     def test_every_fallback_points_at_a_real_column(self):
         from gpustack.schemas.benchmark import BenchmarkMetricsLite
 
-        for t in bm_schemas.SLA_THRESHOLDS:
+        for t in bm_schemas.SLO_THRESHOLDS:
             if t.fallback:
                 assert t.fallback in BenchmarkMetricsLite.model_fields
 
@@ -2009,25 +2009,25 @@ class TestTpotSlaIsDecodeOnly:
         # number left, so the threshold is judged on it. The alternatives are both
         # wrong: 0 ms clears every budget, and failing outright would bracket the
         # ramp on its first point for any server that batches its stream.
-        benchmark = SimpleNamespace(sla_avg_tpot_ms=5.0)
+        benchmark = SimpleNamespace(slo_avg_tpot_ms=5.0)
         one_chunk = _point(4, 4600, 0.0, time_per_output_token_mean=4.7)
-        assert analysis.meets_sla(benchmark, one_chunk)
-        assert analysis.sla_utilization(benchmark, one_chunk) == pytest.approx(0.94)
-        assert not analysis.meets_sla(SimpleNamespace(sla_avg_tpot_ms=4.0), one_chunk)
+        assert analysis.meets_slo(benchmark, one_chunk)
+        assert analysis.slo_utilization(benchmark, one_chunk) == pytest.approx(0.94)
+        assert not analysis.meets_slo(SimpleNamespace(slo_avg_tpot_ms=4.0), one_chunk)
 
     def test_neither_basis_measured_fails_instead_of_waiving_the_threshold(self):
         # Also the shape of an old row written before either column existed:
         # "we did not measure it" is not evidence that the threshold held.
-        benchmark = SimpleNamespace(sla_avg_tpot_ms=5.0)
-        assert not analysis.meets_sla(benchmark, _point(4, 4600, 0.0))
+        benchmark = SimpleNamespace(slo_avg_tpot_ms=5.0)
+        assert not analysis.meets_slo(benchmark, _point(4, 4600, 0.0))
         # ... and it must not report 0% of the budget used either, which is what
-        # decides whether the SLA is described as binding.
-        assert analysis.sla_utilization(benchmark, _point(4, 4600, 0.0)) is None
+        # decides whether the SLO is described as binding.
+        assert analysis.slo_utilization(benchmark, _point(4, 4600, 0.0)) is None
 
     def test_a_measured_tpot_still_passes_and_reports_its_utilization(self):
-        benchmark = SimpleNamespace(sla_avg_tpot_ms=5.0)
-        assert analysis.meets_sla(benchmark, _point(4, 4600, 2.5))
-        assert analysis.sla_utilization(benchmark, _point(4, 4600, 2.5)) == 0.5
+        benchmark = SimpleNamespace(slo_avg_tpot_ms=5.0)
+        assert analysis.meets_slo(benchmark, _point(4, 4600, 2.5))
+        assert analysis.slo_utilization(benchmark, _point(4, 4600, 2.5)) == 0.5
 
 
 class TestOneMissingPercentileDoesNotCostThePoint:
@@ -2047,7 +2047,7 @@ class TestOneMissingPercentileDoesNotCostThePoint:
 
     def test_absence_is_not_zero(self):
         # 0 would be indistinguishable from a real measurement of 0 ms, and it is
-        # what a SLA verdict or an IQR band would then be computed from.
+        # what a SLO verdict or an IQR band would then be computed from.
         from gpustack.worker.schemas.benchmark_runner import Percentiles
 
         dumped = Percentiles.model_validate({"p50": 12.0}).model_dump()


### PR DESCRIPTION
The two words make different claims. An SLO is an objective — TTFT under 10s, TPOT under 50ms — and that is what a benchmark takes: a number to hold while it searches for the most load that still holds it. An SLA is a commitment to a customer, and it carries the things that make it one: availability windows, remedies, penalties for breaching it. Setting a latency ceiling on a load test is not an agreement with anybody, so a report that concluded "within the SLA" was overstating what it had established.

The rename runs the full depth of the feature. A user reading "SLO" on the form while the API takes sla_avg_ttft_ms is being told the two are separate things:

- the nine threshold columns, sla_*_ms -> slo_*_ms, and sla_met_rate -> slo_met_rate
- SLAThreshold / SLA_THRESHOLDS, the table every layer walks instead of hardcoding the grid
- has_sla / meets_sla / sla_boundary_located in the analysis
- the validity codes sla_never_met / sla_not_binding and the stop reason sla_failed, which the detail page maps to its own text
- the shipped preset, "Latency SLA" -> "Meet Latency SLO". It sits beside "Max Throughput", so it reads as the goal you are asking for, not as a category.

The columns are renamed in the v2.3.0 bundle rather than added as a second migration: that version has no tag yet, so no deployment has the old names to migrate off.

The runner pin moves to v0.0.7, which is the floor and not a preference — the flags are how this server states a target, and it now sends --slo-*.