### PR TITLE
feat(gateway): let a deployment declare the API surfaces it serves

### DIFF
--- a/gpustack/gateway/ai_proxy_types.py
+++ b/gpustack/gateway/ai_proxy_types.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Mapping
+from typing import Dict, Optional, List, Mapping
 from pydantic import BaseModel, Field
 from gpustack.schemas.model_provider import ModelProviderTypeEnum
 
@@ -47,6 +47,17 @@ class CustomConfig(BaseModel):
     protocol: Optional[str] = None
     providerDomain: Optional[str] = None
     providerBasePath: Optional[str] = None
+    # Per-API path overrides, keyed by the plugin's ``ApiName`` strings. Entries
+    # merge *over* the provider type's own defaults (the plugin only fills in
+    # keys the config left out), so declaring one API keeps all the others.
+    #
+    # Declaring an API is also what makes ai-proxy treat it as natively served:
+    # an inbound ``/v1/messages`` is rewritten to ``/v1/chat/completions``
+    # exactly when the active provider has no ``anthropic/v1/messages``
+    # capability. Note the plugin filters this map against a whitelist and drops
+    # unknown keys *silently*, so a value that never takes effect looks
+    # identical to one that was never set.
+    capabilities: Optional[Dict[str, str]] = None
 
 
 class ActiveConfig(BaseModel):

--- a/gpustack/gateway/utils.py
+++ b/gpustack/gateway/utils.py
@@ -122,6 +122,12 @@ class ModelAIProxyGroup:
     api_tokens: List[str] = dataclass_field(default_factory=list)
     service_names: Set[str] = dataclass_field(default_factory=set)
     fallback_service_names: Set[str] = dataclass_field(default_factory=set)
+    # Declared on the deployment (``Model.native_anthropic_api``). One answer
+    # per Model is not a simplification but a constraint: the provider entry is
+    # per Model, while the image -- and so the API surfaces actually served --
+    # is settled per instance, so a deployment spread over mismatched images
+    # has to answer once for all of them.
+    native_anthropic_api: bool = False
 
     def provider_id(self) -> str:
         return model_ai_proxy_provider_id(self.model_id)
@@ -1358,8 +1364,22 @@ async def ensure_fallback_filter(
             )
 
 
-def ai_proxy_openai_provider_config(
-    id: str, api_tokens: Optional[List[str]] = None
+# Anthropic capabilities added on top of the openai provider's own defaults.
+# Keys are the plugin's ``ApiName`` strings and their spelling is load-bearing:
+# ai-proxy matches them verbatim and drops keys it does not recognize without
+# complaining. Declaring them is what stops it converting an inbound
+# /v1/messages; the openai provider keeps its full default set either way,
+# which is why this is a top-up rather than a provider-type swap.
+_ai_proxy_anthropic_capabilities: Dict[str, str] = {
+    "anthropic/v1/messages": "/v1/messages",
+    "anthropic/v1/messages/count_tokens": "/v1/messages/count_tokens",
+}
+
+
+def ai_proxy_model_provider_config(
+    id: str,
+    api_tokens: Optional[List[str]] = None,
+    native_anthropic_api: bool = False,
 ) -> Dict[str, Any]:
     """Build an openai-type provider entry for a self-hosted upstream.
 
@@ -1368,11 +1388,19 @@ def ai_proxy_openai_provider_config(
     credential no longer has to be injected per request by ``/token-auth``.
     Left empty, ai-proxy falls back to reading the inbound ``Authorization``
     header, which is the pre-existing behavior.
+
+    ``native_anthropic_api`` adds the Anthropic surfaces to ``capabilities``.
+    The provider type stays ``openai`` either way: it carries the widest default
+    capability set of any provider and never rejects an API it has no capability
+    for, where the ``vllm`` provider would trade ~20 of those defaults for two
+    and turn every unlisted API into a gateway error. A top-up on ``openai`` is
+    strictly additive; a type swap is not.
     """
     return ai_proxy_types.AIProxyDefaultConfig(
         type=ModelProviderTypeEnum.OPENAI,
         id=id,
         apiTokens=api_tokens or None,
+        capabilities=_ai_proxy_anthropic_capabilities if native_anthropic_api else None,
         failover=ai_proxy_types.FailoverConfig(enabled=False),
         retryOnFailure=ai_proxy_types.EnableState(enabled=False),
         # ``exclude_unset`` keeps the nested configs down to the flags set here,
@@ -1403,7 +1431,11 @@ def model_ai_proxy_plugin_spec(
             continue
         provider_id = group.provider_id()
         providers.append(
-            ai_proxy_openai_provider_config(provider_id, api_tokens=group.api_tokens)
+            ai_proxy_model_provider_config(
+                provider_id,
+                api_tokens=group.api_tokens,
+                native_anthropic_api=group.native_anthropic_api,
+            )
         )
         for ingress, service_names in (
             (main_ingress, group.service_names),

--- a/gpustack/migrations/versions/2026_07_15_1600-367a3982fcde_v2_3_0_database_changes.py
+++ b/gpustack/migrations/versions/2026_07_15_1600-367a3982fcde_v2_3_0_database_changes.py
@@ -78,6 +78,17 @@ Bundles the pre-release schema changes for v2.3.0:
    the metering read path derives the value on the fly for soft-deleted rows,
    which are never re-LISTed.
 
+7. ``models.native_anthropic_api``: whether a deployment's inference server
+   implements the Anthropic Messages API itself, so the gateway can forward an
+   inbound ``/v1/messages`` untouched instead of translating it to
+   ``/v1/chat/completions``. Declared per deployment rather than derived from
+   the backend because the answer belongs to the running image, and the image
+   is only settled per instance — one deployment can spread over workers of
+   different accelerators whose images need not agree, while a single ai-proxy
+   provider entry has to cover the whole deployment. NOT NULL with a ``false``
+   server default, which backfills existing rows to the pre-existing behavior
+   and leaves no NULL/false ambiguity for callers.
+
 Revision ID: 367a3982fcde
 Revises: c4d7e8f9a0b1
 Create Date: 2026-07-15 16:00:00.000000
@@ -335,14 +346,26 @@ def upgrade() -> None:
                 )
             )
 
-    # One batch for both columns. On SQLite, batch mode recreates and copies the
-    # whole table per block, so two blocks would rewrite `models` twice; on
-    # PostgreSQL / MySQL each block is a plain ALTER and the grouping is only
-    # tidiness. Written for the worst case, since the revision has to run on all
-    # three.
+    # One batch for all the columns. On SQLite, batch mode recreates and copies
+    # the whole table per block, so separate blocks would rewrite `models` once
+    # each; on PostgreSQL / MySQL each block is a plain ALTER and the grouping is
+    # only tidiness. Written for the worst case, since the revision has to run on
+    # all three.
+    #
+    # ``native_anthropic_api`` carries its own default rather than being
+    # nullable: false is a real answer ("translate, as before"), and a NULL that
+    # means the same thing as false only leaves callers guessing which to send.
+    # Adding a NOT NULL column with a constant default is metadata-only on
+    # PostgreSQL 11+ and MySQL 8, so the backfill costs nothing.
     models_columns = [
         sa.Column('scaling_schedule', sa.JSON(), nullable=True),
         sa.Column('gpu_type_selector', sa.JSON(), nullable=True),
+        sa.Column(
+            'native_anthropic_api',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
     ]
     models_columns = [c for c in models_columns if not column_exists('models', c.name)]
     if models_columns:
@@ -376,6 +399,7 @@ def downgrade() -> None:
         batch_op.drop_column('secret_key_digest')
 
     with op.batch_alter_table('models', schema=None) as batch_op:
+        batch_op.drop_column('native_anthropic_api')
         batch_op.drop_column('gpu_type_selector')
         batch_op.drop_column('scaling_schedule')
 

--- a/gpustack/schemas/models.py
+++ b/gpustack/schemas/models.py
@@ -13,6 +13,7 @@ from pydantic import (
     model_validator,
 )
 from sqlalchemy import JSON, Column, ForeignKey, Integer, UniqueConstraint
+from sqlalchemy import false as sa_false
 from sqlalchemy.orm import selectinload
 from sqlmodel import Field, Relationship, SQLModel, Text, select
 
@@ -463,6 +464,29 @@ class ModelSpecBase(SQLModel, ModelSource):
     backend_parameters: Optional[List[str]] = Field(sa_type=JSON, default=None)
     image_name: Optional[str] = None
     run_command: Optional[str] = Field(sa_type=Text, default=None)
+    # Whether this deployment's inference server implements the Anthropic
+    # Messages API itself, letting the gateway forward an inbound /v1/messages
+    # untouched instead of translating it to /v1/chat/completions. False, the
+    # pre-existing behavior, still serves /v1/messages -- by translating.
+    #
+    # A statement about the server, not about the gateway: what the operator
+    # knows is whether their image is a recent enough vLLM, not what ai-proxy
+    # does with that fact.
+    #
+    # Declared on the deployment rather than derived from its inference backend
+    # because the answer belongs to the running image, and the image is settled
+    # per instance (``ModelInstance.gpu_type`` picks it): one deployment can
+    # spread over workers of different accelerators whose images need not agree
+    # -- vllm-ascend against vllm-openai. A single ai-proxy provider entry
+    # covers the whole deployment, so no per-image source can answer for it.
+    #
+    # Not nullable: with NULL and False meaning the same thing there would be
+    # two spellings of "no" and nothing to tell a caller which to send.
+    native_anthropic_api: bool = Field(
+        default=False,
+        nullable=False,
+        sa_column_kwargs={"server_default": sa_false()},
+    )
 
     env: Optional[Dict[str, str]] = Field(sa_type=JSON, default=None)
     restart_on_error: Optional[bool] = True

--- a/gpustack/server/controllers.py
+++ b/gpustack/server/controllers.py
@@ -1790,6 +1790,7 @@ async def accumulate_model_ai_proxy_group(
         group = mcp_handler.ModelAIProxyGroup(
             model_id=model.id,
             api_tokens=cluster_api_tokens[model.cluster_id],
+            native_anthropic_api=model.native_anthropic_api,
         )
         model_groups[model.id] = group
     service_names = {registry.get_service_name() for _, _, registry in destinations}
@@ -3417,7 +3418,11 @@ async def notify_model_route_target(session: AsyncSession, model: Model, event: 
         return
     should_notify = False
     if event.changed_fields is not None:
-        related_fields = ["ready_replicas", "replicas"]
+        # ``native_anthropic_api`` is read where the route's ai-proxy provider
+        # entry is built, and that only runs off a route event -- so without it
+        # here, flipping the selector would change nothing until the deployment
+        # happened to scale.
+        related_fields = ["ready_replicas", "replicas", "native_anthropic_api"]
         for field in related_fields:
             if field in event.changed_fields:
                 should_notify = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "cachetools>=6.0.0",
     "gpustack-runner==0.1.27.post4",
     "gpustack-runtime==0.2.3.post2",
-    "gpustack-higress-plugins==0.3.0.post7",
+    "gpustack-higress-plugins==0.3.0.post8",
     "websockets==16.0",
     "py-radix>=1.1.0",
     # Usage export, xlsx path only (CSV needs nothing beyond the stdlib).

--- a/tests/gateway/test_ai_proxy_model_grouping.py
+++ b/tests/gateway/test_ai_proxy_model_grouping.py
@@ -9,8 +9,9 @@ from gpustack.gateway.client.extensions_higress_io_v1_api import (
 )
 from gpustack.gateway.utils import (
     ModelAIProxyGroup,
+    _ai_proxy_anthropic_capabilities,
     ai_proxy_diff_spec,
-    ai_proxy_openai_provider_config,
+    ai_proxy_model_provider_config,
     cleanup_ai_proxy_config,
     model_ai_proxy_plugin_spec,
     model_ai_proxy_provider_id,
@@ -66,11 +67,74 @@ def test_provider_id_is_per_deployment():
 
 
 def test_api_tokens_only_present_when_supplied():
-    with_token = ai_proxy_openai_provider_config("gpustack-model-7", ["gpustack_ak_sk"])
+    with_token = ai_proxy_model_provider_config("gpustack-model-7", ["gpustack_ak_sk"])
     assert with_token["apiTokens"] == ["gpustack_ak_sk"]
     # Absent rather than empty: an empty list would be a CR change with no
     # meaning, and ai-proxy's fallback to the inbound header is what we want.
-    assert "apiTokens" not in ai_proxy_openai_provider_config("gpustack-model-7")
+    assert "apiTokens" not in ai_proxy_model_provider_config("gpustack-model-7")
+
+
+def test_capabilities_only_present_when_anthropic_is_native():
+    plain = ai_proxy_model_provider_config("gpustack-model-7")
+    # The openai provider's own defaults already cover the OpenAI surface, so
+    # the common case must not write a capabilities map at all -- an empty one
+    # would be a CR change with no meaning.
+    assert "capabilities" not in plain
+    assert plain["type"] == "openai"
+
+    native = ai_proxy_model_provider_config(
+        "gpustack-model-7", native_anthropic_api=True
+    )
+    # Still an openai provider: capabilities merge over its defaults, so this is
+    # the OpenAI surface *plus* Anthropic rather than a swap.
+    assert native["type"] == "openai"
+    assert native["capabilities"] == {
+        "anthropic/v1/messages": "/v1/messages",
+        "anthropic/v1/messages/count_tokens": "/v1/messages/count_tokens",
+    }
+
+
+def test_capabilities_do_not_alias_the_module_level_map():
+    """Every provider entry owns its capabilities dict.
+
+    Nothing in the builder copies ``_ai_proxy_anthropic_capabilities``
+    explicitly -- pydantic validation and ``model_dump`` each construct a fresh
+    dict on the way through. That makes the isolation an implementation detail
+    of pydantic rather than something the code states, so assert it: a provider
+    entry mutated by a later reconcile step must not reach the shared map or
+    another deployment's entry.
+    """
+    before = dict(_ai_proxy_anthropic_capabilities)
+    first = ai_proxy_model_provider_config(
+        "gpustack-model-1", native_anthropic_api=True
+    )
+    second = ai_proxy_model_provider_config(
+        "gpustack-model-2", native_anthropic_api=True
+    )
+
+    assert first["capabilities"] is not _ai_proxy_anthropic_capabilities
+    assert first["capabilities"] is not second["capabilities"]
+
+    first["capabilities"]["anthropic/v1/messages"] = "/mutated"
+    assert _ai_proxy_anthropic_capabilities == before
+    assert second["capabilities"] == before
+
+
+def test_native_anthropic_api_reaches_the_provider_entry():
+    providers, _ = model_ai_proxy_plugin_spec(
+        [
+            ModelAIProxyGroup(
+                model_id=5,
+                api_tokens=["t"],
+                service_names={"model-5-1.static"},
+                native_anthropic_api=True,
+            )
+        ],
+        ROUTE_A,
+        ROUTE_A_FALLBACK,
+    )
+    (provider,) = providers
+    assert "anthropic/v1/messages" in provider["capabilities"]
 
 
 def test_plugin_spec_groups_by_deployment():
@@ -120,7 +184,7 @@ def test_two_routes_share_one_deployment_provider():
     deployment — the whole point of moving ownership from provider id to ingress.
     """
     live = _spec(
-        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["token"])],
+        providers=[ai_proxy_model_provider_config("gpustack-model-5", ["token"])],
         match_rules=[_rule("gpustack-model-5", ROUTE_B, ["model-5-1.static"])],
     )
     providers, rules = model_ai_proxy_plugin_spec(
@@ -149,7 +213,7 @@ def test_two_routes_share_one_deployment_provider():
 
 def test_route_removal_keeps_provider_while_another_route_references_it():
     live = _spec(
-        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["token"])],
+        providers=[ai_proxy_model_provider_config("gpustack-model-5", ["token"])],
         match_rules=[
             _rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"]),
             _rule("gpustack-model-5", ROUTE_B, ["model-5-1.static"]),
@@ -171,7 +235,7 @@ def test_route_removal_keeps_provider_while_another_route_references_it():
 
 def test_last_route_removal_garbage_collects_the_provider():
     live = _spec(
-        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["token"])],
+        providers=[ai_proxy_model_provider_config("gpustack-model-5", ["token"])],
         match_rules=[_rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"])],
     )
 
@@ -188,7 +252,7 @@ def test_last_route_removal_garbage_collects_the_provider():
 
 def test_fallback_ingress_rule_is_dropped_when_fallback_goes_away():
     live = _spec(
-        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["token"])],
+        providers=[ai_proxy_model_provider_config("gpustack-model-5", ["token"])],
         match_rules=[
             _rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"]),
             _rule("gpustack-model-5", ROUTE_A_FALLBACK, ["model-5-1.static"]),
@@ -218,7 +282,7 @@ def test_fallback_ingress_rule_is_dropped_when_fallback_goes_away():
 
 def test_token_change_updates_the_existing_provider_entry():
     live = _spec(
-        providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["old-token"])],
+        providers=[ai_proxy_model_provider_config("gpustack-model-5", ["old-token"])],
         match_rules=[_rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"])],
     )
     providers, rules = model_ai_proxy_plugin_spec(
@@ -248,7 +312,7 @@ def test_external_provider_reconcile_leaves_deployment_entries_alone():
     """
     live = _spec(
         providers=[
-            ai_proxy_openai_provider_config("gpustack-model-5", ["token"]),
+            ai_proxy_model_provider_config("gpustack-model-5", ["token"]),
             {"id": "provider-3", "type": "openai", "apiTokens": ["stale"]},
         ],
         match_rules=[
@@ -517,7 +581,7 @@ def test_none_config_and_default_config_are_tolerated():
 
     result = ai_proxy_diff_spec(
         live,
-        expected_providers=[ai_proxy_openai_provider_config("gpustack-model-5", ["t"])],
+        expected_providers=[ai_proxy_model_provider_config("gpustack-model-5", ["t"])],
         expected_match_rules=[_rule("gpustack-model-5", ROUTE_A, ["model-5-1.static"])],
         owned_ingresses={ROUTE_A, ROUTE_A_FALLBACK},
     )

--- a/tests/schemas/test_model_native_anthropic_api.py
+++ b/tests/schemas/test_model_native_anthropic_api.py
@@ -1,0 +1,60 @@
+"""``Model.native_anthropic_api`` has to survive the API round trip.
+
+Not a test of pydantic: the risk is that a write path grows a hand-written
+field list -- as ``inference_backend``'s create/update/from-yaml handlers all
+have -- and drops the column without an error. These assertions fail the moment
+one of the Model handlers stops being ``model_dump``-driven.
+"""
+
+from gpustack.schemas.models import (
+    Model,
+    ModelCreate,
+    ModelUpdate,
+    SourceEnum,
+)
+from tests.utils.model import new_model
+
+
+def _payload(**overrides) -> dict:
+    payload = {
+        "name": "m",
+        "source": SourceEnum.HUGGING_FACE,
+        "huggingface_repo_id": "repo/m",
+        "replicas": 1,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_create_carries_the_flag():
+    created = ModelCreate(**_payload(native_anthropic_api=True))
+    # create_model persists ``model_in.model_dump(exclude={"enable_model_route"})``.
+    assert created.model_dump()["native_anthropic_api"] is True
+
+
+def test_it_defaults_to_off():
+    """Absent means "translate", which is the pre-existing behavior -- and it is
+    a real ``False`` rather than a None, so there is one spelling of "no"."""
+    assert ModelCreate(**_payload()).native_anthropic_api is False
+
+
+def test_update_only_touches_what_was_sent():
+    """``ActiveRecordMixin.update`` applies ``model_fields_set``, so a PATCH that
+    omits the flag must leave a previously declared value standing rather than
+    resetting it to the default."""
+    assert "native_anthropic_api" not in ModelUpdate(**_payload()).model_fields_set
+    assert (
+        "native_anthropic_api"
+        in ModelUpdate(**_payload(native_anthropic_api=False)).model_fields_set
+    )
+
+
+def test_a_model_copy_keeps_it():
+    """Several controllers duplicate a row with ``Model(**model.model_dump())``
+    or ``Model.model_validate(model.model_dump())`` -- a field the dump drops
+    would silently reset on every copy."""
+    model = new_model(1, "m", huggingface_repo_id="repo/m")
+    model.native_anthropic_api = True
+
+    assert model.model_dump()["native_anthropic_api"] is True
+    assert Model.model_validate(model.model_dump()).native_anthropic_api is True

--- a/tests/server/test_route_ai_proxy_grouping.py
+++ b/tests/server/test_route_ai_proxy_grouping.py
@@ -6,9 +6,11 @@ from gpustack.gateway.utils import lora_registry_name_suffix
 from gpustack.schemas.clusters import Cluster
 from gpustack.schemas.model_routes import ModelRoute, ModelRouteTarget, TargetStateEnum
 from gpustack.schemas.models import ModelInstanceStateEnum
+from gpustack.server.bus import Event, EventType
 from gpustack.server.controllers import (
     accumulate_model_ai_proxy_group,
     calculate_destinations,
+    notify_model_route_target,
 )
 from tests.utils.model import new_model, new_model_instance
 
@@ -176,3 +178,70 @@ async def test_cluster_token_is_resolved_once_per_cluster():
 
     assert one_by_id.await_count == 1
     assert {group.api_tokens[0] for group in model_groups.values()} == {"cluster-token"}
+
+
+@pytest.mark.asyncio
+async def test_native_anthropic_api_comes_from_the_deployment():
+    """The selector is read straight off the Model -- no lookup, and each
+    deployment answers for itself."""
+    model_groups = {}
+    cluster_api_tokens = {}
+
+    with patch(
+        "gpustack.server.controllers.Cluster.one_by_id",
+        AsyncMock(return_value=_cluster()),
+    ):
+        for model_id, native in ((MODEL_ID, True), (MODEL_ID + 1, False)):
+            model = new_model(model_id, f"m-{model_id}", huggingface_repo_id="repo/m")
+            model.cluster_id = CLUSTER_ID
+            model.native_anthropic_api = native
+            await accumulate_model_ai_proxy_group(
+                session=None,
+                model_groups=model_groups,
+                cluster_api_tokens=cluster_api_tokens,
+                model=model,
+                destinations=[],
+                is_fallback_target=False,
+            )
+
+    assert model_groups[MODEL_ID].native_anthropic_api is True
+    # One deployment's answer must not leak into another's provider entry.
+    assert model_groups[MODEL_ID + 1].native_anthropic_api is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "changed_field, should_notify",
+    [("native_anthropic_api", True), ("replicas", True), ("description", False)],
+)
+async def test_native_anthropic_api_edit_reaches_the_route(
+    changed_field, should_notify
+):
+    """``native_anthropic_api`` is consumed where the route's provider entry is
+    built, and that only runs off a route event -- so the Model controller has
+    to treat it as route-affecting or flipping the selector would change nothing
+    until the deployment happened to scale."""
+    model = new_model(MODEL_ID, "base", huggingface_repo_id="repo/base")
+    model.cluster_id = CLUSTER_ID
+    hydrated = new_model(MODEL_ID, "base", huggingface_repo_id="repo/base")
+    hydrated.model_route_targets = [_target(1)]
+
+    publish = AsyncMock()
+    with (
+        patch(
+            "gpustack.server.controllers.Model.one_by_id",
+            AsyncMock(return_value=hydrated),
+        ),
+        patch("gpustack.server.controllers.event_bus.publish", publish),
+    ):
+        await notify_model_route_target(
+            session=None,
+            model=model,
+            event=Event(
+                type=EventType.UPDATED,
+                data=model,
+                changed_fields={changed_field: (None, "x")},
+            ),
+        )
+
+    assert publish.await_count == (1 if should_notify else 0)

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ requires-dist = [
     { name = "dataclasses-json", specifier = ">=0.6.7" },
     { name = "fastapi", specifier = ">=0.115.0,<0.137.0" },
     { name = "fastapi-cdn-host", specifier = ">=0.8.0" },
-    { name = "gpustack-higress-plugins", specifier = "==0.3.0.post7" },
+    { name = "gpustack-higress-plugins", specifier = "==0.3.0.post8" },
     { name = "gpustack-runner", specifier = "==0.1.27.post4" },
     { name = "gpustack-runtime", specifier = "==0.2.3.post2" },
     { name = "hf-xet", specifier = ">=1.3.1,<2.0.0" },
@@ -1309,7 +1309,7 @@ dev = [
 
 [[package]]
 name = "gpustack-higress-plugins"
-version = "0.3.0.post7"
+version = "0.3.0.post8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
@@ -1317,7 +1317,7 @@ dependencies = [
     { name = "uvicorn" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/30/3d18831d7fd16a5d842b259fb20972c224e1b789b25fe3d66a08ed28e429/gpustack_higress_plugins-0.3.0.post7-py3-none-any.whl", hash = "sha256:0b2f7ac1d4a0f154937ad77a5566f68dc00021c82bcb6edfd35f62732520a397", size = 16487444, upload-time = "2026-08-18T06:56:25.872Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/fa1237f872e88a84c6d43905df743b1a202154e9307564c76e0aad37acdb/gpustack_higress_plugins-0.3.0.post8-py3-none-any.whl", hash = "sha256:ffa64d4124cf9b1c827b94c476c07ab7d0ef4067439e71046d665434fd29c624", size = 16487595, upload-time = "2026-08-27T02:36:32.006Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refer to issue:
- #6010 
- #6026 

Self-hosted instances are all configured as `openai`-type ai-proxy providers, so an inbound `/v1/messages` is always rewritten to `/v1/chat/completions`. Recent vLLM serves Anthropic Messages natively, and translating to reach it reorders `system` on the way (#5934, #5286).

Add `Model.api_type`. `openai-anthropic` becomes a `capabilities` entry on that deployment's provider, which is the flag ai-proxy consults when deciding whether to convert; absent, nothing changes.

Declared per deployment rather than derived from the inference backend because the answer belongs to the running image, and the image is settled per instance (`ModelInstance.gpu_type`): one deployment can spread over accelerators whose images disagree -- vllm-ascend against vllm-openai, the pair in #5934 -- while a single provider entry covers all of them.

The provider type stays `openai` and gains capabilities rather than switching to `vllm`, which would trade ~20 default capabilities for two and turn every unlisted API into a gateway error.

Needs the matching ai-proxy change: the plugin filters configured capabilities against a whitelist with no Anthropic entries and drops them silently, so an unpatched plugin looks exactly like an unconfigured deployment.

API surface:

    POST/PUT /v1/models   { ..., "api_type": "openai-anthropic" | "openai" | null }

null (the default) means the OpenAI surface only, i.e. today's behavior; `GET` returns it on `ModelPublic`. `anthropic` is the intended third value, left out until the ai-proxy `claude` provider is validated against a self-hosted upstream -- it moves the credential to `x-api-key` and deletes the `Authorization` header a worker authenticates on.