### PR TITLE
feat: add OrcaRouter as a named model provider

### DIFF
--- a/docs/user-guide/model-provider-management.md
+++ b/docs/user-guide/model-provider-management.md
@@ -32,6 +32,7 @@ The currently supported providers are:
 - Ollama
 - OpenAI
 - OpenRouter
+- OrcaRouter
 - Alibaba Qwen
 - iFLYTEK SparkDesk
 - StepFun

--- a/gpustack/gateway/utils.py
+++ b/gpustack/gateway/utils.py
@@ -506,7 +506,7 @@ def provider_proxy_plugin_spec(
             "id": provider_registry_name(provider.id),
             "apiTokens": provider.api_tokens,
             **provider.config.model_dump_with_default_override(),
-            "type": provider.config.type.value,
+            "type": provider.config.ai_proxy_provider_type(),
         }
         accessible_llm_model = next(
             (model.name for model in provider.models or [] if model.category == "llm"),

--- a/gpustack/schemas/model_provider.py
+++ b/gpustack/schemas/model_provider.py
@@ -92,6 +92,7 @@ class ModelProviderTypeEnum(str, Enum):
     OLLAMA = "ollama"
     OPENAI = "openai"
     OPENROUTER = "openrouter"
+    ORCAROUTER = "orcarouter"
     QWEN = "qwen"
     SPARK = "spark"
     STEPFUN = "stepfun"
@@ -158,6 +159,16 @@ class BaseProviderConfig(BaseModel):
         the plugin's own field names into the config still wins.
         """
         return {}
+
+    def ai_proxy_provider_type(self) -> str:
+        """The provider type sent to the ai-proxy plugin.
+
+        Named providers map to the plugin's own provider registry by default.
+        A config whose upstream speaks the OpenAI protocol but is not itself a
+        registered plugin type overrides this to ``openai`` and supplies the
+        endpoint through ``providerDomain`` in ``ai_proxy_derived_fields``.
+        """
+        return self.type.value
 
     def model_dump_with_default_override(self) -> Dict[str, Any]:
         """Dumps the model, excluding unset fields, and then merges with `_default_override` values.
@@ -552,6 +563,26 @@ class OpenrouterConfig(BaseProviderConfig):
     _public_endpoint: str = "openrouter.ai"
 
 
+class OrcaRouterConfig(BaseProviderConfig):
+    """OpenAI-compatible AI gateway (models and agents).
+
+    OrcaRouter is not a registered ai-proxy plugin type, so its gateway traffic
+    rides the plugin's ``openai`` provider with the endpoint supplied through
+    the generic ``providerDomain`` override -- the OpenAI surfaces carry over
+    unchanged and the Host header is rewritten to our public endpoint.
+    """
+
+    type: Literal[ModelProviderTypeEnum.ORCAROUTER]
+    _public_endpoint: str = "api.orcarouter.ai"
+    _model_uri = V1_MODELS_URI
+
+    def ai_proxy_provider_type(self) -> str:
+        return ModelProviderTypeEnum.OPENAI.value
+
+    def ai_proxy_derived_fields(self) -> Dict[str, Any]:
+        return {"providerDomain": self._public_endpoint}
+
+
 class QwenConfig(BaseProviderConfig):
     type: Literal[ModelProviderTypeEnum.QWEN]
     qwenEnableSearch: Optional[bool] = None
@@ -627,6 +658,7 @@ ProviderConfigType = Union[
     OllamaConfig,
     OpenAIConfig,
     OpenrouterConfig,
+    OrcaRouterConfig,
     QwenConfig,
     SparkConfig,
     StepfunConfig,

--- a/tests/schemas/test_model_provider_schemas.py
+++ b/tests/schemas/test_model_provider_schemas.py
@@ -80,6 +80,51 @@ class TestGaladriel:
         }
 
 
+class TestOrcaRouter:
+    """An OpenAI-compatible AI gateway exposed as a named provider.
+
+    OrcaRouter is not a registered ai-proxy plugin type, so the provider config
+    keeps its own ``orcarouter`` type while routing gateway traffic through the
+    plugin's ``openai`` provider, with the endpoint supplied via the generic
+    ``providerDomain`` override."""
+
+    def test_endpoints_point_at_orcarouter(self):
+        config = _config_of("orcarouter")
+
+        assert config.get_base_url() == "https://api.orcarouter.ai"
+        assert config.get_chat_url() == (
+            "https://api.orcarouter.ai",
+            "/v1/chat/completions",
+        )
+        assert config.get_model_url() == ("https://api.orcarouter.ai", "/v1/models")
+
+    def test_it_maps_to_the_openai_plugin_provider(self):
+        config = _config_of("orcarouter")
+
+        assert config.ai_proxy_provider_type() == ModelProviderTypeEnum.OPENAI.value
+
+    def test_the_endpoint_reaches_the_ai_proxy_config(self):
+        config = _config_of("orcarouter")
+
+        spec = AIProxyDefaultConfig.model_validate(
+            {
+                "id": "provider-1",
+                "type": config.ai_proxy_provider_type(),
+                **config.model_dump_with_default_override(),
+            }
+        ).model_dump(exclude_none=True)
+
+        assert spec["type"] == "openai"
+        assert spec["providerDomain"] == "api.orcarouter.ai"
+
+    def test_it_carries_no_provider_specific_fields(self):
+        config = _config_of("orcarouter")
+
+        assert config.model_dump(exclude_unset=True) == {
+            "type": ModelProviderTypeEnum.ORCAROUTER
+        }
+
+
 def _claude(**kwargs) -> ClaudeConfig:
     return ClaudeConfig(type=ModelProviderTypeEnum.CLAUDE, **kwargs)
 


### PR DESCRIPTION
## Summary

GPUStack manages public model services as named providers on the `Model` - `Provider` page (its "Public MaaS" integration built on Higress). This PR adds **OrcaRouter** as a first-class provider, mirroring the existing OpenRouter integration.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means GPUStack users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`gpustack/schemas/model_provider.py`**: register `orcarouter` in `ModelProviderTypeEnum` and add `OrcaRouterConfig` (endpoint `api.orcarouter.ai`, OpenAI `/v1/models` + `/v1/chat/completions`), included in `ProviderConfigType`.
- **`gpustack/gateway/utils.py`**: let a provider config decide the type handed to the ai-proxy plugin via a new `ai_proxy_provider_type()` hook on `BaseProviderConfig`. OrcaRouter is OpenAI-compatible but not a registered plugin type, so it maps to the plugin's `openai` provider with the endpoint supplied through the generic `providerDomain` override — the same mechanism `ClaudeConfig.claudeCustomUrl` already uses for custom endpoints.
- **`docs/user-guide/model-provider-management.md`**: add OrcaRouter to the supported provider list.
- **`tests/schemas/test_model_provider_schemas.py`**: cover OrcaRouter's endpoints, its plugin-type mapping, and that `providerDomain` reaches the ai-proxy config.

## Verification

- `uv run pytest` on the affected suites: `tests/schemas/test_model_provider_schemas.py` (66 passed), `tests/gateway/test_ai_proxy_model_grouping.py` + `test_gateway_utils.py` (66 passed), route-layer provider tests (17 passed). Full suite: 3652 passed; the 14 failures are pre-existing on `main` (Ascend NPU resource-fit selector and Hugging Face / ModelScope network tests) and reproduce on a clean checkout.
- `black 24.4.2` (CI-pinned) clean on all changed files.
- L3 live test against `https://api.orcarouter.ai` using the new config path: `GET /v1/models` → 200 (204 models), `POST /v1/chat/completions` → 200.

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
