### PR TITLE
feat(cache): configure MeshFusion vLLM connector

### DIFF
--- a/gpustack/assets/cache-providers.yaml
+++ b/gpustack/assets/cache-providers.yaml
@@ -428,7 +428,7 @@
   attach_locality: node_local
   default_version: "v0.5.2"
   custom_version: true
-  default_run_args: "--host {{host}} --port {{port}} --l1-size-gb {{ram_size}} --chunk-size {{chunk_size}} --http-host {{host}} --http-port {{metrics_port}} --supported-transfer-mode auto --worker-reap-timeout-seconds 60 --eviction-policy {{eviction_policy}} --eviction-trigger-watermark {{eviction_trigger_watermark}} --eviction-ratio {{eviction_ratio}}"
+  default_run_args: "--host {{host}} --port {{port}} --l1-size-gb {{ram_size}} --chunk-size {{chunk_size}} --http-host {{host}} --http-port {{metrics_port}} --eviction-policy {{eviction_policy}} --eviction-trigger-watermark {{eviction_trigger_watermark}} --eviction-ratio {{eviction_ratio}}"
   default_image: "lmcache/vllm-openai:{{version}}"
   default_runtime_images:
     cuda:
@@ -438,6 +438,7 @@
     cann:
       "8": "registry.example.com/lmcache/vllm-openai:{{version}}-cann"
   versions:
+    # Inherit the provider-level launch arguments for this version.
     "v0.5.2": {}
   resource_profile:
     ram_gib: "{{ram_size}}"
@@ -489,19 +490,28 @@
     xdfs:
       display_name: XSKY MeshFusion Store
       icon: /static/catalog_icons/xsky.png
+      # The UI exposes this as a separate switch above the fields. It defaults
+      # to off because MeshFusion Store normally configures itself in the image.
+      adapter_flag_optional: true
+      adapter_flag_default: false
+      adapter_flag_label: Enable L2 Adapter Flag
       description: >-
         XSKY MeshFusion Store distributed storage as the L2 tier; capacity
         and durability scale with the external storage cluster.
+      # The XDFS plugin is exposed through NIXL's dynamic store adapter. Its
+      # plugin-specific values belong under backend_params and are strings,
+      # including max_capacity_gb.
+      adapter_type: nixl_store_dynamic
+      adapter_backend: XDFS_KV
+      adapter_params:
+        conf: conf
+        params_file: params_file
+        tenant_id: tenant_id
+        max_capacity_gb: max_capacity_gb
       fields:
-        - { name: metadata_endpoint, label: Metadata Endpoint, required: true }
-        - { name: sdk_config_file, label: SDK Config File, default: /opt/meshfusion/sdk.flags }
-        - { name: num_workers, label: Workers, type: number, default: 32 }
-        - { name: io_depth, label: IO Depth, type: number, default: 256 }
-        - { name: max_capacity_gb, label: Max Capacity (GiB), type: number, default: 30720 }
-        - { name: policy_id, label: Policy ID, type: number, default: 1 }
-        - { name: timeout_ms, label: Timeout (ms), type: number, default: 60000 }
+        # The image supplies the plugin files and capacity defaults; tenant is
+        # the only service-level override exposed by the form.
         - { name: tenant_id, label: Tenant ID, default: nixl }
-        - { name: max_write_inflight_bytes, label: Max Write Inflight (Bytes), type: number, default: 536870912 }
     resp:
       display_name: Redis / Valkey
       icon: /static/catalog_icons/redis.svg
@@ -612,13 +622,13 @@
           node_local: { mp_transfer_mode: auto }
         kv_transfer_config:
           kv_connector: LMCacheMPConnector
+          kv_connector_module_path: lmcache.integration.vllm.lmcache_mp_connector
           kv_role: kv_both
           kv_connector_extra_config:
             lmcache.mp.host: "tcp://{{host}}"
             lmcache.mp.port: "{{port}}"
             lmcache.mp.mp_transfer_mode: "{{mp_transfer_mode}}"
         args:
-          - "--disable-hybrid-kv-cache-manager"
           # vLLM defaults --shutdown-timeout to 0: on SIGTERM the engine
           # dies without closing its CUDA IPC handles and the driver
           # keeps its KV VRAM charged to the cache server until the
@@ -637,16 +647,16 @@
         env:
           PYTHONHASHSEED: "0"
         locality_params:
-          node_local: { mp_transfer_mode: auto }
+          node_local: { mp_transfer_mode: engine_driven }
         kv_transfer_config:
           kv_connector: LMCacheMPConnector
+          kv_connector_module_path: lmcache.integration.vllm.lmcache_mp_connector
           kv_role: kv_both
           kv_connector_extra_config:
             lmcache.mp.host: "tcp://{{host}}"
             lmcache.mp.port: "{{port}}"
             lmcache.mp.mp_transfer_mode: "{{mp_transfer_mode}}"
         args:
-          - "--disable-hybrid-kv-cache-manager"
           # vLLM defaults --shutdown-timeout to 0: on SIGTERM the engine
           # dies without closing its CUDA IPC handles and the driver
           # keeps its KV VRAM charged to the cache server until the

--- a/gpustack/routes/cache_services.py
+++ b/gpustack/routes/cache_services.py
@@ -21,7 +21,10 @@ from gpustack.api.tenant import (
     tenant_list_conditions,
 )
 from gpustack.routes.models import assert_cluster_belongs_to_org
-from gpustack.schemas.cache_providers import CUSTOM_VERSION
+from gpustack.schemas.cache_providers import (
+    CUSTOM_VERSION,
+    CacheProviderL2Backend,
+)
 from gpustack.schemas.cache_services import (
     CacheServiceAttachedMetrics,
     CacheServiceMetricsPublic,
@@ -33,6 +36,7 @@ from gpustack.schemas.cache_services import (
     CacheServiceInstance,
     CacheServiceInstancePublic,
     CacheServiceInstancesPublic,
+    CacheServiceL2Storage,
     CacheServiceModeEnum,
     CacheServiceModelSummary,
     CacheServiceModelsPublic,
@@ -733,6 +737,109 @@ def _validate_cache_service_config(config: Optional[CacheServiceConfig]) -> None
             )
 
 
+def _l2_adapter_enabled(
+    storage: CacheServiceL2Storage,
+    backend_key: str,
+    backend_spec: CacheProviderL2Backend,
+) -> bool:
+    if not backend_spec.adapter_flag_optional:
+        if storage.adapter_flag_enabled is not None:
+            raise BadRequestException(
+                message=(
+                    f"adapter_flag_enabled is not applicable to L2 "
+                    f"backend '{backend_key}'"
+                )
+            )
+        return True
+
+    enabled = (
+        backend_spec.adapter_flag_default
+        if storage.adapter_flag_enabled is None
+        else storage.adapter_flag_enabled
+    )
+    if not enabled:
+        # Hidden fields have no runtime meaning while the adapter is disabled.
+        storage.params = {}
+    return enabled
+
+
+def _l2_required_fields(backend_spec: CacheProviderL2Backend):
+    mapped_names = set(backend_spec.adapter_params.values())
+    if backend_spec.adapter_backend and not mapped_names:
+        mapped_names = {field.name for field in backend_spec.fields}
+    if backend_spec.adapter_params or backend_spec.adapter_backend:
+        return [
+            field
+            for field in backend_spec.fields
+            if field.name in mapped_names or field.env_name
+        ]
+    return backend_spec.fields
+
+
+def _validate_l2_storage_params(
+    backend_key: str,
+    backend_spec: CacheProviderL2Backend,
+    params: Dict[str, Any],
+) -> None:
+    declared = {field.name: field for field in backend_spec.fields}
+    unknown = sorted(set(params) - set(declared))
+    if unknown:
+        raise BadRequestException(
+            message=(
+                f"Unknown L2 storage parameter(s) for backend "
+                f"'{backend_key}': " + ", ".join(unknown)
+            )
+        )
+
+    missing = [
+        field.name
+        for field in _l2_required_fields(backend_spec)
+        if field.required
+        and (params.get(field.name) is None or params.get(field.name) == "")
+    ]
+    if missing:
+        raise BadRequestException(
+            message=(
+                f"Missing required L2 storage parameter(s) for backend "
+                f"'{backend_key}': " + ", ".join(missing)
+            )
+        )
+
+    for name, value in params.items():
+        field = declared[name]
+        if (
+            field.type == "number"
+            and value is not None
+            and (isinstance(value, bool) or not isinstance(value, (int, float)))
+        ):
+            raise BadRequestException(
+                message=f"L2 storage parameter '{name}' must be a number"
+            )
+
+
+def _record_l2_env_sources(
+    backend_key: str,
+    backend_spec: CacheProviderL2Backend,
+    params: Dict[str, Any],
+    env_sources: Dict[str, str],
+) -> None:
+    for field in backend_spec.fields:
+        if not field.env_name:
+            continue
+        value = params.get(field.name, field.default)
+        if value is None or value == "":
+            continue
+        if field.env_name in env_sources:
+            raise BadRequestException(
+                message=(
+                    f"L2 storage entries '{env_sources[field.env_name]}' "
+                    f"and '{backend_key}' both deliver the env var "
+                    f"'{field.env_name}'; only one entry may set it"
+                )
+            )
+        env_sources[field.env_name] = backend_key
+
+
 def _validate_cache_service_l2_storage(cache_service_in: CacheServiceBase) -> None:
     """L2 storage config only applies to managed services and must match the
     provider's declared adapter backends. Each entry is checked for a known
@@ -776,104 +883,12 @@ def _validate_cache_service_l2_storage(cache_service_in: CacheServiceBase) -> No
                 )
             )
 
-        if not backend_spec.adapter_flag_optional:
-            if l2_storage.adapter_flag_enabled is not None:
-                raise BadRequestException(
-                    message=(
-                        f"adapter_flag_enabled is not applicable to L2 "
-                        f"backend '{backend_key}'"
-                    )
-                )
-            adapter_enabled = True
-        else:
-            adapter_enabled = (
-                backend_spec.adapter_flag_default
-                if l2_storage.adapter_flag_enabled is None
-                else l2_storage.adapter_flag_enabled
-            )
-            if not adapter_enabled:
-                # Hidden fields have no runtime meaning while the adapter is
-                # disabled. Drop stale form values so a later read mirrors
-                # what the UI shows and no secret remains stored invisibly.
-                l2_storage.params = {}
-                continue
+        if not _l2_adapter_enabled(l2_storage, backend_key, backend_spec):
+            continue
 
         params = l2_storage.params or {}
-        declared = {field.name: field for field in backend_spec.fields}
-
-        unknown = sorted(set(params) - set(declared))
-        if unknown:
-            raise BadRequestException(
-                message=(
-                    f"Unknown L2 storage parameter(s) for backend "
-                    f"'{backend_key}': " + ", ".join(unknown)
-                )
-            )
-
-        # Some adapters retain legacy fields while their current envelope
-        # uses a nested backend_params mapping. For the current shape,
-        # legacy required fields are irrelevant and must not prevent it from
-        # being accepted; only an explicitly legacy payload uses them.
-        required_fields = backend_spec.fields
-        mapped_names = set(backend_spec.adapter_params.values())
-        if backend_spec.adapter_backend and not mapped_names:
-            mapped_names = {field.name for field in backend_spec.fields}
-        legacy_shape = bool(
-            backend_spec.adapter_params
-            and "metadata_endpoint" in params
-            and not (set(params) & mapped_names)
-        )
-        if (
-            backend_spec.adapter_params or backend_spec.adapter_backend
-        ) and not legacy_shape:
-            required_fields = [
-                field
-                for field in backend_spec.fields
-                if field.name in mapped_names or field.env_name
-            ]
-
-        missing = [
-            field.name
-            for field in required_fields
-            if field.required
-            and (params.get(field.name) is None or params.get(field.name) == "")
-        ]
-        if missing:
-            raise BadRequestException(
-                message=(
-                    f"Missing required L2 storage parameter(s) for backend "
-                    f"'{backend_key}': " + ", ".join(missing)
-                )
-            )
-
-        for name, value in params.items():
-            field = declared[name]
-            if (
-                field.type == "number"
-                and value is not None
-                and (isinstance(value, bool) or not isinstance(value, (int, float)))
-            ):
-                raise BadRequestException(
-                    message=f"L2 storage parameter '{name}' must be a number"
-                )
-
-        # Mirror the rendering rule: only fields that resolve to a value
-        # (explicitly or via default) reach the container env.
-        for field in backend_spec.fields:
-            if not field.env_name:
-                continue
-            value = params.get(field.name, field.default)
-            if value is None or value == "":
-                continue
-            if field.env_name in env_sources:
-                raise BadRequestException(
-                    message=(
-                        f"L2 storage entries '{env_sources[field.env_name]}' "
-                        f"and '{backend_key}' both deliver the env var "
-                        f"'{field.env_name}'; only one entry may set it"
-                    )
-                )
-            env_sources[field.env_name] = backend_key
+        _validate_l2_storage_params(backend_key, backend_spec, params)
+        _record_l2_env_sources(backend_key, backend_spec, params, env_sources)
 
 
 def _validate_cache_service_worker_selector(

--- a/gpustack/routes/cache_services.py
+++ b/gpustack/routes/cache_services.py
@@ -737,7 +737,8 @@ def _validate_cache_service_l2_storage(cache_service_in: CacheServiceBase) -> No
     """L2 storage config only applies to managed services and must match the
     provider's declared adapter backends. Each entry is checked for a known
     backend key, all required fields set, no undeclared parameter names
-    (typo guard), and numeric values for number-typed fields; across entries,
+    (typo guard), and numeric values for number-typed fields; optional adapter
+    backends skip and clear their hidden fields while disabled. Across entries,
     no two may deliver a value through the same env var — env vars are
     process-global, so the values would clobber each other."""
     config = cache_service_in.config
@@ -775,6 +776,28 @@ def _validate_cache_service_l2_storage(cache_service_in: CacheServiceBase) -> No
                 )
             )
 
+        if not backend_spec.adapter_flag_optional:
+            if l2_storage.adapter_flag_enabled is not None:
+                raise BadRequestException(
+                    message=(
+                        f"adapter_flag_enabled is not applicable to L2 "
+                        f"backend '{backend_key}'"
+                    )
+                )
+            adapter_enabled = True
+        else:
+            adapter_enabled = (
+                backend_spec.adapter_flag_default
+                if l2_storage.adapter_flag_enabled is None
+                else l2_storage.adapter_flag_enabled
+            )
+            if not adapter_enabled:
+                # Hidden fields have no runtime meaning while the adapter is
+                # disabled. Drop stale form values so a later read mirrors
+                # what the UI shows and no secret remains stored invisibly.
+                l2_storage.params = {}
+                continue
+
         params = l2_storage.params or {}
         declared = {field.name: field for field in backend_spec.fields}
 
@@ -787,9 +810,31 @@ def _validate_cache_service_l2_storage(cache_service_in: CacheServiceBase) -> No
                 )
             )
 
+        # Some adapters retain legacy fields while their current envelope
+        # uses a nested backend_params mapping. For the current shape,
+        # legacy required fields are irrelevant and must not prevent it from
+        # being accepted; only an explicitly legacy payload uses them.
+        required_fields = backend_spec.fields
+        mapped_names = set(backend_spec.adapter_params.values())
+        if backend_spec.adapter_backend and not mapped_names:
+            mapped_names = {field.name for field in backend_spec.fields}
+        legacy_shape = bool(
+            backend_spec.adapter_params
+            and "metadata_endpoint" in params
+            and not (set(params) & mapped_names)
+        )
+        if (
+            backend_spec.adapter_params or backend_spec.adapter_backend
+        ) and not legacy_shape:
+            required_fields = [
+                field
+                for field in backend_spec.fields
+                if field.name in mapped_names or field.env_name
+            ]
+
         missing = [
             field.name
-            for field in backend_spec.fields
+            for field in required_fields
             if field.required
             and (params.get(field.name) is None or params.get(field.name) == "")
         ]

--- a/gpustack/schemas/cache_providers.py
+++ b/gpustack/schemas/cache_providers.py
@@ -630,6 +630,72 @@ def _coerce_l2_field_value(field: CacheProviderL2Field, value: Any) -> Any:
     return value
 
 
+def _l2_adapter_output_name(
+    backend_spec: CacheProviderL2Backend, field_name: str
+) -> Optional[str]:
+    output_name = next(
+        (
+            name
+            for name, mapped_field in backend_spec.adapter_params.items()
+            if mapped_field == field_name
+        ),
+        None,
+    )
+    if output_name is not None:
+        return output_name
+    if field_name in backend_spec.adapter_params:
+        return backend_spec.adapter_params[field_name]
+    if backend_spec.adapter_backend is not None and not backend_spec.adapter_params:
+        return field_name
+    return None
+
+
+def _render_l2_adapter_fields(
+    backend_spec: CacheProviderL2Backend,
+    params: Dict[str, Any],
+    adapter: Dict[str, Any],
+    nested_values: Optional[Dict[str, Any]],
+) -> Dict[str, str]:
+    env: Dict[str, str] = {}
+    for field in backend_spec.fields:
+        if field.metrics_target:
+            continue
+        value = params.get(field.name, field.default)
+        if value is None or value == "":
+            continue
+        value = _coerce_l2_field_value(field, value)
+        if field.env_name:
+            env[field.env_name] = str(value)
+            continue
+        if nested_values is None:
+            adapter[field.name] = value
+            continue
+
+        output_name = _l2_adapter_output_name(backend_spec, field.name)
+        if output_name is not None:
+            # NIXL plugin backend_params are string-valued, even for values
+            # that look numeric (for example capacity in GiB).
+            nested_values[output_name] = str(value)
+    return env
+
+
+def _attach_l2_backend_params(
+    backend_spec: CacheProviderL2Backend,
+    adapter: Dict[str, Any],
+    nested_values: Optional[Dict[str, Any]],
+) -> None:
+    if nested_values is None:
+        return
+    if backend_spec.adapter_params:
+        adapter["backend_params"] = {
+            name: nested_values[name]
+            for name in backend_spec.adapter_params
+            if name in nested_values
+        }
+    else:
+        adapter["backend_params"] = nested_values
+
+
 def render_l2_adapter(
     provider: CacheProvider,
     backend: str,
@@ -663,78 +729,18 @@ def render_l2_adapter(
     if backend_spec.adapter_flag_optional and not flag_enabled:
         return [], {}
 
-    # Most LMCache adapters use the catalog backend key as their adapter
-    # type and put fields directly on the object.  Some plugins (notably
-    # XSKY's NIXL XDFS plugin) use a two-level envelope instead.
-    legacy_shape = bool(
-        backend_spec.adapter_params
-        and "metadata_endpoint" in params
-        and not (set(params) & set(backend_spec.adapter_params.values()))
-    )
     adapter: Dict[str, Any] = {
-        "type": backend if legacy_shape else (backend_spec.adapter_type or backend),
+        "type": backend_spec.adapter_type or backend,
     }
-    if backend_spec.adapter_backend is not None and not legacy_shape:
+    if backend_spec.adapter_backend is not None:
         adapter["backend"] = backend_spec.adapter_backend
     nested_values: Optional[Dict[str, Any]] = (
         {}
         if (backend_spec.adapter_backend is not None or backend_spec.adapter_params)
-        and not legacy_shape
         else None
     )
-    env: Dict[str, str] = {}
-    for field in backend_spec.fields:
-        if field.metrics_target:
-            # Scrape-address fields configure GPUStack's metrics
-            # collection, not the cache server.
-            continue
-        if legacy_shape and field.name not in params:
-            # Preserve the old xdfs payload for already-stored services;
-            # newly introduced plugin defaults must not leak into it.
-            continue
-        value = params.get(field.name, field.default)
-        if value is None or value == "":
-            continue
-        value = _coerce_l2_field_value(field, value)
-        if field.env_name:
-            env[field.env_name] = str(value)
-        elif nested_values is not None:
-            output_name = next(
-                (
-                    name
-                    for name, field_name in backend_spec.adapter_params.items()
-                    if field_name == field.name
-                ),
-                None,
-            )
-            if output_name is None and field.name in backend_spec.adapter_params:
-                output_name = backend_spec.adapter_params[field.name]
-            if (
-                output_name is None
-                and backend_spec.adapter_backend is not None
-                and not backend_spec.adapter_params
-            ):
-                output_name = field.name
-            if output_name is not None:
-                # NIXL plugin backend_params are string-valued, even for
-                # values that look numeric (for example capacity in GiB).
-                nested_values[output_name] = (
-                    str(value) if field.type == "string" else value
-                )
-            elif legacy_shape:
-                adapter[field.name] = value
-        else:
-            adapter[field.name] = value
-
-    if nested_values is not None:
-        if backend_spec.adapter_params:
-            adapter["backend_params"] = {
-                name: nested_values[name]
-                for name in backend_spec.adapter_params
-                if name in nested_values
-            }
-        else:
-            adapter["backend_params"] = nested_values
+    env = _render_l2_adapter_fields(backend_spec, params, adapter, nested_values)
+    _attach_l2_backend_params(backend_spec, adapter, nested_values)
 
     args = [provider.l2_adapter_flag, json.dumps(adapter, separators=(",", ":"))]
     return args, env

--- a/gpustack/schemas/cache_providers.py
+++ b/gpustack/schemas/cache_providers.py
@@ -124,6 +124,10 @@ class CacheProviderKVTransferConfig(BaseModel):
     """Engine argument that carries the serialized payload."""
 
     kv_connector: str
+    kv_connector_module_path: Optional[str] = None
+    """Optional Python module path for engines that load the connector
+    implementation outside their default registry."""
+
     kv_role: str = "kv_both"
     kv_connector_extra_config: Dict[str, Any] = {}
     """Connector-specific settings. String values support {{placeholder}};
@@ -298,6 +302,29 @@ class CacheProviderL2Backend(BaseModel):
     description: Optional[str] = None
     icon: Optional[str] = None
     """Logo URL for brand display; the UI falls back to a generic icon."""
+
+    adapter_flag_optional: bool = False
+    """Whether the UI should offer a separate switch for enabling the
+    provider's ``l2_adapter_flag`` for this backend."""
+
+    adapter_flag_default: bool = True
+    """Default state of the optional adapter-flag switch."""
+
+    adapter_flag_label: Optional[str] = None
+    """Label for the optional adapter-flag switch."""
+
+    adapter_type: Optional[str] = None
+    """JSON ``type`` emitted for this backend; defaults to its catalog key."""
+
+    adapter_backend: Optional[str] = None
+    """Optional JSON ``backend`` value for adapters with a second type."""
+
+    adapter_params: Dict[str, str] = {}
+    """Mapping of nested ``backend_params`` keys to declared field names.
+
+    When set, field values are emitted under ``backend_params`` instead of
+    being placed directly on the adapter object.
+    """
 
     fields: List[CacheProviderL2Field] = []
 
@@ -604,7 +631,10 @@ def _coerce_l2_field_value(field: CacheProviderL2Field, value: Any) -> Any:
 
 
 def render_l2_adapter(
-    provider: CacheProvider, backend: str, params: Dict[str, Any]
+    provider: CacheProvider,
+    backend: str,
+    params: Dict[str, Any],
+    adapter_flag_enabled: Optional[bool] = None,
 ) -> Tuple[List[str], Dict[str, str]]:
     """
     Build the (command args, container env) that configure a managed cache
@@ -614,23 +644,53 @@ def render_l2_adapter(
     omitted from both. Raises ValueError when the provider has no L2 support
     or does not declare the backend.
     """
-    if not provider.l2_adapter_flag:
-        raise ValueError(
-            f"Cache provider '{provider.name}' does not support L2 storage"
-        )
     backend_spec = provider.l2_backends.get(backend)
     if backend_spec is None:
         raise ValueError(
             f"Cache provider '{provider.name}' has no L2 storage "
             f"backend '{backend}'"
         )
+    if not provider.l2_adapter_flag:
+        raise ValueError(
+            f"Cache provider '{provider.name}' does not support L2 storage"
+        )
 
-    adapter: Dict[str, Any] = {"type": backend}
+    flag_enabled = (
+        backend_spec.adapter_flag_default
+        if adapter_flag_enabled is None
+        else bool(adapter_flag_enabled)
+    )
+    if backend_spec.adapter_flag_optional and not flag_enabled:
+        return [], {}
+
+    # Most LMCache adapters use the catalog backend key as their adapter
+    # type and put fields directly on the object.  Some plugins (notably
+    # XSKY's NIXL XDFS plugin) use a two-level envelope instead.
+    legacy_shape = bool(
+        backend_spec.adapter_params
+        and "metadata_endpoint" in params
+        and not (set(params) & set(backend_spec.adapter_params.values()))
+    )
+    adapter: Dict[str, Any] = {
+        "type": backend if legacy_shape else (backend_spec.adapter_type or backend),
+    }
+    if backend_spec.adapter_backend is not None and not legacy_shape:
+        adapter["backend"] = backend_spec.adapter_backend
+    nested_values: Optional[Dict[str, Any]] = (
+        {}
+        if (backend_spec.adapter_backend is not None or backend_spec.adapter_params)
+        and not legacy_shape
+        else None
+    )
     env: Dict[str, str] = {}
     for field in backend_spec.fields:
         if field.metrics_target:
             # Scrape-address fields configure GPUStack's metrics
             # collection, not the cache server.
+            continue
+        if legacy_shape and field.name not in params:
+            # Preserve the old xdfs payload for already-stored services;
+            # newly introduced plugin defaults must not leak into it.
             continue
         value = params.get(field.name, field.default)
         if value is None or value == "":
@@ -638,8 +698,43 @@ def render_l2_adapter(
         value = _coerce_l2_field_value(field, value)
         if field.env_name:
             env[field.env_name] = str(value)
+        elif nested_values is not None:
+            output_name = next(
+                (
+                    name
+                    for name, field_name in backend_spec.adapter_params.items()
+                    if field_name == field.name
+                ),
+                None,
+            )
+            if output_name is None and field.name in backend_spec.adapter_params:
+                output_name = backend_spec.adapter_params[field.name]
+            if (
+                output_name is None
+                and backend_spec.adapter_backend is not None
+                and not backend_spec.adapter_params
+            ):
+                output_name = field.name
+            if output_name is not None:
+                # NIXL plugin backend_params are string-valued, even for
+                # values that look numeric (for example capacity in GiB).
+                nested_values[output_name] = (
+                    str(value) if field.type == "string" else value
+                )
+            elif legacy_shape:
+                adapter[field.name] = value
         else:
             adapter[field.name] = value
+
+    if nested_values is not None:
+        if backend_spec.adapter_params:
+            adapter["backend_params"] = {
+                name: nested_values[name]
+                for name in backend_spec.adapter_params
+                if name in nested_values
+            }
+        else:
+            adapter["backend_params"] = nested_values
 
     args = [provider.l2_adapter_flag, json.dumps(adapter, separators=(",", ":"))]
     return args, env
@@ -743,8 +838,12 @@ def render_kv_transfer_config(
     [flag, compact JSON payload]."""
     payload: Dict[str, Any] = {
         "kv_connector": config.kv_connector,
-        "kv_role": config.kv_role,
     }
+    if config.kv_connector_module_path:
+        payload["kv_connector_module_path"] = render_typed_template(
+            config.kv_connector_module_path, params
+        )
+    payload["kv_role"] = config.kv_role
     if config.kv_connector_extra_config:
         payload["kv_connector_extra_config"] = {
             key: render_typed_template(value, params)

--- a/gpustack/schemas/cache_services.py
+++ b/gpustack/schemas/cache_services.py
@@ -96,6 +96,11 @@ class CacheServiceL2Storage(BaseModel):
     params: Dict[str, Any] = {}
     """Backend field name -> value, per the provider's field declarations."""
 
+    adapter_flag_enabled: Optional[bool] = None
+    """Optional per-backend switch. When the provider marks its adapter flag
+    optional, ``None`` uses the catalog default; false tells the UI to hide
+    the backend fields and does not emit the adapter flag."""
+
 
 class CacheServiceConfig(BaseModel):
     ram_size: Optional[int] = None

--- a/gpustack/worker/cache_service_manager.py
+++ b/gpustack/worker/cache_service_manager.py
@@ -585,7 +585,10 @@ class CacheServiceManager:
         env_sources: Dict[str, str] = {}
         for l2_storage in l2_storages:
             entry_args, entry_env = render_l2_adapter(
-                provider, l2_storage.backend, l2_storage.params or {}
+                provider,
+                l2_storage.backend,
+                l2_storage.params or {},
+                l2_storage.adapter_flag_enabled,
             )
             for env_name, value in entry_env.items():
                 if env_name in env_sources:

--- a/tests/routes/test_cache_services.py
+++ b/tests/routes/test_cache_services.py
@@ -123,7 +123,7 @@ def _provider_with_optional_l2_adapter() -> CacheProvider:
         adapter_flag_optional=True,
         adapter_flag_default=False,
         adapter_flag_label="Enable L2 Adapter Flag",
-        fields=[CacheProviderL2Field(name="metadata_endpoint", required=True)],
+        fields=[CacheProviderL2Field(name="tenant_id", required=True)],
     )
     return provider
 
@@ -1367,7 +1367,7 @@ async def test_create_optional_l2_adapter_requires_fields_when_enabled(monkeypat
             ),
         )
 
-    assert "metadata_endpoint" in exc_info.value.message
+    assert "tenant_id" in exc_info.value.message
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_cache_services.py
+++ b/tests/routes/test_cache_services.py
@@ -117,6 +117,17 @@ def _provider_with_l2(supported_modes=None) -> CacheProvider:
     return provider
 
 
+def _provider_with_optional_l2_adapter() -> CacheProvider:
+    provider = _provider_with_l2()
+    provider.l2_backends["xdfs"] = CacheProviderL2Backend(
+        adapter_flag_optional=True,
+        adapter_flag_default=False,
+        adapter_flag_label="Enable L2 Adapter Flag",
+        fields=[CacheProviderL2Field(name="metadata_endpoint", required=True)],
+    )
+    return provider
+
+
 def _l2_config(backend: str, **params) -> CacheServiceConfig:
     return CacheServiceConfig(
         ram_size=20,
@@ -1304,6 +1315,59 @@ async def test_create_accepts_valid_l2_storage(monkeypatch, config):
     assert created.config["l2_storages"] == [
         entry.model_dump() for entry in config.l2_storages
     ]
+
+
+@pytest.mark.asyncio
+async def test_create_optional_l2_adapter_can_be_disabled_without_fields(
+    monkeypatch,
+):
+    worker = SimpleNamespace(id=5, deleted_at=None, cluster_id=1)
+    _patch_create_prereqs(monkeypatch, worker=worker)
+    _patch_provider(monkeypatch, _provider_with_optional_l2_adapter())
+    monkeypatch.setattr(
+        cache_services_route.CacheService,
+        "create",
+        AsyncMock(side_effect=lambda session, source: SimpleNamespace(**source)),
+    )
+    storage = CacheServiceL2Storage(
+        backend="xdfs", adapter_flag_enabled=False, params={}
+    )
+
+    created = await cache_services_route.create_cache_service(
+        session=MagicMock(),
+        ctx=_user_ctx(),
+        cache_service_in=_managed_create(
+            config=CacheServiceConfig(ram_size=20, l2_storages=[storage])
+        ),
+    )
+
+    assert created.config["l2_storages"][0]["adapter_flag_enabled"] is False
+    assert created.config["l2_storages"][0]["params"] == {}
+
+
+@pytest.mark.asyncio
+async def test_create_optional_l2_adapter_requires_fields_when_enabled(monkeypatch):
+    worker = SimpleNamespace(id=5, deleted_at=None, cluster_id=1)
+    _patch_create_prereqs(monkeypatch, worker=worker)
+    _patch_provider(monkeypatch, _provider_with_optional_l2_adapter())
+
+    with pytest.raises(BadRequestException) as exc_info:
+        await cache_services_route.create_cache_service(
+            session=MagicMock(),
+            ctx=_user_ctx(),
+            cache_service_in=_managed_create(
+                config=CacheServiceConfig(
+                    ram_size=20,
+                    l2_storages=[
+                        CacheServiceL2Storage(
+                            backend="xdfs", adapter_flag_enabled=True, params={}
+                        )
+                    ],
+                )
+            ),
+        )
+
+    assert "metadata_endpoint" in exc_info.value.message
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_cache_provider_catalog.py
+++ b/tests/server/test_cache_provider_catalog.py
@@ -531,12 +531,13 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
     }
     assert differing == set()
 
-    # The versions diverge from LMCache's only by the staged Ascend
-    # build (an assumed image for XSKY to correct) and by which version
-    # each provider defaults to; at a given version the CUDA builds stay
-    # LMCache's.
+    # The version inherits MeshFusion's provider-level launch arguments;
+    # only the staged Ascend build and provider default version diverge.
     mf_version = meshfusion.versions[meshfusion.default_version]
     lm_version = lmcache.versions[meshfusion.default_version]
+    assert mf_version.run_command is None
+    assert mf_version.run_args == meshfusion.default_run_args
+    assert "--supported-transfer-mode auto" not in mf_version.run_args
     assert mf_version.runtime_images["cuda"] == lm_version.runtime_images["cuda"]
     assert "cann" in mf_version.runtime_images
     assert "cann" not in lm_version.runtime_images
@@ -545,7 +546,8 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
     # accelerator gate. MeshFusion diverges from LMCache only by the
     # extra cann-scoped vLLM entry (an assumed placeholder for XSKY;
     # vllm-ascend trails vLLM, so its attachable range is declared
-    # separately). The cuda entries mirror LMCache's.
+    # separately). The connector settings mirror LMCache's, while MeshFusion
+    # omits the non-hybrid manager flag because its image owns that setup.
     vllm_entries = [
         c for c in meshfusion.inference_backend_integrations if c.backend == "vLLM"
     ]
@@ -555,8 +557,27 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
     ]
     lm_vllm = lmcache.integration_for("vLLM", "cuda")
     assert lm_vllm.frameworks == ["cuda"]
+    assert [
+        entry.injection.locality_params["node_local"]["mp_transfer_mode"]
+        for entry in vllm_entries
+    ] == ["auto", "engine_driven"]
     for entry in vllm_entries:
-        assert entry.injection == lm_vllm.injection
+        mesh_injection = entry.injection.model_dump()
+        lm_injection = lm_vllm.injection.model_dump()
+        mesh_injection.pop("locality_params", None)
+        lm_injection.pop("locality_params", None)
+        mesh_kv_config = mesh_injection["kv_transfer_config"]
+        lm_kv_config = lm_injection["kv_transfer_config"]
+        mesh_kv_config.pop("kv_connector_module_path", None)
+        lm_kv_config.pop("kv_connector_module_path", None)
+        assert {
+            key: value for key, value in mesh_injection.items() if key != "args"
+        } == {key: value for key, value in lm_injection.items() if key != "args"}
+        assert entry.injection.args == ["--shutdown-timeout", "20"]
+        assert (
+            entry.injection.kv_transfer_config.kv_connector_module_path
+            == "lmcache.integration.vllm.lmcache_mp_connector"
+        )
     sglang_entries = [
         c for c in meshfusion.inference_backend_integrations if c.backend == "SGLang"
     ]
@@ -572,8 +593,9 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
     assert meshfusion.integration_for("SGLang", "cann") is None
     assert all(c.frameworks == ["cuda"] for c in lmcache.inference_backend_integrations)
 
-    # MeshFusion adds XSKY's store L2 backend (adapter type "xdfs",
-    # branded with the XSKY icon) on top of the LMCache-inherited
+    # MeshFusion adds XSKY's store L2 backend (catalog key "xdfs", rendered
+    # as the NIXL dynamic adapter and branded with the XSKY icon) on top of
+    # the LMCache-inherited
     # backends; LMCache has none of it.
     assert "xdfs" not in lmcache.l2_backends
     # The inherited backends must stay byte-identical, not just share keys.
@@ -581,21 +603,47 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
         assert meshfusion.l2_backends[key] == backend
     xdfs = meshfusion.l2_backends["xdfs"]
     assert xdfs.icon == "/static/catalog_icons/xsky.png"
+    assert xdfs.adapter_flag_optional is True
+    assert xdfs.adapter_flag_default is False
+    assert xdfs.adapter_flag_label == "Enable L2 Adapter Flag"
+    assert xdfs.adapter_type == "nixl_store_dynamic"
+    assert xdfs.adapter_backend == "XDFS_KV"
+    assert xdfs.adapter_params == {
+        "conf": "conf",
+        "params_file": "params_file",
+        "tenant_id": "tenant_id",
+        "max_capacity_gb": "max_capacity_gb",
+    }
     xdfs_fields = {field.name for field in xdfs.fields}
-    assert {"metadata_endpoint", "sdk_config_file", "max_write_inflight_bytes"} <= (
-        xdfs_fields
-    )
-    assert next(f for f in xdfs.fields if f.name == "metadata_endpoint").required
-    # No store-side metrics scrape this version: L2 observability rides on
-    # the cache server's own lmcache_mp_* metrics.
-    assert all(field.metrics_target is False for field in xdfs.fields)
+    # MeshFusion supplies the plugin files from its image; the service form
+    # exposes only the tenant override.
+    assert xdfs_fields == {"tenant_id"}
+    assert next(f for f in xdfs.fields if f.name == "tenant_id").default == "nixl"
 
     args, env = render_l2_adapter(
         meshfusion,
         "xdfs",
-        {"metadata_endpoint": "10.0.0.20:8000"},
+        {},
+        adapter_flag_enabled=False,
     )
-    assert '"metadata_endpoint":"10.0.0.20:8000"' in args[1]
+    # MeshFusion Store is configured by the image itself; the backend must
+    # not emit the generic LMCache adapter flag or JSON payload.
+    assert args == []
+    assert env == {}
+
+    args, env = render_l2_adapter(
+        meshfusion,
+        "xdfs",
+        {
+            "tenant_id": "glmint4mix-1787763619",
+        },
+        adapter_flag_enabled=True,
+    )
+    assert args == [
+        "--l2-adapter",
+        '{"type":"nixl_store_dynamic","backend":"XDFS_KV",'
+        '"backend_params":{"tenant_id":"glmint4mix-1787763619"}}',
+    ]
     assert env == {}
 
 
@@ -677,6 +725,44 @@ def test_render_injection_substitutes_host_and_port():
     # engine-driven copies since IPC handles cannot cross hosts.
     assert '"lmcache.mp.mp_transfer_mode":"auto"' in args[1]
     assert args[2] == "--disable-hybrid-kv-cache-manager"
+
+
+def test_meshfusion_vllm_injection_includes_connector_module_path():
+    provider = get_cache_provider("XSKY MeshFusion")
+    rendered = render_injection(
+        provider,
+        "vLLM",
+        {"host": "127.0.0.1", "port": 5556, "locality": "node_local"},
+    )
+    assert rendered is not None
+    _, args, _ = rendered
+    payload = json.loads(args[1])
+    assert payload["kv_connector"] == "LMCacheMPConnector"
+    assert (
+        payload["kv_connector_module_path"]
+        == "lmcache.integration.vllm.lmcache_mp_connector"
+    )
+    assert payload["kv_role"] == "kv_both"
+    assert (
+        payload["kv_connector_extra_config"]["lmcache.mp.host"]
+        == "tcp://127.0.0.1"
+    )
+    assert payload["kv_connector_extra_config"]["lmcache.mp.port"] == 5556
+    assert args[2:] == ["--shutdown-timeout", "20"]
+
+    rendered_cann = render_injection(
+        provider,
+        "vLLM",
+        {"host": "127.0.0.1", "port": 5556, "locality": "node_local"},
+        framework="cann",
+    )
+    assert rendered_cann is not None
+    _, cann_args, _ = rendered_cann
+    cann_payload = json.loads(cann_args[1])
+    assert (
+        cann_payload["kv_connector_extra_config"]["lmcache.mp.mp_transfer_mode"]
+        == "engine_driven"
+    )
 
 
 def test_kv_transfer_config_renders_structured_slot_with_types():

--- a/tests/server/test_cache_provider_catalog.py
+++ b/tests/server/test_cache_provider_catalog.py
@@ -5,6 +5,8 @@ from pydantic import ValidationError
 
 from gpustack.schemas.cache_providers import (
     CacheProvider,
+    CacheProviderL2Backend,
+    CacheProviderL2Field,
     CacheProviderVersionConfig,
     render_l2_adapter,
     validate_injection_templates,
@@ -647,6 +649,26 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
     assert env == {}
 
 
+def test_render_l2_adapter_stringifies_nested_backend_params():
+    provider = CacheProvider(
+        name="nested-adapter",
+        l2_adapter_flag="--l2-adapter",
+        l2_backends={
+            "store": CacheProviderL2Backend(
+                adapter_type="dynamic",
+                adapter_backend="STORE",
+                adapter_params={"capacity": "max_capacity_gb"},
+                fields=[CacheProviderL2Field(name="max_capacity_gb", type="number")],
+            )
+        },
+    )
+
+    args, env = render_l2_adapter(provider, "store", {"max_capacity_gb": 1048576})
+
+    assert json.loads(args[1])["backend_params"] == {"capacity": "1048576"}
+    assert env == {}
+
+
 def test_provider_brand_links():
     lmcache = get_cache_provider("LMCache")
     assert {link.label for link in lmcache.links} == {"Documentation", "GitHub"}
@@ -743,10 +765,7 @@ def test_meshfusion_vllm_injection_includes_connector_module_path():
         == "lmcache.integration.vllm.lmcache_mp_connector"
     )
     assert payload["kv_role"] == "kv_both"
-    assert (
-        payload["kv_connector_extra_config"]["lmcache.mp.host"]
-        == "tcp://127.0.0.1"
-    )
+    assert payload["kv_connector_extra_config"]["lmcache.mp.host"] == "tcp://127.0.0.1"
     assert payload["kv_connector_extra_config"]["lmcache.mp.port"] == 5556
     assert args[2:] == ["--shutdown-timeout", "20"]
 

--- a/tests/worker/test_cache_service_manager.py
+++ b/tests/worker/test_cache_service_manager.py
@@ -817,6 +817,54 @@ def test_start_instance_without_l2_storage_omits_flag():
     assert "--l2-adapter" not in command
 
 
+def test_start_instance_xdfs_l2_backend_omits_adapter_flag():
+    """MeshFusion Store owns its L2 setup and must not receive LMCache's
+    generic --l2-adapter JSON argument."""
+    manager, clientset = _build_manager(worker_id=1)
+    cache_service = _new_cache_service(
+        config=CacheServiceConfig(
+            ram_size=8,
+            l2_storages=[
+                CacheServiceL2Storage(
+                    backend="xdfs",
+                    adapter_flag_enabled=False,
+                )
+            ],
+        )
+    )
+    provider = _l2_provider(
+        l2_backends={
+            **_l2_provider().l2_backends,
+            "xdfs": CacheProviderL2Backend(
+                fields=[
+                    CacheProviderL2Field(
+                        name="metadata_endpoint", required=True
+                    )
+                ],
+                adapter_flag_optional=True,
+                adapter_flag_default=False,
+            ),
+        }
+    )
+
+    create, update = _run_start(manager, clientset, cache_service, provider)
+
+    command = create.call_args[0][0].containers[0].execution.command
+    assert "--l2-adapter" not in command
+    assert update.call_args[1]["state"] == CacheServiceStateEnum.STARTING
+
+    cache_service.config.l2_storages[0].adapter_flag_enabled = True
+    cache_service.config.l2_storages[0].params = {
+        "metadata_endpoint": "10.0.0.20:8000"
+    }
+    create, _ = _run_start(manager, clientset, cache_service, provider)
+    command = create.call_args[0][0].containers[0].execution.command
+    assert command[-2:] == [
+        "--l2-adapter",
+        '{"type":"xdfs","metadata_endpoint":"10.0.0.20:8000"}',
+    ]
+
+
 def test_start_instance_renders_l2_cascade_in_declared_order():
     """Each L2 entry renders as its own flag occurrence, kept in list order:
     the cache server reads from the earliest tier that hits and writes to
@@ -966,7 +1014,16 @@ def test_start_instance_l2_without_provider_support_sets_error():
         )
     )
 
-    create, update = _run_start(manager, clientset, cache_service, _new_provider())
+    # Keep the backend declaration so this exercises the provider-level
+    # "no adapter flag" branch rather than the unknown-backend validation.
+    provider = _new_provider(
+        l2_backends={
+            "fs": CacheProviderL2Backend(
+                fields=[CacheProviderL2Field(name="base_path", required=True)]
+            )
+        }
+    )
+    create, update = _run_start(manager, clientset, cache_service, provider)
 
     create.assert_not_called()
     assert update.call_args[1]["state"] == CacheServiceStateEnum.ERROR

--- a/tests/worker/test_cache_service_manager.py
+++ b/tests/worker/test_cache_service_manager.py
@@ -836,11 +836,7 @@ def test_start_instance_xdfs_l2_backend_omits_adapter_flag():
         l2_backends={
             **_l2_provider().l2_backends,
             "xdfs": CacheProviderL2Backend(
-                fields=[
-                    CacheProviderL2Field(
-                        name="metadata_endpoint", required=True
-                    )
-                ],
+                fields=[CacheProviderL2Field(name="tenant_id", required=True)],
                 adapter_flag_optional=True,
                 adapter_flag_default=False,
             ),
@@ -854,14 +850,12 @@ def test_start_instance_xdfs_l2_backend_omits_adapter_flag():
     assert update.call_args[1]["state"] == CacheServiceStateEnum.STARTING
 
     cache_service.config.l2_storages[0].adapter_flag_enabled = True
-    cache_service.config.l2_storages[0].params = {
-        "metadata_endpoint": "10.0.0.20:8000"
-    }
+    cache_service.config.l2_storages[0].params = {"tenant_id": "nixl"}
     create, _ = _run_start(manager, clientset, cache_service, provider)
     command = create.call_args[0][0].containers[0].execution.command
     assert command[-2:] == [
         "--l2-adapter",
-        '{"type":"xdfs","metadata_endpoint":"10.0.0.20:8000"}',
+        '{"type":"xdfs","tenant_id":"nixl"}',
     ]
 
 


### PR DESCRIPTION
## Summary

  - Add XSKY MeshFusion cache provider configuration and XDFS L2 adapter support.
  - Add `kv_connector_module_path` support for structured vLLM KV transfer configuration.
  - Configure MeshFusion vLLM integrations:
    - CUDA uses `mp_transfer_mode: auto`
    - CANN uses `mp_transfer_mode: engine_driven`
  - Add optional L2 adapter flag handling and tenant configuration.
  - Update cache service validation, worker startup, rendering logic, and related unit tests.