### PR TITLE
fix(clusters): restore the k8s data dir volume mount on upgraded clusters

### DIFF
--- a/gpustack/k8s/daemonset.jinja
+++ b/gpustack/k8s/daemonset.jinja
@@ -160,13 +160,11 @@ spec:
               mountPath: /usr/local/PPU_SDK
               readOnly: true
             {%- endif %}
-            {%- if config.k8s_options and config.k8s_options.volume_mounts %}
-            {%- for vm in config.k8s_options.volume_mounts %}
+            {%- for vm in config.volume_mounts %}
             - name: {{ vm.name | to_yaml }}
               mountPath: {{ vm.mount_path | to_yaml }}
               readOnly: {{ vm.read_only | lower }}
             {%- endfor %}
-            {%- endif %}
           ports:
             - name: api
               containerPort: {{ config.worker_port }}
@@ -251,12 +249,10 @@ spec:
             path: /usr/local/PPU_SDK
             type: DirectoryOrCreate
         {%- endif %}
-        {%- if config.k8s_options and config.k8s_options.volume_mounts %}
-        {%- for vm in config.k8s_options.volume_mounts %}
+        {%- for vm in config.volume_mounts %}
         - name: {{ vm.name | to_yaml }}
           {{ vm.volume_source | to_yaml | indent(10) }}
         {%- endfor %}
-        {%- endif %}
       {%- if config.multi_vendor_mode %}
       affinity:
         podAntiAffinity:

--- a/gpustack/k8s/manifest_template.py
+++ b/gpustack/k8s/manifest_template.py
@@ -8,7 +8,12 @@ from pydantic import BaseModel, ConfigDict, computed_field
 from gpustack import __operator_version__
 from gpustack.gpu_instances.cluster_apis_util import get_namespace_name
 from gpustack.utils.compat_importlib import pkg_resources
-from gpustack.schemas.clusters import ClusterRegistrationTokenPublic, K8sOptions
+from gpustack.schemas.clusters import (
+    ClusterRegistrationTokenPublic,
+    K8sOptions,
+    K8sVolumeMount,
+    ensure_data_dir_mount,
+)
 from gpustack_runtime.detector import ManufacturerEnum
 
 
@@ -153,6 +158,23 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
         if self.k8s_options and self.k8s_options.namespace:
             return self.k8s_options.namespace
         return _DEFAULT_CLUSTER_NAMESPACE
+
+    @computed_field
+    @property
+    def volume_mounts(self) -> List[K8sVolumeMount]:
+        """
+        Pod volumes / container volumeMounts applied to every worker DaemonSet,
+        with the reserved gpustack data-dir mount guaranteed present and first.
+
+        The templates read this instead of ``k8s_options.volume_mounts`` so the
+        data dir can never be rendered away: a cluster created before the mount
+        became configurable (v2.2.0) holds no ``volumeMounts`` at all, and the
+        DaemonSet would otherwise come out with no persistent
+        ``/var/lib/gpustack`` — worker data lost on every pod restart, silently.
+        Only injects; the persisted shape is normalized by the routes layer.
+        """
+        k8s_options = self.k8s_options or K8sOptions()
+        return ensure_data_dir_mount(k8s_options.volume_mounts)
 
     @computed_field
     @property

--- a/gpustack/migrations/versions/2026_08_28_1000-e4a1c8b7d0f3_backfill_k8s_data_dir_volume_mount.py
+++ b/gpustack/migrations/versions/2026_08_28_1000-e4a1c8b7d0f3_backfill_k8s_data_dir_volume_mount.py
@@ -1,0 +1,184 @@
+"""backfill the gpustack data dir volume mount on Kubernetes clusters
+
+Before v2.2.0 the worker DaemonSet hardcoded its ``/var/lib/gpustack`` volume.
+v2.2.0 made the host path configurable by rendering it from
+``clusters.k8s_options.volumeMounts`` instead, but nothing backfilled the entry
+for clusters that already existed, so an upgraded cluster is left with no
+``volumeMounts`` at all: its worker DaemonSets render with no persistent data
+dir (worker data lost on every pod restart), and — until the route layer
+started synthesizing the mount — every edit of the cluster was rejected for the
+missing entry.
+
+Backfilled with the pre-v2.2.0 host path, ``/var/lib/gpustack``, so the data
+already on the nodes is picked up as is rather than the worker starting over in
+a fresh directory.
+
+Revision ID: e4a1c8b7d0f3
+Revises: b7e2c4d15a80
+Create Date: 2026-08-28 10:00:00.000000
+
+"""
+import json
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e4a1c8b7d0f3'
+down_revision: Union[str, None] = 'b7e2c4d15a80'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Frozen copies of the reserved-mount constants in schemas/clusters.py. A
+# migration describes one moment in the schema's history, so it must not follow
+# the live values if those are ever changed.
+DATA_DIR_MOUNT_NAME = 'gpustack-data-dir'
+DATA_DIR_MOUNT_PATH = '/var/lib/gpustack'
+DATA_DIR_HOST_PATH = '/var/lib/gpustack'
+
+clusters_jsonable = sa.table(
+    'clusters',
+    sa.column('id', sa.Integer),
+    sa.column('k8s_options', sa.JSON),
+)
+
+
+def _as_dict(value) -> dict:
+    """Read a JSON column that may come back as text, a dict, or NULL."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value) if value else {}
+        except json.JSONDecodeError:
+            value = {}
+    # Covers None, the JSON literal "null" (which parses to None), and any
+    # other non-dict shape the column might somehow be holding.
+    if not isinstance(value, dict):
+        return {}
+    return value
+
+
+def _either(mapping: dict, camel: str, snake: str):
+    """Read a key that may be stored under either form.
+
+    The live column is written by ``pydantic_column_type``, which encodes by
+    alias, so camelCase is what is there today; a migration outlives that
+    guarantee, and reading both costs nothing. Every key form has to be covered
+    on every level of the mount, not just the top one — a partial reading would
+    silently answer "no" for a shape it was meant to recognize.
+    """
+    value = mapping.get(camel)
+    return value if value is not None else mapping.get(snake)
+
+
+def _is_backfilled_data_dir_mount(mount) -> bool:
+    """Whether a mount is exactly what :func:`backfilled` writes."""
+    if not isinstance(mount, dict):
+        return False
+    volume_source = _either(mount, 'volumeSource', 'volume_source') or {}
+    host_path = _either(volume_source, 'hostPath', 'host_path') or {}
+    return (
+        mount.get('name') == DATA_DIR_MOUNT_NAME
+        and _either(mount, 'mountPath', 'mount_path') == DATA_DIR_MOUNT_PATH
+        and host_path.get('path') == DATA_DIR_HOST_PATH
+    )
+
+
+def _volume_mounts(k8s_options: dict) -> list:
+    """The stored volume mounts, under either key form."""
+    for key in ('volumeMounts', 'volume_mounts'):
+        mounts = k8s_options.get(key)
+        if isinstance(mounts, list):
+            return mounts
+    return []
+
+
+def backfilled(k8s_options) -> Union[dict, None]:
+    """The cluster's ``k8s_options`` with the data-dir mount in the reserved slot.
+
+    None when nothing needs writing. An empty ``volumeMounts`` is the signal to
+    backfill: the field did not exist before v2.2.0, and every write since then
+    puts the data dir at index 0, so a non-empty list already has it — and its
+    host path may have been set deliberately (or backfilled by hand with the
+    workaround for the issue this migration fixes).
+    """
+    k8s_options = _as_dict(k8s_options)
+    mounts = _volume_mounts(k8s_options)
+    if mounts:
+        return None
+
+    # The column is written by ``pydantic_column_type``, which encodes by
+    # alias, so the camelCase key is the one already in the row.
+    k8s_options.pop('volume_mounts', None)
+    k8s_options['volumeMounts'] = [
+        {
+            'name': DATA_DIR_MOUNT_NAME,
+            'mountPath': DATA_DIR_MOUNT_PATH,
+            'readOnly': False,
+            'volumeSource': {
+                'hostPath': {
+                    'path': DATA_DIR_HOST_PATH,
+                    'type': 'DirectoryOrCreate',
+                }
+            },
+        }
+    ]
+    return k8s_options
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    rows = conn.execute(
+        sa.text(
+            "SELECT id, k8s_options FROM clusters WHERE provider = 'Kubernetes'"
+        )
+    ).fetchall()
+
+    for cluster_id, k8s_options in rows:
+        updated = backfilled(k8s_options)
+        if updated is None:
+            continue
+
+        conn.execute(
+            sa.update(clusters_jsonable)
+            .where(clusters_jsonable.c.id == cluster_id)
+            .values(k8s_options=updated)
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    rows = conn.execute(
+        sa.text(
+            "SELECT id, k8s_options FROM clusters WHERE provider = 'Kubernetes'"
+        )
+    ).fetchall()
+
+    for cluster_id, k8s_options in rows:
+        k8s_options = _as_dict(k8s_options)
+        mounts = _volume_mounts(k8s_options)
+        if not mounts:
+            continue
+
+        # Only drop the exact entry this migration would have written, in the
+        # slot it would have written it. One pointing at a different host path
+        # was configured by the user, and the pre-upgrade code renders it fine —
+        # it is the *absence* of the mount that the older server tolerated, not
+        # a foreign host path.
+        if not _is_backfilled_data_dir_mount(mounts[0]):
+            continue
+
+        kept = mounts[1:]
+        k8s_options.pop('volume_mounts', None)
+        if kept:
+            k8s_options['volumeMounts'] = kept
+        else:
+            k8s_options.pop('volumeMounts', None)
+
+        conn.execute(
+            sa.update(clusters_jsonable)
+            .where(clusters_jsonable.c.id == cluster_id)
+            .values(k8s_options=k8s_options or None)
+        )

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -57,6 +57,11 @@ from gpustack.schemas.clusters import (
     WorkerPool,
     CloudOptions,
     K8sOptions,
+    DATA_DIR_MOUNT_NAME,
+    DATA_DIR_MOUNT_PATH,
+    claims_data_dir,
+    mount_host_path,
+    normalize_data_dir_mount,
     is_gpu_service_cluster,
     is_gpu_service_k8s_options,
 )
@@ -510,23 +515,9 @@ def create_update_check(
     if provider == ClusterProvider.Shuihua:
         apply_shuihua_defaults(input, existing)
         check_shuihua_requirements(input, existing)
-    if provider == ClusterProvider.Kubernetes:
-        # check for volume mounts (now nested under k8s_options)
-        volume_mounts = (
-            input.k8s_options.volume_mounts if input.k8s_options is not None else None
-        )
-        if volume_mounts is None or len(volume_mounts) < 1:
-            # at least one volume mount is required, and the default one is for gpustack data dir.
-            raise InvalidException(
-                message="At least one k8s_options.volume_mount is required, and the default one is for gpustack data dir."
-            )
-        if (
-            volume_mounts[0].volume_source is None
-            or volume_mounts[0].volume_source.host_path is None
-        ):
-            raise InvalidException(
-                message="The first k8s_options.volume_mount must be for gpustack data dir with hostPath volume source."
-            )
+    # The Kubernetes data-dir volume mount is checked by
+    # ``enforce_data_dir_mounts``, after it has normalized the value — see the
+    # note there on why it can't be validated off the request body.
 
 
 def hoist_system_default_container_registry(
@@ -601,17 +592,98 @@ async def check_cluster_purpose_switch(
 
 def enforce_data_dir_mounts(input: Union[ClusterCreate, ClusterUpdate]):
     """
-    Assuming the first item of k8s_options.volume_mounts is for gpustack data dir,
-    enforce that it is always present and has the correct settings.
+    Require the reserved gpustack data-dir volume mount at index 0 of the value
+    about to be persisted, and own every field of it except the host path.
+
+    Index 0 is the whole locating rule, the same one the UI enforces on its
+    side. The entry there is *verified*, not adopted: an unrelated mount in the
+    reserved slot is refused rather than quietly rewritten into the data dir,
+    which is what the workaround for #6145 ("add some mount to get past the
+    validation") would otherwise have run into.
+
+    A submitted ``k8s_options`` whose slot is empty is refused rather than
+    completed. Every write path goes through here and the backfill migration
+    fixed the historical rows, so the mount is present on every Kubernetes
+    cluster by construction — a submission missing it means the caller built the
+    payload wrong, and since the column is replaced wholesale it is probably
+    dropping ``gpuInstanceOptions`` / ``namespace`` in the same breath. Refusing
+    surfaces that; synthesizing the entry would answer the request correctly and
+    swallow the anomaly.
+
+    What is *not* refused is leaving ``k8s_options`` out of an update
+    altogether: that is how the API says "unchanged" for every other field, and
+    it used to be the second half of this check's deadlock.
     """
-    # the first volume must exist as it's validated in create_update_check, and it must be for gpustack data dir, so we enforce it here.
-    data_dir_mount = input.k8s_options.volume_mounts[0]
-    data_dir_mount.name = "gpustack-data-dir"
-    data_dir_mount.mount_path = "/var/lib/gpustack"
-    data_dir_mount.read_only = False
-    data_dir_mount.volume_source.host_path.type = "DirectoryOrCreate"
-    data_dir_mount.volume_source.config_map = None
-    data_dir_mount.volume_source.persistent_volume_claim = None
+    is_update = not isinstance(input, ClusterCreate)
+    if is_update and "k8s_options" not in input.model_fields_set:
+        # The caller didn't touch the field. ``ActiveRecord.update`` only assigns
+        # keys in ``model_fields_set``, so the stored value — namespace,
+        # gpuInstanceOptions and all — stands. Nothing to check, and touching
+        # ``input.k8s_options`` here would turn "leave alone" into "overwrite".
+        return
+
+    if input.k8s_options is None:
+        raise InvalidException(
+            message=(
+                "k8s_options is required for a Kubernetes cluster, including a "
+                f"volumeMounts entry for the gpustack data dir ({DATA_DIR_MOUNT_PATH}). "
+                "Omit the field entirely to leave the stored options unchanged."
+            )
+        )
+
+    mounts = input.k8s_options.volume_mounts or []
+    if not mounts:
+        raise InvalidException(
+            message=(
+                "The first k8s_options.volumeMounts entry is reserved for the "
+                f"gpustack data dir ({DATA_DIR_MOUNT_PATH}) and is required. "
+                "Send back the entry the cluster already carries, or omit "
+                "k8s_options entirely to leave the stored options unchanged."
+            )
+        )
+    if not claims_data_dir(mounts[0]):
+        raise InvalidException(
+            message=(
+                "The first k8s_options.volumeMounts entry is reserved for the "
+                f"gpustack data dir, so it must be named {DATA_DIR_MOUNT_NAME} "
+                f"or mounted at {DATA_DIR_MOUNT_PATH}; got "
+                f"'{mounts[0].name}' at '{mounts[0].mount_path}'. Move that "
+                "mount after the data dir entry."
+            )
+        )
+    if mount_host_path(mounts[0]) is None:
+        raise InvalidException(
+            message=(
+                f"The {DATA_DIR_MOUNT_PATH} volume mount is reserved for the "
+                "gpustack data dir and must use a hostPath volume source."
+            )
+        )
+    if any(claims_data_dir(m) for m in mounts[1:]):
+        raise InvalidException(
+            message=(
+                f"Only the first k8s_options.volumeMounts entry may use the "
+                f"name {DATA_DIR_MOUNT_NAME} or the mount path "
+                f"{DATA_DIR_MOUNT_PATH}; both are reserved for the gpustack "
+                "data dir. A second entry claiming either would render a "
+                "DaemonSet Kubernetes rejects."
+            )
+        )
+
+    normalize_data_dir_mount(input.k8s_options)
+
+    # Post-condition on the shape about to be persisted, so a normalization bug
+    # surfaces here rather than as a worker DaemonSet rendered without a
+    # persistent data dir.
+    persisted = input.k8s_options.volume_mounts[0]
+    if (
+        persisted.name != DATA_DIR_MOUNT_NAME
+        or persisted.mount_path != DATA_DIR_MOUNT_PATH
+        or persisted.read_only
+        or mount_host_path(persisted) is None
+    ):
+        raise InternalServerErrorException(
+            message="Failed to resolve the gpustack data dir volume mount."
+        )
 
 
 @router.post("", response_model=ClusterPublic, response_model_exclude_none=True)

--- a/gpustack/schemas/clusters.py
+++ b/gpustack/schemas/clusters.py
@@ -283,8 +283,10 @@ class K8sOptions(BaseModel):
         alias="volumeMounts",
         description=(
             "Pod spec volumes and volumeMounts applied to every worker "
-            "DaemonSet. The first entry is reserved for the gpustack data "
-            "dir; the route layer enforces that invariant."
+            "DaemonSet. The first entry is reserved for the gpustack data dir "
+            "and is required whenever k8s_options is submitted; the server owns "
+            "every field of it but the hostPath it points at, overwriting the "
+            "name, mountPath and readOnly it is sent with."
         ),
     )
     operator_image: Optional[str] = PydanticField(
@@ -357,6 +359,103 @@ def is_gpu_service_cluster(cluster: "Cluster") -> bool:
     which carries the invariant and the reason for the shape.
     """
     return is_gpu_service_k8s_options(cluster.k8s_options)
+
+
+# The gpustack data dir volume mount is reserved and server-owned: it lives at
+# index 0 of ``volume_mounts``, the worker container always reads/writes its
+# data dir at DATA_DIR_MOUNT_PATH, and the entry always carries the reserved
+# name. Only the *host* path is the caller's to choose.
+#
+# Index 0 is the single locating rule, shared with the UI, which renders that
+# row with its name / mountPath / readOnly / source type locked and only the
+# host path editable. Nothing here searches the list for the data dir: one
+# definition of "which entry is it", asserted in both halves of the product.
+DATA_DIR_MOUNT_NAME = "gpustack-data-dir"
+DATA_DIR_MOUNT_PATH = "/var/lib/gpustack"
+# Host path the worker DaemonSet hardcoded before the mount became
+# configurable (v2.2.0). Clusters created back then hold their data here, so
+# it has to stay the default or an upgraded cluster would silently start over
+# on a fresh directory.
+DEFAULT_DATA_DIR_HOST_PATH = "/var/lib/gpustack"
+
+
+def claims_data_dir(volume_mount: K8sVolumeMount) -> bool:
+    """Whether a mount claims the reserved data dir, by name or mount path.
+
+    A *check*, not a locator: the data dir is always index 0. This answers two
+    questions about a submission — does the entry in the reserved slot actually
+    look like the data dir (rather than an unrelated mount the caller happened
+    to send first, which must not be silently rewritten into the data dir), and
+    is some other entry trying to claim the reserved name or path.
+    """
+    return (
+        volume_mount.name == DATA_DIR_MOUNT_NAME
+        or volume_mount.mount_path == DATA_DIR_MOUNT_PATH
+    )
+
+
+def mount_host_path(volume_mount: Optional[K8sVolumeMount]) -> Optional[str]:
+    """The host path a mount points at, or None if it isn't a hostPath mount."""
+    if volume_mount is None or volume_mount.volume_source is None:
+        return None
+    if volume_mount.volume_source.host_path is None:
+        return None
+    return volume_mount.volume_source.host_path.path or None
+
+
+def build_data_dir_mount(host_path: Optional[str] = None) -> K8sVolumeMount:
+    """The canonical data-dir mount for a host path."""
+    return K8sVolumeMount(
+        name=DATA_DIR_MOUNT_NAME,
+        mount_path=DATA_DIR_MOUNT_PATH,
+        read_only=False,
+        volume_source=VolumeSource(
+            host_path=HostPathVolumeSource(
+                path=host_path or DEFAULT_DATA_DIR_HOST_PATH,
+                type="DirectoryOrCreate",
+            )
+        ),
+    )
+
+
+def ensure_data_dir_mount(
+    volume_mounts: Optional[List[K8sVolumeMount]],
+) -> List[K8sVolumeMount]:
+    """Return the list with the reserved slot filled, defaulting the host path.
+
+    An empty list means the row predates the mount being configurable
+    (``volume_mounts`` did not exist before v2.2.0, and every write since then
+    goes through :func:`normalize_data_dir_mount`, so a non-empty list always
+    holds the data dir at index 0). This is the *render*-side backstop for such
+    a row: the DaemonSet template has no fallback of its own, so without this
+    it would render with no persistent data dir — worker data lost on every pod
+    restart, with nobody to report it to. A list that is already populated is
+    passed through untouched; rewriting stored values is the persist path's job.
+    """
+    mounts = list(volume_mounts or [])
+    if mounts:
+        return mounts
+    return [build_data_dir_mount()]
+
+
+def normalize_data_dir_mount(k8s_options: "K8sOptions") -> None:
+    """Rewrite the reserved slot of ``k8s_options.volume_mounts`` in place.
+
+    Index 0 is replaced with the canonical mount carrying its own host path:
+    name, mountPath, readOnly and the hostPath type are the server's, so
+    whatever the caller sent for them is dropped. The rest of the list is left
+    exactly as submitted — the caller's own mounts, in the caller's order.
+
+    Callers validate the slot first (the route layer refuses a submission whose
+    index 0 is missing, is not the data dir, or is not a hostPath mount), so an
+    absent host path falls back to :data:`DEFAULT_DATA_DIR_HOST_PATH` rather
+    than being an error here.
+    """
+    mounts = k8s_options.volume_mounts or []
+    k8s_options.volume_mounts = [
+        build_data_dir_mount(mount_host_path(mounts[0]) if mounts else None),
+        *mounts[1:],
+    ]
 
 
 class CloudOptions(BaseModel):

--- a/tests/k8s/test_template_render.py
+++ b/tests/k8s/test_template_render.py
@@ -11,6 +11,9 @@ from gpustack.k8s.manifest_template import (
 from gpustack.schemas.clusters import ClusterRegistrationTokenPublic
 from gpustack.schemas.clusters import (
     Cluster,
+    DATA_DIR_MOUNT_NAME,
+    DATA_DIR_MOUNT_PATH,
+    DEFAULT_DATA_DIR_HOST_PATH,
     GpuInstanceOptions,
     HostPathVolumeSource,
     ImageCredential,
@@ -88,13 +91,16 @@ def test_unknown_runtime_renders_cpu_daemonset_only():
 
 
 def test_cpu_daemonset_no_vendor_volumes():
-    """CPU DaemonSet has no vendor-specific volumeMounts or volumes."""
+    """CPU DaemonSet has no vendor-specific volumeMounts or volumes.
+
+    The reserved data-dir mount is always there — it is not vendor-specific.
+    """
     docs = _render_docs()
     ds = _daemonsets(docs)[WORKER_DS_BASENAME]
     mounts = _pod_spec(ds)["containers"][0].get("volumeMounts") or []
-    assert mounts == []
+    assert [m["name"] for m in mounts] == [DATA_DIR_MOUNT_NAME]
     volumes = _pod_spec(ds).get("volumes") or []
-    assert volumes == []
+    assert [v["name"] for v in volumes] == [DATA_DIR_MOUNT_NAME]
 
 
 def test_cpu_daemonset_no_runtime_class():
@@ -150,6 +156,7 @@ def test_single_gpu_runtime_ascend_keeps_vendor_volume_mounts():
     assert {m["name"] for m in mounts} == {
         "gpustack-ascend-driver",
         "gpustack-ascend-toolkit",
+        DATA_DIR_MOUNT_NAME,
     }
 
 
@@ -489,6 +496,67 @@ def test_user_volume_mounts_flow_through_via_k8s_options():
         assert "data-dir" in volume_names
 
 
+def _data_dir_volumes(ds):
+    return [
+        v
+        for v in (_pod_spec(ds).get("volumes") or [])
+        if v["name"] == DATA_DIR_MOUNT_NAME
+    ]
+
+
+def test_data_dir_mount_rendered_without_any_k8s_options():
+    """A cluster with no volumeMounts still gets a persistent data dir.
+
+    Clusters created before the mount became configurable (v2.2.0) hold no
+    volumeMounts at all; rendering them without the data-dir volume would lose
+    worker data on every pod restart.
+    """
+    docs = _render_docs(runtimes=[ManufacturerEnum.NVIDIA])
+    dses = _daemonsets(docs)
+    assert dses
+    for ds in dses.values():
+        mounts = _pod_spec(ds)["containers"][0]["volumeMounts"]
+        data_dir = next(m for m in mounts if m["name"] == DATA_DIR_MOUNT_NAME)
+        assert data_dir["mountPath"] == DATA_DIR_MOUNT_PATH
+        assert data_dir["readOnly"] is False
+        # The host path, not the container mount path — they carry the same
+        # value today but are different things.
+        assert _data_dir_volumes(ds) == [
+            {
+                "name": DATA_DIR_MOUNT_NAME,
+                "hostPath": {
+                    "path": DEFAULT_DATA_DIR_HOST_PATH,
+                    "type": "DirectoryOrCreate",
+                },
+            }
+        ]
+
+
+def test_data_dir_mount_keeps_a_configured_host_path():
+    """A stored data-dir mount is rendered as is, not replaced by the default."""
+    values = K8sOptions(
+        volume_mounts=[
+            K8sVolumeMount(
+                name=DATA_DIR_MOUNT_NAME,
+                mount_path=DATA_DIR_MOUNT_PATH,
+                volume_source=VolumeSource(
+                    host_path=HostPathVolumeSource(
+                        path="/mnt/data/gpustack", type="DirectoryOrCreate"
+                    )
+                ),
+            )
+        ]
+    )
+    docs = _render_docs(k8s_options=values)
+    ds = _daemonsets(docs)[WORKER_DS_BASENAME]
+    assert _data_dir_volumes(ds) == [
+        {
+            "name": DATA_DIR_MOUNT_NAME,
+            "hostPath": {"path": "/mnt/data/gpustack", "type": "DirectoryOrCreate"},
+        }
+    ]
+
+
 def test_multi_vendor_volume_mounts_applied_only_to_owning_vendor():
     docs = _render_docs(
         runtimes=[ManufacturerEnum.ASCEND, ManufacturerEnum.AMD],
@@ -501,13 +569,17 @@ def test_multi_vendor_volume_mounts_applied_only_to_owning_vendor():
             for m in (_pod_spec(ds)["containers"][0].get("volumeMounts") or [])
         }
 
-    # CPU DS has no vendor-specific mounts.
-    assert mount_names(dses[WORKER_DS_BASENAME]) == set()
+    # CPU DS has no vendor-specific mounts (the data dir is not vendor-specific).
+    assert mount_names(dses[WORKER_DS_BASENAME]) == {DATA_DIR_MOUNT_NAME}
     # Each GPU DS has its own vendor mounts.
-    assert mount_names(dses[f"{WORKER_DS_BASENAME}-amd"]) == {"gpustack-amd-driver"}
+    assert mount_names(dses[f"{WORKER_DS_BASENAME}-amd"]) == {
+        "gpustack-amd-driver",
+        DATA_DIR_MOUNT_NAME,
+    }
     assert mount_names(dses[f"{WORKER_DS_BASENAME}-ascend"]) == {
         "gpustack-ascend-driver",
         "gpustack-ascend-toolkit",
+        DATA_DIR_MOUNT_NAME,
     }
 
 

--- a/tests/migrations/test_backfill_k8s_data_dir_volume_mount.py
+++ b/tests/migrations/test_backfill_k8s_data_dir_volume_mount.py
@@ -1,0 +1,195 @@
+"""Offline tests for the data-dir volume mount backfill migration.
+
+No database: the merge the migration applies per cluster row is a pure function
+over the ``k8s_options`` JSON column, so it is checked directly against the
+shapes that column is known to hold (MySQL hands back text, PostgreSQL a dict).
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from gpustack.schemas.clusters import (
+    DATA_DIR_MOUNT_NAME,
+    DATA_DIR_MOUNT_PATH,
+    DEFAULT_DATA_DIR_HOST_PATH,
+    K8sOptions,
+)
+
+MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "gpustack"
+    / "migrations"
+    / "versions"
+    / "2026_08_28_1000-e4a1c8b7d0f3_backfill_k8s_data_dir_volume_mount.py"
+)
+
+
+@pytest.fixture(scope="module")
+def migration():
+    spec = importlib.util.spec_from_file_location("_backfill_data_dir", MIGRATION)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _data_dir_mount(host_path=DEFAULT_DATA_DIR_HOST_PATH):
+    return {
+        "name": DATA_DIR_MOUNT_NAME,
+        "mountPath": DATA_DIR_MOUNT_PATH,
+        "readOnly": False,
+        "volumeSource": {"hostPath": {"path": host_path, "type": "DirectoryOrCreate"}},
+    }
+
+
+EXTRA_MOUNT = {
+    "name": "model-cache",
+    "mountPath": "/mnt/models",
+    "volumeSource": {"hostPath": {"path": "/data/models", "type": "Directory"}},
+}
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        None,
+        "null",
+        {},
+        json.dumps({}),
+        {"volumeMounts": []},
+        {"namespace": "gpustack-system-abc123"},
+        json.dumps({"namespace": "gpustack-system-abc123"}),
+    ],
+    ids=[
+        "null-column",
+        "json-null-text",
+        "empty-dict",
+        "empty-dict-text",
+        "empty-mount-list",
+        "namespace-only",
+        "namespace-only-text",
+    ],
+)
+def test_a_cluster_without_the_mount_is_backfilled(migration, stored):
+    updated = migration.backfilled(stored)
+
+    assert updated is not None
+    assert updated["volumeMounts"] == [_data_dir_mount()]
+
+
+def test_the_rest_of_k8s_options_is_preserved(migration):
+    """Dropping namespace would repoint the cluster's manifests, and dropping
+    gpuInstanceOptions would flip its purpose."""
+    updated = migration.backfilled(
+        {
+            "namespace": "gpustack-system-abc123",
+            "gpuInstanceOptions": {"gpuInstanceTypeMixedOnNode": True},
+        }
+    )
+
+    assert updated["namespace"] == "gpustack-system-abc123"
+    assert updated["gpuInstanceOptions"] == {"gpuInstanceTypeMixedOnNode": True}
+
+
+@pytest.mark.parametrize(
+    "existing",
+    [
+        [_data_dir_mount()],
+        [_data_dir_mount("/mnt/data/gpustack")],
+        [_data_dir_mount(), EXTRA_MOUNT],
+        # Written before the reserved name was enforced.
+        [
+            {
+                "name": "data-dir",
+                "mountPath": DATA_DIR_MOUNT_PATH,
+                "volumeSource": {
+                    "hostPath": {"path": "/mnt/data", "type": "Directory"}
+                },
+            }
+        ],
+    ],
+    ids=["default", "custom-host-path", "with-user-mount", "legacy-name"],
+)
+def test_a_populated_list_is_left_alone(migration, existing):
+    """A non-empty volumeMounts already holds the data dir at index 0: the field
+    did not exist before v2.2.0 and every write since then puts it there. The
+    host path in such a row may have been set deliberately."""
+    assert migration.backfilled({"volumeMounts": existing}) is None
+
+
+def test_the_snake_case_key_form_is_recognized(migration):
+    """``volume_mounts`` reads back fine (populate_by_name), but the column is
+    written by alias, so the backfill leaves a single camelCase key."""
+    assert migration.backfilled({"volume_mounts": [_data_dir_mount()]}) is None
+
+    updated = migration.backfilled({"volume_mounts": [], "namespace": "ns"})
+
+    assert "volume_mounts" not in updated
+    assert updated["volumeMounts"] == [_data_dir_mount()]
+
+
+# --------------------------------------------------------------------------
+# downgrade: only the exact entry the upgrade wrote is dropped
+# --------------------------------------------------------------------------
+
+
+def _snake_case(mount: dict) -> dict:
+    """The same mount with every key in the snake_case form."""
+    host_path = mount["volumeSource"]["hostPath"]
+    return {
+        "name": mount["name"],
+        "mount_path": mount["mountPath"],
+        "read_only": mount["readOnly"],
+        "volume_source": {"host_path": dict(host_path)},
+    }
+
+
+@pytest.mark.parametrize(
+    "mount, expected",
+    [
+        (_data_dir_mount(), True),
+        # Every key form has to be read on every level of the mount, not just
+        # the top one; a partial reading answers "no" for a shape it was meant
+        # to recognize and leaves the entry behind on downgrade.
+        (_snake_case(_data_dir_mount()), True),
+        # A host path the user chose: the pre-upgrade code renders it fine, so
+        # it is not ours to remove.
+        (_data_dir_mount("/mnt/data/gpustack"), False),
+        (_snake_case(_data_dir_mount("/mnt/data/gpustack")), False),
+        # Not the reserved name.
+        ({**_data_dir_mount(), "name": "data-dir"}, False),
+        # No volume source at all.
+        ({"name": DATA_DIR_MOUNT_NAME, "mountPath": DATA_DIR_MOUNT_PATH}, False),
+        (EXTRA_MOUNT, False),
+        ("not-a-mount", False),
+    ],
+    ids=[
+        "camel-default",
+        "snake-default",
+        "camel-custom-host-path",
+        "snake-custom-host-path",
+        "legacy-name",
+        "no-volume-source",
+        "user-mount",
+        "not-a-dict",
+    ],
+)
+def test_only_the_entry_the_upgrade_wrote_is_recognized(migration, mount, expected):
+    assert migration._is_backfilled_data_dir_mount(mount) is expected
+
+
+def test_the_backfilled_value_parses_as_k8s_options(migration):
+    """The row has to load through the live schema after the migration."""
+    updated = migration.backfilled({"namespace": "gpustack-system-abc123"})
+
+    k8s_options = K8sOptions.model_validate(updated)
+
+    assert k8s_options.namespace == "gpustack-system-abc123"
+    mount = k8s_options.volume_mounts[0]
+    assert mount.name == DATA_DIR_MOUNT_NAME
+    assert mount.mount_path == DATA_DIR_MOUNT_PATH
+    assert mount.read_only is False
+    assert mount.volume_source.host_path.path == DEFAULT_DATA_DIR_HOST_PATH
+    assert mount.volume_source.host_path.type == "DirectoryOrCreate"

--- a/tests/routes/test_k8s_data_dir_mount.py
+++ b/tests/routes/test_k8s_data_dir_mount.py
@@ -1,0 +1,288 @@
+"""Offline tests for the reserved gpustack data-dir volume mount.
+
+No database and no network: ``enforce_data_dir_mounts`` operates on the request
+model alone.
+
+Regression cover for the upgrade deadlock in
+https://github.com/gpustack/gpustack/issues/6145 — a Kubernetes cluster created
+before the mount became configurable (v2.2.0) has no ``volumeMounts`` at all,
+and the check used to reject *any* update of it, including one that never
+mentioned ``k8s_options``. The historical rows are repaired by the backfill
+migration; what is fixed here is the second half, the check reading the request
+body as if it were the whole cluster.
+"""
+
+import pytest
+
+from gpustack.api.exceptions import InternalServerErrorException, InvalidException
+from gpustack.routes.clusters import enforce_data_dir_mounts
+from gpustack.schemas.clusters import (
+    ClusterCreate,
+    ClusterProvider,
+    ClusterUpdate,
+    ConfigMapVolumeSource,
+    DATA_DIR_MOUNT_NAME,
+    DATA_DIR_MOUNT_PATH,
+    HostPathVolumeSource,
+    K8sOptions,
+    K8sVolumeMount,
+    PersistentVolumeClaimVolumeSource,
+    VolumeSource,
+)
+
+
+def _host_path_mount(path, name=DATA_DIR_MOUNT_NAME, mount_path=DATA_DIR_MOUNT_PATH):
+    return K8sVolumeMount(
+        name=name,
+        mount_path=mount_path,
+        volume_source=VolumeSource(
+            host_path=HostPathVolumeSource(path=path, type="DirectoryOrCreate")
+        ),
+    )
+
+
+def _extra_mount():
+    return K8sVolumeMount(
+        name="model-cache",
+        mount_path="/mnt/models",
+        volume_source=VolumeSource(
+            host_path=HostPathVolumeSource(path="/data/models", type="Directory")
+        ),
+    )
+
+
+def _create(**kwargs):
+    return ClusterCreate(name="c1", provider=ClusterProvider.Kubernetes, **kwargs)
+
+
+def _update(**kwargs):
+    return ClusterUpdate(name="c1", **kwargs)
+
+
+def _data_dir(input):
+    mounts = input.k8s_options.volume_mounts
+    assert mounts, "the data dir mount must always be present"
+    return mounts[0]
+
+
+def _host_path(input):
+    return _data_dir(input).volume_source.host_path.path
+
+
+# --------------------------------------------------------------------------
+# an untouched k8s_options is left alone — the half of the deadlock that was
+# rejecting valid partial updates
+# --------------------------------------------------------------------------
+
+
+def test_update_without_k8s_options_is_accepted_and_leaves_the_field_alone():
+    """``ActiveRecord.update`` only assigns keys in ``model_fields_set``, so the
+    stored value — namespace, gpuInstanceOptions and all — stands. Touching
+    ``input.k8s_options`` here would turn "leave alone" into "overwrite"."""
+    input = _update(description="renamed")
+
+    enforce_data_dir_mounts(input)
+
+    assert input.k8s_options is None
+    assert "k8s_options" not in input.model_fields_set
+
+
+def test_update_carrying_the_mount_round_trips():
+    """What the UI does: GET the cluster, edit a field, PUT it all back."""
+    input = _update(
+        k8s_options=K8sOptions(
+            namespace="gpustack-system-abc123",
+            volume_mounts=[_host_path_mount("/mnt/data/gpustack"), _extra_mount()],
+        )
+    )
+
+    enforce_data_dir_mounts(input)
+
+    assert _host_path(input) == "/mnt/data/gpustack"
+    assert [m.name for m in input.k8s_options.volume_mounts] == [
+        DATA_DIR_MOUNT_NAME,
+        "model-cache",
+    ]
+    assert input.k8s_options.namespace == "gpustack-system-abc123"
+
+
+# --------------------------------------------------------------------------
+# a submitted k8s_options must carry the mount
+# --------------------------------------------------------------------------
+
+
+def test_create_without_k8s_options_is_rejected():
+    with pytest.raises(InvalidException) as excinfo:
+        enforce_data_dir_mounts(_create())
+
+    assert DATA_DIR_MOUNT_PATH in str(excinfo.value.message)
+
+
+def test_a_submitted_k8s_options_without_the_mount_is_rejected():
+    """Not completed from the stored value: every write goes through this check
+    and the backfill fixed the old rows, so a submission missing the mount is a
+    malformed payload — and the column is replaced wholesale, so it is likely
+    dropping other keys in the same breath."""
+    input = _update(k8s_options=K8sOptions(namespace="gpustack-system-abc123"))
+
+    with pytest.raises(InvalidException) as excinfo:
+        enforce_data_dir_mounts(input)
+
+    assert "volumeMounts" in str(excinfo.value.message)
+
+
+def test_an_explicit_null_k8s_options_is_rejected():
+    """Clearing the column would drop namespace / gpuInstanceOptions too."""
+    input = _update(k8s_options=None)
+    assert "k8s_options" in input.model_fields_set
+
+    with pytest.raises(InvalidException) as excinfo:
+        enforce_data_dir_mounts(input)
+
+    assert "required" in str(excinfo.value.message)
+
+
+def test_an_unrelated_mount_in_the_reserved_slot_is_rejected():
+    """The reserved slot is verified, not adopted.
+
+    The workaround for the deadlock was to add *some* mount to get past the old
+    check; adopting whatever sits at index 0 would have silently turned that
+    mount into the data dir and lost it.
+    """
+    input = _create(k8s_options=K8sOptions(volume_mounts=[_extra_mount()]))
+
+    with pytest.raises(InvalidException) as excinfo:
+        enforce_data_dir_mounts(input)
+
+    assert "reserved" in str(excinfo.value.message)
+    # The offending entry is named, so the caller can see what to move.
+    assert "model-cache" in str(excinfo.value.message)
+
+
+def test_a_second_entry_claiming_the_reserved_path_is_rejected():
+    """Two entries on /var/lib/gpustack render a DaemonSet k8s rejects."""
+    input = _create(
+        k8s_options=K8sOptions(
+            volume_mounts=[
+                _host_path_mount("/mnt/first"),
+                _host_path_mount("/mnt/second", name="other-data"),
+            ]
+        )
+    )
+
+    with pytest.raises(InvalidException) as excinfo:
+        enforce_data_dir_mounts(input)
+
+    assert "reserved" in str(excinfo.value.message)
+
+
+@pytest.mark.parametrize(
+    "volume_source",
+    [
+        None,
+        VolumeSource(
+            persistent_volume_claim=PersistentVolumeClaimVolumeSource(claim_name="pvc")
+        ),
+        VolumeSource(config_map=ConfigMapVolumeSource(name="cm")),
+    ],
+    ids=["no-source", "pvc", "config-map"],
+)
+def test_a_non_host_path_data_dir_is_rejected(volume_source):
+    input = _create(
+        k8s_options=K8sOptions(
+            volume_mounts=[
+                K8sVolumeMount(
+                    name=DATA_DIR_MOUNT_NAME,
+                    mount_path=DATA_DIR_MOUNT_PATH,
+                    volume_source=volume_source,
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(InvalidException) as excinfo:
+        enforce_data_dir_mounts(input)
+
+    assert "hostPath" in str(excinfo.value.message)
+
+
+# --------------------------------------------------------------------------
+# everything but the host path is the server's
+# --------------------------------------------------------------------------
+
+
+def test_the_server_owned_fields_are_forced():
+    input = _create(
+        k8s_options=K8sOptions(
+            volume_mounts=[
+                K8sVolumeMount(
+                    name="my-data",
+                    mount_path=DATA_DIR_MOUNT_PATH,
+                    read_only=True,
+                    volume_source=VolumeSource(
+                        host_path=HostPathVolumeSource(
+                            path="/mnt/data", type="Directory"
+                        ),
+                        config_map=ConfigMapVolumeSource(name="cm"),
+                    ),
+                )
+            ]
+        )
+    )
+
+    enforce_data_dir_mounts(input)
+
+    data_dir = _data_dir(input)
+    assert data_dir.name == DATA_DIR_MOUNT_NAME
+    assert data_dir.read_only is False
+    assert data_dir.volume_source.host_path.type == "DirectoryOrCreate"
+    assert data_dir.volume_source.config_map is None
+    # Only the host path is the caller's to choose.
+    assert _host_path(input) == "/mnt/data"
+
+
+def test_the_callers_own_mounts_are_left_exactly_as_submitted():
+    input = _create(
+        k8s_options=K8sOptions(
+            volume_mounts=[_host_path_mount("/mnt/data/gpustack"), _extra_mount()]
+        )
+    )
+
+    enforce_data_dir_mounts(input)
+
+    mounts = input.k8s_options.volume_mounts
+    assert [m.name for m in mounts] == [DATA_DIR_MOUNT_NAME, "model-cache"]
+    assert mounts[1].mount_path == "/mnt/models"
+    assert mounts[1].volume_source.host_path.path == "/data/models"
+
+
+def test_the_reserved_slot_may_be_claimed_by_mount_path_alone():
+    """The slot check accepts either marker, so a row written before the
+    reserved name was enforced still passes — and is renamed on the way
+    through, keeping its host path."""
+    input = _update(
+        k8s_options=K8sOptions(
+            volume_mounts=[_host_path_mount("/mnt/data", name="data-dir")]
+        )
+    )
+
+    enforce_data_dir_mounts(input)
+
+    assert _data_dir(input).name == DATA_DIR_MOUNT_NAME
+    assert _host_path(input) == "/mnt/data"
+
+
+def test_the_post_condition_catches_a_broken_normalization(monkeypatch):
+    """The invariant is asserted on the value about to be persisted, so a
+    normalization bug surfaces here rather than as a worker DaemonSet rendered
+    without a persistent data dir."""
+    monkeypatch.setattr(
+        "gpustack.routes.clusters.normalize_data_dir_mount",
+        lambda k8s_options: None,
+    )
+    input = _create(
+        k8s_options=K8sOptions(volume_mounts=[_host_path_mount("/mnt/data", name="x")])
+    )
+
+    with pytest.raises(InternalServerErrorException):
+        enforce_data_dir_mounts(input)


### PR DESCRIPTION
Refer to issues:
- #6145 


Before v2.2.0 the worker DaemonSet hardcoded its /var/lib/gpustack volume. v2.2.0 made the host path configurable by rendering it from clusters.k8s_options.volumeMounts, but nothing backfilled the entry for clusters that already existed, leaving upgraded clusters with no volumeMounts at all. Two consequences, one reported and one not:

- Every edit of such a cluster was rejected for the missing entry, and the entry could not be supplied through the UI: with the list empty there is no row 0, and the row the user adds to satisfy the check lands in the reserved slot, where the UI locks its name and mount path — leaving a required field that cannot be filled and a row that cannot be removed.
- Their worker DaemonSets rendered with no /var/lib/gpustack volume, so worker data was not persisted on the node. Silent, and unnoticed until a pod restart.

Three parts:

- A migration backfills the entry with the pre-v2.2.0 host path, so the data already on the nodes is picked up as is rather than the worker starting over in a fresh directory. The host path is state — where the data actually is — so it is frozen in the row rather than derived from a code constant at read time.

- The route check no longer reads the request body as if it were the whole cluster. Leaving k8s_options out of an update is how the API says "unchanged" for every other field (ActiveRecord.update only assigns keys in model_fields_set), and demanding it forced callers into a read-modify-write of a column that is replaced wholesale — an incomplete echo silently drops namespace or gpuInstanceOptions. A submitted k8s_options must still carry the mount: every write path goes through this check and the migration fixed the historical rows, so a submission missing it is a malformed payload, not a state to be completed. What is left of the check moved after normalization, as a post-condition on the shape about to be persisted.

- The DaemonSet template renders from TemplateConfig.volume_mounts, which fills the reserved slot when a row does not carry it. The persist path can refuse a bad request because someone is waiting for the response; at render time there is nobody to tell, and the failure mode is silent data loss.

Index 0 stays the single locating rule, matching what the UI enforces on its side (that row's name, mount path, readOnly and source type are locked, only the host path is editable). What changes is that the entry there is verified rather than adopted: an unrelated mount in the reserved slot is refused instead of being rewritten into the data dir, which is what the workaround for this issue ("add some mount to get past the validation") would have run into.