### PR TITLE
feat: link a cache service to its engine's management console

### DIFF
--- a/gpustack/assets/cache-providers.yaml
+++ b/gpustack/assets/cache-providers.yaml
@@ -418,6 +418,9 @@
     backend (e.g. XSKY's store) extends the reuse across nodes.
   links:
     - { label: Product Page, url: "https://www.xsky.com" }
+  # XSKY ships the MeshFusion management console; declaring this makes
+  # the service form offer the management_url link field.
+  management_url: true
   supported_modes: [managed]
   topology: per_node
   # The MP connector's zero-copy path is CUDA IPC: engines can only

--- a/gpustack/routes/benchmarks.py
+++ b/gpustack/routes/benchmarks.py
@@ -20,6 +20,7 @@ from gpustack.api.tenant import (
     cluster_scoped_system,
     scoped_cluster_row_visible,
 )
+from gpustack.schemas.cache_services import CacheService
 from gpustack.schemas.models import (
     Model,
     ModelInstance,
@@ -653,7 +654,20 @@ async def get_benchmark_snapshot(
     gpu_snapshots = {}
     instance_snapshots = {}
 
-    instance_snapshots[mi.name] = create_model_instance_snapshot(mi, model)
+    cache_service_name = None
+    if (
+        model.extended_kv_cache
+        and model.extended_kv_cache.is_shared()
+        and model.extended_kv_cache.cache_service_id
+    ):
+        cache_service = await CacheService.one_by_id(
+            session, model.extended_kv_cache.cache_service_id
+        )
+        if cache_service is not None:
+            cache_service_name = cache_service.name
+    instance_snapshots[mi.name] = create_model_instance_snapshot(
+        mi, model, cache_service_name=cache_service_name
+    )
 
     w: Worker = await WorkerService(session).get_by_id(mi.worker_id)
     w_snapshot, gpus_snapshots = create_worker_snapshot(w, mi.gpu_type, mi.gpu_indexes)

--- a/gpustack/routes/cache_services.py
+++ b/gpustack/routes/cache_services.py
@@ -888,6 +888,11 @@ async def _validate_cache_service_mode(
             raise BadRequestException(
                 message="config.ram_size is required for managed cache services"
             )
+        management_url = cache_service_in.config.management_url
+        if management_url and not management_url.startswith(("http://", "https://")):
+            raise BadRequestException(
+                message="config.management_url must be an http(s) URL"
+            )
 
         provider = get_cache_provider(cache_service_in.provider_name)
         topology = provider.topology if provider else "singleton"

--- a/gpustack/routes/cache_services.py
+++ b/gpustack/routes/cache_services.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 import aiohttp
 from fastapi import APIRouter, Request, status
@@ -867,6 +867,49 @@ def _validate_cache_service_worker_selector(
         )
 
 
+def _validate_management_url(cache_service_in: CacheServiceCreate) -> None:
+    """Validate the engine-management link and canonicalize blanks to None.
+
+    The field rides ``config``, which managed and external services both
+    accept, so this runs with the top-level validators for either mode —
+    after ``_validate_cache_service_provider``, which already rejected
+    unknown providers.
+    """
+    if cache_service_in.config is None:
+        return
+    management_url = (cache_service_in.config.management_url or "").strip()
+    cache_service_in.config.management_url = management_url or None
+    if not management_url:
+        return
+    provider = get_cache_provider(cache_service_in.provider_name)
+    if provider is None or not provider.management_url:
+        raise BadRequestException(
+            message=(
+                f"config.management_url is not supported by cache "
+                f"provider '{cache_service_in.provider_name}'"
+            )
+        )
+    if len(management_url) > 2048:
+        raise BadRequestException(
+            message="config.management_url must be at most 2048 characters"
+        )
+    # urlparse accepts whitespace inside the netloc, so guard separately
+    parsed = urlparse(management_url)
+    if (
+        parsed.scheme not in ("http", "https")
+        or not parsed.netloc
+        or any(ch.isspace() for ch in management_url)
+    ):
+        raise BadRequestException(
+            message="config.management_url must be a valid http(s) URL"
+        )
+    # a display-only link must not smuggle credentials into stored config
+    if parsed.username or parsed.password:
+        raise BadRequestException(
+            message="config.management_url must not embed credentials"
+        )
+
+
 async def _validate_cache_service_mode(
     session, cache_service_in: CacheServiceCreate
 ) -> None:
@@ -888,12 +931,6 @@ async def _validate_cache_service_mode(
             raise BadRequestException(
                 message="config.ram_size is required for managed cache services"
             )
-        management_url = cache_service_in.config.management_url
-        if management_url and not management_url.startswith(("http://", "https://")):
-            raise BadRequestException(
-                message="config.management_url must be an http(s) URL"
-            )
-
         provider = get_cache_provider(cache_service_in.provider_name)
         topology = provider.topology if provider else "singleton"
         if topology == "per_node":
@@ -1093,6 +1130,7 @@ async def create_cache_service(
     _validate_cache_service_provider(cache_service_in)
     _validate_cache_service_custom_version(cache_service_in)
     _validate_cache_service_config(cache_service_in.config)
+    _validate_management_url(cache_service_in)
     _validate_managed_fields(cache_service_in)
     _validate_cache_service_l2_storage(cache_service_in)
     _validate_cache_service_worker_selector(cache_service_in)
@@ -1173,6 +1211,7 @@ async def update_cache_service(
     _validate_cache_service_provider(cache_service_in)
     _validate_cache_service_custom_version(cache_service_in)
     _validate_cache_service_config(cache_service_in.config)
+    _validate_management_url(cache_service_in)
     _validate_managed_fields(cache_service_in)
     _validate_cache_service_l2_storage(cache_service_in)
     _validate_cache_service_worker_selector(cache_service_in)

--- a/gpustack/schemas/benchmark.py
+++ b/gpustack/schemas/benchmark.py
@@ -261,6 +261,11 @@ class ModelInstanceSnapshot(ModelInstanceRuntimeInfo):
         sa_type=pydantic_column_type(ExtendedKVCacheConfig), default=None
     )
 
+    cache_service_name: Optional[str] = None
+    """Name of the attached shared cache service at benchmark time — the
+    config above stores only the id, and the snapshot must keep naming
+    the service after it is deleted."""
+
     speculative_config: Optional[SpeculativeConfig] = Field(
         sa_type=pydantic_column_type(SpeculativeConfig), default=None
     )

--- a/gpustack/schemas/cache_providers.py
+++ b/gpustack/schemas/cache_providers.py
@@ -396,6 +396,11 @@ class CacheProvider(BaseModel):
     LMCache-style providers — a distributed pool may run per-node data
     components while engines attach its cluster-wide endpoint."""
 
+    management_url: bool = False
+    """Whether the engine ships its own management UI worth linking to:
+    the service form then offers a management_url config field, rendered
+    as a link beside the service name."""
+
     default_version: Optional[str] = None
     versions: Dict[str, CacheProviderVersionConfig] = {}
 

--- a/gpustack/schemas/cache_services.py
+++ b/gpustack/schemas/cache_services.py
@@ -124,6 +124,11 @@ class CacheServiceConfig(BaseModel):
     """Managed mode only: ordered L2 storage backends forming a cascade.
     The first entry is the preferred read tier; all entries receive writes."""
 
+    management_url: Optional[str] = None
+    """Link to the cache engine's own management console (e.g. the
+    MeshFusion UI), rendered as a button on the service detail page.
+    Display-only: the platform never calls it."""
+
 
 @dataclass
 class CacheServiceDeploymentMetadata:

--- a/gpustack/schemas/cache_services.py
+++ b/gpustack/schemas/cache_services.py
@@ -125,9 +125,9 @@ class CacheServiceConfig(BaseModel):
     The first entry is the preferred read tier; all entries receive writes."""
 
     management_url: Optional[str] = None
-    """Link to the cache engine's own management console (e.g. the
-    MeshFusion UI), rendered as a button on the service detail page.
-    Display-only: the platform never calls it."""
+    """Link to the cache engine's own management UI, rendered beside the
+    service name in the list and detail views. Display-only: the
+    platform never calls it."""
 
 
 @dataclass

--- a/gpustack/utils/snapshot.py
+++ b/gpustack/utils/snapshot.py
@@ -13,9 +13,14 @@ from gpustack.utils.gpu import make_gpu_id
 
 
 def create_model_instance_snapshot(
-    model_instance: ModelInstance, model: Model
+    model_instance: ModelInstance,
+    model: Model,
+    cache_service_name: Optional[str] = None,
 ) -> ModelInstanceSnapshot:
-    """Create a snapshot of the model instance."""
+    """Create a snapshot of the model instance. ``cache_service_name``
+    names the attached shared cache service (resolved by the caller,
+    which holds the session): the config carries only the id, and the
+    snapshot keeps the name after the service is deleted."""
 
     subordinate_workers_snapshots: Optional[List[ModelInstanceRuntimeInfo]] = None
     if (
@@ -67,6 +72,7 @@ def create_model_instance_snapshot(
         image_name=model.image_name,
         run_command=model.run_command,
         extended_kv_cache=model.extended_kv_cache,
+        cache_service_name=cache_service_name,
         speculative_config=model.speculative_config,
     )
 

--- a/tests/routes/test_benchmark_snapshot.py
+++ b/tests/routes/test_benchmark_snapshot.py
@@ -1,0 +1,104 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gpustack.routes.benchmarks as benchmarks_route
+from gpustack.schemas.models import (
+    ExtendedKVCacheConfig,
+    KVCacheModeEnum,
+    Model,
+    ModelInstance,
+    ModelInstanceStateEnum,
+)
+
+
+def _patch_worker_side(monkeypatch):
+    """The worker/GPU half of the snapshot is not under test here."""
+    monkeypatch.setattr(
+        benchmarks_route,
+        "WorkerService",
+        lambda session: MagicMock(get_by_id=AsyncMock(return_value=None)),
+    )
+    monkeypatch.setattr(
+        benchmarks_route, "create_worker_snapshot", lambda *args: (None, None)
+    )
+
+
+def _instance() -> ModelInstance:
+    return ModelInstance(
+        id=11,
+        name="mi-1",
+        worker_id=3,
+        worker_name="w1",
+        state=ModelInstanceStateEnum.RUNNING,
+    )
+
+
+def _model(extended_kv_cache=None) -> Model:
+    return Model(name="m1", extended_kv_cache=extended_kv_cache)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_names_the_attached_shared_cache_service(monkeypatch):
+    _patch_worker_side(monkeypatch)
+    one_by_id = AsyncMock(return_value=SimpleNamespace(name="svc-cache"))
+    monkeypatch.setattr(benchmarks_route.CacheService, "one_by_id", one_by_id)
+
+    snapshot = await benchmarks_route.get_benchmark_snapshot(
+        session=MagicMock(),
+        mi=_instance(),
+        model=_model(
+            ExtendedKVCacheConfig(
+                enabled=True, mode=KVCacheModeEnum.SHARED, cache_service_id=7
+            )
+        ),
+    )
+
+    assert snapshot.instances["mi-1"].cache_service_name == "svc-cache"
+    assert one_by_id.await_args.args[1] == 7
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extended_kv_cache",
+    [
+        None,
+        ExtendedKVCacheConfig(enabled=True, mode=KVCacheModeEnum.LOCAL),
+    ],
+)
+async def test_snapshot_skips_the_lookup_without_a_shared_cache(
+    monkeypatch, extended_kv_cache
+):
+    _patch_worker_side(monkeypatch)
+    one_by_id = AsyncMock()
+    monkeypatch.setattr(benchmarks_route.CacheService, "one_by_id", one_by_id)
+
+    snapshot = await benchmarks_route.get_benchmark_snapshot(
+        session=MagicMock(),
+        mi=_instance(),
+        model=_model(extended_kv_cache),
+    )
+
+    assert snapshot.instances["mi-1"].cache_service_name is None
+    one_by_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_tolerates_a_deleted_cache_service(monkeypatch):
+    _patch_worker_side(monkeypatch)
+    monkeypatch.setattr(
+        benchmarks_route.CacheService, "one_by_id", AsyncMock(return_value=None)
+    )
+
+    snapshot = await benchmarks_route.get_benchmark_snapshot(
+        session=MagicMock(),
+        mi=_instance(),
+        model=_model(
+            ExtendedKVCacheConfig(
+                enabled=True, mode=KVCacheModeEnum.SHARED, cache_service_id=7
+            )
+        ),
+    )
+
+    assert snapshot.instances["mi-1"].cache_service_name is None

--- a/tests/routes/test_cache_services.py
+++ b/tests/routes/test_cache_services.py
@@ -75,7 +75,10 @@ def _system_ctx() -> TenantContext:
 
 
 def _provider(
-    supported_modes=None, topology="singleton", custom_version=False
+    supported_modes=None,
+    topology="singleton",
+    custom_version=False,
+    management_url=False,
 ) -> CacheProvider:
     return CacheProvider(
         name="LMCache",
@@ -84,6 +87,7 @@ def _provider(
         default_version="v1",
         versions={"v1": CacheProviderVersionConfig(image="lmcache:v1")},
         custom_version=custom_version,
+        management_url=management_url,
         inference_backend_integrations=[CacheProviderIntegration(backend="vLLM")],
     )
 
@@ -338,6 +342,157 @@ async def test_create_rejects_custom_version_for_external_mode(monkeypatch):
         )
 
     assert "managed" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_management_url_without_provider_support(monkeypatch):
+    _patch_create_prereqs(monkeypatch)
+    _patch_provider(monkeypatch, _provider())
+
+    with pytest.raises(BadRequestException) as exc_info:
+        await cache_services_route.create_cache_service(
+            session=MagicMock(),
+            ctx=_user_ctx(),
+            cache_service_in=_managed_create(
+                config=CacheServiceConfig(
+                    ram_size=20, management_url="https://console.example.com"
+                ),
+            ),
+        )
+
+    assert "not supported by cache provider" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_management_url_for_external_mode_too(monkeypatch):
+    """The field rides config, which external services also accept."""
+    _patch_create_prereqs(monkeypatch)
+    _patch_provider(monkeypatch, _provider())
+
+    with pytest.raises(BadRequestException) as exc_info:
+        await cache_services_route.create_cache_service(
+            session=MagicMock(),
+            ctx=_user_ctx(),
+            cache_service_in=_external_create(
+                config=CacheServiceConfig(management_url="https://console.example.com"),
+            ),
+        )
+
+    assert "not supported by cache provider" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "https://",  # no host
+        "ftp://console.example.com",  # wrong scheme
+        "console.example.com",  # no scheme
+        "https://console example.com",  # space breaks the netloc
+    ],
+)
+async def test_create_rejects_malformed_management_url(monkeypatch, bad_url):
+    _patch_create_prereqs(monkeypatch)
+    _patch_provider(monkeypatch, _provider(management_url=True))
+
+    with pytest.raises(BadRequestException) as exc_info:
+        await cache_services_route.create_cache_service(
+            session=MagicMock(),
+            ctx=_user_ctx(),
+            cache_service_in=_managed_create(
+                config=CacheServiceConfig(ram_size=20, management_url=bad_url),
+            ),
+        )
+
+    assert "valid http(s) URL" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_management_url_with_credentials(monkeypatch):
+    """A display-only link must not smuggle credentials into stored config."""
+    _patch_create_prereqs(monkeypatch)
+    _patch_provider(monkeypatch, _provider(management_url=True))
+
+    with pytest.raises(BadRequestException) as exc_info:
+        await cache_services_route.create_cache_service(
+            session=MagicMock(),
+            ctx=_user_ctx(),
+            cache_service_in=_managed_create(
+                config=CacheServiceConfig(
+                    ram_size=20,
+                    management_url="https://user:pass@console.example.com",
+                ),
+            ),
+        )
+
+    assert "must not embed credentials" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_overlong_management_url(monkeypatch):
+    _patch_create_prereqs(monkeypatch)
+    _patch_provider(monkeypatch, _provider(management_url=True))
+
+    with pytest.raises(BadRequestException) as exc_info:
+        await cache_services_route.create_cache_service(
+            session=MagicMock(),
+            ctx=_user_ctx(),
+            cache_service_in=_managed_create(
+                config=CacheServiceConfig(
+                    ram_size=20,
+                    management_url="https://console.example.com/" + "a" * 2048,
+                ),
+            ),
+        )
+
+    assert "at most 2048 characters" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_management_url_with_provider_support(monkeypatch):
+    worker = SimpleNamespace(id=5, deleted_at=None, cluster_id=1)
+    _patch_create_prereqs(monkeypatch, worker=worker)
+    _patch_provider(monkeypatch, _provider(management_url=True))
+    monkeypatch.setattr(
+        cache_services_route.CacheService,
+        "create",
+        AsyncMock(side_effect=lambda session, source: SimpleNamespace(**source)),
+    )
+
+    created = await cache_services_route.create_cache_service(
+        session=MagicMock(),
+        ctx=_user_ctx(),
+        cache_service_in=_managed_create(
+            config=CacheServiceConfig(
+                ram_size=20, management_url="https://console.example.com"
+            ),
+        ),
+    )
+
+    assert created.config["management_url"] == "https://console.example.com"
+
+
+@pytest.mark.asyncio
+async def test_create_canonicalizes_blank_management_url(monkeypatch):
+    """Whitespace-only values store as None instead of tripping validation."""
+    worker = SimpleNamespace(id=5, deleted_at=None, cluster_id=1)
+    _patch_create_prereqs(monkeypatch, worker=worker)
+    _patch_provider(monkeypatch, _provider())
+    monkeypatch.setattr(
+        cache_services_route.CacheService,
+        "create",
+        AsyncMock(side_effect=lambda session, source: SimpleNamespace(**source)),
+    )
+
+    created = await cache_services_route.create_cache_service(
+        session=MagicMock(),
+        ctx=_user_ctx(),
+        cache_service_in=_managed_create(
+            config=CacheServiceConfig(ram_size=20, management_url="   "),
+        ),
+    )
+
+    assert created.config["management_url"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_cache_provider_catalog.py
+++ b/tests/server/test_cache_provider_catalog.py
@@ -504,6 +504,9 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
         "description",
         "links",
         "dashboard_uid",
+        # whether a vendor ships its own management UI is branding, not
+        # an engine trait the clone would inherit
+        "management_url",
     }
     diverging_fields = {
         "l2_backends",


### PR DESCRIPTION
1. configurable management URL
2. Add cache service name metadata to benchmark

Examples:

<img width="1162" height="638" alt="image" src="https://github.com/user-attachments/assets/f795df8f-cd53-4023-a9ba-4e7fda6992a6" />


<img width="696" height="306" alt="image" src="https://github.com/user-attachments/assets/45828b52-a03a-4be3-9234-3928ee7f5c07" />


<img width="1182" height="1086" alt="image" src="https://github.com/user-attachments/assets/ecb8c22f-e64b-48c6-b120-3a6160f8ab8f" />

<img width="1958" height="708" alt="image" src="https://github.com/user-attachments/assets/4a611361-4e27-4bff-877c-642cc5c8404c" />
