### PR TITLE
feat: chart cache service metrics from declared semantics

### DIFF
--- a/docker-compose/grafana/grafana_dashboards/gpustack-cache-service.json
+++ b/docker-compose/grafana/grafana_dashboards/gpustack-cache-service.json
@@ -68,7 +68,7 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 1
       },
@@ -136,8 +136,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 1
       },
       "id": 3,
@@ -203,8 +203,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 1
       },
       "id": 4,
@@ -241,6 +241,73 @@
         }
       ],
       "title": "L1 Memory Usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(lmcache_mp_l2_usage_bytes{cluster_name=\"$cluster_name\", cache_service_name=\"$cache_service_name\", worker_name=~\"$worker_name\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "L2 Usage",
       "type": "stat"
     },
     {
@@ -655,12 +722,108 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "lmcache_mp_l2_usage_bytes{cluster_name=\"$cluster_name\", cache_service_name=\"$cache_service_name\", worker_name=~\"$worker_name\"}",
+          "instant": false,
+          "legendFormat": "{{worker_name}} ({{l2_name}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "L2 Usage",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 31
       },
       "id": 10,
       "panels": [],
@@ -729,7 +892,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 32
       },
       "id": 11,
       "options": {
@@ -861,7 +1024,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 32
       },
       "id": 12,
       "options": {
@@ -901,7 +1064,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 40
       },
       "id": 13,
       "panels": [],
@@ -972,7 +1135,7 @@
         "h": 8,
         "w": 16,
         "x": 8,
-        "y": 33
+        "y": 41
       },
       "id": 15,
       "options": {
@@ -1059,7 +1222,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 33
+        "y": 41
       },
       "id": 16,
       "options": {

--- a/gpustack/assets/cache-providers.yaml
+++ b/gpustack/assets/cache-providers.yaml
@@ -121,7 +121,14 @@
         Spills KV cache to a local directory (e.g. NVMe) on the worker.
         max_capacity_gb caps disk usage; 0 or unset means uncapped.
       fields:
-        - { name: base_path, label: Base Path, required: true }
+        # Defaults into the platform data dir: on containerized workers
+        # the mirrored deployment carries the worker's /var/lib/gpustack
+        # host mount into the cache container, so spilled cache lands on
+        # host disk and survives container recreation.
+        - name: base_path
+          label: Base Path
+          required: true
+          default: /var/lib/gpustack/cache/lmcache/l2
         - { name: max_capacity_gb, label: Max Capacity (GiB), type: number }
         - { name: num_workers, label: I/O Workers, type: number }
         - { name: use_odirect, label: Direct I/O (O_DIRECT), type: boolean }
@@ -200,11 +207,39 @@
     scheme: http
     path: /healthcheck
     target: metrics
-  # Exposition follows the LMCache MP observability docs
-  # (https://docs.lmcache.ai/mp/observability.html); semantic metric
-  # mappings will return with the native-UI metrics integration.
+  # Metric names follow the LMCache MP observability docs
+  # (https://docs.lmcache.ai/mp/observability.html). The mappings feed
+  # the cache-service metrics endpoint backing the UI charts.
+  # Known limitation: metrics declare at provider level, shared by all
+  # versions — if upstream renames a metric across versions (the
+  # _GB_per_second suffix is an OTel exporter artifact and a likely
+  # candidate), the declaration needs a version-scoped override
+  # mechanism first.
   metrics:
     path: /metrics
+    mappings:
+      hit_rate:
+        ratio:
+          numerator: lmcache_mp_lookup_hit_tokens_total
+          denominator: lmcache_mp_lookup_requested_tokens_total
+      l1_usage_bytes:
+        gauge: lmcache_mp_l1_memory_usage_bytes
+      l1_usage_ratio:
+        gauge: lmcache_mp_l1_usage_ratio
+        aggregate: avg
+      # One series per configured L2 adapter (l2_name label). Bytes
+      # only: upstream exposes no L2 capacity gauge, so no ratio form.
+      l2_usage_bytes:
+        gauge: lmcache_mp_l2_usage_bytes
+      # Lookup traffic gives the hit-rate chart its denominator context:
+      # an empty hit-rate window reads as no traffic, not as a fault.
+      lookup_tokens_per_second:
+        rate: lmcache_mp_lookup_requested_tokens_total
+    throughput:
+      l0_l1_store: { histogram_avg: lmcache_mp_l0_l1_store_throughput_GB_per_second }
+      l0_l1_load: { histogram_avg: lmcache_mp_l0_l1_load_throughput_GB_per_second }
+      l2_store: { histogram_avg: lmcache_mp_l2_store_throughput_GB_per_second }
+      l2_load: { histogram_avg: lmcache_mp_l2_load_throughput_GB_per_second }
   inference_backend_integrations:
     # The MP server speaks ZMQ: clients attach through the MP connector
     # pointed at tcp://host:port (the server's --port), and the connector
@@ -323,11 +358,20 @@
   health_check:
     scheme: tcp
   # The master serves Prometheus text on its metrics port (GET /metrics,
-  # enable_metric_reporting defaults to true); default_port seeds the
-  # registration form's metrics-port field.
+  # enable_metric_reporting defaults to true). Metric names follow
+  # mooncake-store's master_metric_manager. Lookup-hit accounting lives
+  # in the engine-side connector, not the master, so there is no
+  # hit_rate mapping; usage is the pool's allocated-vs-capacity view.
   metrics:
     path: /metrics
     default_port: 9003
+    mappings:
+      l1_usage_bytes:
+        gauge: master_allocated_bytes
+      l1_usage_ratio:
+        gauge_ratio:
+          numerator: master_allocated_bytes
+          denominator: master_total_capacity_bytes
   inference_backend_integrations:
     # MooncakeStoreConnector uses the Mooncake distributed store as a
     # shared KV pool. The connector reads its configuration solely from
@@ -429,7 +473,14 @@
         Spills KV cache to a local directory (e.g. NVMe) on the worker.
         max_capacity_gb caps disk usage; 0 or unset means uncapped.
       fields:
-        - { name: base_path, label: Base Path, required: true }
+        # Defaults into the platform data dir: on containerized workers
+        # the mirrored deployment carries the worker's /var/lib/gpustack
+        # host mount into the cache container, so spilled cache lands on
+        # host disk and survives container recreation.
+        - name: base_path
+          label: Base Path
+          required: true
+          default: /var/lib/gpustack/cache/lmcache/l2
         - { name: max_capacity_gb, label: Max Capacity (GiB), type: number }
         - { name: num_workers, label: I/O Workers, type: number }
         - { name: use_odirect, label: Direct I/O (O_DIRECT), type: boolean }
@@ -521,6 +572,29 @@
     target: metrics
   metrics:
     path: /metrics
+    mappings:
+      hit_rate:
+        ratio:
+          numerator: lmcache_mp_lookup_hit_tokens_total
+          denominator: lmcache_mp_lookup_requested_tokens_total
+      l1_usage_bytes:
+        gauge: lmcache_mp_l1_memory_usage_bytes
+      l1_usage_ratio:
+        gauge: lmcache_mp_l1_usage_ratio
+        aggregate: avg
+      # One series per configured L2 adapter (l2_name label). Bytes
+      # only: upstream exposes no L2 capacity gauge, so no ratio form.
+      l2_usage_bytes:
+        gauge: lmcache_mp_l2_usage_bytes
+      # Lookup traffic gives the hit-rate chart its denominator context:
+      # an empty hit-rate window reads as no traffic, not as a fault.
+      lookup_tokens_per_second:
+        rate: lmcache_mp_lookup_requested_tokens_total
+    throughput:
+      l0_l1_store: { histogram_avg: lmcache_mp_l0_l1_store_throughput_GB_per_second }
+      l0_l1_load: { histogram_avg: lmcache_mp_l0_l1_load_throughput_GB_per_second }
+      l2_store: { histogram_avg: lmcache_mp_l2_store_throughput_GB_per_second }
+      l2_load: { histogram_avg: lmcache_mp_l2_load_throughput_GB_per_second }
   inference_backend_integrations:
     - backend: vLLM
       frameworks: [cuda]

--- a/gpustack/assets/cache-providers.yaml
+++ b/gpustack/assets/cache-providers.yaml
@@ -210,12 +210,11 @@
   # Metric names follow the LMCache MP observability docs
   # (https://docs.lmcache.ai/mp/observability.html). The mappings feed
   # the cache-service metrics endpoint backing the UI charts.
-  # Known limitation: metrics declare at provider level, shared by all
-  # versions — if upstream renames a metric across versions (the
-  # _GB_per_second suffix is an OTel exporter artifact and a likely
-  # candidate), the declaration needs a version-scoped override
-  # mechanism first.
-  metrics:
+  # This block is the all-version default; a version that renames
+  # metrics (the _GB_per_second suffix is an OTel exporter artifact and
+  # a likely candidate) declares its own metrics block, which overrides
+  # this one whole for services pinned to it.
+  default_metrics:
     path: /metrics
     mappings:
       hit_rate:
@@ -362,7 +361,7 @@
   # mooncake-store's master_metric_manager. Lookup-hit accounting lives
   # in the engine-side connector, not the master, so there is no
   # hit_rate mapping; usage is the pool's allocated-vs-capacity view.
-  metrics:
+  default_metrics:
     path: /metrics
     default_port: 9003
     mappings:
@@ -570,7 +569,7 @@
     scheme: http
     path: /healthcheck
     target: metrics
-  metrics:
+  default_metrics:
     path: /metrics
     mappings:
       hit_rate:

--- a/gpustack/exporter/exporter.py
+++ b/gpustack/exporter/exporter.py
@@ -491,7 +491,7 @@ async def _cache_service_targets(
             groups.extend(
                 _extra_metrics_target_groups(service, provider, cluster_names)
             )
-        metrics = provider.metrics if provider else None
+        metrics = provider.metrics_for(service.provider_version) if provider else None
         if metrics is None:
             continue
         provider_path = _normalize_metrics_path(metrics.path)

--- a/gpustack/routes/cache_services.py
+++ b/gpustack/routes/cache_services.py
@@ -23,6 +23,8 @@ from gpustack.api.tenant import (
 from gpustack.routes.models import assert_cluster_belongs_to_org
 from gpustack.schemas.cache_providers import CUSTOM_VERSION
 from gpustack.schemas.cache_services import (
+    CacheServiceAttachedMetrics,
+    CacheServiceMetricsPublic,
     CacheService,
     CacheServiceBase,
     CacheServiceConfig,
@@ -44,12 +46,17 @@ from gpustack.schemas.cache_services import (
 from gpustack.schemas.common import Pagination
 from gpustack.config.config import get_global_config
 from gpustack.schemas.clusters import Cluster
-from gpustack.schemas.models import Model, get_backend
+from gpustack.schemas.models import Model, ModelInstance, get_backend
 from gpustack.schemas.principals import PrincipalType, platform_principal_id
 from gpustack.schemas.workers import Worker
 from gpustack.server.cache_provider_catalog import get_cache_provider
 from gpustack.server.cache_services import probe_cache_service
 from gpustack.server.db import async_session
+from gpustack.schemas.principals import OrgRole
+from gpustack.server.cache_service_metrics import (
+    collect_cache_service_metrics,
+    parse_window as parse_metrics_window,
+)
 from gpustack.server.deps import ListParamsDep, SessionDep, TenantContextDep
 from gpustack.server.worker_request import request_to_worker, stream_to_worker
 from gpustack.utils.grafana import resolve_grafana_base_url
@@ -96,7 +103,13 @@ def _redacted_for_user(cache_service) -> CacheServicePublic:
     write through to the row (or to the event payload other stream
     subscribers see)."""
     data = (
-        cache_service.model_dump()
+        # The dump-then-validate pair is the deep copy (validating from
+        # attributes would pass nested objects through by reference and
+        # let the redaction write through to the row). The dump itself
+        # would warn on every call: the enum-typed columns deliberately
+        # store plain strings (no DB enum casts), so ORM rows carry str
+        # values that the validation below coerces — expected, not a bug.
+        cache_service.model_dump(warnings=False)
         if hasattr(cache_service, "model_dump")
         else cache_service
     )
@@ -520,6 +533,91 @@ async def get_cache_service_dashboard(
         dashboard_url = f"{dashboard_url}?{urlencode(query_params)}"
 
     return RedirectResponse(url=dashboard_url, status_code=302)
+
+
+@router.get("/{id}/metrics", response_model=CacheServiceMetricsPublic)
+async def get_cache_service_metrics(
+    request: Request,
+    session: SessionDep,
+    ctx: TenantContextDep,
+    id: int,
+    window: str = "1h",
+    workers: Optional[str] = None,
+):
+    """Chartable semantic metric series for the service, translated from
+    the provider's catalog declaration and queried from the built-in
+    Prometheus with a server-injected service-label selector. The whole
+    router mounts Org-owner-only; the explicit assertion below keeps
+    this telemetry gated on its own, independent of the mount policy."""
+    cache_service = await CacheService.one_by_id(session, id)
+    assert_resource_visible(
+        ctx, cache_service, not_found_message="Cache service not found"
+    )
+    ctx.assert_org_role(OrgRole.OWNER)
+    try:
+        window_seconds = parse_metrics_window(window)
+    except ValueError as e:
+        raise BadRequestException(message=str(e))
+    provider = get_cache_provider(cache_service.provider_name)
+    # The database enumerates the attached deployments' instances (the
+    # rows the UI shows); metrics only fill their numbers. The model-id
+    # scope also bounds the Prometheus queries, so a caller only ever
+    # reads the engines wired to this service. The cluster's models load
+    # whole and filter in Python: extended_kv_cache is a JSON column and
+    # the platform convention keeps JSON predicates out of SQL (the set
+    # is bounded by one cluster's deployments).
+    models = await Model.all_by_fields(
+        session,
+        fields={"cluster_id": cache_service.cluster_id},
+        extra_conditions=[Model.deleted_at.is_(None)],
+    )
+    attached_models = {
+        model.id: model
+        for model in models
+        if model.extended_kv_cache
+        and model.extended_kv_cache.is_shared()
+        and model.extended_kv_cache.cache_service_id == cache_service.id
+    }
+    attached = []
+    if attached_models:
+        instances = await ModelInstance.all_by_fields(
+            session,
+            extra_conditions=[ModelInstance.model_id.in_(attached_models.keys())],
+        )
+        attached = [
+            CacheServiceAttachedMetrics(
+                model_id=instance.model_id,
+                model_name=attached_models[instance.model_id].name,
+                model_instance_name=instance.name,
+                worker_name=instance.worker_name,
+            )
+            for instance in instances
+        ]
+        # a stable row order regardless of how the batched query returns
+        attached.sort(
+            key=lambda row: (row.model_name or "", row.model_instance_name or "")
+        )
+    worker_names = (
+        [name.strip() for name in workers.split(",") if name.strip()]
+        if workers
+        else None
+    )
+    if worker_names and len(worker_names) > 100:
+        raise BadRequestException(message="workers filter accepts at most 100 names")
+    if worker_names:
+        # the worker scope applies to the whole response: charts filter
+        # inside PromQL, the row set filters here
+        selected = set(worker_names)
+        attached = [row for row in attached if row.worker_name in selected]
+    return await collect_cache_service_metrics(
+        provider.metrics if provider else None,
+        cache_service.id,
+        window_seconds,
+        cluster_id=cache_service.cluster_id,
+        attached=attached,
+        worker_names=worker_names,
+        client=getattr(request.app.state, "http_client_no_proxy", None),
+    )
 
 
 @router.get("/{id}", response_model=CacheServicePublic)

--- a/gpustack/routes/cache_services.py
+++ b/gpustack/routes/cache_services.py
@@ -610,7 +610,7 @@ async def get_cache_service_metrics(
         selected = set(worker_names)
         attached = [row for row in attached if row.worker_name in selected]
     return await collect_cache_service_metrics(
-        provider.metrics if provider else None,
+        provider.metrics_for(cache_service.provider_version) if provider else None,
         cache_service.id,
         window_seconds,
         cluster_id=cache_service.cluster_id,

--- a/gpustack/schemas/cache_providers.py
+++ b/gpustack/schemas/cache_providers.py
@@ -181,8 +181,62 @@ class CacheProviderResourceProfile(BaseModel):
     cpu: Optional[float] = None
 
 
+class CacheProviderMetricValue(BaseModel):
+    """How to extract one semantic metric value from the provider's
+    Prometheus exposition. At most one of the forms is set (validated —
+    the query builder would otherwise silently pick one of several).
+    Consumed by the cache-service metrics endpoint, which translates the
+    form into a PromQL query over the service's scrape series."""
+
+    gauge: Optional[str] = None
+    """Gauge metric name; charted as-is."""
+
+    rate: Optional[str] = None
+    """Counter metric name; charted as its per-second rate over the
+    chart's rate window (e.g. lookup traffic in tokens per second)."""
+
+    ratio: Optional[Dict[str, str]] = None
+    """{"numerator": counter, "denominator": counter}: the ratio of the
+    two counters' increases over the chart's rate window."""
+
+    gauge_ratio: Optional[Dict[str, str]] = None
+    """{"numerator": gauge, "denominator": gauge}: the instantaneous ratio
+    of two gauges (e.g. allocated / capacity)."""
+
+    histogram_avg: Optional[str] = None
+    """Histogram base name: increase(_sum) / increase(_count) over the
+    rate window, i.e. the average observed value."""
+
+    aggregate: Optional[str] = None
+    """How gauge values combine into the service-level series: "sum"
+    (default — capacities, byte counts) or "avg" (ratios). Only valid
+    with the gauge form: the other forms aggregate naturally (operands
+    sum before dividing, weighting instances by their actual traffic)."""
+
+    @model_validator(mode="after")
+    def _validate_forms(self):
+        forms = [
+            name
+            for name in ("gauge", "rate", "ratio", "gauge_ratio", "histogram_avg")
+            if getattr(self, name)
+        ]
+        if len(forms) > 1:
+            raise ValueError(
+                f"metric rule sets multiple extraction forms: {', '.join(forms)}"
+            )
+        if self.aggregate is not None:
+            if self.aggregate not in ("sum", "avg"):
+                raise ValueError(
+                    f"aggregate must be 'sum' or 'avg', got '{self.aggregate}'"
+                )
+            if not self.gauge:
+                raise ValueError("aggregate applies only to the gauge form")
+        return self
+
+
 class CacheProviderMetrics(BaseModel):
-    """Where a cache service's Prometheus exposition is scraped."""
+    """Where a cache service's Prometheus exposition is scraped, and how
+    its semantic metrics are extracted from it."""
 
     path: str = "/metrics"
     """HTTP path of the Prometheus exposition on the metrics port."""
@@ -190,6 +244,16 @@ class CacheProviderMetrics(BaseModel):
     default_port: Optional[int] = None
     """The engine's conventional metrics port (external mode: seeds the
     registration form's metrics-port field)."""
+
+    mappings: Dict[str, CacheProviderMetricValue] = {}
+    """Semantic key -> extraction rule. Keys use the platform's tier
+    vocabulary — L1 is the memory (near) tier, L2 the capacity tier
+    (disk/remote) — regardless of the provider's own naming: hit_rate,
+    l1_usage_bytes, l1_usage_ratio, l2_usage_bytes. A provider with
+    several L2 backends keeps them apart by series label, not by key."""
+
+    throughput: Dict[str, CacheProviderMetricValue] = {}
+    """Named throughput series (unit: GB/s) -> extraction rule."""
 
 
 class CacheProviderL2Field(BaseModel):

--- a/gpustack/schemas/cache_providers.py
+++ b/gpustack/schemas/cache_providers.py
@@ -74,6 +74,13 @@ class CacheProviderVersionConfig(BaseModel):
     env: Optional[Dict[str, str]] = None
     """Env template for the managed container. Values support {{placeholder}}."""
 
+    metrics: Optional["CacheProviderMetrics"] = None
+    """Overrides the provider-level metrics declaration for this version,
+    whole — declared when the version's exposition renames metrics (an
+    exporter change typically renames a family at once, so per-key
+    inheritance would hide half the picture). Undeclared versions read
+    the provider default."""
+
     def supports_runtime(self, backend: Optional[str]) -> bool:
         """Whether the version can run on the node's accelerator.
         runtime_images doubles as the support matrix: a node with a
@@ -256,6 +263,11 @@ class CacheProviderMetrics(BaseModel):
     """Named throughput series (unit: GB/s) -> extraction rule."""
 
 
+# CacheProviderVersionConfig.metrics forward-references this module's
+# tail; resolve it now that the metrics classes exist.
+CacheProviderVersionConfig.model_rebuild()
+
+
 class CacheProviderL2Field(BaseModel):
     """One configurable parameter of an L2 storage backend."""
 
@@ -428,7 +440,12 @@ class CacheProvider(BaseModel):
 
     resource_profile: Optional[CacheProviderResourceProfile] = None
     health_check: CacheProviderHealthCheck = CacheProviderHealthCheck()
-    metrics: Optional[CacheProviderMetrics] = None
+    default_metrics: Optional[CacheProviderMetrics] = None
+    """The all-version default declaration, named like the other
+    provider-level defaults (default_image, default_run_command). Do not
+    read it directly for a service — a version may carry its own metrics
+    block; metrics_for() resolves the effective one."""
+
     inference_backend_integrations: List[CacheProviderIntegration] = []
 
     common_parameters: List[str] = []
@@ -443,6 +460,21 @@ class CacheProvider(BaseModel):
     l2_backends: Dict[str, CacheProviderL2Backend] = {}
     """Adapter type identifier (the "type" value in the adapter JSON)
     -> backend declaration."""
+
+    def metrics_for(self, version: Optional[str]) -> Optional[CacheProviderMetrics]:
+        """The effective metrics declaration for a service pinned to
+        ``version``. Resolution rides get_version_config, so None falls
+        back to the default version like everywhere else (a managed
+        service created without an explicit version stores None). A
+        resolved version owns its block whole; versions without one —
+        and the custom version, whose image ships unknown metrics — fall
+        back to the provider default (best effort, and a mismatch
+        surfaces as a reasoned all-queries-failed degradation rather
+        than silently empty charts)."""
+        config, _ = self.get_version_config(version)
+        if config is not None and config.metrics is not None:
+            return config.metrics
+        return self.default_metrics
 
     @model_validator(mode="after")
     def resolve_version_defaults(self) -> "CacheProvider":

--- a/gpustack/schemas/cache_services.py
+++ b/gpustack/schemas/cache_services.py
@@ -346,6 +346,57 @@ class TestCacheServiceConnectionResponse(BaseModel):
     message: Optional[str] = None
 
 
+class CacheServiceMetricSeries(BaseModel):
+    """One chartable series of a semantic metric: filtered identifying
+    labels (worker/instance) plus [timestamp, value] points; value is
+    None where the sample is non-finite (chart gap)."""
+
+    labels: Dict[str, str] = {}
+    points: List[List[Optional[float]]] = []
+
+
+class CacheServiceMetricChart(BaseModel):
+    """One semantic metric, charted at two granularities: the
+    service-level aggregate (ratios weighted by actual traffic — the
+    default view, readable at any fleet size) and the per-instance
+    breakdown behind a toggle."""
+
+    aggregate: List[CacheServiceMetricSeries] = []
+    instances: List[CacheServiceMetricSeries] = []
+
+
+class CacheServiceAttachedMetrics(BaseModel):
+    """External-cache hit accounting of one attached engine instance
+    over the requested window. The row set is database-enumerated; the
+    numbers come from the engine's own counters (vLLM's
+    external_prefix_cache_*), so an instance whose engine exports none
+    keeps its row with empty values."""
+
+    model_id: Optional[int] = None
+    model_name: Optional[str] = None
+    model_instance_name: Optional[str] = None
+    worker_name: Optional[str] = None
+    hit_tokens: Optional[float] = None
+    queried_tokens: Optional[float] = None
+    hit_rate: Optional[float] = None
+
+
+class CacheServiceMetricsPublic(BaseModel):
+    """Semantic metric series for one cache service, translated from the
+    provider's declared mappings and queried from the built-in
+    Prometheus. available=False carries why charts cannot render (no
+    declaration / observability disabled / Prometheus unreachable)."""
+
+    available: bool = False
+    reason: Optional[str] = None
+    start: Optional[float] = None
+    end: Optional[float] = None
+    step: Optional[int] = None
+    mappings: Dict[str, CacheServiceMetricChart] = {}
+    throughput: Dict[str, CacheServiceMetricChart] = {}
+    attached: List[CacheServiceAttachedMetrics] = []
+
+
 def cache_service_spec_digest(service: "CacheService") -> str:
     """Digest of the spec fields that shape a running cache container:
     provider_version and config (image, capacity, parameters, env,

--- a/gpustack/server/cache_service_metrics.py
+++ b/gpustack/server/cache_service_metrics.py
@@ -1,0 +1,505 @@
+"""Semantic metrics for cache services, proxied from Prometheus.
+
+The provider catalog declares *what* each provider's metrics mean
+(``metrics.mappings`` / ``metrics.throughput``: semantic keys mapped to
+extraction rules over the provider's Prometheus exposition). This module
+is the consumer of those declarations: it translates each rule into a
+PromQL ``query_range`` against the built-in Prometheus, scoped to one
+service through the ``cache_service_id`` label the exporter's scrape
+discovery stamps on every target. The UI receives ready-to-chart
+semantic series and never learns PromQL or per-provider metric names —
+and because the label selector is injected server-side, a caller can
+only ever read the series of a service it was authorized for.
+"""
+
+import asyncio
+import json
+import logging
+import re
+import time
+from typing import List, Optional
+
+import aiohttp
+
+from gpustack.config.config import get_global_config
+from gpustack.schemas.cache_providers import (
+    CacheProviderMetrics,
+    CacheProviderMetricValue,
+)
+from gpustack.schemas.cache_services import (
+    CacheServiceAttachedMetrics,
+    CacheServiceMetricChart,
+    CacheServiceMetricSeries,
+    CacheServiceMetricsPublic,
+)
+
+logger = logging.getLogger(__name__)
+
+_WINDOW_PATTERN = re.compile(r"^(\d+)([mhd])$")
+_WINDOW_UNIT_SECONDS = {"m": 60, "h": 3600, "d": 86400}
+MIN_WINDOW_SECONDS = 5 * 60
+MAX_WINDOW_SECONDS = 7 * 86400
+
+# Labels worth returning per series: enough for the UI to draw one line
+# per instance; scrape plumbing labels (job, instance, __*) stay out.
+# l2_name distinguishes LMCache's per-adapter L2 usage series; on one
+# instance every adapter shares the scrape labels, so dropping it would
+# collapse the adapters into duplicate series.
+_SERIES_LABEL_KEYS = ("worker_name", "cache_service_instance_id", "l2_name")
+
+_QUERY_TIMEOUT_SECONDS = 10.0
+# Overall budget for one collection (charts + attached): with the
+# per-query timeout and the fan-out this bounds a stuck Prometheus to
+# one predictable failure instead of a near-minute hang.
+_COLLECT_DEADLINE_SECONDS = 15.0
+
+
+def _promql_regex_literal(value: str) -> str:
+    """A label value -> a safe literal inside a =~"..." matcher.
+
+    Two escaping layers stack: RE2 metacharacters for the regex itself,
+    then the PromQL string literal around it — its lexer follows Go and
+    errors on unknown escape sequences, so re.escape's lone \\- would
+    be a parse error rather than a literal dash. Backslashes double
+    before quotes are escaped, or the added quote-escapes would double
+    again."""
+    return re.escape(value).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def parse_window(window: str) -> int:
+    """A chart window like "30m" / "6h" / "7d" -> seconds.
+    Raises ValueError outside [5m, 7d] or on an unknown format."""
+    match = _WINDOW_PATTERN.match(window or "")
+    if not match:
+        raise ValueError(f"Invalid window '{window}': expected e.g. 30m, 6h, 7d")
+    seconds = int(match.group(1)) * _WINDOW_UNIT_SECONDS[match.group(2)]
+    if not MIN_WINDOW_SECONDS <= seconds <= MAX_WINDOW_SECONDS:
+        raise ValueError(f"Window '{window}' out of range (5m to 7d)")
+    return seconds
+
+
+def build_metric_query(
+    rule: CacheProviderMetricValue, selector: str, rate_window: str
+) -> Optional[str]:
+    """One extraction rule -> one PromQL expression.
+
+    Counter ratios and histogram averages divide increases over the
+    rate window (both operands come from the same target, so the label
+    sets match and the division joins per series); gauges chart as-is.
+    """
+    if rule.gauge:
+        return f"{rule.gauge}{selector}"
+    if rule.rate:
+        return f"rate({rule.rate}{selector}[{rate_window}])"
+    if rule.ratio:
+        numerator = rule.ratio.get("numerator")
+        denominator = rule.ratio.get("denominator")
+        if not numerator or not denominator:
+            return None
+        return (
+            f"increase({numerator}{selector}[{rate_window}])"
+            f" / increase({denominator}{selector}[{rate_window}])"
+        )
+    if rule.gauge_ratio:
+        numerator = rule.gauge_ratio.get("numerator")
+        denominator = rule.gauge_ratio.get("denominator")
+        if not numerator or not denominator:
+            return None
+        return f"{numerator}{selector} / {denominator}{selector}"
+    if rule.histogram_avg:
+        base = rule.histogram_avg
+        return (
+            f"increase({base}_sum{selector}[{rate_window}])"
+            f" / increase({base}_count{selector}[{rate_window}])"
+        )
+    return None
+
+
+def build_aggregate_query(
+    rule: CacheProviderMetricValue, selector: str, rate_window: str
+) -> Optional[str]:
+    """The service-level form of one extraction rule.
+
+    Ratio and histogram forms sum their operands before dividing, so the
+    aggregate is weighted by each instance's actual traffic (a mean of
+    per-instance ratios would weight an idle instance like a busy one);
+    gauges combine by their declared aggregate (sum by default, avg for
+    ratio-shaped gauges)."""
+    if rule.gauge:
+        op = "avg" if rule.aggregate == "avg" else "sum"
+        return f"{op}({rule.gauge}{selector})"
+    if rule.rate:
+        return f"sum(rate({rule.rate}{selector}[{rate_window}]))"
+    if rule.ratio:
+        numerator = rule.ratio.get("numerator")
+        denominator = rule.ratio.get("denominator")
+        if not numerator or not denominator:
+            return None
+        return (
+            f"sum(increase({numerator}{selector}[{rate_window}]))"
+            f" / sum(increase({denominator}{selector}[{rate_window}]))"
+        )
+    if rule.gauge_ratio:
+        numerator = rule.gauge_ratio.get("numerator")
+        denominator = rule.gauge_ratio.get("denominator")
+        if not numerator or not denominator:
+            return None
+        return f"sum({numerator}{selector}) / sum({denominator}{selector})"
+    if rule.histogram_avg:
+        base = rule.histogram_avg
+        return (
+            f"sum(increase({base}_sum{selector}[{rate_window}]))"
+            f" / sum(increase({base}_count{selector}[{rate_window}]))"
+        )
+    return None
+
+
+# Engine-side external-cache hit accounting: the worker's metrics
+# aggregator maps vLLM's external_prefix_cache_* counters to these
+# unified names on the scraped /metrics exposition (the raw vllm:*
+# names live on /metrics/raw, which Prometheus does not scrape) and
+# relabels them with model/instance identity. Engine counters, not
+# provider metrics — hence platform-known names here and not a catalog
+# declaration. Only vLLM maps them today; other engines' instances
+# keep None values.
+# The names carry the _total suffix the Prometheus client appends to
+# counters at exposition — the scraped series name, not the registered
+# one.
+_ENGINE_HIT_COUNTER = "gpustack:external_prefix_cache_hits_total"
+_ENGINE_QUERY_COUNTER = "gpustack:external_prefix_cache_queries_total"
+_ATTACHED_GROUP_LABELS = "(model_instance_name)"
+
+
+def _to_series(result: List[dict]) -> List[CacheServiceMetricSeries]:
+    """A Prometheus query_range matrix -> chartable series. Non-finite
+    samples (an idle counter ratio evaluates 0/0 = NaN) become None so
+    the chart shows a gap instead of a bogus value."""
+    series = []
+    for entry in result:
+        metric = entry.get("metric") or {}
+        labels = {key: metric[key] for key in _SERIES_LABEL_KEYS if metric.get(key)}
+        points: List[List[Optional[float]]] = []
+        for timestamp, value in entry.get("values") or []:
+            try:
+                parsed = float(value)
+                if parsed != parsed or parsed in (float("inf"), float("-inf")):
+                    parsed = None
+            except (TypeError, ValueError):
+                parsed = None
+            points.append([float(timestamp), parsed])
+        series.append(CacheServiceMetricSeries(labels=labels, points=points))
+    return series
+
+
+async def _query_range(
+    client: aiohttp.ClientSession,
+    base_url: str,
+    query: str,
+    start: float,
+    end: float,
+    step: int,
+) -> List[dict]:
+    # The built-in Prometheus serves under the /prometheus route prefix,
+    # mirroring the admin proxy route.
+    url = f"{base_url}/prometheus/api/v1/query_range"
+    async with client.get(
+        url,
+        params={
+            "query": query,
+            "start": start,
+            "end": end,
+            "step": step,
+        },
+        timeout=aiohttp.ClientTimeout(total=_QUERY_TIMEOUT_SECONDS),
+    ) as response:
+        return await _read_result(response)
+
+
+async def _query_instant(
+    client: aiohttp.ClientSession,
+    base_url: str,
+    query: str,
+    at: float,
+) -> List[dict]:
+    url = f"{base_url}/prometheus/api/v1/query"
+    async with client.get(
+        url,
+        params={"query": query, "time": at},
+        timeout=aiohttp.ClientTimeout(total=_QUERY_TIMEOUT_SECONDS),
+    ) as response:
+        return await _read_result(response)
+
+
+async def _read_result(response: aiohttp.ClientResponse) -> List[dict]:
+    """Parse a Prometheus API response body. Every failure mode — a
+    non-200 status, a non-JSON body (a gateway error page), an
+    API-level error — raises ValueError, so a bad response stays
+    isolated to its own query instead of blanking the collection."""
+    body = await response.text()
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        payload = None
+    if (
+        response.status != 200
+        or not isinstance(payload, dict)
+        or payload.get("status") != "success"
+    ):
+        error = payload.get("error") if isinstance(payload, dict) else None
+        raise ValueError(
+            f"Prometheus returned {response.status}: "
+            f"{error or body[:200] or 'unknown error'}"
+        )
+    return (payload.get("data") or {}).get("result") or []
+
+
+def _instant_value(entry: dict) -> Optional[float]:
+    try:
+        value = float(entry["value"][1])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return None
+    if value != value or value in (float("inf"), float("-inf")):
+        return None
+    return value
+
+
+async def _collect_attached(
+    client: aiohttp.ClientSession,
+    prometheus_url: str,
+    cluster_id: int,
+    attached: List[CacheServiceAttachedMetrics],
+    window_seconds: int,
+    at: float,
+) -> List[CacheServiceAttachedMetrics]:
+    """Fill the DB-enumerated attached instances with the engines'
+    external-cache hit accounting over the window.
+
+    The database is the authority on which instances exist — metrics
+    only carry the numbers. Driving the row set off Prometheus series
+    would lag it in both directions: a fresh instance is invisible
+    until its first scrape, a deleted one lingers for the window, and
+    an engine without the counters would vanish instead of showing
+    empty values."""
+    if not attached:
+        return []
+    model_ids = sorted(
+        {record.model_id for record in attached if record.model_id is not None}
+    )
+    if not model_ids:
+        return attached
+    ids = "|".join(str(model_id) for model_id in model_ids)
+    selector = f'{{cluster_id="{cluster_id}",model_id=~"{ids}"}}'
+    window = f"{window_seconds}s"
+    by_instance = {record.model_instance_name: record for record in attached}
+    # Both counters buffer before any record is touched: hits landing
+    # while queries fail would leave rows claiming hits out of zero
+    # lookups. Failure leaves every row empty instead.
+    buffered: dict = {}
+    for field, counter in (
+        ("hit_tokens", _ENGINE_HIT_COUNTER),
+        ("queried_tokens", _ENGINE_QUERY_COUNTER),
+    ):
+        query = (
+            f"sum by {_ATTACHED_GROUP_LABELS} "
+            f"(increase({counter}{selector}[{window}]))"
+        )
+        try:
+            result = await _query_instant(client, prometheus_url, query, at)
+        except ValueError as e:
+            logger.warning(f"Attached cache metrics query failed: {e}")
+            return attached
+        buffered[field] = {
+            (entry.get("metric") or {}).get("model_instance_name"): _instant_value(
+                entry
+            )
+            for entry in result
+        }
+    for field, by_name in buffered.items():
+        for name, value in by_name.items():
+            record = by_instance.get(name)
+            if record is not None:
+                setattr(record, field, value)
+    for record in attached:
+        if record.queried_tokens:
+            record.hit_rate = (record.hit_tokens or 0.0) / record.queried_tokens
+    return attached
+
+
+async def _collect_charts(
+    client: aiohttp.ClientSession,
+    prometheus_url: str,
+    metrics: CacheProviderMetrics,
+    result: CacheServiceMetricsPublic,
+    cache_service_id: int,
+    selector: str,
+    rate_window: str,
+    start: float,
+    end: float,
+    step: int,
+) -> None:
+    """One query per declared key and granularity: they run concurrently
+    (a catalog like LMCache's declares ~18), capped below the built-in
+    Prometheus's query-concurrency limit. A ValueError stays isolated to
+    its own chart; connection-level errors surface after the batch and
+    degrade the collection."""
+    query_slots = asyncio.Semaphore(8)
+    failures: List[str] = []
+
+    async def _fill(chart: CacheServiceMetricChart, attr: str, key: str, query: str):
+        try:
+            async with query_slots:
+                series = _to_series(
+                    await _query_range(client, prometheus_url, query, start, end, step)
+                )
+            setattr(chart, attr, series)
+        except (ValueError, asyncio.TimeoutError) as e:
+            # a per-query timeout is one chart's failure like any other
+            # (a heavy 7d query must not blank the page); the
+            # collection-wide deadline stays with wait_for, whose
+            # cancellation propagates as CancelledError and is not
+            # caught here
+            message = str(e) or "timed out"
+            failures.append(f"{key}: {message}")
+            logger.warning(
+                f"Cache service {cache_service_id} metric "
+                f"'{key}' query failed: {message}"
+            )
+
+    fills = []
+    for target, rules in (
+        (result.mappings, metrics.mappings),
+        (result.throughput, metrics.throughput),
+    ):
+        for key, rule in rules.items():
+            chart = CacheServiceMetricChart()
+            for attr, query in (
+                ("aggregate", build_aggregate_query(rule, selector, rate_window)),
+                ("instances", build_metric_query(rule, selector, rate_window)),
+            ):
+                if query is not None:
+                    fills.append(_fill(chart, attr, key, query))
+            target[key] = chart
+    if fills:
+        outcomes = await asyncio.gather(*fills, return_exceptions=True)
+        for outcome in outcomes:
+            if isinstance(outcome, BaseException):
+                raise outcome
+    # Isolation is for partial failures; every query failing is one
+    # systematic cause (a bad selector, a broken declaration) that must
+    # not present as a wall of silently empty charts.
+    if fills and len(failures) == len(fills):
+        raise ValueError(
+            f"all {len(fills)} metric queries failed; first: {failures[0]}"
+        )
+
+
+async def collect_cache_service_metrics(
+    metrics: Optional[CacheProviderMetrics],
+    cache_service_id: int,
+    window_seconds: int,
+    cluster_id: Optional[int] = None,
+    attached: Optional[List[CacheServiceAttachedMetrics]] = None,
+    worker_names: Optional[List[str]] = None,
+    client: Optional[aiohttp.ClientSession] = None,
+) -> CacheServiceMetricsPublic:
+    """Chartable semantic series for one cache service.
+
+    Every declared key charts at two granularities (service aggregate +
+    per-instance breakdown); ``attached`` (DB-enumerated instances of the
+    attached deployments) comes back filled with the engines' own hit
+    accounting where the counters exist. ``worker_names`` narrows the
+    charts to the selected workers' instances — filtered inside the
+    PromQL selector, so the aggregate over the subset stays weighted by
+    the selected instances' actual traffic (a client-side filter could
+    not re-aggregate ratios correctly).
+
+    ``available=False`` carries the reason the charts cannot render at
+    all (no declaration, observability disabled, Prometheus down); a
+    single failing query only logs and yields an empty chart for its
+    key, so one bad declaration entry cannot blank every chart.
+    """
+    if metrics is None or not (metrics.mappings or metrics.throughput):
+        return CacheServiceMetricsPublic(
+            available=False,
+            reason="The provider declares no metrics",
+        )
+
+    prometheus_url = get_global_config().get_builtin_prometheus_url()
+    if not prometheus_url:
+        return CacheServiceMetricsPublic(
+            available=False,
+            reason=(
+                "The built-in Prometheus is not available (observability is "
+                "disabled or delegated to an external stack)"
+            ),
+        )
+
+    end = time.time()
+    start = end - window_seconds
+    step = max(window_seconds // 120, 15)
+    # The increase() lookback covers one step plus a scrape-interval
+    # cushion (Grafana's $__rate_interval convention): long enough that
+    # activity between evaluation points is never missed, short enough
+    # that a burst charts near when it happened — a lookback of several
+    # steps would smear it up to that far past its actual time.
+    rate_window = f"{max(step + 60, 60)}s"
+    matchers = [f'cache_service_id="{cache_service_id}"']
+    if worker_names:
+        names = "|".join(
+            _promql_regex_literal(name) for name in sorted(set(worker_names))
+        )
+        matchers.append(f'worker_name=~"{names}"')
+    selector = "{" + ",".join(matchers) + "}"
+
+    result = CacheServiceMetricsPublic(available=True, start=start, end=end, step=step)
+    # The caller may hand in the app's shared session (queries carry
+    # their own timeout); without one, a session is created and closed
+    # here.
+    owned = client is None
+    try:
+        if owned:
+            client = aiohttp.ClientSession()
+
+        async def _run():
+            await _collect_charts(
+                client,
+                prometheus_url,
+                metrics,
+                result,
+                cache_service_id,
+                selector,
+                rate_window,
+                start,
+                end,
+                step,
+            )
+            if cluster_id is not None:
+                result.attached = await _collect_attached(
+                    client,
+                    prometheus_url,
+                    cluster_id,
+                    attached or [],
+                    window_seconds,
+                    end,
+                )
+
+        await asyncio.wait_for(_run(), timeout=_COLLECT_DEADLINE_SECONDS)
+    # On 3.11+ asyncio.TimeoutError is TimeoutError, a subclass of
+    # OSError: this arm must stay ahead of the OSError one below or the
+    # deadline would report as "unreachable".
+    except asyncio.TimeoutError:
+        return CacheServiceMetricsPublic(
+            available=False,
+            reason="Prometheus queries timed out",
+        )
+    except ValueError as e:
+        return CacheServiceMetricsPublic(available=False, reason=str(e))
+    except (aiohttp.ClientError, OSError) as e:
+        return CacheServiceMetricsPublic(
+            available=False,
+            reason=f"Prometheus is unreachable: {str(e) or e.__class__.__name__}",
+        )
+    finally:
+        if owned and client is not None:
+            await client.close()
+    return result

--- a/tests/exporter/test_exporter.py
+++ b/tests/exporter/test_exporter.py
@@ -330,6 +330,7 @@ def _cache_service(**overrides):
         id=3,
         name="shared-lmcache",
         provider_name="LMCache",
+        provider_version=None,
         mode=CacheServiceModeEnum.MANAGED,
         state=CacheServiceStateEnum.RUNNING,
         cluster_id=1,

--- a/tests/routes/test_cache_service_metrics_endpoint.py
+++ b/tests/routes/test_cache_service_metrics_endpoint.py
@@ -57,6 +57,7 @@ def _service(**overrides):
         id=5,
         name="lmcache-svc",
         provider_name="LMCache",
+        provider_version="v0.5.4",
         cluster_id=1,
         owner_principal_id=ORG_PRINCIPAL,
         deleted_at=None,

--- a/tests/routes/test_cache_service_metrics_endpoint.py
+++ b/tests/routes/test_cache_service_metrics_endpoint.py
@@ -1,0 +1,610 @@
+"""Cache-service semantic metrics endpoint.
+
+The provider catalog declares what each provider's metrics mean; the
+endpoint translates those declarations into PromQL scoped by a
+server-injected service-label selector and returns chartable semantic
+series. The router mounts Org-owner-only; the handler asserts the role
+itself, so the gate holds independent of mount policy. Missing
+observability degrades to available=False instead of erroring, so the
+UI can hide the charts with a reason.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gpustack.api.exceptions import BadRequestException, ForbiddenException
+from gpustack.api.tenant import TenantContext
+from gpustack.routes import cache_services as cache_services_route
+from gpustack.schemas.cache_providers import (
+    CacheProviderMetrics,
+    CacheProviderMetricValue,
+)
+from gpustack.schemas.cache_services import CacheServiceAttachedMetrics
+from gpustack.schemas.principals import OrgRole, PrincipalType
+from gpustack.server import cache_service_metrics as metrics_module
+from gpustack.server.cache_service_metrics import (
+    build_aggregate_query,
+    build_metric_query,
+    collect_cache_service_metrics,
+    parse_window,
+)
+
+ORG_PRINCIPAL = 42
+
+
+def _ctx(org_role=None, is_platform_admin=False) -> TenantContext:
+    user = MagicMock()
+    user.kind = PrincipalType.USER
+    return TenantContext(
+        user=user,
+        is_platform_admin=is_platform_admin,
+        current_principal_id=ORG_PRINCIPAL,
+        org_role=org_role,
+    )
+
+
+def _request():
+    # the route reads request.app.state.http_client_no_proxy with a
+    # getattr fallback, so bare namespaces suffice
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+
+
+def _service(**overrides):
+    fields = dict(
+        id=5,
+        name="lmcache-svc",
+        provider_name="LMCache",
+        cluster_id=1,
+        owner_principal_id=ORG_PRINCIPAL,
+        deleted_at=None,
+    )
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _declaration() -> CacheProviderMetrics:
+    return CacheProviderMetrics(
+        mappings={
+            "hit_rate": CacheProviderMetricValue(
+                ratio={
+                    "numerator": "hit_total",
+                    "denominator": "requested_total",
+                }
+            ),
+            "l1_usage_bytes": CacheProviderMetricValue(gauge="l1_usage_bytes"),
+        },
+        throughput={
+            "l2_store": CacheProviderMetricValue(histogram_avg="l2_store_tp"),
+        },
+    )
+
+
+def test_parse_window():
+    assert parse_window("30m") == 1800
+    assert parse_window("6h") == 6 * 3600
+    assert parse_window("7d") == 7 * 86400
+    for invalid in ("", "1s", "10x", "1m", "8d", "0h"):
+        with pytest.raises(ValueError):
+            parse_window(invalid)
+
+
+def test_build_metric_query_forms():
+    selector = '{cache_service_id="5"}'
+    assert (
+        build_metric_query(
+            CacheProviderMetricValue(gauge="l1_usage_bytes"), selector, "60s"
+        )
+        == 'l1_usage_bytes{cache_service_id="5"}'
+    )
+    assert build_metric_query(
+        CacheProviderMetricValue(ratio={"numerator": "hit", "denominator": "req"}),
+        selector,
+        "60s",
+    ) == (
+        'increase(hit{cache_service_id="5"}[60s])'
+        ' / increase(req{cache_service_id="5"}[60s])'
+    )
+    assert build_metric_query(
+        CacheProviderMetricValue(
+            gauge_ratio={"numerator": "allocated", "denominator": "capacity"}
+        ),
+        selector,
+        "60s",
+    ) == ('allocated{cache_service_id="5"} / capacity{cache_service_id="5"}')
+    assert build_metric_query(
+        CacheProviderMetricValue(histogram_avg="tp"), selector, "60s"
+    ) == (
+        'increase(tp_sum{cache_service_id="5"}[60s])'
+        ' / increase(tp_count{cache_service_id="5"}[60s])'
+    )
+    assert build_metric_query(
+        CacheProviderMetricValue(rate="lookup_total"), selector, "60s"
+    ) == ('rate(lookup_total{cache_service_id="5"}[60s])')
+    assert build_metric_query(CacheProviderMetricValue(), selector, "60s") is None
+
+
+def test_metric_rule_declaration_validation():
+    """A rule sets at most one extraction form (the builder would
+    otherwise silently pick one of several), and aggregate only
+    modifies the gauge form."""
+    with pytest.raises(ValueError):
+        CacheProviderMetricValue(gauge="a", rate="b")
+    with pytest.raises(ValueError):
+        CacheProviderMetricValue(
+            ratio={"numerator": "a", "denominator": "b"}, aggregate="sum"
+        )
+    with pytest.raises(ValueError):
+        CacheProviderMetricValue(gauge="a", aggregate="max")
+    assert CacheProviderMetricValue(gauge="a", aggregate="avg").aggregate == "avg"
+
+
+def test_build_aggregate_query_forms():
+    """Service-level forms: ratio/histogram operands sum before dividing
+    (traffic-weighted), gauges combine by their declared aggregate."""
+    selector = '{cache_service_id="5"}'
+    assert build_aggregate_query(
+        CacheProviderMetricValue(gauge="l1_usage_bytes"), selector, "60s"
+    ) == ('sum(l1_usage_bytes{cache_service_id="5"})')
+    assert build_aggregate_query(
+        CacheProviderMetricValue(gauge="l1_usage_ratio", aggregate="avg"),
+        selector,
+        "60s",
+    ) == ('avg(l1_usage_ratio{cache_service_id="5"})')
+    assert build_aggregate_query(
+        CacheProviderMetricValue(ratio={"numerator": "hit", "denominator": "req"}),
+        selector,
+        "60s",
+    ) == (
+        'sum(increase(hit{cache_service_id="5"}[60s]))'
+        ' / sum(increase(req{cache_service_id="5"}[60s]))'
+    )
+    assert build_aggregate_query(
+        CacheProviderMetricValue(histogram_avg="tp"), selector, "60s"
+    ) == (
+        'sum(increase(tp_sum{cache_service_id="5"}[60s]))'
+        ' / sum(increase(tp_count{cache_service_id="5"}[60s]))'
+    )
+    assert build_aggregate_query(
+        CacheProviderMetricValue(rate="lookup_total"), selector, "60s"
+    ) == ('sum(rate(lookup_total{cache_service_id="5"}[60s]))')
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def text(self):
+        # a non-dict payload stands in for a non-JSON body (e.g. a
+        # gateway error page)
+        if isinstance(self._payload, str):
+            return self._payload
+        return json.dumps(self._payload)
+
+
+class _FakeAsyncCtx:
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeHTTPClient:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self._status = status
+        self.requests = []
+
+    def get(self, url, params=None, timeout=None):
+        self.requests.append((url, params))
+        return _FakeAsyncCtx(_FakeResponse(self._payload, status=self._status))
+
+    async def close(self):
+        pass
+
+
+def _patch_prometheus(monkeypatch, client, url="http://127.0.0.1:19090"):
+    monkeypatch.setattr(
+        metrics_module,
+        "get_global_config",
+        lambda: SimpleNamespace(get_builtin_prometheus_url=lambda: url),
+    )
+    monkeypatch.setattr(
+        metrics_module.aiohttp,
+        "ClientSession",
+        lambda *args, **kwargs: client,
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_returns_semantic_series(monkeypatch):
+    payload = {
+        "status": "success",
+        "data": {
+            "result": [
+                {
+                    "metric": {
+                        "worker_name": "w1",
+                        "cache_service_instance_id": "11",
+                        "l2_name": "fs_native",
+                        "job": "scrape-plumbing",
+                        "instance": "10.0.0.5:9188",
+                    },
+                    # an idle counter ratio evaluates 0/0 = NaN: charted
+                    # as a gap, never as a bogus number
+                    "values": [[1000, "0.5"], [1030, "NaN"]],
+                }
+            ]
+        },
+    }
+    client = _FakeHTTPClient(payload)
+    _patch_prometheus(monkeypatch, client)
+
+    result = await collect_cache_service_metrics(_declaration(), 5, 3600)
+
+    assert result.available is True
+    assert set(result.mappings) == {"hit_rate", "l1_usage_bytes"}
+    assert set(result.throughput) == {"l2_store"}
+    chart = result.mappings["hit_rate"]
+    # both granularities chart: the aggregate default view and the
+    # per-instance breakdown
+    assert chart.aggregate and chart.instances
+    series = chart.instances[0]
+    # scrape plumbing labels are filtered; identity labels stay,
+    # including the per-adapter l2_name that keeps multi-adapter
+    # usage series apart
+    assert series.labels == {
+        "worker_name": "w1",
+        "cache_service_instance_id": "11",
+        "l2_name": "fs_native",
+    }
+    assert series.points == [[1000.0, 0.5], [1030.0, None]]
+    # every query carries the server-injected service selector
+    queries = [params["query"] for _, params in client.requests]
+    assert all('cache_service_id="5"' in q for q in queries)
+    assert any(q.startswith("sum(increase(hit_total") for q in queries)
+
+
+@pytest.mark.asyncio
+async def test_collect_filters_by_worker_names(monkeypatch):
+    """A worker filter lands inside the PromQL selector (regex-escaped),
+    so the aggregate over the subset stays weighted by the selected
+    instances' traffic."""
+    payload = {"status": "success", "data": {"result": []}}
+    client = _FakeHTTPClient(payload)
+    _patch_prometheus(monkeypatch, client)
+
+    await collect_cache_service_metrics(
+        _declaration(), 5, 3600, worker_names=["worker-1", "w2.node", 'x"y']
+    )
+
+    for _, params in client.requests:
+        # two escaping layers: RE2 metacharacters, then the PromQL
+        # string literal (whose lexer rejects unknown escapes like a
+        # lone \-)
+        assert r'worker_name=~"w2\\.node|worker\\-1|x\"y"' in params["query"]
+
+
+@pytest.mark.asyncio
+async def test_collect_without_observability(monkeypatch):
+    monkeypatch.setattr(
+        metrics_module,
+        "get_global_config",
+        lambda: SimpleNamespace(get_builtin_prometheus_url=lambda: None),
+    )
+    result = await collect_cache_service_metrics(_declaration(), 5, 3600)
+    assert result.available is False
+    assert "observability is disabled" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_collect_without_declaration():
+    result = await collect_cache_service_metrics(None, 5, 3600)
+    assert result.available is False
+    assert "declares no metrics" in result.reason
+
+    result = await collect_cache_service_metrics(
+        CacheProviderMetrics(path="/metrics"), 5, 3600
+    )
+    assert result.available is False
+
+
+@pytest.mark.asyncio
+async def test_collect_single_query_timeout_keeps_other_charts(monkeypatch):
+    """A per-query timeout is one chart's failure like any other — a
+    heavy query hitting its timeout must not blank the page."""
+    import asyncio as _asyncio
+
+    class _SlowOneClient(_FakeHTTPClient):
+        def get(self, url, params=None, timeout=None):
+            self.requests.append((url, params))
+            if "l1_usage_bytes" in params["query"]:
+                raise _asyncio.TimeoutError()
+            return _FakeAsyncCtx(_FakeResponse(self._payload))
+
+    payload = {
+        "status": "success",
+        "data": {"result": [{"metric": {}, "values": [[1000, "1"]]}]},
+    }
+    client = _SlowOneClient(payload)
+    _patch_prometheus(monkeypatch, client)
+
+    result = await collect_cache_service_metrics(_declaration(), 5, 3600)
+
+    assert result.available is True
+    assert result.mappings["l1_usage_bytes"].aggregate == []
+    assert result.mappings["hit_rate"].instances[0].points == [[1000.0, 1.0]]
+
+
+@pytest.mark.asyncio
+async def test_collect_all_queries_failing_degrades_with_reason(monkeypatch):
+    """Failure isolation is for partial failures; every query failing
+    (e.g. a gateway error page on each) is one systematic cause and
+    degrades the collection with a reason instead of presenting a wall
+    of silently empty charts."""
+    client = _FakeHTTPClient("<html>Bad Gateway</html>", status=502)
+    _patch_prometheus(monkeypatch, client)
+
+    result = await collect_cache_service_metrics(_declaration(), 5, 3600)
+
+    assert result.available is False
+    assert "502" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_collect_prometheus_unreachable(monkeypatch):
+    class _RefusingClient(_FakeHTTPClient):
+        def get(self, url, params=None, timeout=None):
+            raise metrics_module.aiohttp.ClientError("connection refused")
+
+    _patch_prometheus(monkeypatch, _RefusingClient(None))
+    result = await collect_cache_service_metrics(_declaration(), 5, 3600)
+    assert result.available is False
+    assert "unreachable" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_collect_single_query_failure_keeps_other_charts(monkeypatch):
+    """One failing query (e.g. a bad declaration entry) yields an empty
+    list for its key without blanking the other charts."""
+
+    class _MixedClient(_FakeHTTPClient):
+        def get(self, url, params=None, timeout=None):
+            self.requests.append((url, params))
+            if "l1_usage_bytes" in params["query"]:
+                return _FakeAsyncCtx(
+                    _FakeResponse({"status": "error", "error": "bad query"}, status=400)
+                )
+            return _FakeAsyncCtx(_FakeResponse(self._payload))
+
+    payload = {
+        "status": "success",
+        "data": {"result": [{"metric": {}, "values": [[1000, "1"]]}]},
+    }
+    client = _MixedClient(payload)
+    _patch_prometheus(monkeypatch, client)
+
+    result = await collect_cache_service_metrics(_declaration(), 5, 3600)
+    assert result.available is True
+    assert result.mappings["l1_usage_bytes"].aggregate == []
+    assert result.mappings["l1_usage_bytes"].instances == []
+    assert result.mappings["hit_rate"].instances[0].points == [[1000.0, 1.0]]
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_requires_org_owner(monkeypatch):
+    """The handler itself rejects members and admits Org owners and
+    platform admins, independent of the router's owner-only mount."""
+    with (
+        patch(
+            "gpustack.routes.cache_services.CacheService.one_by_id",
+            AsyncMock(return_value=_service()),
+        ),
+        patch(
+            "gpustack.routes.cache_services.Model.all_by_fields",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        with pytest.raises(ForbiddenException):
+            await cache_services_route.get_cache_service_metrics(
+                request=_request(),
+                session=MagicMock(),
+                ctx=_ctx(org_role=OrgRole.MEMBER),
+                id=5,
+            )
+
+        collected = AsyncMock(
+            return_value=metrics_module.CacheServiceMetricsPublic(available=True)
+        )
+        monkeypatch.setattr(
+            cache_services_route, "collect_cache_service_metrics", collected
+        )
+        result = await cache_services_route.get_cache_service_metrics(
+            request=_request(),
+            session=MagicMock(),
+            ctx=_ctx(org_role=OrgRole.OWNER),
+            id=5,
+        )
+        assert result.available is True
+
+        result = await cache_services_route.get_cache_service_metrics(
+            request=_request(),
+            session=MagicMock(),
+            ctx=_ctx(is_platform_admin=True),
+            id=5,
+        )
+        assert result.available is True
+        # the window parses server-side; the declaration drives queries
+        assert collected.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_collect_attached_buffers_both_counters(monkeypatch):
+    """The two counter queries land atomically: hits arriving while
+    queries fail must not leave rows claiming hits out of zero
+    lookups — the failed round leaves every row empty."""
+
+    class _HalfFailingClient(_FakeHTTPClient):
+        def get(self, url, params=None, timeout=None):
+            self.requests.append((url, params))
+            if "queries_total" in (params or {}).get("query", ""):
+                return _FakeAsyncCtx(_FakeResponse("<html>boom</html>", status=502))
+            return _FakeAsyncCtx(_FakeResponse(self._payload))
+
+    payload = {
+        "status": "success",
+        "data": {
+            "result": [
+                {
+                    "metric": {"model_instance_name": "qwen-abc12"},
+                    "value": [1000, "80"],
+                }
+            ]
+        },
+    }
+    client = _HalfFailingClient(payload)
+    _patch_prometheus(monkeypatch, client)
+
+    attached = [
+        CacheServiceAttachedMetrics(model_id=3, model_instance_name="qwen-abc12")
+    ]
+    result = await collect_cache_service_metrics(
+        _declaration(), 5, 3600, cluster_id=1, attached=attached
+    )
+
+    entry = result.attached[0]
+    assert entry.hit_tokens is None
+    assert entry.queried_tokens is None
+    assert entry.hit_rate is None
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_caps_worker_filter():
+    with (
+        patch(
+            "gpustack.routes.cache_services.CacheService.one_by_id",
+            AsyncMock(return_value=_service()),
+        ),
+        patch(
+            "gpustack.routes.cache_services.Model.all_by_fields",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        with pytest.raises(BadRequestException):
+            await cache_services_route.get_cache_service_metrics(
+                request=_request(),
+                session=MagicMock(),
+                ctx=_ctx(org_role=OrgRole.OWNER),
+                id=5,
+                workers=",".join(f"w{i}" for i in range(101)),
+            )
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_rejects_bad_window():
+    with patch(
+        "gpustack.routes.cache_services.CacheService.one_by_id",
+        AsyncMock(return_value=_service()),
+    ):
+        with pytest.raises(BadRequestException):
+            await cache_services_route.get_cache_service_metrics(
+                request=_request(),
+                session=MagicMock(),
+                ctx=_ctx(org_role=OrgRole.OWNER),
+                id=5,
+                window="99x",
+            )
+
+
+@pytest.mark.asyncio
+async def test_collect_attached_engine_hit_accounting(monkeypatch):
+    """The database enumerates the attached instances (the row set);
+    metrics only fill their numbers — an instance whose engine exports
+    no counters keeps None values instead of vanishing, and the queries
+    use the unified metric names the worker exposes on the scraped
+    /metrics (raw vllm:* names live on the unscraped /metrics/raw)."""
+
+    class _AttachedClient(_FakeHTTPClient):
+        def get(self, url, params=None, timeout=None):
+            self.requests.append((url, params))
+            if url.endswith("/api/v1/query"):
+                counter_value = (
+                    "80" if "external_prefix_cache_hits" in params["query"] else "100"
+                )
+                return _FakeAsyncCtx(
+                    _FakeResponse(
+                        {
+                            "status": "success",
+                            "data": {
+                                "result": [
+                                    {
+                                        "metric": {
+                                            "model_instance_name": "qwen-abc12",
+                                        },
+                                        "value": [1000, counter_value],
+                                    }
+                                ]
+                            },
+                        }
+                    )
+                )
+            return _FakeAsyncCtx(_FakeResponse(self._payload))
+
+    payload = {
+        "status": "success",
+        "data": {"result": [{"metric": {}, "values": [[1000, "1"]]}]},
+    }
+    client = _AttachedClient(payload)
+    _patch_prometheus(monkeypatch, client)
+
+    attached = [
+        CacheServiceAttachedMetrics(
+            model_id=3,
+            model_name="qwen",
+            model_instance_name="qwen-abc12",
+            worker_name="worker-1",
+        ),
+        # a second instance with no exported counters (e.g. SGLang, or
+        # not yet scraped): the row survives with empty values
+        CacheServiceAttachedMetrics(
+            model_id=4, model_name="glm", model_instance_name="glm-def34"
+        ),
+    ]
+    result = await collect_cache_service_metrics(
+        _declaration(), 5, 3600, cluster_id=1, attached=attached
+    )
+
+    assert result.available is True
+    assert len(result.attached) == 2
+    entry = result.attached[0]
+    assert entry.model_instance_name == "qwen-abc12"
+    assert entry.worker_name == "worker-1"
+    assert entry.hit_tokens == 80.0
+    assert entry.queried_tokens == 100.0
+    assert entry.hit_rate == 0.8
+    silent = result.attached[1]
+    assert silent.model_instance_name == "glm-def34"
+    assert silent.hit_tokens is None
+    assert silent.hit_rate is None
+    # unified names, scoped to the cluster and the attached model ids
+    instant_queries = [
+        params["query"]
+        for url, params in client.requests
+        if url.endswith("/api/v1/query")
+    ]
+    assert instant_queries
+    for query in instant_queries:
+        # the scraped series carry the client-appended _total suffix
+        assert query.startswith(
+            "sum by (model_instance_name) (increase(gpustack:external_prefix_cache_"
+        )
+        assert "_total{" in query
+        assert 'cluster_id="1"' in query
+        assert 'model_id=~"3|4"' in query

--- a/tests/routes/test_cache_services.py
+++ b/tests/routes/test_cache_services.py
@@ -1950,7 +1950,7 @@ def _secretful_service(**overrides):
         **fields,
         # mirrors pydantic's recursive model_dump so the detached-copy
         # guarantee of the redaction path is actually exercised
-        model_dump=lambda: {
+        model_dump=lambda **kwargs: {
             k: (v.model_dump() if hasattr(v, "model_dump") else v)
             for k, v in fields.items()
             if k not in ("update", "delete")

--- a/tests/server/test_cache_provider_catalog.py
+++ b/tests/server/test_cache_provider_catalog.py
@@ -257,12 +257,36 @@ def test_lmcache_metrics_declaration():
     provider = get_cache_provider("LMCache")
     assert provider is not None
 
-    # The declaration only locates the exposition (scrape targets ride
-    # on it); semantic metric mappings return with the native-UI
-    # metrics integration.
     metrics = provider.metrics
     assert metrics is not None
     assert metrics.path == "/metrics"
+
+    hit_rate = metrics.mappings["hit_rate"]
+    assert hit_rate.ratio == {
+        "numerator": "lmcache_mp_lookup_hit_tokens_total",
+        "denominator": "lmcache_mp_lookup_requested_tokens_total",
+    }
+    assert (
+        metrics.mappings["l1_usage_bytes"].gauge == "lmcache_mp_l1_memory_usage_bytes"
+    )
+    assert metrics.mappings["l1_usage_ratio"].gauge == "lmcache_mp_l1_usage_ratio"
+    assert metrics.mappings["l2_usage_bytes"].gauge == "lmcache_mp_l2_usage_bytes"
+
+    assert set(metrics.throughput) == {
+        "l0_l1_store",
+        "l0_l1_load",
+        "l2_store",
+        "l2_load",
+    }
+    for rule in metrics.throughput.values():
+        assert rule.histogram_avg
+        assert rule.gauge is None and rule.ratio is None
+    # The OTel Prometheus exporter appends the histograms' "GB/s" unit to
+    # the exported name; the declaration must carry the exported form.
+    assert (
+        metrics.throughput["l0_l1_store"].histogram_avg
+        == "lmcache_mp_l0_l1_store_throughput_GB_per_second"
+    )
 
 
 def test_lmcache_l2_declaration():
@@ -280,6 +304,10 @@ def test_lmcache_l2_declaration():
         "use_odirect",
     }
     assert fs_fields["base_path"].required is True
+    # seeded into the form so a plain "add Local Filesystem" works
+    # without inventing a path; lands in the platform data dir, which
+    # the mirrored deployment mounts from the host
+    assert fs_fields["base_path"].default == "/var/lib/gpustack/cache/lmcache/l2"
     assert fs_fields["max_capacity_gb"].type == "number"
     assert fs_fields["num_workers"].type == "number"
     assert fs_fields["use_odirect"].type == "boolean"
@@ -342,12 +370,19 @@ def test_mooncake_provider_declaration():
     assert provider.versions == {}
     assert provider.health_check.scheme == "tcp"
 
-    # Master-side exposition on the master's conventional metrics port;
-    # default_port seeds the registration form's metrics-port field.
+    # Master-side metrics: the pool's allocated/capacity view on the
+    # master's Prometheus endpoint (conventionally port 9003). Lookup-hit
+    # accounting lives in the engine-side connector, so no hit_rate.
     metrics = provider.metrics
     assert metrics is not None
     assert metrics.path == "/metrics"
     assert metrics.default_port == 9003
+    assert "hit_rate" not in metrics.mappings
+    assert metrics.mappings["l1_usage_bytes"].gauge == "master_allocated_bytes"
+    assert metrics.mappings["l1_usage_ratio"].gauge_ratio == {
+        "numerator": "master_allocated_bytes",
+        "denominator": "master_total_capacity_bytes",
+    }
     assert provider.dashboard_uid == "gpustack-mooncake"
 
     fields = {field.name: field for field in provider.external_fields}

--- a/tests/server/test_cache_provider_catalog.py
+++ b/tests/server/test_cache_provider_catalog.py
@@ -253,11 +253,47 @@ def test_lmcache_provider_declaration():
     assert compat is not None
 
 
+def test_metrics_for_resolves_version_override():
+    """A version carrying its own metrics block owns it whole; versions
+    without one and the custom version read the provider default — and
+    a service stored without an explicit version (None) resolves through
+    the default version like every other version lookup, so an override
+    on the default version reaches the services actually running it."""
+    from gpustack.schemas.cache_providers import (
+        CacheProvider,
+        CacheProviderMetrics,
+        CacheProviderMetricValue,
+        CacheProviderVersionConfig,
+    )
+
+    default = CacheProviderMetrics(
+        mappings={"hit_rate": CacheProviderMetricValue(gauge="old_name")}
+    )
+    renamed = CacheProviderMetrics(
+        mappings={"hit_rate": CacheProviderMetricValue(gauge="new_name")}
+    )
+    provider = CacheProvider(
+        name="X",
+        default_version="v2",
+        versions={
+            "v1": CacheProviderVersionConfig(image="img:v1"),
+            "v2": CacheProviderVersionConfig(image="img:v2", metrics=renamed),
+        },
+        default_metrics=default,
+    )
+
+    assert provider.metrics_for("v1").mappings["hit_rate"].gauge == "old_name"
+    assert provider.metrics_for("v2").mappings["hit_rate"].gauge == "new_name"
+    assert provider.metrics_for("custom").mappings["hit_rate"].gauge == "old_name"
+    assert provider.metrics_for("v9-unknown").mappings["hit_rate"].gauge == "old_name"
+    assert provider.metrics_for(None).mappings["hit_rate"].gauge == "new_name"
+
+
 def test_lmcache_metrics_declaration():
     provider = get_cache_provider("LMCache")
     assert provider is not None
 
-    metrics = provider.metrics
+    metrics = provider.default_metrics
     assert metrics is not None
     assert metrics.path == "/metrics"
 
@@ -373,7 +409,7 @@ def test_mooncake_provider_declaration():
     # Master-side metrics: the pool's allocated/capacity view on the
     # master's Prometheus endpoint (conventionally port 9003). Lookup-hit
     # accounting lives in the engine-side connector, so no hit_rate.
-    metrics = provider.metrics
+    metrics = provider.default_metrics
     assert metrics is not None
     assert metrics.path == "/metrics"
     assert metrics.default_port == 9003


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5805

A cache service's monitoring reads entirely from the provider catalog: each provider declares what its Prometheus exposition means (gauge, counter rate, counter ratio, gauge ratio, histogram average), and the metrics endpoint translates the declarations into PromQL scoped by a server-injected service selector — with an optional worker filter — returning chartable series at two granularities. The service-level aggregate weights ratios by each instance's traffic; the per-instance breakdown keeps identity labels, including LMCache's per-adapter l2_name.

Mapping keys use the platform tier vocabulary (L1 the memory tier, L2 the capacity tier): hit_rate, l1_usage_bytes, l1_usage_ratio, l2_usage_bytes, lookup_tokens_per_second, plus named throughput series. The rate lookback is one step plus a scrape cushion, so a burst charts near when it happened.

Attached-engine rows come from the database — the models wired to the service and their instances, each carrying its worker — and Prometheus only fills their hit accounting, read from the engines' own external-cache counters under their scraped names (the client appends _total at exposition). Engines without the counters keep their row with empty values.

Access is platform admin or org owner. Missing observability degrades to available=False with a reason instead of erroring, and the user-facing redaction dump no longer warns on every read.


Examples:
<img width="3228" height="2300" alt="e321ddfa9f3c9c8de88e45e33aa2865d" src="https://github.com/user-attachments/assets/238597f6-65a9-4750-ba5f-5a3a0ea7ae87" />
<img width="3230" height="1094" alt="dedad435682e450822727c04603eb146" src="https://github.com/user-attachments/assets/d1c83b36-9ed1-4671-af62-301a11eaab5f" />
