### PR TITLE
feat(cache): let a provider declare no version and take the image per service

### DIFF
--- a/gpustack/assets/cache-providers.yaml
+++ b/gpustack/assets/cache-providers.yaml
@@ -426,20 +426,13 @@
   # The MP connector's zero-copy path is CUDA IPC: engines can only
   # attach the cache server on their own node.
   attach_locality: node_local
-  default_version: "v0.5.2"
+  # MeshFusion images are not published: every service names the image it
+  # runs, so the catalog declares no release line and the form asks for an
+  # image instead of a version. The launch arguments stay here — they are
+  # the whole launch declaration such an entry has, and every image the
+  # user names must be compatible with them.
   custom_version: true
   default_run_args: "--host {{host}} --port {{port}} --l1-size-gb {{ram_size}} --chunk-size {{chunk_size}} --http-host {{host}} --http-port {{metrics_port}} --eviction-policy {{eviction_policy}} --eviction-trigger-watermark {{eviction_trigger_watermark}} --eviction-ratio {{eviction_ratio}}"
-  default_image: "lmcache/vllm-openai:{{version}}"
-  default_runtime_images:
-    cuda:
-      "13": "lmcache/vllm-openai:{{version}}"
-      "12": "lmcache/vllm-openai:{{version}}-cu129"
-    # PLACEHOLDER. Change as needed.
-    cann:
-      "8": "registry.example.com/lmcache/vllm-openai:{{version}}-cann"
-  versions:
-    # Inherit the provider-level launch arguments for this version.
-    "v0.5.2": {}
   resource_profile:
     ram_gib: "{{ram_size}}"
     cpu: 2
@@ -469,24 +462,9 @@
       step: 0.05
       description: Fraction of memory (0-1) evicted per trigger.
   l2_adapter_flag: "--l2-adapter"
+  # The store is the only L2 tier MeshFusion is deployed with; a lone
+  # declared backend is what the service form preselects.
   l2_backends:
-    fs_native:
-      display_name: Local Filesystem
-      description: >-
-        Spills KV cache to a local directory (e.g. NVMe) on the worker.
-        max_capacity_gb caps disk usage; 0 or unset means uncapped.
-      fields:
-        # Defaults into the platform data dir: on containerized workers
-        # the mirrored deployment carries the worker's /var/lib/gpustack
-        # host mount into the cache container, so spilled cache lands on
-        # host disk and survives container recreation.
-        - name: base_path
-          label: Base Path
-          required: true
-          default: /var/lib/gpustack/cache/lmcache/l2
-        - { name: max_capacity_gb, label: Max Capacity (GiB), type: number }
-        - { name: num_workers, label: I/O Workers, type: number }
-        - { name: use_odirect, label: Direct I/O (O_DIRECT), type: boolean }
     xdfs:
       display_name: XSKY MeshFusion Store
       icon: /static/catalog_icons/xsky.png
@@ -512,38 +490,6 @@
         # The image supplies the plugin files and capacity defaults; tenant is
         # the only service-level override exposed by the form.
         - { name: tenant_id, label: Tenant ID, default: nixl }
-    resp:
-      display_name: Redis / Valkey
-      icon: /static/catalog_icons/redis.svg
-      description: Shared L2 in a Redis or Valkey server; cache survives cache-server restarts.
-      fields:
-        - { name: host, label: Host, required: true }
-        - { name: port, label: Port, type: number, required: true }
-        - { name: username, label: Username, env_name: LMCACHE_RESP_USERNAME }
-        - name: password
-          label: Password
-          type: password
-          env_name: LMCACHE_RESP_PASSWORD
-        - { name: max_capacity_gb, label: Max Capacity (GiB), type: number }
-    s3:
-      display_name: S3
-      icon: /static/catalog_icons/s3.svg
-      description: >-
-        Shared L2 in an S3-compatible object store (AWS S3, MinIO, Ceph
-        RGW). The endpoint uses virtual-hosted style — the bucket name is
-        part of the host, e.g. "kvcache.s3.example.com"; path-style
-        addressing is not supported. max_capacity_gb caps aggregate
-        usage; 0 or unset means uncapped.
-      fields:
-        - { name: s3_endpoint, label: Bucket Endpoint, required: true }
-        - { name: s3_region, label: Region, required: true }
-        - { name: aws_access_key_id, label: Access Key ID, env_name: AWS_ACCESS_KEY_ID }
-        - name: aws_secret_access_key
-          label: Secret Access Key
-          type: password
-          env_name: AWS_SECRET_ACCESS_KEY
-        - { name: disable_tls, label: Disable TLS (HTTP Endpoint), type: boolean }
-        - { name: max_capacity_gb, label: Max Capacity (GiB), type: number }
   common_parameters:
     - --l2-adapter
     # CLI-entry-only groups (coordinator / P2P), valid again now that the

--- a/gpustack/routes/cache_services.py
+++ b/gpustack/routes/cache_services.py
@@ -655,6 +655,19 @@ def _validate_cache_service_provider(cache_service_in: CacheServiceCreate) -> No
             )
         )
 
+    # A provider declaring no versions publishes no image of its own, so
+    # every managed service supplies one — which is what the reserved
+    # "custom" identifier stands for. Naming it is then redundant: an
+    # omitted version reads as it, instead of failing a version lookup
+    # that could never resolve.
+    if (
+        cache_service_in.mode == CacheServiceModeEnum.MANAGED
+        and not provider.versions
+        and provider.custom_version
+        and not cache_service_in.provider_version
+    ):
+        cache_service_in.provider_version = CUSTOM_VERSION
+
     # The reserved "custom" identifier is not a catalog version; it is
     # checked by _validate_cache_service_custom_version.
     if cache_service_in.provider_version == CUSTOM_VERSION:

--- a/gpustack/schemas/cache_providers.py
+++ b/gpustack/schemas/cache_providers.py
@@ -556,7 +556,41 @@ class CacheProvider(BaseModel):
                     "neither image nor runtime_images and inherit the "
                     "provider's default_image"
                 )
+        if not self.versions and "managed" in self.supported_modes:
+            # A provider with no release line to declare (an image that is
+            # not published, so every service names its own) still needs a
+            # way to reach an image: the custom version is it.
+            if not self.custom_version:
+                raise ValueError(
+                    f"Cache provider '{self.name}' declares no versions: a "
+                    "managed provider then resolves no image at all unless "
+                    "it allows the custom version"
+                )
+            if self.default_run_command and self.default_run_args:
+                raise ValueError(
+                    f"Cache provider '{self.name}' declares both "
+                    "default_run_command and default_run_args: a command and "
+                    "its arguments form one vector, so state it as whichever "
+                    "one the image's entrypoint calls for"
+                )
         return self
+
+    def custom_version_config(self) -> Optional[CacheProviderVersionConfig]:
+        """The launch template a service pinning the reserved "custom"
+        version runs with: the default version's config, or — for a provider
+        declaring no versions at all — one built from the provider-level
+        launch defaults, the only launch declaration such a catalog entry
+        has. None when the provider declares versions but no usable default,
+        which leaves the custom version nothing to template."""
+        config, _ = self.get_version_config(None)
+        if config is not None:
+            return config
+        if self.versions:
+            return None
+        return CacheProviderVersionConfig(
+            run_command=self.default_run_command,
+            run_args=self.default_run_args,
+        )
 
     def get_version_config(
         self, version: Optional[str] = None

--- a/gpustack/worker/cache_service_manager.py
+++ b/gpustack/worker/cache_service_manager.py
@@ -435,10 +435,10 @@ class CacheServiceManager:
         """
         Resolve the (version config, version identifier, container image)
         the instance runs with. The reserved "custom" version keeps the
-        default version's run command and env templates but takes the
-        image from the service config, so the image must be
-        command-compatible with the default declaration. Raises ValueError
-        when the catalog or the service config cannot serve the request.
+        provider's run command and env templates but takes the image from
+        the service config, so the image must be command-compatible with
+        that declaration. Raises ValueError when the catalog or the service
+        config cannot serve the request.
         """
         if cache_service.provider_version == CUSTOM_VERSION:
             if not provider.custom_version:
@@ -446,7 +446,7 @@ class CacheServiceManager:
                     f"Cache provider {cache_service.provider_name} does not "
                     f"allow the custom version"
                 )
-            version_config, _ = provider.get_version_config(None)
+            version_config = provider.custom_version_config()
             if version_config is None:
                 raise ValueError(
                     f"Cache provider {cache_service.provider_name} has no "

--- a/tests/exporter/test_exporter.py
+++ b/tests/exporter/test_exporter.py
@@ -568,6 +568,8 @@ def _l2_metrics_provider() -> CacheProvider:
     return CacheProvider(
         name="StubCache",
         supported_modes=["managed"],
+        default_version="v1",
+        versions={"v1": {"image": "stub/cache:v1"}},
         l2_backends={
             "stub_store": CacheProviderL2Backend(
                 fields=[

--- a/tests/routes/test_cache_services.py
+++ b/tests/routes/test_cache_services.py
@@ -299,6 +299,55 @@ async def test_create_rejects_custom_version_without_image(monkeypatch, config):
 
 
 @pytest.mark.asyncio
+async def test_create_defaults_to_custom_version_without_declared_versions(monkeypatch):
+    """A provider publishing no image declares no version to name, so an
+    omitted provider_version reads as the custom one."""
+    worker = SimpleNamespace(id=5, deleted_at=None, cluster_id=1)
+    _patch_create_prereqs(monkeypatch, worker=worker)
+    provider = _provider(custom_version=True)
+    provider.versions = {}
+    provider.default_version = None
+    _patch_provider(monkeypatch, provider)
+    monkeypatch.setattr(
+        cache_services_route.CacheService,
+        "create",
+        AsyncMock(side_effect=lambda session, source: SimpleNamespace(**source)),
+    )
+
+    created = await cache_services_route.create_cache_service(
+        session=MagicMock(),
+        ctx=_user_ctx(),
+        cache_service_in=_managed_create(
+            config=CacheServiceConfig(ram_size=20, image="myteam/meshfusion:dev"),
+        ),
+    )
+
+    assert created.provider_version == "custom"
+    assert created.config["image"] == "myteam/meshfusion:dev"
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_missing_image_without_declared_versions(monkeypatch):
+    """The image is the only way such a provider reaches one, so leaving
+    it out fails as a missing custom-version image."""
+    worker = SimpleNamespace(id=5, deleted_at=None, cluster_id=1)
+    _patch_create_prereqs(monkeypatch, worker=worker)
+    provider = _provider(custom_version=True)
+    provider.versions = {}
+    provider.default_version = None
+    _patch_provider(monkeypatch, provider)
+
+    with pytest.raises(BadRequestException) as exc_info:
+        await cache_services_route.create_cache_service(
+            session=MagicMock(),
+            ctx=_user_ctx(),
+            cache_service_in=_managed_create(config=CacheServiceConfig(ram_size=20)),
+        )
+
+    assert "config.image is required" in exc_info.value.message
+
+
+@pytest.mark.asyncio
 async def test_create_rejects_custom_version_without_provider_opt_in(monkeypatch):
     _patch_create_prereqs(monkeypatch)
     _patch_provider(monkeypatch, _provider())

--- a/tests/server/test_cache_provider_catalog.py
+++ b/tests/server/test_cache_provider_catalog.py
@@ -124,6 +124,29 @@ def test_version_without_any_image_is_rejected():
         CacheProvider(name="Imageless", versions={"v1.0": {}})
 
 
+def test_managed_provider_without_versions_must_allow_the_custom_version():
+    """A provider declaring no release line resolves no image of its own;
+    without the custom version its managed services could never start."""
+    with pytest.raises(ValidationError):
+        CacheProvider(name="Versionless", supported_modes=["managed"])
+
+    provider = CacheProvider(
+        name="Versionless",
+        supported_modes=["managed"],
+        custom_version=True,
+        default_run_args="--port {{port}}",
+    )
+    # The provider-level launch declaration is what the service's own
+    # image runs on, reached through the same version-config contract.
+    template = provider.custom_version_config()
+    assert template.run_args == "--port {{port}}"
+    assert template.run_command is None
+
+    # An external-only provider runs no container at all, so declaring no
+    # version says nothing about images.
+    CacheProvider(name="Registered", supported_modes=["external"])
+
+
 def test_own_launch_takes_over_the_pair_whole():
     """run_command and run_args are two slots of one launch: a version
     supplying arguments for the image's own entrypoint must not also
@@ -514,8 +537,9 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
         "l2_backends",
         "versions",
         "default_version",
-        # The staged Ascend build lives in the image templates; the CUDA
-        # layout and the run command are asserted equal below.
+        # MeshFusion images are not published, so it declares no image
+        # layout at all; the custom version carries the service's own.
+        "default_image",
         "default_runtime_images",
         # The two launch through different slots: MeshFusion's image is
         # expected to start the cache server itself.
@@ -533,16 +557,17 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
     }
     assert differing == set()
 
-    # The version inherits MeshFusion's provider-level launch arguments;
-    # only the staged Ascend build and provider default version diverge.
-    mf_version = meshfusion.versions[meshfusion.default_version]
-    lm_version = lmcache.versions[meshfusion.default_version]
-    assert mf_version.run_command is None
-    assert mf_version.run_args == meshfusion.default_run_args
-    assert "--supported-transfer-mode auto" not in mf_version.run_args
-    assert mf_version.runtime_images["cuda"] == lm_version.runtime_images["cuda"]
-    assert "cann" in mf_version.runtime_images
-    assert "cann" not in lm_version.runtime_images
+    # No release line to declare: services name the image themselves under
+    # the reserved custom version, which runs on the provider-level launch
+    # arguments — the entry's only launch declaration.
+    assert meshfusion.versions == {}
+    assert meshfusion.default_version is None
+    assert meshfusion.custom_version is True
+    custom_config = meshfusion.custom_version_config()
+    assert custom_config.run_command is None
+    assert custom_config.run_args == meshfusion.default_run_args
+    assert "--supported-transfer-mode auto" not in custom_config.run_args
+    assert lmcache.versions
 
     # Every integration is framework-scoped — the catalog is the single
     # accelerator gate. MeshFusion diverges from LMCache only by the
@@ -595,14 +620,11 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
     assert meshfusion.integration_for("SGLang", "cann") is None
     assert all(c.frameworks == ["cuda"] for c in lmcache.inference_backend_integrations)
 
-    # MeshFusion adds XSKY's store L2 backend (catalog key "xdfs", rendered
-    # as the NIXL dynamic adapter and branded with the XSKY icon) on top of
-    # the LMCache-inherited
-    # backends; LMCache has none of it.
+    # XSKY's store (catalog key "xdfs", rendered as the NIXL dynamic
+    # adapter and branded with the XSKY icon) is the only L2 tier
+    # MeshFusion is deployed with, and LMCache has none of it.
     assert "xdfs" not in lmcache.l2_backends
-    # The inherited backends must stay byte-identical, not just share keys.
-    for key, backend in lmcache.l2_backends.items():
-        assert meshfusion.l2_backends[key] == backend
+    assert set(meshfusion.l2_backends) == {"xdfs"}
     xdfs = meshfusion.l2_backends["xdfs"]
     assert xdfs.icon == "/static/catalog_icons/xsky.png"
     assert xdfs.adapter_flag_optional is True

--- a/tests/server/test_cache_service_controller.py
+++ b/tests/server/test_cache_service_controller.py
@@ -26,6 +26,8 @@ def _provider(topology="singleton") -> CacheProvider:
         name="LMCache",
         supported_modes=["managed"],
         topology=topology,
+        default_version="v1",
+        versions={"v1": {"image": "lmcache:v1"}},
     )
 
 

--- a/tests/worker/test_cache_service_manager.py
+++ b/tests/worker/test_cache_service_manager.py
@@ -725,19 +725,53 @@ def test_start_instance_custom_version_without_provider_support_sets_error():
 
 def test_start_instance_custom_version_without_default_version_sets_error():
     """The custom version borrows the default version's templates, so a
-    provider without a resolvable default version cannot serve it."""
+    provider whose declared versions hold no resolvable default cannot
+    serve it."""
     manager, clientset = _build_manager(worker_id=1)
     cache_service = _new_cache_service(
         provider_version="custom",
         config=CacheServiceConfig(ram_size=8, image="myteam/cache-server:dev"),
     )
-    provider = _new_provider(custom_version=True, default_version=None, versions={})
+    provider = _new_provider(custom_version=True, default_version=None)
 
     create, update = _run_start(manager, clientset, cache_service, provider)
 
     create.assert_not_called()
     assert update.call_args[1]["state"] == CacheServiceStateEnum.ERROR
     assert "default version" in update.call_args[1]["state_message"]
+
+
+def test_start_instance_custom_version_without_declared_versions():
+    """A provider publishing no image declares no version at all: the
+    service's own image runs on the provider-level launch arguments."""
+    manager, clientset = _build_manager(worker_id=1)
+    cache_service = _new_cache_service(
+        provider_version="custom",
+        config=CacheServiceConfig(ram_size=8, image="myteam/cache-server:dev"),
+    )
+    provider = _new_provider(
+        custom_version=True,
+        default_version=None,
+        versions={},
+        default_run_args="--host {{host}} --port {{port}} --ram {{ram_size}}",
+    )
+
+    create, update = _run_start(manager, clientset, cache_service, provider)
+
+    container = create.call_args[0][0].containers[0]
+    assert container.image == "myteam/cache-server:dev"
+    # run_args keeps the image's own entrypoint, so the rendered template
+    # lands in the args slot with the platform placeholders filled.
+    assert container.execution.command is None
+    assert container.execution.args == [
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "40001",
+        "--ram",
+        "8",
+    ]
+    assert update.call_args[1]["state"] != CacheServiceStateEnum.ERROR
 
 
 def test_start_instance_renders_fs_l2_adapter():


### PR DESCRIPTION

A cache provider whose image is not published has no release line to declare: the service names the image it runs, which is what the reserved "custom" version already stands for. Such an entry declares only its launch arguments, and the custom version now templates off those provider-level defaults instead of requiring a default version to borrow them from. An omitted provider_version reads as the custom one, and a managed provider declaring neither versions nor the custom version is rejected at load — it could never resolve an image at all.

MeshFusion is the first such entry: it drops its staged version and image layout, and keeps XSKY's store as its only L2 backend.