### PR TITLE
fix(k8s): inject default data-dir volume mount

### DIFF
--- a/gpustack/migrations/versions/2026_08_27_1745-c8f3a1b9d2e4_backfill_k8s_data_dir_volume_mount.py
+++ b/gpustack/migrations/versions/2026_08_27_1745-c8f3a1b9d2e4_backfill_k8s_data_dir_volume_mount.py
@@ -1,0 +1,92 @@
+"""backfill k8s data-dir volume mount
+
+Revision ID: c8f3a1b9d2e4
+Revises: b7e2c4d15a80
+Create Date: 2026-08-27 17:45:00.000000
+
+K8s clusters created before v2.2.0 have no ``k8s_options.volumeMounts``.
+The worker DaemonSet now renders ``/var/lib/gpustack`` from
+``volumeMounts[0]`` instead of hardcoding it, and create/update require
+that entry. Backfill the default hostPath mount so upgraded clusters
+keep persisting worker data and can be edited without a validation
+deadlock (see https://github.com/gpustack/gpustack/issues/6145).
+"""
+
+import json
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "c8f3a1b9d2e4"
+down_revision: Union[str, None] = "b7e2c4d15a80"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_DEFAULT_DATA_DIR_MOUNT = {
+    "name": "gpustack-data-dir",
+    "mountPath": "/var/lib/gpustack",
+    "readOnly": False,
+    "volumeSource": {
+        "hostPath": {"path": "/var/lib/gpustack", "type": "DirectoryOrCreate"}
+    },
+}
+
+
+def _parse_json(value):
+    if isinstance(value, str):
+        try:
+            value = json.loads(value) if value else {}
+        except json.JSONDecodeError:
+            return {}
+    if not isinstance(value, dict):
+        return {}
+    return value
+
+
+def _needs_data_dir_mount(k8s_options: dict) -> bool:
+    mounts = k8s_options.get("volumeMounts") or k8s_options.get("volume_mounts")
+    if not mounts:
+        return True
+    first = mounts[0] if isinstance(mounts, list) else None
+    if not isinstance(first, dict):
+        return True
+    source = first.get("volumeSource") or first.get("volume_source") or {}
+    if not isinstance(source, dict):
+        return True
+    return source.get("hostPath") is None and source.get("host_path") is None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    clusters_jsonable = sa.table(
+        "clusters",
+        sa.column("id", sa.Integer),
+        sa.column("k8s_options", sa.JSON),
+    )
+    rows = conn.execute(
+        sa.text("SELECT id, k8s_options FROM clusters WHERE provider = 'Kubernetes'")
+    ).fetchall()
+    for cluster_id, k8s_options in rows:
+        k8s_options = _parse_json(k8s_options)
+        if not _needs_data_dir_mount(k8s_options):
+            continue
+        mounts = k8s_options.get("volumeMounts") or k8s_options.get("volume_mounts") or []
+        if not isinstance(mounts, list):
+            mounts = []
+        k8s_options.pop("volume_mounts", None)
+        k8s_options["volumeMounts"] = [_DEFAULT_DATA_DIR_MOUNT] + [
+            m
+            for m in mounts
+            if not (isinstance(m, dict) and m.get("name") == "gpustack-data-dir")
+        ]
+        conn.execute(
+            sa.update(clusters_jsonable)
+            .where(clusters_jsonable.c.id == cluster_id)
+            .values(k8s_options=k8s_options)
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -57,6 +57,9 @@ from gpustack.schemas.clusters import (
     WorkerPool,
     CloudOptions,
     K8sOptions,
+    K8sVolumeMount,
+    VolumeSource,
+    HostPathVolumeSource,
     is_gpu_service_cluster,
     is_gpu_service_k8s_options,
 )
@@ -477,6 +480,69 @@ def check_shuihua_requirements(
         )
 
 
+def _default_data_dir_mount() -> K8sVolumeMount:
+    return K8sVolumeMount(
+        name="gpustack-data-dir",
+        mount_path="/var/lib/gpustack",
+        read_only=False,
+        volume_source=VolumeSource(
+            host_path=HostPathVolumeSource(
+                path="/var/lib/gpustack", type="DirectoryOrCreate"
+            )
+        ),
+    )
+
+
+def _copy_k8s_options(opts: Any) -> K8sOptions:
+    if opts is None:
+        return K8sOptions()
+    if isinstance(opts, K8sOptions):
+        return opts.model_copy(deep=True)
+    return K8sOptions.model_validate(opts)
+
+
+def _first_mount_is_host_path(opts: Any) -> bool:
+    if opts is None:
+        return False
+    parsed = opts if isinstance(opts, K8sOptions) else _copy_k8s_options(opts)
+    mounts = parsed.volume_mounts
+    if not mounts:
+        return False
+    src = mounts[0].volume_source
+    return src is not None and src.host_path is not None
+
+
+def ensure_k8s_data_dir_mount(
+    input: Union[ClusterCreate, ClusterUpdate],
+    existing: Optional[Cluster] = None,
+):
+    """Ensure the reserved gpustack data-dir volume mount is present.
+
+    The first ``k8s_options.volume_mounts`` entry is the worker data dir.
+    Pre-v2.2 clusters and some clients omit it; inject the default instead
+    of rejecting the request. On update, if the caller omitted
+    ``k8s_options``, copy the stored object first so assigning a default
+    does not wipe namespace / gpuInstanceOptions.
+    """
+    opts = input.k8s_options
+    if opts is None:
+        stored = existing.k8s_options if existing is not None else None
+        if _first_mount_is_host_path(stored):
+            return
+        opts = _copy_k8s_options(stored)
+        input.k8s_options = opts
+    if not opts.volume_mounts:
+        opts.volume_mounts = [_default_data_dir_mount()]
+        return
+    if not _first_mount_is_host_path(opts):
+        raise InvalidException(
+            message=(
+                "The first k8s_options.volume_mount must be for gpustack "
+                "data dir with hostPath volume source."
+            )
+        )
+
+
 def create_update_check(
     provider: ClusterProvider,
     input: Union[ClusterCreate, ClusterUpdate],
@@ -511,22 +577,7 @@ def create_update_check(
         apply_shuihua_defaults(input, existing)
         check_shuihua_requirements(input, existing)
     if provider == ClusterProvider.Kubernetes:
-        # check for volume mounts (now nested under k8s_options)
-        volume_mounts = (
-            input.k8s_options.volume_mounts if input.k8s_options is not None else None
-        )
-        if volume_mounts is None or len(volume_mounts) < 1:
-            # at least one volume mount is required, and the default one is for gpustack data dir.
-            raise InvalidException(
-                message="At least one k8s_options.volume_mount is required, and the default one is for gpustack data dir."
-            )
-        if (
-            volume_mounts[0].volume_source is None
-            or volume_mounts[0].volume_source.host_path is None
-        ):
-            raise InvalidException(
-                message="The first k8s_options.volume_mount must be for gpustack data dir with hostPath volume source."
-            )
+        ensure_k8s_data_dir_mount(input, existing)
 
 
 def hoist_system_default_container_registry(
@@ -604,7 +655,8 @@ def enforce_data_dir_mounts(input: Union[ClusterCreate, ClusterUpdate]):
     Assuming the first item of k8s_options.volume_mounts is for gpustack data dir,
     enforce that it is always present and has the correct settings.
     """
-    # the first volume must exist as it's validated in create_update_check, and it must be for gpustack data dir, so we enforce it here.
+    if input.k8s_options is None or not input.k8s_options.volume_mounts:
+        return
     data_dir_mount = input.k8s_options.volume_mounts[0]
     data_dir_mount.name = "gpustack-data-dir"
     data_dir_mount.mount_path = "/var/lib/gpustack"

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -7,6 +7,7 @@ from pydantic import (
     BaseModel,
     computed_field,
     field_validator,
+    model_validator,
     ConfigDict,
     PrivateAttr,
     Field as PydanticField,
@@ -570,6 +571,25 @@ class ClusterUpdate(SQLModel):
             )
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def hoist_legacy_k8s_volume_mounts(cls, data: Any) -> Any:
+        """Accept the pre-``k8s_options`` field name used by older clients."""
+        if not isinstance(data, dict):
+            return data
+        legacy = data.pop("k8s_volume_mounts", None)
+        if not legacy:
+            return data
+        opts = data.get("k8s_options")
+        if opts is None:
+            data["k8s_options"] = {"volumeMounts": legacy}
+            return data
+        if isinstance(opts, dict) and not (
+            opts.get("volumeMounts") or opts.get("volume_mounts")
+        ):
+            data["k8s_options"] = {**opts, "volumeMounts": legacy}
+        return data
 
     @field_validator("server_url")
     def validate_server_url(cls, v: Optional[str]) -> Optional[str]:

--- a/tests/schemas/test_k8s_data_dir_volume_mount.py
+++ b/tests/schemas/test_k8s_data_dir_volume_mount.py
@@ -1,0 +1,124 @@
+import pytest
+
+from gpustack.api.exceptions import InvalidException
+from gpustack.routes.clusters import create_update_check, ensure_k8s_data_dir_mount
+from gpustack.schemas.clusters import (
+    ClusterCreate,
+    ClusterProvider,
+    ClusterUpdate,
+    K8sOptions,
+    K8sVolumeMount,
+    VolumeSource,
+    HostPathVolumeSource,
+    PersistentVolumeClaimVolumeSource,
+)
+
+
+def _host_path_mount(path="/var/lib/gpustack"):
+    return {
+        "name": "gpustack-data-dir",
+        "mountPath": "/var/lib/gpustack",
+        "readOnly": False,
+        "volumeSource": {"hostPath": {"path": path, "type": "DirectoryOrCreate"}},
+    }
+
+
+def test_legacy_k8s_volume_mounts_hoisted_into_k8s_options():
+    created = ClusterCreate.model_validate(
+        {
+            "name": "c1",
+            "provider": "Kubernetes",
+            "k8s_volume_mounts": [_host_path_mount()],
+        }
+    )
+    assert created.k8s_options is not None
+    assert created.k8s_options.volume_mounts is not None
+    assert created.k8s_options.volume_mounts[0].name == "gpustack-data-dir"
+    assert (
+        created.k8s_options.volume_mounts[0].volume_source.host_path.path
+        == "/var/lib/gpustack"
+    )
+
+
+def test_legacy_k8s_volume_mounts_do_not_override_existing_k8s_options_mounts():
+    created = ClusterCreate.model_validate(
+        {
+            "name": "c1",
+            "provider": "Kubernetes",
+            "k8s_options": {"volumeMounts": [_host_path_mount("/data")]},
+            "k8s_volume_mounts": [_host_path_mount("/ignored")],
+        }
+    )
+    assert (
+        created.k8s_options.volume_mounts[0].volume_source.host_path.path == "/data"
+    )
+
+
+def test_create_injects_default_data_dir_mount_when_omitted():
+    created = ClusterCreate(name="c1", provider=ClusterProvider.Kubernetes)
+    create_update_check(ClusterProvider.Kubernetes, created)
+    assert created.k8s_options.volume_mounts[0].name == "gpustack-data-dir"
+    assert (
+        created.k8s_options.volume_mounts[0].volume_source.host_path.path
+        == "/var/lib/gpustack"
+    )
+
+
+def test_update_omitted_k8s_options_keeps_stored_valid_mount():
+    stored = K8sOptions(
+        namespace="gpustack-system-abc",
+        volume_mounts=[
+            K8sVolumeMount(
+                name="gpustack-data-dir",
+                mount_path="/var/lib/gpustack",
+                volume_source=VolumeSource(
+                    host_path=HostPathVolumeSource(
+                        path="/var/lib/gpustack", type="DirectoryOrCreate"
+                    )
+                ),
+            )
+        ],
+    )
+
+    class _Cluster:
+        k8s_options = stored
+
+    update = ClusterUpdate(name="c1")
+    ensure_k8s_data_dir_mount(update, existing=_Cluster())
+    # Caller omitted k8s_options; stored mount is valid so leave the request
+    # field unset and let Cluster.update keep the JSON column as-is.
+    assert update.k8s_options is None
+
+
+def test_update_backfills_when_stored_mount_is_missing():
+    stored = K8sOptions(namespace="gpustack-system-abc")
+
+    class _Cluster:
+        k8s_options = stored
+
+    update = ClusterUpdate(name="c1")
+    ensure_k8s_data_dir_mount(update, existing=_Cluster())
+    assert update.k8s_options.namespace == "gpustack-system-abc"
+    assert update.k8s_options.volume_mounts[0].name == "gpustack-data-dir"
+
+
+def test_first_non_hostpath_mount_is_rejected():
+    update = ClusterUpdate(
+        name="c1",
+        k8s_options=K8sOptions(
+            volume_mounts=[
+                K8sVolumeMount(
+                    name="models",
+                    mount_path="/models",
+                    volume_source=VolumeSource(
+                        persistent_volume_claim=PersistentVolumeClaimVolumeSource(
+                            claim_name="models-pvc"
+                        )
+                    ),
+                )
+            ]
+        ),
+    )
+    with pytest.raises(InvalidException) as exc_info:
+        ensure_k8s_data_dir_mount(update)
+    assert "hostPath" in exc_info.value.message


### PR DESCRIPTION
## Summary
- Creating or editing a Kubernetes cluster failed with `At least one k8s_options.volume_mount is required` when `k8s_options.volumeMounts` was missing (upgraded pre-v2.2 clusters, empty UI payload, or the legacy `k8s_volume_mounts` field).
- Inject the reserved `gpustack-data-dir` hostPath mount instead of rejecting, hoist `k8s_volume_mounts` into `k8s_options.volumeMounts`, and backfill existing Kubernetes clusters in a migration.

Fixes #6145

## Test plan
- [ ] `POST /v2/clusters` with `provider=Kubernetes` and no `k8s_options` succeeds; stored `volumeMounts[0]` is the data-dir hostPath.
- [ ] `POST /v2/clusters` with top-level `k8s_volume_mounts` (old UI shape) succeeds and persists under `k8s_options.volumeMounts`.
- [ ] Edit a pre-v2.2 Kubernetes cluster that has no `volumeMounts`; save succeeds and keeps existing `namespace` / `gpuInstanceOptions`.
- [ ] `uv run pytest tests/schemas/test_k8s_data_dir_volume_mount.py` passes.

Made with [Cursor](https://cursor.com)