### PR TITLE
fix: search and sort gpu service lists by the name they display

### DIFF
--- a/docs/user-guide/gpuservice-instance-templates.md
+++ b/docs/user-guide/gpuservice-instance-templates.md
@@ -10,7 +10,7 @@ Navigate to the `GPU Service` > `Instance Templates` page to browse all availabl
 
 ![Screenshot: Instance Templates list](../assets/gpuservice/instance-templates/list.png)
 
-You can filter templates by name or vendor.
+You can filter templates by display name or name — either value a card may show — or by vendor.
 
 ## Adding a Template
 

--- a/docs/user-guide/gpuservice-instance-types.md
+++ b/docs/user-guide/gpuservice-instance-types.md
@@ -16,7 +16,7 @@ Open `GPU Service` > `Instance Types`. The page lists the instance types of ever
 - **Cluster**: The cluster the type belongs to.
 - **Status**: `Active` types can be selected in the *Add GPU Instance* form; `Inactive` ones cannot.
 
-Use the `Filter by cluster` selector in the toolbar to narrow the list to a single cluster, and the search box to match types by name; filtering, sorting, and pagination are all applied server-side. Row actions — deactivate, activate, delete — always act on the cluster named in the row's Cluster column.
+Use the `Filter by cluster` selector in the toolbar to narrow the list to a single cluster, and the search box to match types by display name or name — either value the `Name` column may show. Filtering, sorting, and pagination are all applied server-side, and sorting the `Name` column orders by the label it displays. Row actions — deactivate, activate, delete — always act on the cluster named in the row's Cluster column.
 
 The list is a control-plane record rather than a live read from each cluster: while a cluster is unreachable, its rows read as last observed. The live capacity view below remains the authority for current remaining capacity.
 

--- a/docs/user-guide/gpuservice-instances.md
+++ b/docs/user-guide/gpuservice-instances.md
@@ -161,7 +161,7 @@ After creation, you return to the `GPU Service` > `GPU Instances` page, where al
 
 ![Screenshot: GPU Instances list](../assets/gpuservice/instances/list.png)
 
-You can filter instances by name.
+You can filter instances by display name or name — either value the `Name` column may show. Sorting the `Name` column orders by the label it displays.
 
 ### Accessing an Instance
 

--- a/docs/user-guide/gpuservice-ssh-public-keys.md
+++ b/docs/user-guide/gpuservice-ssh-public-keys.md
@@ -10,7 +10,7 @@ Navigate to the `GPU Service` > `SSH Public Keys` page to browse all registered 
 
 ![Screenshot: SSH Public Keys list](../assets/gpuservice/ssh-public-keys/list.png)
 
-You can filter SSH public keys by name.
+You can filter SSH public keys by display name or name — either value the `Name` column may show. Sorting the `Name` column orders by the label it displays.
 
 ## Adding an SSH Public Key
 

--- a/docs/user-guide/gpuservice-storage-types.md
+++ b/docs/user-guide/gpuservice-storage-types.md
@@ -12,7 +12,7 @@ Navigate to the `GPU Service` > `Storage Types` page to browse all storage types
 
 ![Screenshot: Storage Types list](../assets/gpuservice/storage-types/list.png)
 
-You can filter storage types by name.
+You can filter storage types by display name or name — either value the `Name` column may show. Sorting the `Name` column orders by the label it displays.
 
 ## Adding a Storage Type
 

--- a/docs/user-guide/gpuservice-storage.md
+++ b/docs/user-guide/gpuservice-storage.md
@@ -14,7 +14,7 @@ Navigate to the `GPU Service` > `Storage` page to browse all storage and its det
 
 ![Screenshot: Storage list](../assets/gpuservice/storage/list.png)
 
-You can filter storage by name.
+You can filter storage by display name or name — either value the `Name` column may show. Sorting the `Name` column orders by the label it displays.
 
 ## Adding Storage
 

--- a/gpustack/mixins/active_record.py
+++ b/gpustack/mixins/active_record.py
@@ -98,6 +98,37 @@ def send_post_commit_events(session: AsyncSession):
             logger.exception(f"Failed to publish events: {e}")
 
 
+# ``LIKE`` reads ``%`` and ``_`` in the pattern as wildcards, so an unescaped
+# needle silently changed what a search meant: ``team_a`` matched ``teamXa`` and a
+# lone ``%`` matched every row. The watch stream's ``_match_fuzzy_fields`` does a
+# plain Python substring test and never had wildcards, so the two disagreed — a
+# searched page listed a superset of the rows it then received updates for.
+# Escaping converges the SQL onto the literal reading the stream already had.
+_LIKE_ESCAPE = "\\"
+
+
+def _fuzzy_pattern(value: Any) -> str:
+    """``value`` as a case-folded ``LIKE`` pattern matching it literally."""
+    needle = str(value).lower()
+    # The escape character first, or escaping the wildcards would re-escape it.
+    for special in (_LIKE_ESCAPE, "%", "_"):
+        needle = needle.replace(special, _LIKE_ESCAPE + special)
+    return f"%{needle}%"
+
+
+def _fuzzy_conditions(cls, fuzzy_fields: Optional[dict]) -> List:
+    """The OR-ed ``LIKE`` predicates for ``fuzzy_fields``, lowered on both sides.
+
+    One definition, because both the item query and its COUNT need the identical
+    predicate: they used to be written out separately and drifted, the count
+    losing the ``lower()`` on each side.
+    """
+    return [
+        func.lower(getattr(cls, key)).like(_fuzzy_pattern(value), escape=_LIKE_ESCAPE)
+        for key, value in (fuzzy_fields or {}).items()
+    ]
+
+
 class ActiveRecordMixin:
     """ActiveRecordMixin provides a set of methods to interact with the database."""
 
@@ -244,11 +275,8 @@ class ActiveRecordMixin:
         for key, value in fields.items():
             statement = statement.where(getattr(cls, key) == value)
 
-        if fuzzy_fields:
-            fuzzy_conditions = [
-                func.lower(getattr(cls, key)).like(f"%{str(value).lower()}%")
-                for key, value in fuzzy_fields.items()
-            ]
+        fuzzy_conditions = _fuzzy_conditions(cls, fuzzy_fields)
+        if fuzzy_conditions:
             statement = statement.where(or_(*fuzzy_conditions))
 
         if extra_conditions:
@@ -297,11 +325,14 @@ class ActiveRecordMixin:
             ]
             statement = statement.where(and_(*conditions))
 
-        if fuzzy_fields:
-            fuzzy_conditions = [
-                func.lower(getattr(cls, key)).like(f"%{str(value).lower()}%")
-                for key, value in fuzzy_fields.items()
-            ]
+        # Built once and applied to the COUNT below as well, the way
+        # ``extra_conditions`` already is. Rebuilding the predicate a second time
+        # is what let the two drift: the count omitted the ``lower()`` on each
+        # side, so on a database whose LIKE is case-sensitive a search differing
+        # in case from the stored value returned rows ``total`` did not count —
+        # a page rendering items its pagination said were not there.
+        fuzzy_conditions = _fuzzy_conditions(cls, fuzzy_fields)
+        if fuzzy_conditions:
             statement = statement.where(or_(*fuzzy_conditions))
 
         if extra_conditions:
@@ -346,11 +377,7 @@ class ActiveRecordMixin:
             ]
             count_statement = count_statement.where(and_(*conditions))
 
-        if fuzzy_fields:
-            fuzzy_conditions = [
-                col(getattr(cls, key)).like(f"%{value}%")
-                for key, value in fuzzy_fields.items()
-            ]
+        if fuzzy_conditions:
             count_statement = count_statement.where(or_(*fuzzy_conditions))
 
         if extra_conditions:
@@ -933,10 +960,21 @@ class ActiveRecordMixin:
 
     @classmethod
     def _match_fuzzy_fields(cls, event: Any, fuzzy_fields: Optional[dict]) -> bool:
-        """Match fuzzy fields using OR condition."""
+        """Match fuzzy fields using OR condition.
+
+        A key whose attribute is None is skipped rather than stringified: SQL is
+        the reference here, and ``NULL LIKE '%x%'`` is NULL, never true. Reading
+        it as ``str(None)`` made every row with a NULL column match the term
+        "none", so a search for it returned nothing from the read while the
+        stream kept delivering those rows — they appeared in an empty list one by
+        one as they changed. An id-only payload resolves every key to None the
+        same way.
+        """
         for key, value in (fuzzy_fields or {}).items():
-            attr_value = str(getattr(event.data, key, "")).lower()
-            if str(value).lower() in attr_value:
+            attr_value = getattr(event.data, key, None)
+            if attr_value is None:
+                continue
+            if str(value).lower() in str(attr_value).lower():
                 return True
         return not fuzzy_fields
 

--- a/gpustack/routes/gpu_instance_persistent_volume_types.py
+++ b/gpustack/routes/gpu_instance_persistent_volume_types.py
@@ -30,6 +30,10 @@ from gpustack.schemas import (
     GPUInstancePersistentVolumeTypePhase,
 )
 from gpustack.schemas.principals import platform_principal_id
+from gpustack.routes.gpu_instances_helper import (
+    display_name_label,
+    order_by_display_label,
+)
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 
@@ -57,7 +61,10 @@ async def get_gpu_instance_persistent_volume_types(
     """
     fuzzy_fields: dict = {}
     if search:
+        # The Name column renders ``display_name || name``, so searching only
+        # ``name`` hid rows behind the label the list actually shows (#6104).
         fuzzy_fields["name"] = search
+        fuzzy_fields["display_name"] = search
 
     extra_conditions: list = []
     filter_func = lambda row: is_visible(row, ctx)  # noqa: E731
@@ -98,7 +105,9 @@ async def get_gpu_instance_persistent_volume_types(
             session=session,
             fields={},
             fuzzy_fields=fuzzy_fields,
-            order_by=params.order_by,
+            order_by=order_by_display_label(
+                params.order_by, display_name_label(GPUInstancePersistentVolumeType)
+            ),
             page=params.page,
             per_page=params.perPage,
             extra_conditions=extra_conditions,

--- a/gpustack/routes/gpu_instance_persistent_volumes.py
+++ b/gpustack/routes/gpu_instance_persistent_volumes.py
@@ -37,6 +37,10 @@ from gpustack.schemas.gpu_instance_persistent_volumes import (
 )
 from gpustack.schemas.principals import platform_principal_id
 from gpustack.server.bus import EventType
+from gpustack.routes.gpu_instances_helper import (
+    display_name_label,
+    order_by_display_label,
+)
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 
@@ -59,7 +63,10 @@ async def get_gpu_instance_persistent_volumes(
 
     fuzzy_fields: dict = {}
     if search:
+        # The Name column renders ``display_name || name``, so searching only
+        # ``name`` hid rows behind the label the list actually shows (#6104).
         fuzzy_fields["name"] = search
+        fuzzy_fields["display_name"] = search
 
     if params.watch:
         return StreamingResponse(
@@ -76,7 +83,9 @@ async def get_gpu_instance_persistent_volumes(
             session=session,
             fields=fields,
             fuzzy_fields=fuzzy_fields,
-            order_by=params.order_by,
+            order_by=order_by_display_label(
+                params.order_by, display_name_label(GPUInstancePersistentVolume)
+            ),
             page=params.page,
             per_page=params.perPage,
         )

--- a/gpustack/routes/gpu_instance_ssh_public_keys.py
+++ b/gpustack/routes/gpu_instance_ssh_public_keys.py
@@ -26,6 +26,10 @@ from gpustack.schemas import (
     GPUInstanceSSHPublicKeyCreate,
 )
 from gpustack.schemas.principals import platform_principal_id
+from gpustack.routes.gpu_instances_helper import (
+    display_name_label,
+    order_by_display_label,
+)
 from gpustack.server.db import async_session
 from gpustack.server.deps import SessionDep, TenantContextDep
 
@@ -48,7 +52,10 @@ async def get_gpu_instance_ssh_public_keys(
 
     fuzzy_fields: dict = {}
     if search:
+        # The Name column renders ``display_name || name``, so searching only
+        # ``name`` hid rows behind the label the list actually shows (#6104).
         fuzzy_fields["name"] = search
+        fuzzy_fields["display_name"] = search
 
     if params.watch:
         return StreamingResponse(
@@ -64,7 +71,9 @@ async def get_gpu_instance_ssh_public_keys(
             session=session,
             fields=fields,
             fuzzy_fields=fuzzy_fields,
-            order_by=params.order_by,
+            order_by=order_by_display_label(
+                params.order_by, display_name_label(GPUInstanceSSHPublicKey)
+            ),
             page=params.page,
             per_page=params.perPage,
         )

--- a/gpustack/routes/gpu_instance_templates.py
+++ b/gpustack/routes/gpu_instance_templates.py
@@ -59,7 +59,10 @@ async def get_gpu_instance_templates(
 
     fuzzy_fields: dict = {}
     if search:
+        # The card renders ``display_name || name``, so searching only ``name``
+        # hid rows behind the label the list actually shows (#6104).
         fuzzy_fields["name"] = search
+        fuzzy_fields["display_name"] = search
 
     extra_conditions = manageable_conditions(ctx) if mine else visible_conditions(ctx)
 

--- a/gpustack/routes/gpu_instance_types.py
+++ b/gpustack/routes/gpu_instance_types.py
@@ -23,8 +23,10 @@ from gpustack.gpu_instances.gateway import count_ready_workers
 from gpustack.routes.gpu_instances_helper import (
     assert_cluster_gpu_service,
     build_cluster_ops,
+    display_name_label,
     ensure_writable,
     handle_error,
+    order_by_display_label,
     watch_event_stream,
 )
 
@@ -217,7 +219,15 @@ async def get_gpu_instance_types(
     fields = {"deleted_at": None}
     if name:
         fields["name"] = name
-    fuzzy_fields = {"name": search} if search else {}
+
+    fuzzy_fields: dict = {}
+    if search:
+        # The Name column renders ``display_name || name``, so searching only
+        # ``name`` hid rows behind the label the list actually shows (#6104).
+        # ``display_name`` is a hybrid here rather than a column, which is why
+        # this reads the same as every other GPU Service list.
+        fuzzy_fields["name"] = search
+        fuzzy_fields["display_name"] = search
 
     if params.watch:
         # Deliberately ahead of the empty-set guard below: that guard is about the
@@ -248,7 +258,9 @@ async def get_gpu_instance_types(
             extra_conditions=[GPUInstanceType.cluster_id.in_(allowed_ids)],
             page=params.page,
             per_page=params.perPage,
-            order_by=params.order_by,
+            order_by=order_by_display_label(
+                params.order_by, display_name_label(GPUInstanceType)
+            ),
         )
 
 

--- a/gpustack/routes/gpu_instances.py
+++ b/gpustack/routes/gpu_instances.py
@@ -52,7 +52,11 @@ from gpustack.api.tenant import (
 from gpustack.gpu_instances import validate_k8s_object_name
 from gpustack.gpu_instances.placeholders import substitute_generated_placeholders
 from gpustack.routes.gpu_instance_persistent_volumes import resolve_pv_type_for_ctx
-from gpustack.routes.gpu_instances_helper import assert_cluster_gpu_service
+from gpustack.routes.gpu_instances_helper import (
+    assert_cluster_gpu_service,
+    display_name_label,
+    order_by_display_label,
+)
 from gpustack.schemas.clusters import Cluster
 
 from gpustack.schemas import (
@@ -98,7 +102,10 @@ async def get_gpu_instances(
 
     fuzzy_fields: dict = {}
     if search:
+        # The Name column renders ``display_name || name``, so searching only
+        # ``name`` hid rows behind the label the list actually shows (#6104).
         fuzzy_fields["name"] = search
+        fuzzy_fields["display_name"] = search
 
     if params.watch:
         return StreamingResponse(
@@ -114,7 +121,9 @@ async def get_gpu_instances(
             session=session,
             fields=fields,
             fuzzy_fields=fuzzy_fields,
-            order_by=params.order_by,
+            order_by=order_by_display_label(
+                params.order_by, display_name_label(GPUInstance)
+            ),
             page=params.page,
             per_page=params.perPage,
         )

--- a/gpustack/routes/gpu_instances_helper.py
+++ b/gpustack/routes/gpu_instances_helper.py
@@ -5,6 +5,11 @@ CRD client) and translate cluster access + Kubernetes failures into the
 project's HTTP semantics, so the route modules stay thin. :func:`watch_event_stream`
 is a transport-level helper shared by both the per-cluster and the aggregated
 watch routes, framing a normalized watch source as GPUStack SSE.
+:func:`display_name_label` / :func:`order_by_display_label` are shared by the
+five GPU Service lists whose Name column carries a sorter, so the one rule about
+what that column shows and orders by has one definition. Templates are a card
+view with no column sorter, so they search the display name without ordering by
+it and do not use these.
 """
 
 import asyncio
@@ -12,11 +17,12 @@ import http
 import json
 import logging
 from contextlib import aclosing, asynccontextmanager, suppress
-from typing import Any, AsyncIterator, Callable, Optional, Tuple
+from typing import Any, AsyncIterator, Callable, List, Optional, Tuple
 
 from fastapi import Request
 from fastapi.encoders import jsonable_encoder
 from kubernetes_asyncio import client
+from sqlalchemy import func
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from gpustack.api.exceptions import (
@@ -60,6 +66,61 @@ _WATCH_QUEUE_MAXSIZE = 100
 # Producer-done sentinel: dequeuing it means the source ended (vs. a wait_for
 # timeout, which means "no event yet — send a heartbeat").
 _DONE = object()
+
+
+def display_name_label(model: Any) -> Any:
+    """SQL for what a GPU Service list renders in its Name column.
+
+    ``display_name || name`` as the UI writes it, where ``nullif(..., '')`` is
+    what makes an empty display name fall back the way a falsy ``||`` does.
+
+    ``model.display_name`` is a real column on every GPU Service table but
+    ``gpu_instance_types``, where it lives inside the ``spec`` JSON and the model
+    exposes it as a hybrid instead — so one call covers all of them.
+    """
+    return func.coalesce(func.nullif(model.display_name, ""), model.name)
+
+
+def order_by_display_label(
+    order_by: Optional[List[Tuple[str, str]]],
+    label: Any,
+) -> Optional[List[Tuple[Any, str]]]:
+    """Point a ``sort_by=name`` request at the label the Name column renders.
+
+    These Name columns are ``sorter: true`` and send ``sort_by=name``, so
+    ordering on the ``name`` column sorted each column by a value it does not
+    display. Shared rather than repeated per route because it is one product
+    rule over five lists, and a rule written five times is one that drifts.
+
+    ``sortable_fields`` stays as it is: the wire name is still ``name``, because
+    it is the Name column being sorted. The consequence, accepted, is that
+    ``sort_by=name`` orders by the displayed label. Every other sortable field
+    passes through untouched, for ``paginated_by_query`` to resolve by attribute
+    lookup.
+
+    The label is expanded rather than substituted, and the result always ends on
+    a unique key, because ``LIMIT``/``OFFSET`` paging over a non-unique sort key
+    is not deterministic: rows sharing a key have engine-defined relative order,
+    which can differ between the page-1 and the page-2 query, so one row comes
+    back twice and another never. Labels collide by construction — the operator
+    stamps ``CPU-only`` on every cluster's collapsed generic pool — and ``name``
+    does not settle it either: ``gpu_instance_types`` is unique on ``snapshot``,
+    the rest only per owner, while these lists span owners and clusters. So the
+    label orders, ``name`` breaks ties meaningfully, and ``id`` guarantees a
+    total order.
+    """
+    if not order_by:
+        return order_by
+
+    translated: List[Tuple[Any, str]] = []
+    for field, direction in order_by:
+        if field == "name":
+            translated.append((label, direction))
+        translated.append((field, direction))
+
+    if not any(field == "id" for field, _ in translated):
+        translated.append(("id", translated[-1][1]))
+    return translated
 
 
 def ensure_visible(obj: Cluster, ctx: TenantContext) -> Cluster:

--- a/gpustack/schemas/gpu_instance_types.py
+++ b/gpustack/schemas/gpu_instance_types.py
@@ -5,6 +5,7 @@ from typing import ClassVar, Optional, List
 
 from pydantic import ConfigDict, BaseModel
 from sqlalchemy import UniqueConstraint, Column, Index, Integer, ForeignKey
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlmodel import SQLModel, Field
 
 from gpustack.mixins import BaseModelMixin
@@ -578,6 +579,11 @@ class GPUInstanceType(SQLModel, BaseModelMixin, table=True):
     and the snapshot stamped onto a ``GPUInstance`` at create/update time.
     """
 
+    # ``display_name`` below is a SQLAlchemy hybrid, not a field. Pydantic
+    # rejects an unannotated class attribute outright, and annotating it would
+    # make it a field with a column; this is the documented escape hatch.
+    model_config = ConfigDict(ignored_types=(hybrid_property,))
+
     __tablename__ = "gpu_instance_types"
     __table_args__ = (
         # ``snapshot`` encodes (cluster_id, name, spec), so it is the row's
@@ -670,6 +676,36 @@ class GPUInstanceType(SQLModel, BaseModelMixin, table=True):
     and ``snapshot`` doubles as ``metered_usage.sku``, so a provenance marker
     must not be able to move it.
     """
+
+    @hybrid_property
+    def display_name(self) -> Optional[str]:
+        """The mutable label, reachable the way every other GPU Service model
+        exposes it — as ``display_name`` on the model.
+
+        It is stored inside the ``spec`` JSON column rather than as a column of
+        its own, deliberately: it is the one mutable spec field and the one
+        excluded from the identity ``snapshot``. That storage decision should
+        not leak into every caller, though. The list route narrows and orders on
+        the display name exactly as its siblings do — ``fuzzy_fields`` resolves
+        the key with ``getattr(cls, key)`` for SQL and ``getattr(event.data,
+        key)`` for the watch stream, and both land here.
+
+        Not a column and not a field: it adds no migration, and ``model_dump``
+        does not carry it (the wire form stays ``spec.displayName``).
+        """
+        return self.spec.display_name if self.spec else None
+
+    @display_name.expression
+    def display_name(cls):  # noqa: N805 - SQLAlchemy hybrid expression form
+        """The SQL twin, via SQLAlchemy's generic JSON indexing.
+
+        Each dialect compiles its own extraction — ``spec ->> 'displayName'`` on
+        PostgreSQL, ``JSON_UNQUOTE(JSON_EXTRACT(...))`` on MySQL — so there is no
+        raw SQL and no dialect branching here. A row without a display name is
+        SQL NULL, which is what lets a search fall through to the ``name`` arm
+        and a sort coalesce back to ``name``.
+        """
+        return cls.spec["displayName"].as_string()
 
     def is_deleted(self) -> bool:
         """Whether the type row is soft-deleted (``deleted_at`` set)."""

--- a/tests/mixins/test_active_record_fuzzy_stream.py
+++ b/tests/mixins/test_active_record_fuzzy_stream.py
@@ -1,0 +1,87 @@
+"""A NULL column must not match the watch stream's fuzzy predicate.
+
+``_match_fuzzy_fields`` is the Python twin of the ``fuzzy_fields`` LIKE the read
+builds, and it read ``str(getattr(event.data, key, "")).lower()`` — so a NULL
+column yielded the string ``"none"``. Confirmed against PostgreSQL 17: with a
+nullable ``display_name`` in the dict, ``search=none`` returns ``[]`` from the
+read while the stream accepts every row whose display name is NULL. A user
+searching it sees an empty list, then rows appearing in it one by one as they
+change.
+
+SQL is the reference: ``NULL LIKE '%none%'`` is NULL, never true. So the key is
+skipped when the attribute is None, which can only narrow the stream toward what
+the read returns.
+
+``GPUInstanceSSHPublicKey`` stands in for the family — it is one of the routes
+that passes a nullable ``display_name`` — but the fix is in the mixin, so every
+route that passes ``fuzzy_fields`` inherits it.
+"""
+
+from gpustack.schemas.gpu_instance_ssh_public_keys import (
+    GPUInstanceSSHPublicKey,
+    GPUInstanceSSHPublicKeySpec,
+)
+from gpustack.server.bus import Event, EventType
+
+BOTH_NAMES = {"name": "none", "display_name": "none"}
+
+
+def _event(name, display_name):
+    return Event(
+        type=EventType.UPDATED,
+        data=GPUInstanceSSHPublicKey(
+            owner_principal_id=1,
+            name=name,
+            display_name=display_name,
+            spec=GPUInstanceSSHPublicKeySpec(data="ssh-ed25519 AAAA"),
+        ),
+    )
+
+
+def test_a_null_display_name_does_not_match_the_word_none():
+    # The regression: str(None) is "none", so this returned True while the read
+    # returned no rows at all.
+    event = _event("res-000002", None)
+    assert GPUInstanceSSHPublicKey._match_fuzzy_fields(event, BOTH_NAMES) is False
+
+
+def test_a_null_display_name_still_matches_by_name():
+    # Positive control — skipping the NULL key must not drop the other arm.
+    event = _event("res-000002", None)
+    assert (
+        GPUInstanceSSHPublicKey._match_fuzzy_fields(
+            event, {"name": "000002", "display_name": "000002"}
+        )
+        is True
+    )
+
+
+def test_a_set_display_name_still_matches():
+    event = _event("res-7f3a91", "Team A Pool")
+    assert (
+        GPUInstanceSSHPublicKey._match_fuzzy_fields(
+            event, {"name": "team a", "display_name": "team a"}
+        )
+        is True
+    )
+
+
+def test_an_empty_display_name_matches_nothing_but_an_empty_term():
+    # An empty string is a value, not an absence: it stays a literal match, as
+    # SQL's ``'' LIKE '%none%'`` does.
+    event = _event("res-000003", "")
+    assert GPUInstanceSSHPublicKey._match_fuzzy_fields(event, BOTH_NAMES) is False
+
+
+def test_an_id_only_payload_is_rejected():
+    # A DELETED event can carry an id-only dict. Every key resolves to None, so
+    # nothing matches — and nothing raises.
+    event = Event(type=EventType.DELETED, data={"id": 7})
+    assert GPUInstanceSSHPublicKey._match_fuzzy_fields(event, BOTH_NAMES) is False
+
+
+def test_no_fuzzy_fields_accepts_everything():
+    # The unsearched stream: an empty filter is not a filter.
+    event = _event("res-000002", None)
+    assert GPUInstanceSSHPublicKey._match_fuzzy_fields(event, None) is True
+    assert GPUInstanceSSHPublicKey._match_fuzzy_fields(event, {}) is True

--- a/tests/mixins/test_active_record_pagination.py
+++ b/tests/mixins/test_active_record_pagination.py
@@ -1,0 +1,172 @@
+"""``pagination.total`` has to count the rows ``items`` returned.
+
+``paginated_by_query`` lowers both sides of each ``fuzzy_fields`` LIKE for the
+item query and neither side for the COUNT. So a search whose case differs from
+the stored value returns the row while reporting a ``total`` that does not
+include it: the page renders items the pagination says are not there, and with
+enough rows the later pages become unreachable. Reproduced on PostgreSQL 17 as
+``items=['A10G', 'a10g-lower'] total=1``.
+
+Nothing noticed because SQLite's LIKE is ASCII-case-insensitive, which makes both
+predicates agree by accident; ``PRAGMA case_sensitive_like = ON`` gives the
+fixture engine PostgreSQL's semantics, so the defect is reproducible without a
+live database.
+
+``GPUInstanceType`` stands in for every model with the shape, as in
+``test_active_record_streaming``: the fix is in the mixin, so all the routes that
+pass ``fuzzy_fields`` inherit it.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from gpustack.schemas.gpu_instance_types import GPUInstanceType, GPUInstanceTypeSpec
+from gpustack.server.bus import Event, EventType
+
+
+@pytest_asyncio.fixture
+async def engine():
+    e = create_async_engine("sqlite+aiosqlite://")
+
+    @event.listens_for(e.sync_engine, "connect")
+    def _case_sensitive_like(dbapi_conn, _record):
+        # Without this, SQLite matches 'a10' against 'A10G' in both predicates
+        # and the divergence is invisible.
+        dbapi_conn.execute("PRAGMA case_sensitive_like = ON")
+
+    async with e.begin() as conn:
+        await conn.run_sync(GPUInstanceType.__table__.create)
+    yield e
+    await e.dispose()
+
+
+async def _seed(engine, *names):
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        for name in names:
+            row = GPUInstanceType(
+                cluster_id=1, name=name, spec=GPUInstanceTypeSpec(display_name=None)
+            )
+            row.snapshot = row.compute_snapshot()
+            session.add(row)
+        await session.commit()
+
+
+async def _page(engine, needle):
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        return await GPUInstanceType.paginated_by_query(
+            session=session, fuzzy_fields={"name": needle}
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_case_differing_search_is_counted(engine):
+    # The regression: items held the row while total said there were none.
+    await _seed(engine, "A10G")
+
+    page = await _page(engine, "a10")
+
+    assert [i.name for i in page.items] == ["A10G"]
+    assert page.pagination.total == 1
+    assert page.pagination.totalPage == 1
+
+
+@pytest.mark.asyncio
+async def test_every_matched_row_is_counted(engine):
+    # The PostgreSQL reproduction's exact shape: two rows match, only the
+    # case-identical one was counted.
+    await _seed(engine, "A10G", "a10g-lower", "H100")
+
+    page = await _page(engine, "a10")
+
+    assert sorted(i.name for i in page.items) == ["A10G", "a10g-lower"]
+    assert page.pagination.total == 2
+
+
+@pytest.mark.asyncio
+async def test_a_case_identical_search_still_counts_the_same(engine):
+    # Positive control — the case-insensitive count must not start over-counting
+    # what a case-sensitive one already got right.
+    await _seed(engine, "A10G", "a10g-lower")
+
+    page = await _page(engine, "a10g-lower")
+
+    assert [i.name for i in page.items] == ["a10g-lower"]
+    assert page.pagination.total == 1
+
+
+@pytest.mark.asyncio
+async def test_a_non_matching_search_counts_nothing(engine):
+    await _seed(engine, "A10G")
+
+    page = await _page(engine, "l40s")
+
+    assert page.items == []
+    assert (page.pagination.total, page.pagination.totalPage) == (0, 0)
+
+
+#
+# The needle is a LIKE pattern, so its wildcards have to be escaped or the search
+# means something the user did not type — and something the watch stream, which
+# does a plain Python substring test, never agreed with.
+#
+
+
+@pytest.mark.asyncio
+async def test_a_percent_matches_a_literal_percent_not_everything(engine):
+    await _seed(engine, "100%-reserved", "plain")
+
+    page = await _page(engine, "%")
+
+    assert [i.name for i in page.items] == ["100%-reserved"]
+    assert page.pagination.total == 1
+
+
+@pytest.mark.asyncio
+async def test_an_underscore_matches_a_literal_underscore_not_any_character(engine):
+    await _seed(engine, "team_a", "teamXa")
+
+    page = await _page(engine, "team_a")
+
+    assert [i.name for i in page.items] == ["team_a"]
+    assert page.pagination.total == 1
+
+
+@pytest.mark.asyncio
+async def test_a_backslash_matches_a_literal_backslash(engine):
+    # The escape character itself: escaped first, or escaping the wildcards would
+    # re-escape it and the pattern would stop meaning what it says.
+    await _seed(engine, "back\\slash", "plain")
+
+    page = await _page(engine, "back\\slash")
+
+    assert [i.name for i in page.items] == ["back\\slash"]
+    assert page.pagination.total == 1
+
+
+@pytest.mark.asyncio
+async def test_the_stream_twin_agrees_on_wildcard_characters(engine):
+    """The read and the watch stream have to accept the same rows. Before the
+    escaping they did not: SQL read ``%`` as "everything" while the stream read it
+    as the character, so a searched page listed a superset of the rows it then
+    received updates for."""
+    await _seed(engine, "100%-reserved", "team_a", "teamXa", "plain")
+    rows = [
+        GPUInstanceType(
+            cluster_id=1, name=n, spec=GPUInstanceTypeSpec(display_name=None)
+        )
+        for n in ("100%-reserved", "team_a", "teamXa", "plain")
+    ]
+
+    for needle in ("%", "_", "team_a", "plain"):
+        listed = {i.name for i in (await _page(engine, needle)).items}
+        accepted = {
+            r.name
+            for r in rows
+            if GPUInstanceType._match_fuzzy_fields(
+                Event(type=EventType.UPDATED, data=r), {"name": needle}
+            )
+        }
+        assert accepted == listed, needle

--- a/tests/routes/test_gpu_instance_types.py
+++ b/tests/routes/test_gpu_instance_types.py
@@ -19,6 +19,8 @@ from types import SimpleNamespace
 import pytest
 import pytest_asyncio
 from kubernetes_asyncio import client
+from sqlalchemy import func
+from sqlalchemy.dialects import mysql, postgresql, sqlite
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.responses import StreamingResponse
@@ -34,6 +36,7 @@ from gpustack.api.exceptions import (
 )
 from gpustack.routes import gpu_instance_types as it_routes
 from gpustack.routes import gpu_instances_helper as helper
+from gpustack.routes.gpu_instances_helper import display_name_label
 from gpustack.schemas.clusters import ClusterProvider, GpuInstanceOptions, K8sOptions
 from gpustack.schemas.gpu_instance_types import (
     GPUInstanceType,
@@ -47,6 +50,7 @@ from gpustack.schemas.gpu_instance_types import (
     GPUInstanceTypesPublic,
 )
 from gpustack.schemas.principals import OrgRole, PrincipalType
+from gpustack.server.bus import Event, EventType
 
 # SYSTEM principal → bypasses tenant filters (visible + writable everywhere).
 CTX = SimpleNamespace(
@@ -274,6 +278,11 @@ def _row(
     )
     row.snapshot = row.compute_snapshot()
     return row
+
+
+def _event(row):
+    """A bus event carrying ``row``, as the watch stream's predicates see it."""
+    return Event(type=EventType.UPDATED, data=row)
 
 
 async def _seed(engine, *rows):
@@ -518,31 +527,74 @@ async def test_search_matches_the_name_case_insensitively(monkeypatch, engine):
     out = await _list(search="a10")
 
     assert [i.name for i in out.items] == ["A10G"]
-    # CAUTION: this passes here only because the fixture engine is SQLite, whose
-    # LIKE is ASCII-case-insensitive. ``paginated_by_query`` lowers both sides for
-    # the item query but neither side for the COUNT, so on PostgreSQL this same
-    # request returns the item while reporting ``total == 0``. The assertion below
-    # therefore does NOT protect production — it would keep passing straight
-    # through that failure. It is kept as the tripwire that fires the first time
-    # this suite is run against PostgreSQL; do not read it as coverage of the
-    # count path. Recorded in the spec's Open Questions; the fix is one
-    # ``func.lower`` on each side of the count predicate in a shared mixin, which
-    # is outside this change's scope.
+    # ``total`` is asserted alongside because the item query and the COUNT build
+    # the fuzzy predicate from one shared definition, lowered on both sides — they
+    # used to be written out separately and drifted, the count losing the
+    # ``lower()`` and reporting fewer rows than the page rendered.
     assert out.pagination.total == 1
 
 
 @pytest.mark.asyncio
-async def test_search_does_not_match_the_spec_display_name(monkeypatch, engine):
-    # Only real columns are fuzzy-filterable: ``paginated_by_query`` builds its
-    # LIKE predicates with ``getattr(cls, key)``, and display_name lives inside
-    # the ``spec`` JSON column.
-    await _seed(engine, _row(1, "h100", display_name="A10G Pool"))
+async def test_search_matches_the_spec_display_name(monkeypatch, engine):
+    # #6104. The Name column renders ``spec.displayName || name``, so the string a
+    # user copies out of the table is the display name — and for an
+    # operator-derived type the two never coincide: the operator stamps the
+    # ``CPU-only`` sentinel on a collapsed generic pool whose CR name is derived
+    # from the node's features instead.
+    await _seed(
+        engine,
+        _row(1, "gpustack--generic-linux-amd64", display_name="CPU-only"),
+        _row(1, "h100"),
+    )
     _patch_db(monkeypatch, engine)
     _patch_visible_clusters(monkeypatch, _cluster(1))
 
-    out = await _list(search="a10")
+    out = await _list(search="CPU-only")
+
+    assert [i.name for i in out.items] == ["gpustack--generic-linux-amd64"]
+    assert out.pagination.total == 1
+
+
+@pytest.mark.asyncio
+async def test_search_matches_the_display_name_case_insensitively(monkeypatch, engine):
+    await _seed(
+        engine, _row(1, "gpustack--generic-linux-amd64", display_name="CPU-only")
+    )
+    _patch_db(monkeypatch, engine)
+    _patch_visible_clusters(monkeypatch, _cluster(1))
+
+    out = await _list(search="cpu-ONLY")
+
+    assert [i.name for i in out.items] == ["gpustack--generic-linux-amd64"]
+
+
+@pytest.mark.asyncio
+async def test_search_matching_neither_name_returns_an_empty_page(monkeypatch, engine):
+    # The display-name arm has to widen the match, not defeat it: a row whose
+    # display name is SQL NULL must still be excluded by a non-matching term
+    # rather than dragged in by the OR.
+    await _seed(engine, _row(1, "h100"), _row(1, "a10g", display_name="A10G Pool"))
+    _patch_db(monkeypatch, engine)
+    _patch_visible_clusters(monkeypatch, _cluster(1))
+
+    out = await _list(search="l40s")
 
     assert out.items == []
+    assert out.pagination.total == 0
+
+
+@pytest.mark.asyncio
+async def test_name_stays_an_exact_display_name_blind_match(monkeypatch, engine):
+    # ``name`` is the object's identity — DELETE / activate / deactivate / PUT all
+    # key on it, and a display name is neither unique within a cluster nor
+    # immutable. Only ``search`` widened.
+    await _seed(engine, _row(1, "h100", display_name="CPU-only"))
+    _patch_db(monkeypatch, engine)
+    _patch_visible_clusters(monkeypatch, _cluster(1))
+
+    assert [i.name for i in (await _list(name="h100")).items] == ["h100"]
+    assert (await _list(name="CPU-only")).items == []
+    assert (await _list(name="h10")).items == []
 
 
 @pytest.mark.asyncio
@@ -619,6 +671,8 @@ async def test_visible_clusters_come_from_the_cluster_visibility_filter(
 
 @pytest.mark.asyncio
 async def test_sort_by_orders_the_list(monkeypatch, engine):
+    # No display names anywhere, so the Name order falls back to ``name`` — the
+    # control for the label ordering asserted below.
     await _seed(engine, _row(1, "b"), _row(1, "a"), _row(1, "c"))
     _patch_db(monkeypatch, engine)
     _patch_visible_clusters(monkeypatch, _cluster(1))
@@ -628,6 +682,105 @@ async def test_sort_by_orders_the_list(monkeypatch, engine):
 
     assert [i.name for i in ascending.items] == ["a", "b", "c"]
     assert [i.name for i in descending.items] == ["c", "b", "a"]
+
+
+def _labels(page):
+    """What the Name column renders for each row, in the order returned."""
+    return [(i.spec.display_name or i.name) for i in page.items]
+
+
+@pytest.mark.asyncio
+async def test_sort_by_name_orders_by_the_displayed_label(monkeypatch, engine):
+    # ``sorter: true`` on the Name column sends ``sort_by=name``, so ordering by
+    # the row's ``name`` sorted the column by a value it does not display.
+    await _seed(
+        engine,
+        _row(1, "gpustack--generic-linux-amd64", display_name="CPU-only"),
+        _row(1, "zzz-handmade"),  # no display name -> falls back to name
+        _row(1, "aaa-handmade", display_name=""),  # empty -> the UI's falsy ``||``
+    )
+    _patch_db(monkeypatch, engine)
+    _patch_visible_clusters(monkeypatch, _cluster(1))
+
+    ascending = await _list(sort_by="name")
+    descending = await _list(sort_by="-name")
+
+    # Uppercase-before-lowercase is the fixture engine's binary collation, not a
+    # claim about production's: what is under test is WHICH value is ordered.
+    assert _labels(ascending) == ["CPU-only", "aaa-handmade", "zzz-handmade"]
+    assert _labels(descending) == ["zzz-handmade", "aaa-handmade", "CPU-only"]
+
+
+# ``GPUInstanceType.display_name`` is a hybrid, not a column: it reaches into the
+# ``spec`` JSON with SQLAlchemy's generic indexing, which each dialect compiles
+# its own way. Production runs PostgreSQL and MySQL; every test above runs on the
+# SQLite fixture engine, so nothing there would notice an expression that only
+# SQLite accepts.
+PRODUCTION_JSON_EXTRACTION = [
+    pytest.param(
+        postgresql.dialect(),
+        "gpu_instance_types.spec ->> 'displayName'",
+        id="postgresql",
+    ),
+    pytest.param(
+        mysql.dialect(),
+        "JSON_EXTRACT(gpu_instance_types.spec, '$.\"displayName\"')",
+        id="mysql",
+    ),
+    pytest.param(
+        sqlite.dialect(),
+        "JSON_EXTRACT(gpu_instance_types.spec, '$.\"displayName\"')",
+        id="sqlite",
+    ),
+]
+
+
+def _sql(expression, dialect):
+    return str(
+        expression.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    )
+
+
+@pytest.mark.parametrize("dialect,extraction", PRODUCTION_JSON_EXTRACTION)
+def test_the_display_name_hybrid_compiles_on_every_dialect(dialect, extraction):
+    assert extraction in _sql(GPUInstanceType.display_name, dialect)
+
+
+@pytest.mark.parametrize("dialect,extraction", PRODUCTION_JSON_EXTRACTION)
+def test_the_search_predicate_compiles_on_every_dialect(dialect, extraction):
+    # The predicate ``paginated_by_query`` builds from ``fuzzy_fields`` — the
+    # hybrid has to survive ``lower()`` on every dialect, or a differently-cased
+    # term silently stops matching on PostgreSQL, whose LIKE is case-sensitive.
+    sql = _sql(func.lower(GPUInstanceType.display_name).like("%cpu-only%"), dialect)
+
+    assert extraction in sql
+    assert sql.startswith("lower(")
+
+
+@pytest.mark.parametrize("dialect,extraction", PRODUCTION_JSON_EXTRACTION)
+def test_the_name_order_expression_compiles_on_every_dialect(dialect, extraction):
+    sql = _sql(display_name_label(GPUInstanceType), dialect)
+
+    assert extraction in sql
+    assert sql.startswith("coalesce(nullif(")
+    # The fallback arm, without which a row with no display name sorts as NULL
+    # instead of by its name.
+    assert sql.endswith(", gpu_instance_types.name)")
+
+
+def test_the_display_name_hybrid_reads_the_spec_on_an_instance():
+    # The hybrid has two implementations — SQL above, Python here — and the watch
+    # stream's ``_match_fuzzy_fields`` uses the Python one. They are asserted
+    # against each other end-to-end in the parity test further down; this pins the
+    # instance side on its own, including the absent case that lets a search fall
+    # through to ``name``.
+    assert _row(1, "h100", display_name="CPU-only").display_name == "CPU-only"
+    assert _row(1, "h100").display_name is None
+    assert _row(1, "h100", display_name="").display_name == ""
+    # Not a field and not a column: no migration, and the wire form is unchanged.
+    assert "display_name" not in GPUInstanceType.model_fields
+    assert "display_name" not in {c.name for c in GPUInstanceType.__table__.columns}
+    assert "display_name" not in _row(1, "h100", display_name="CPU-only").model_dump()
 
 
 #
@@ -1541,14 +1694,27 @@ async def test_watch_streams_from_the_bus_under_the_same_narrowing(monkeypatch, 
     _patch_visible_clusters(monkeypatch, _cluster(1), _cluster(2))
     capture = _patch_streaming(monkeypatch)
 
-    resp = await _list(watch=True, search="a10")
+    resp = await _list(watch=True, search="CPU-only")
 
     assert isinstance(resp, StreamingResponse)
     assert resp.media_type == "text/event-stream"
     assert capture["fields"] == {"deleted_at": None}
-    assert capture["fuzzy_fields"] == {"name": "a10"}
-    # Bus events never see the SQL extra_conditions, so visibility has to ride on
-    # the filter_func or the stream leaks rows the REST read hides.
+    # The search rides ``fuzzy_fields``, exactly as it does on every other GPU
+    # Service list: ``display_name`` is a hybrid, so the shared
+    # ``_match_fuzzy_fields`` resolves it on a row like any other attribute and
+    # no route-specific predicate is needed.
+    assert capture["fuzzy_fields"] == {"name": "CPU-only", "display_name": "CPU-only"}
+    matched = capture["fuzzy_fields"]
+    shown_only = _event(
+        _row(1, "gpustack--generic-linux-amd64", display_name="CPU-only")
+    )
+    assert GPUInstanceType._match_fuzzy_fields(shown_only, matched) is True
+    assert (
+        GPUInstanceType._match_fuzzy_fields(_event(_row(1, "h100")), matched) is False
+    )
+
+    # Bus events never see the SQL extra_conditions, so visibility still has to
+    # ride on the filter_func or the stream leaks rows the REST read hides.
     visible = capture["filter_func"]
     assert visible(_row(1, "a10g")) is True
     assert visible(_row(3, "a10g")) is False
@@ -1556,6 +1722,40 @@ async def test_watch_streams_from_the_bus_under_the_same_narrowing(monkeypatch, 
     # with). A bare attribute read would raise, and ``streaming`` swallows that
     # and silently ends the whole stream, so it must be handled, not trusted.
     assert visible({"id": 7}) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("search", ["cpu", "CPU-only", "handmade", "l40s", "-"])
+async def test_the_watch_filter_and_the_query_agree_on_who_matches(
+    monkeypatch, engine, search
+):
+    """``display_name`` has two implementations — the hybrid's SQL expression for
+    the read, its Python body for the stream — so the two are asserted against
+    each other rather than each against its own expectation. A drift between them
+    shows up as a searched page whose rows stop updating, or one that receives
+    rows it does not list."""
+    rows = [
+        _row(1, "gpustack--generic-linux-amd64", display_name="CPU-only"),
+        _row(1, "cpu-only-handmade"),
+        _row(1, "zzz-handmade"),  # no display name at all
+        _row(1, "aaa-handmade", display_name=""),  # empty display name
+        _row(1, "h100", display_name="NVIDIA H100"),
+    ]
+    await _seed(engine, *rows)
+    _patch_db(monkeypatch, engine)
+    _patch_visible_clusters(monkeypatch, _cluster(1))
+
+    listed = {i.name for i in (await _list(search=search)).items}
+
+    capture = _patch_streaming(monkeypatch)
+    await _list(watch=True, search=search)
+    accepted = {
+        r.name
+        for r in rows
+        if GPUInstanceType._match_fuzzy_fields(_event(r), capture["fuzzy_fields"])
+    }
+
+    assert accepted == listed
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_gpu_service_search_alignment.py
+++ b/tests/routes/test_gpu_service_search_alignment.py
@@ -1,0 +1,426 @@
+"""Every GPU Service list route searches the name it displays.
+
+All of them render ``displayName || name`` in the Name column and all of them
+send ``search=``, but each narrowed on ``name`` alone — so a display name was
+unfindable by the very string the list shows (#6104, first fixed for instance
+types, where the display name lives inside a JSON column).
+
+Here it is a real column, so it simply joins ``fuzzy_fields`` — which each route
+already hands to ``paginated_by_query`` *and* ``streaming``, so the read and the
+watch stream are covered together and no per-route predicate is needed.
+
+Parametrized over the family rather than split per module on purpose: the claim
+under test is that the family is aligned. ``ROUTES`` is hand-maintained, so
+``test_every_gpu_service_list_route_is_covered`` derives the family from the
+route modules themselves and fails when one is added without being listed here —
+otherwise a sixth route would be silently uncovered rather than caught.
+"""
+
+import importlib
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+from starlette.responses import StreamingResponse
+
+from gpustack.routes import gpu_instance_persistent_volume_types as pvt_routes
+from gpustack.routes import gpu_instance_persistent_volumes as pv_routes
+from gpustack.routes import gpu_instance_ssh_public_keys as key_routes
+from gpustack.routes import gpu_instance_templates as template_routes
+from gpustack.routes import gpu_instances as instance_routes
+from gpustack.routes.gpu_instances_helper import (
+    display_name_label,
+    order_by_display_label,
+)
+from gpustack.schemas.gpu_instance_persistent_volume_types import (
+    GPUInstancePersistentVolumeType,
+    GPUInstancePersistentVolumeTypeListParams,
+    GPUInstancePersistentVolumeTypeSpec,
+)
+from gpustack.schemas.gpu_instance_persistent_volumes import (
+    GPUInstancePersistentVolume,
+    GPUInstancePersistentVolumeListParams,
+    GPUInstancePersistentVolumeSpec,
+)
+from gpustack.schemas.gpu_instance_ssh_public_keys import (
+    GPUInstanceSSHPublicKey,
+    GPUInstanceSSHPublicKeyListParams,
+    GPUInstanceSSHPublicKeySpec,
+)
+from gpustack.schemas.gpu_instance_templates import (
+    GPUInstanceSpecTemplate,
+    GPUInstanceTemplate,
+    GPUInstanceTemplateListParams,
+)
+from gpustack.schemas.gpu_instances import (
+    GPUInstance,
+    GPUInstanceListParams,
+    GPUInstanceSpec,
+)
+from gpustack.schemas.principals import PrincipalType
+from gpustack.server.bus import Event, EventType
+
+# SYSTEM principal → bypasses every tenant filter, so each handler reduces to the
+# narrowing under test rather than to its own visibility rules.
+CTX = SimpleNamespace(
+    user=SimpleNamespace(kind=PrincipalType.SYSTEM, id=1),
+    is_platform_admin=True,
+    current_principal_id=None,
+    scoped_cluster_id=None,
+)
+
+# A user-supplied display name and an opaque generated name: the pair a user sees
+# in the table versus the one the row is keyed by. Searched with a differently
+# cased substring, so the match is case-insensitive on the display-name arm too.
+TERM = "team a"
+SHOWN = "Team A Pool"
+OPAQUE = "res-7f3a91"
+
+SEEDED = (
+    (OPAQUE, SHOWN),  # findable only by what the table shows
+    ("res-000002", None),  # no display name at all
+    ("res-000003", ""),  # empty display name
+    ("res-000004", "Team B Pool"),  # a display name that does not match
+)
+
+
+def _instance(name, display_name):
+    return GPUInstance(
+        owner_principal_id=1,
+        cluster_id=1,
+        name=name,
+        display_name=display_name,
+        spec=GPUInstanceSpec(type_="gpu", image="busybox"),
+    )
+
+
+def _template(name, display_name):
+    return GPUInstanceTemplate(
+        owner_principal_id=1,
+        name=name,
+        display_name=display_name,
+        spec=GPUInstanceSpecTemplate(image="busybox"),
+    )
+
+
+def _volume(name, display_name):
+    return GPUInstancePersistentVolume(
+        owner_principal_id=1,
+        name=name,
+        display_name=display_name,
+        persistent_volume_type_id=1,
+        spec=GPUInstancePersistentVolumeSpec(type_="nfs"),
+    )
+
+
+def _volume_type(name, display_name):
+    return GPUInstancePersistentVolumeType(
+        owner_principal_id=1,
+        name=name,
+        display_name=display_name,
+        spec=GPUInstancePersistentVolumeTypeSpec(),
+    )
+
+
+def _public_key(name, display_name):
+    return GPUInstanceSSHPublicKey(
+        owner_principal_id=1,
+        name=name,
+        display_name=display_name,
+        spec=GPUInstanceSSHPublicKeySpec(data="ssh-ed25519 AAAA"),
+    )
+
+
+ROUTES = [
+    pytest.param(
+        instance_routes,
+        instance_routes.get_gpu_instances,
+        GPUInstance,
+        GPUInstanceListParams,
+        _instance,
+        id="gpu_instances",
+    ),
+    pytest.param(
+        template_routes,
+        template_routes.get_gpu_instance_templates,
+        GPUInstanceTemplate,
+        GPUInstanceTemplateListParams,
+        _template,
+        id="gpu_instance_templates",
+    ),
+    pytest.param(
+        pv_routes,
+        pv_routes.get_gpu_instance_persistent_volumes,
+        GPUInstancePersistentVolume,
+        GPUInstancePersistentVolumeListParams,
+        _volume,
+        id="gpu_instance_persistent_volumes",
+    ),
+    pytest.param(
+        pvt_routes,
+        pvt_routes.get_gpu_instance_persistent_volume_types,
+        GPUInstancePersistentVolumeType,
+        GPUInstancePersistentVolumeTypeListParams,
+        _volume_type,
+        id="gpu_instance_persistent_volume_types",
+    ),
+    pytest.param(
+        key_routes,
+        key_routes.get_gpu_instance_ssh_public_keys,
+        GPUInstanceSSHPublicKey,
+        GPUInstanceSSHPublicKeyListParams,
+        _public_key,
+        id="gpu_instance_ssh_public_keys",
+    ),
+]
+
+FAMILY = "module,handler,model,params_cls,build"
+
+# Templates are excluded from the sort family: the page is a card view with no
+# column sorter, so it has no displayed ordering to align — its ``sort_by=name``
+# keeps meaning ``name``.
+SORTABLE_ROUTES = [p for p in ROUTES if p.id != "gpu_instance_templates"]
+
+# All labels lowercase on purpose: the claim under test is WHICH value is
+# ordered. An uppercase label would instead be testing collation, which differs
+# between this fixture engine (binary) and production PostgreSQL (en_US.utf8).
+# By ``name`` these sort res-aaa, res-bbb, res-nnn, res-zzz; by label they sort
+# "mmm pool", "nnn pool", res-aaa, res-bbb.
+SORT_SEEDED = (
+    ("res-zzz", "mmm pool"),
+    ("res-aaa", None),  # no display name -> falls back to name
+    ("res-bbb", ""),  # empty display name -> the UI's falsy ``||``
+    ("res-nnn", "nnn pool"),
+)
+SORT_BY_LABEL = ["res-zzz", "res-nnn", "res-aaa", "res-bbb"]
+
+
+@pytest_asyncio.fixture
+async def engine():
+    """Every table, not just the one under test: some handlers enrich their page
+    from a sibling table (a PV reads its attachments), and the point here is the
+    narrowing, not each route's incidental queries."""
+    e = create_async_engine("sqlite+aiosqlite://")
+    async with e.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield e
+    await e.dispose()
+
+
+async def _seed(engine, *rows):
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        for row in rows:
+            session.add(row)
+        await session.commit()
+
+
+def _patch_db(monkeypatch, module, engine):
+    monkeypatch.setattr(
+        module, "async_session", lambda: AsyncSession(engine, expire_on_commit=False)
+    )
+
+
+def _patch_streaming(monkeypatch, model):
+    capture = {}
+
+    def fake_streaming(**kwargs):
+        capture.update(kwargs)
+
+        async def _events():
+            for frame in ():
+                yield frame
+
+        return _events()
+
+    monkeypatch.setattr(model, "streaming", fake_streaming)
+    return capture
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(FAMILY, ROUTES)
+async def test_search_matches_the_display_name(
+    monkeypatch, engine, module, handler, model, params_cls, build
+):
+    await _seed(engine, *(build(*row) for row in SEEDED))
+    _patch_db(monkeypatch, module, engine)
+
+    page = await handler(CTX, params_cls(), search=TERM)
+
+    assert [i.name for i in page.items] == [OPAQUE]
+    # ``total`` is asserted alongside: a count that disagrees with the items is
+    # how this same search box reports "no results" over a page that has some.
+    assert page.pagination.total == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(FAMILY, ROUTES)
+async def test_search_still_matches_the_name(
+    monkeypatch, engine, module, handler, model, params_cls, build
+):
+    # The arm that already worked, kept as a control: a row with no display name
+    # at all must not fall out because the predicate grew a second arm. Its own
+    # term, because a k8s object name and a human label share no substring.
+    await _seed(engine, *(build(*row) for row in SEEDED))
+    _patch_db(monkeypatch, module, engine)
+
+    page = await handler(CTX, params_cls(), search="000002")
+
+    assert [i.name for i in page.items] == ["res-000002"]
+    assert page.pagination.total == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(FAMILY, ROUTES)
+async def test_search_matching_neither_name_returns_an_empty_page(
+    monkeypatch, engine, module, handler, model, params_cls, build
+):
+    # The display-name arm must widen the match, not defeat it.
+    await _seed(engine, build(OPAQUE, SHOWN), build("res-000002", None))
+    _patch_db(monkeypatch, module, engine)
+
+    page = await handler(CTX, params_cls(), search="l40s")
+
+    assert page.items == []
+    assert (page.pagination.total, page.pagination.totalPage) == (0, 0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(FAMILY, SORTABLE_ROUTES)
+async def test_sort_by_name_orders_by_the_displayed_label(
+    monkeypatch, engine, module, handler, model, params_cls, build
+):
+    # ``sorter: true`` on the Name column sends ``sort_by=name``, so ordering by
+    # the row's ``name`` sorted the column by a value it does not display.
+    await _seed(engine, *(build(*row) for row in SORT_SEEDED))
+    _patch_db(monkeypatch, module, engine)
+
+    ascending = await handler(CTX, params_cls(sort_by="name"))
+    descending = await handler(CTX, params_cls(sort_by="-name"))
+
+    assert [i.name for i in ascending.items] == SORT_BY_LABEL
+    assert [i.name for i in descending.items] == list(reversed(SORT_BY_LABEL))
+
+
+def test_only_the_name_entry_is_translated():
+    # Unit-level twin of the test above, over the shared translation itself: the
+    # other sortable fields are real columns and must reach
+    # ``paginated_by_query`` as the plain names it resolves by attribute lookup.
+    label = display_name_label(GPUInstance)
+    translated = order_by_display_label(
+        [("name", "asc"), ("cluster_id", "desc"), ("created_at", "asc")], label
+    )
+
+    # The label is expanded, not substituted: ``name`` still follows it.
+    assert translated[0] == (label, "asc")
+    assert translated[1] == ("name", "asc")
+    assert translated[2:4] == [("cluster_id", "desc"), ("created_at", "asc")]
+    assert order_by_display_label(None, label) is None
+
+
+def test_the_order_always_ends_on_a_unique_key():
+    """Without it, LIMIT/OFFSET paging is not deterministic.
+
+    Rows sharing a sort key have engine-defined relative order, which can differ
+    between the page-1 and the page-2 query — one row comes back on both pages
+    and another on neither. The label collides by construction (every cluster's
+    collapsed generic pool is stamped ``CPU-only``) and ``name`` does not settle
+    it: ``gpu_instance_types`` is unique on ``snapshot``, the others only per
+    owner, while these lists span owners and clusters.
+    """
+    label = display_name_label(GPUInstance)
+
+    assert order_by_display_label([("name", "asc")], label)[-1] == ("id", "asc")
+    assert order_by_display_label([("name", "desc")], label)[-1] == ("id", "desc")
+    # Not only the translated entry: any non-unique key has the same problem.
+    assert order_by_display_label([("created_at", "desc")], label)[-1] == ("id", "desc")
+    # Already asked for by the caller -> not appended twice.
+    assert order_by_display_label([("id", "asc")], label) == [("id", "asc")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(FAMILY, SORTABLE_ROUTES)
+async def test_rows_sharing_a_label_page_deterministically(
+    monkeypatch, engine, module, handler, model, params_cls, build
+):
+    # Walk the list one row at a time: every row must appear exactly once across
+    # the pages, even though all four share the label the column sorts on.
+    await _seed(engine, *(build(f"res-{i}", "Team A Pool") for i in range(4)))
+    _patch_db(monkeypatch, module, engine)
+
+    seen = []
+    for page in range(1, 5):
+        result = await handler(CTX, params_cls(page=page, perPage=1, sort_by="name"))
+        seen += [i.name for i in result.items]
+
+    assert sorted(seen) == ["res-0", "res-1", "res-2", "res-3"]
+
+
+def test_every_gpu_service_list_route_is_covered():
+    """The family is derived, not trusted to a hand-maintained list.
+
+    A new GPU Service list route that takes ``search`` has to be added to
+    ``ROUTES`` (or, like instance types, be covered by its own module) — without
+    this it would simply go untested, which is exactly how the divergence this
+    module guards against got in.
+    """
+    covered = {p.values[0].__name__ for p in ROUTES} | {
+        # Instance types are exercised in tests/routes/test_gpu_instance_types.py,
+        # which has the cluster-visibility scaffolding this module does not.
+        "gpustack.routes.gpu_instance_types"
+    }
+
+    family = set()
+    for path in sorted(Path(instance_routes.__file__).parent.glob("gpu_instance*.py")):
+        module = importlib.import_module(f"gpustack.routes.{path.stem}")
+        for name, obj in vars(module).items():
+            if not (name.startswith("get_gpu") and inspect.iscoroutinefunction(obj)):
+                continue
+            if "search" in inspect.signature(obj).parameters:
+                family.add(module.__name__)
+
+    assert (
+        family <= covered
+    ), f"GPU Service list routes with no coverage: {family - covered}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(FAMILY, SORTABLE_ROUTES)
+async def test_the_other_sortable_fields_are_untouched(
+    monkeypatch, engine, module, handler, model, params_cls, build
+):
+    # Only the Name column renders a label; the rest are real columns and must
+    # reach ``paginated_by_query`` as the plain names it resolves by attribute
+    # lookup.
+    await _seed(engine, *(build(*row) for row in SORT_SEEDED))
+    _patch_db(monkeypatch, module, engine)
+
+    page = await handler(CTX, params_cls(sort_by="id"))
+
+    assert [i.name for i in page.items] == [name for name, _ in SORT_SEEDED]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(FAMILY, ROUTES)
+async def test_the_watch_stream_narrows_on_both_names(
+    monkeypatch, engine, module, handler, model, params_cls, build
+):
+    """Without this a searched page keeps its rows but stops being told about
+    their changes, which reads as a stale table rather than a missing filter."""
+    _patch_db(monkeypatch, module, engine)
+    capture = _patch_streaming(monkeypatch, model)
+
+    resp = await handler(CTX, params_cls(watch=True), search=TERM)
+
+    assert isinstance(resp, StreamingResponse)
+    assert capture["fuzzy_fields"] == {"name": TERM, "display_name": TERM}
+    # ``_match_fuzzy_fields`` ORs the keys, so the display-name arm is what
+    # carries a row the name arm cannot match.
+    shown_only = Event(type=EventType.UPDATED, data=build(OPAQUE, SHOWN))
+    unrelated = Event(type=EventType.UPDATED, data=build("res-000002", "Team B Pool"))
+    assert model._match_fuzzy_fields(shown_only, capture["fuzzy_fields"]) is True
+    assert model._match_fuzzy_fields(unrelated, capture["fuzzy_fields"]) is False


### PR DESCRIPTION
Refer to issue:
- #6104

Every GPU Service list renders `display_name || name` in its Name column, and every one of them sends `search=`, but each narrowed on `name` alone. For an operator-derived instance type the two never coincide — the operator stamps the `CPU-only` sentinel on a collapsed generic pool whose CR name is `gpustack--generic-linux-amd64`, derived from the node's features — so typing the `CPU-only` the table plainly shows emptied it. The same split ran through the sort: the column is `sorter: true` and sends `sort_by=name`, ordering it by a value it does not display.

Six routes were affected, not one: GPU instances, templates, storage, storage types and SSH public keys have the same rendering rule and the same `name`-only narrowing.

Those five keep the display name in a column, so it simply joins `fuzzy_fields`, which each route already hands to both `paginated_by_query` and `streaming` — the read and the watch stream are covered together.

Instance types keep theirs inside the `spec` JSON, deliberately: it is the one mutable spec field and the one excluded from the identity `snapshot`, which doubles as `metered_usage.sku`. Rather than making that route special, the model exposes `display_name` as a SQLAlchemy hybrid — a JSON extraction for SQL, a read of `spec.display_name` for the stream — so the route reads exactly like its siblings. It is neither a column nor a field: no migration, and `model_dump` and the public schema are unchanged, so the wire form stays `spec.displayName`.

Promoting it to a real column was rejected: it would cost a migration, a controller projection change and a backfill of already-projected rows, and would move a mutable non-identity field into the row's column set. The hybrid buys the same uniformity as a read accessor over the existing storage.

The Name column now orders by `coalesce(nullif(display_name, ''), name)`, mirroring the UI's falsy `||` so an absent or empty display name falls back to the name. Exposing `spec.display_name` as a new sortable field instead would sort rows without one as NULL rather than falling back, so the order still would not match the rendered column. The rule is shared from the GPU Service route helper rather than repeated per route, since a rule written five times is one that drifts. Templates are left out of it: a card view with no column sorter has no displayed ordering to align.

The exact `name` parameter is untouched. It is the object's identity, which `DELETE`, `PUT`, activate and deactivate all key on, and which `use-gpu-type-display-name.ts` maps recorded type names through, while a display name is neither unique within a cluster nor immutable. Only `search` widened; the UI never sends `name=` here anyway.

Three shared-mixin defects surfaced along the way, each of which made a list disagree with itself, and each fixed in the first commit so it can be reverted alone:

- The COUNT had lost the `lower()` the item query applies to both sides, so on any database whose LIKE is case-sensitive a term differing in case from the stored value returned rows that `total` did not count — a page rendering items its own pagination said were not there, and later pages unreachable. Reproduced on PostgreSQL 17 as `items=['A10G','a10g-lower']` with `total=1`. The predicate is now built once and shared, the way `extra_conditions` already was; rebuilding it separately is what let the two drift.
- The watch stream's twin stringified a NULL column, so `str(None)` made every row with an unset display name match a search for the word `none` — a term the read answers with nothing, leaving those rows to appear one by one in an empty list as they changed.
- `%` and `_` reached LIKE unescaped, so `team_a` matched `teamXa` and a lone `%` matched every row, while the stream matched both literally — a searched page listing a superset of the rows it then received updates for.

All three converge the SQL onto the literal, case-insensitive reading the watch stream already had. They are pre-existing and reach the 21 routes that pass `fuzzy_fields`; on MySQL, whose default collation is case-insensitive, the count divergence was never observable.

API surface:

    GET /v2/gpu-instance-types?search=<term>     # matches spec.displayName or metadata.name
    GET /v2/gpu-instance-types?sort_by=name      # orders by the displayed label
    # and the same for gpu-instances, instance-templates, persistent-volumes,
    # persistent-volume-types and ssh-public-keys

`sort_by=name` consequently orders by the displayed label rather than the stored name, on the five lists whose Name column carries a sorter — the honest reading, since `name` is the list's Name column, and those pages are its only consumers that sort. `sortable_fields` is unchanged, so the wire name stays `name`.

Verification beyond the suite: the search and sort predicates, plus the read-vs-watch-stream agreement, were executed against PostgreSQL 17.10 and MySQL 8.4.11 with mocked rows, over empty strings, SQL NULL and empty display names, LIKE metacharacters, unicode labels and injection payloads. `' OR 1=1 --`, `'; DROP TABLE gpu_instance_types; --` and friends each return zero rows and leave the table intact, while a quote stored in a value (`O'Brien Pool`) still matches literally — the needle is a bound parameter throughout.
