### PR TITLE
feat(cache): localize the provider catalog's display text

### DIFF
--- a/gpustack/assets/cache-providers.yaml
+++ b/gpustack/assets/cache-providers.yaml
@@ -36,13 +36,20 @@
   display_name: LMCache
   source: built_in
   icon: /static/catalog_icons/lmcache.png
-  description: >-
-    LMCache is a KV cache layer for LLM serving. As a shared cache service it
-    runs a cache server on every worker; deployments and replicas on the same
-    node share KV cache through it, and a shared L2 storage backend extends
-    the reuse across nodes.
+  description:
+    default: >-
+      LMCache is a KV cache layer for LLM serving. As a shared cache service it
+      runs a cache server on every worker; deployments and replicas on the same
+      node share KV cache through it, and a shared L2 storage backend extends
+      the reuse across nodes.
+    zh-CN: >-
+      LMCache 是面向大模型推理的 KV Cache 层。作为共享缓存服务，它在每个 worker
+      上运行一个缓存服务端，同节点的部署与副本通过它共享 KV Cache，共享的 L2
+      存储后端把复用范围扩展到跨节点。
   links:
-    - { label: Documentation, url: "https://docs.lmcache.ai" }
+    - label: { default: Documentation, zh-CN: 文档 }
+      url: "https://docs.lmcache.ai"
+    # A brand name reads the same in every locale, so it stays bare.
     - { label: GitHub, url: "https://github.com/LMCache/LMCache" }
   # Managed only: LMCache is the out-of-box single-container engine
   # GPUStack runs itself. Its distributed form (operator + coordinator +
@@ -90,80 +97,126 @@
   # policy is required upstream, so its default always renders.
   managed_fields:
     - name: eviction_policy
-      label: Eviction Policy
+      label: { default: Eviction Policy, zh-CN: 淘汰策略 }
       default: LRU
+      # Engine enum values: they reach the command line verbatim and stay
+      # untranslated, so what each one means lives in the description.
       options: [LRU, IsolatedLRU, noop]
-      description: >-
-        LRU evicts least-recently-used chunks. IsolatedLRU keeps one LRU
-        list per cache salt and requires per-salt quotas via the HTTP
-        API. noop never evicts.
+      description:
+        default: >-
+          LRU evicts least-recently-used chunks. IsolatedLRU keeps one LRU
+          list per cache salt and requires per-salt quotas via the HTTP
+          API. noop never evicts.
+        zh-CN: >-
+          LRU 淘汰最近最少使用的分块。IsolatedLRU 为每个 cache salt 维护独立的 LRU
+          列表，并需通过 HTTP API 为每个 salt 设置配额。noop 从不淘汰。
     - name: eviction_trigger_watermark
-      label: Eviction Trigger Watermark
+      label: { default: Eviction Trigger Watermark, zh-CN: 淘汰触发水位 }
       type: number
       default: 0.85
       min: 0
       max: 1
       step: 0.05
-      description: Memory usage fraction (0-1) that triggers eviction.
+      description:
+        default: Memory usage fraction (0-1) that triggers eviction.
+        zh-CN: 触发淘汰的内存使用率（0-1）。
     - name: eviction_ratio
-      label: Eviction Ratio
+      label: { default: Eviction Ratio, zh-CN: 淘汰比例 }
       type: number
       default: 0.1
       min: 0
       max: 1
       step: 0.05
-      description: Fraction of memory (0-1) evicted per trigger.
+      description:
+        default: Fraction of memory (0-1) evicted per trigger.
+        zh-CN: 每次触发所淘汰的内存比例（0-1）。
   l2_adapter_flag: "--l2-adapter"
   l2_backends:
     fs_native:
-      display_name: Local Filesystem
-      description: >-
-        Spills KV cache to a local directory (e.g. NVMe) on the worker.
-        max_capacity_gb caps disk usage; 0 or unset means uncapped.
+      display_name: { default: Local Filesystem, zh-CN: 本地文件系统 }
+      description:
+        default: >-
+          Spills KV cache to a local directory (e.g. NVMe) on the worker.
+          max_capacity_gb caps disk usage; 0 or unset means uncapped.
+        zh-CN: >-
+          将 KV Cache 溢出到 worker 上的本地目录（如 NVMe）。max_capacity_gb
+          限制磁盘用量；填 0 或留空表示不限制。
       fields:
         # Defaults into the platform data dir: on containerized workers
         # the mirrored deployment carries the worker's /var/lib/gpustack
         # host mount into the cache container, so spilled cache lands on
         # host disk and survives container recreation.
         - name: base_path
-          label: Base Path
+          label: { default: Base Path, zh-CN: 基础路径 }
           required: true
           default: /var/lib/gpustack/cache/lmcache/l2
-        - { name: max_capacity_gb, label: Max Capacity (GiB), type: number }
-        - { name: num_workers, label: I/O Workers, type: number }
-        - { name: use_odirect, label: Direct I/O (O_DIRECT), type: boolean }
+        - name: max_capacity_gb
+          label: { default: Max Capacity (GiB), zh-CN: 最大容量（GiB） }
+          type: number
+        - name: num_workers
+          label: { default: I/O Workers, zh-CN: I/O 工作线程 }
+          type: number
+        - name: use_odirect
+          label: { default: Direct I/O (O_DIRECT), zh-CN: 直接 I/O（O_DIRECT） }
+          type: boolean
     resp:
+      # A brand name reads the same in every locale, so it stays bare.
       display_name: Redis / Valkey
       icon: /static/catalog_icons/redis.svg
-      description: Shared L2 in a Redis or Valkey server; cache survives cache-server restarts.
+      description:
+        default: Shared L2 in a Redis or Valkey server; cache survives cache-server restarts.
+        zh-CN: 以 Redis 或 Valkey 服务端作为共享 L2；缓存服务端重启后缓存仍然保留。
       fields:
-        - { name: host, label: Host, required: true }
-        - { name: port, label: Port, type: number, required: true }
-        - { name: username, label: Username, env_name: LMCACHE_RESP_USERNAME }
+        - { name: host, label: { default: Host, zh-CN: 主机 }, required: true }
+        - name: port
+          label: { default: Port, zh-CN: 端口 }
+          type: number
+          required: true
+        - name: username
+          label: { default: Username, zh-CN: 用户名 }
+          env_name: LMCACHE_RESP_USERNAME
         - name: password
-          label: Password
+          label: { default: Password, zh-CN: 密码 }
           type: password
           env_name: LMCACHE_RESP_PASSWORD
-        - { name: max_capacity_gb, label: Max Capacity (GiB), type: number }
+        - name: max_capacity_gb
+          label: { default: Max Capacity (GiB), zh-CN: 最大容量（GiB） }
+          type: number
     s3:
       display_name: S3
       icon: /static/catalog_icons/s3.svg
-      description: >-
-        Shared L2 in an S3-compatible object store (AWS S3, MinIO, Ceph
-        RGW). The endpoint uses virtual-hosted style — the bucket name is
-        part of the host, e.g. "kvcache.s3.example.com"; path-style
-        addressing is not supported. max_capacity_gb caps aggregate
-        usage; 0 or unset means uncapped.
+      description:
+        default: >-
+          Shared L2 in an S3-compatible object store (AWS S3, MinIO, Ceph
+          RGW). The endpoint uses virtual-hosted style — the bucket name is
+          part of the host, e.g. "kvcache.s3.example.com"; path-style
+          addressing is not supported. max_capacity_gb caps aggregate
+          usage; 0 or unset means uncapped.
+        zh-CN: >-
+          以兼容 S3 的对象存储作为共享 L2（AWS S3、MinIO、Ceph RGW）。地址采用
+          virtual-hosted 风格——bucket 名是主机名的一部分，例如
+          "kvcache.s3.example.com"；不支持 path-style 寻址。max_capacity_gb
+          限制总用量；填 0 或留空表示不限制。
       fields:
-        - { name: s3_endpoint, label: Bucket Endpoint, required: true }
-        - { name: s3_region, label: Region, required: true }
+        - name: s3_endpoint
+          label: { default: Bucket Endpoint, zh-CN: Bucket 地址 }
+          required: true
+        - name: s3_region
+          label: { default: Region, zh-CN: 区域 }
+          required: true
+        # Access Key ID and Secret Access Key are the object store's own
+        # credential names; they stay bare, as every S3 console shows them.
         - { name: aws_access_key_id, label: Access Key ID, env_name: AWS_ACCESS_KEY_ID }
         - name: aws_secret_access_key
           label: Secret Access Key
           type: password
           env_name: AWS_SECRET_ACCESS_KEY
-        - { name: disable_tls, label: Disable TLS (HTTP Endpoint), type: boolean }
-        - { name: max_capacity_gb, label: Max Capacity (GiB), type: number }
+        - name: disable_tls
+          label: { default: Disable TLS (HTTP Endpoint), zh-CN: 禁用 TLS（HTTP 端点） }
+          type: boolean
+        - name: max_capacity_gb
+          label: { default: Max Capacity (GiB), zh-CN: 最大容量（GiB） }
+          type: number
   # Completion hints for the extra-parameters editor. Deliberately
   # excludes the flags GPUStack always renders from structured config.
   common_parameters:
@@ -314,14 +367,20 @@
   display_name: Mooncake
   source: built_in
   icon: /static/catalog_icons/mooncake.png
-  description: >-
-    Mooncake Store is a distributed KV cache pool with a cluster-wide master
-    and per-node clients that transfer KV blocks peer-to-peer over RDMA/TCP.
-    It is deployed and operated outside GPUStack; register the master address
-    and GPUStack attaches inference engines to it, probes it, and (once
-    calibrated) scrapes its metrics.
+  description:
+    default: >-
+      Mooncake Store is a distributed KV cache pool with a cluster-wide master
+      and per-node clients that transfer KV blocks peer-to-peer over RDMA/TCP.
+      It is deployed and operated outside GPUStack; register the master address
+      and GPUStack attaches inference engines to it, probes it, and (once
+      calibrated) scrapes its metrics.
+    zh-CN: >-
+      Mooncake Store 是一个分布式 KV Cache 池，由集群级 master 和各节点客户端组成，节点间通过
+      RDMA/TCP 点对点传输 KV 块。它在 GPUStack 之外部署和运维；注册 master
+      地址后，GPUStack 负责把推理引擎接入、探活，并在完成校准后采集其指标。
   links:
-    - { label: Documentation, url: "https://kvcache-ai.github.io/Mooncake/" }
+    - label: { default: Documentation, zh-CN: 文档 }
+      url: "https://kvcache-ai.github.io/Mooncake/"
     - { label: GitHub, url: "https://github.com/kvcache-ai/Mooncake" }
   # Provider-specific Grafana dashboard provisioned from
   # docker-compose/grafana/grafana_dashboards/gpustack-mooncake.json,
@@ -335,24 +394,34 @@
   # metadata service registers its "etcd://" / "http://" address instead.
   external_fields:
     - name: metadata_server
-      label: Metadata Server
-      description: >-
-        Transfer Engine peer-discovery backend: P2PHANDSHAKE (decentralized),
-        or an etcd:// / redis:// / http:// address.
+      label: { default: Metadata Server, zh-CN: 元数据服务 }
+      description:
+        default: >-
+          Transfer Engine peer-discovery backend: P2PHANDSHAKE (decentralized),
+          or an etcd:// / redis:// / http:// address.
+        zh-CN: >-
+          Transfer Engine 的节点发现后端：P2PHANDSHAKE（去中心化），或一个
+          etcd:// / redis:// / http:// 地址。
       default: P2PHANDSHAKE
     - name: protocol
-      label: Transport Protocol
-      description: RDMA for production performance; TCP for functional setups.
+      label: { default: Transport Protocol, zh-CN: 传输协议 }
+      description:
+        default: RDMA for production performance; TCP for functional setups.
+        zh-CN: 生产环境用 RDMA 以获得性能；功能验证用 TCP。
       default: tcp
       options: [tcp, rdma]
     - name: device_name
-      label: RDMA Device
-      description: NIC device(s) for the RDMA protocol; leave empty for TCP.
+      label: { default: RDMA Device, zh-CN: RDMA 设备 }
+      description:
+        default: NIC device(s) for the RDMA protocol; leave empty for TCP.
+        zh-CN: RDMA 协议使用的网卡设备；使用 TCP 时留空。
     - name: local_buffer_size
-      label: Local Buffer Size
-      description: >-
-        Per-GPU staging buffer for the engine's own store operations
-        (e.g. 1GB).
+      label: { default: Local Buffer Size, zh-CN: 本地缓冲区大小 }
+      description:
+        default: >-
+          Per-GPU staging buffer for the engine's own store operations
+          (e.g. 1GB).
+        zh-CN: 引擎自身 store 操作所用的每 GPU 暂存缓冲区（如 1GB）。
       default: 1GB
   health_check:
     scheme: tcp
@@ -411,13 +480,19 @@
   display_name: XSKY MeshFusion
   source: partner
   icon: /static/catalog_icons/xsky.png
-  description: >-
-    XSKY MeshFusion is a KV cache layer for LLM serving. As a shared cache
-    service it runs a cache server on every worker; deployments and replicas
-    on the same node share KV cache through it, and a shared L2 storage
-    backend (e.g. XSKY's store) extends the reuse across nodes.
+  description:
+    default: >-
+      XSKY MeshFusion is a KV cache layer for LLM serving. As a shared cache
+      service it runs a cache server on every worker; deployments and replicas
+      on the same node share KV cache through it, and a shared L2 storage
+      backend (e.g. XSKY's store) extends the reuse across nodes.
+    zh-CN: >-
+      XSKY MeshFusion 是面向大模型推理的 KV Cache 层。作为共享缓存服务，它在每个 worker
+      上运行一个缓存服务端，同节点的部署与副本通过它共享 KV Cache，共享的 L2
+      存储后端（如 XSKY 的存储）把复用范围扩展到跨节点。
   links:
-    - { label: Product Page, url: "https://www.xsky.com" }
+    - label: { default: Product Page, zh-CN: 产品主页 }
+      url: "https://www.xsky.com"
   # XSKY ships the MeshFusion management console; declaring this makes
   # the service form offer the management_url link field.
   management_url: true
@@ -438,29 +513,37 @@
     cpu: 2
   managed_fields:
     - name: eviction_policy
-      label: Eviction Policy
+      label: { default: Eviction Policy, zh-CN: 淘汰策略 }
       default: LRU
       options: [LRU, IsolatedLRU, noop]
-      description: >-
-        LRU evicts least-recently-used chunks. IsolatedLRU keeps one LRU
-        list per cache salt and requires per-salt quotas via the HTTP
-        API. noop never evicts.
+      description:
+        default: >-
+          LRU evicts least-recently-used chunks. IsolatedLRU keeps one LRU
+          list per cache salt and requires per-salt quotas via the HTTP
+          API. noop never evicts.
+        zh-CN: >-
+          LRU 淘汰最近最少使用的分块。IsolatedLRU 为每个 cache salt 维护独立的 LRU
+          列表，并需通过 HTTP API 为每个 salt 设置配额。noop 从不淘汰。
     - name: eviction_trigger_watermark
-      label: Eviction Trigger Watermark
+      label: { default: Eviction Trigger Watermark, zh-CN: 淘汰触发水位 }
       type: number
       default: 0.85
       min: 0
       max: 1
       step: 0.05
-      description: Memory usage fraction (0-1) that triggers eviction.
+      description:
+        default: Memory usage fraction (0-1) that triggers eviction.
+        zh-CN: 触发淘汰的内存使用率（0-1）。
     - name: eviction_ratio
-      label: Eviction Ratio
+      label: { default: Eviction Ratio, zh-CN: 淘汰比例 }
       type: number
       default: 0.1
       min: 0
       max: 1
       step: 0.05
-      description: Fraction of memory (0-1) evicted per trigger.
+      description:
+        default: Fraction of memory (0-1) evicted per trigger.
+        zh-CN: 每次触发所淘汰的内存比例（0-1）。
   l2_adapter_flag: "--l2-adapter"
   # The store is the only L2 tier MeshFusion is deployed with; a lone
   # declared backend is what the service form preselects.
@@ -472,10 +555,16 @@
       # to off because MeshFusion Store normally configures itself in the image.
       adapter_flag_optional: true
       adapter_flag_default: false
-      adapter_flag_label: Enable L2 Adapter Flag
-      description: >-
-        XSKY MeshFusion Store distributed storage as the L2 tier; capacity
-        and durability scale with the external storage cluster.
+      adapter_flag_label:
+        default: Enable L2 Adapter Flag
+        zh-CN: 启用 L2 适配器参数
+      description:
+        default: >-
+          XSKY MeshFusion Store distributed storage as the L2 tier; capacity
+          and durability scale with the external storage cluster.
+        zh-CN: >-
+          企业级 KV Cache 扩展加速方案，激活 GPU 节点本地 DRAM 与 SSD 加速模型推理。基于端到端的
+          NVMe 技术，提供跨节点共享、本地优先读写、自动淘汰策略、主动保护 SSD 寿命等多种能力。
       # The XDFS plugin is exposed through NIXL's dynamic store adapter. Its
       # plugin-specific values belong under backend_params and are strings,
       # including max_capacity_gb.
@@ -489,7 +578,9 @@
       fields:
         # The image supplies the plugin files and capacity defaults; tenant is
         # the only service-level override exposed by the form.
-        - { name: tenant_id, label: Tenant ID, default: nixl }
+        - name: tenant_id
+          label: { default: Tenant ID, zh-CN: 租户 ID }
+          default: nixl
   common_parameters:
     - --l2-adapter
     # CLI-entry-only groups (coordinator / P2P), valid again now that the

--- a/gpustack/routes/cache_providers.py
+++ b/gpustack/routes/cache_providers.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from fastapi import APIRouter
 
 from gpustack.api.exceptions import NotFoundException
-from gpustack.schemas.cache_providers import CacheProvider
+from gpustack.schemas.cache_providers import CacheProvider, localized_values
 from gpustack.schemas.common import PaginatedList, Pagination
 from gpustack.server.cache_provider_catalog import (
     get_cache_provider,
@@ -23,11 +23,17 @@ async def list_cache_providers(
     providers: List[CacheProvider] = get_cache_providers()
     if search:
         search = search.strip().lower()
+        # Every translation of the display name is searchable, not just
+        # the fallback: the term a user types is in the locale they are
+        # reading the catalog in.
         providers = [
             provider
             for provider in providers
             if search in provider.name.lower()
-            or (provider.display_name and search in provider.display_name.lower())
+            or any(
+                search in name.lower()
+                for name in localized_values(provider.display_name)
+            )
         ]
 
     count = len(providers)

--- a/gpustack/schemas/cache_providers.py
+++ b/gpustack/schemas/cache_providers.py
@@ -1,7 +1,7 @@
 import json
 import re
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, model_validator
 
@@ -10,6 +10,53 @@ from gpustack.utils.version import pick_runtime_version
 CUSTOM_VERSION = "custom"
 """Reserved provider_version identifier: the service pins a user-supplied
 container image (config.image) instead of a declared version."""
+
+LocalizedText = Union[str, Dict[str, str]]
+"""A user-facing string, either bare or keyed by locale.
+
+A bare string is the text in every locale. A mapping carries one entry per
+locale plus the required "default" fallback:
+
+    description:
+      default: XSKY MeshFusion Store distributed storage as the L2 tier.
+      zh-CN: 以 XSKY MeshFusion Store 分布式存储作为 L2 层。
+
+Only display text is localizable. Identity a declaration renders or
+validates against — field ``name``, ``options`` values, catalog keys — stays
+verbatim, so a translated catalog produces byte-identical connector config.
+
+The API serves the mapping as declared and the UI resolves it against the
+locale the user picked, which the request carries no reliable signal of.
+"""
+
+DEFAULT_LOCALE = "default"
+"""Locale key every localized mapping must carry: what the UI falls back to
+for a locale the declaration does not translate, and the text non-UI
+consumers (catalog search, logs) read."""
+
+# BCP 47 shape, loose enough to admit any real tag: a two- or three-letter
+# primary subtag (ISO 639-1 "zh", 639-2/3 "yue") plus any number of script,
+# region or variant subtags. Its job is to catch a typo like "ZH_cn", which
+# would otherwise be text that renders for nobody — a tag it rejects costs
+# the whole provider, so it must not reject one a UI could legitimately ask
+# for.
+LOCALE_PATTERN = re.compile(r"^(default|[a-z]{2,3}(-[A-Za-z0-9]+)*)$")
+
+
+def localized_default(value: Optional[LocalizedText]) -> Optional[str]:
+    """The declaration's fallback text: the bare string, or the mapping's
+    "default" entry."""
+    if isinstance(value, dict):
+        return value.get(DEFAULT_LOCALE)
+    return value
+
+
+def localized_values(value: Optional[LocalizedText]) -> List[str]:
+    """Every translation of a localized string, for consumers matching
+    against text in a locale they do not know (catalog search)."""
+    if isinstance(value, dict):
+        return [text for text in value.values() if text]
+    return [value] if value else []
 
 
 class CacheProviderSourceEnum(str, Enum):
@@ -22,7 +69,7 @@ class CacheProviderLink(BaseModel):
     """A brand link (docs, product page, support) rendered on the
     provider's catalog card."""
 
-    label: str
+    label: LocalizedText
     url: str
 
 
@@ -276,7 +323,7 @@ class CacheProviderL2Field(BaseModel):
     """One configurable parameter of an L2 storage backend."""
 
     name: str
-    label: Optional[str] = None
+    label: Optional[LocalizedText] = None
     """UI label; defaults to name."""
 
     type: str = "string"
@@ -298,8 +345,8 @@ class CacheProviderL2Field(BaseModel):
 class CacheProviderL2Backend(BaseModel):
     """A storage backend the provider's L2 adapter can spill KV cache to."""
 
-    display_name: Optional[str] = None
-    description: Optional[str] = None
+    display_name: Optional[LocalizedText] = None
+    description: Optional[LocalizedText] = None
     icon: Optional[str] = None
     """Logo URL for brand display; the UI falls back to a generic icon."""
 
@@ -310,7 +357,7 @@ class CacheProviderL2Backend(BaseModel):
     adapter_flag_default: bool = True
     """Default state of the optional adapter-flag switch."""
 
-    adapter_flag_label: Optional[str] = None
+    adapter_flag_label: Optional[LocalizedText] = None
     """Label for the optional adapter-flag switch."""
 
     adapter_type: Optional[str] = None
@@ -342,8 +389,8 @@ class CacheProviderField(BaseModel):
     """Placeholder name; must not collide with the reserved platform
     placeholders (host/port/metrics_port/ram_size/chunk_size)."""
 
-    label: Optional[str] = None
-    description: Optional[str] = None
+    label: Optional[LocalizedText] = None
+    description: Optional[LocalizedText] = None
 
     type: str = "string"
     """Value type: "string" | "number" | "boolean" (booleans render as
@@ -368,10 +415,10 @@ class CacheProviderExternalField(BaseModel):
     (host/port) instead, not here."""
 
     name: str
-    label: Optional[str] = None
+    label: Optional[LocalizedText] = None
     """UI label; defaults to name."""
 
-    description: Optional[str] = None
+    description: Optional[LocalizedText] = None
 
     type: str = "string"
     """Value type: "string" | "number" | "boolean" | "password"."""
@@ -391,9 +438,9 @@ class CacheProviderExternalField(BaseModel):
 
 class CacheProvider(BaseModel):
     name: str
-    display_name: Optional[str] = None
+    display_name: Optional[LocalizedText] = None
     source: CacheProviderSourceEnum = CacheProviderSourceEnum.BUILT_IN
-    description: Optional[str] = None
+    description: Optional[LocalizedText] = None
     icon: Optional[str] = None
 
     links: List[CacheProviderLink] = []
@@ -852,6 +899,74 @@ def validate_injection_templates(provider: "CacheProvider") -> List[str]:
                 f"{prefix} references placeholder '{name}', which is not a "
                 "reserved placeholder, a declared field, or a key present "
                 "in every locality bucket"
+            )
+    return errors
+
+
+def _localized_violations(value: Any, where: str) -> List[str]:
+    """Check one localized slot against the mapping contract."""
+    if not isinstance(value, dict):
+        return []
+    if not value:
+        return [f"{where} is an empty locale mapping"]
+    errors: List[str] = []
+    if not value.get(DEFAULT_LOCALE):
+        # Without a fallback, a locale the declaration skips has nothing
+        # to render and the slot reads as untranslated rather than as
+        # the author's canonical text.
+        errors.append(f"{where} has no '{DEFAULT_LOCALE}' entry")
+    for locale in sorted(value):
+        if not LOCALE_PATTERN.match(locale):
+            errors.append(f"{where} has invalid locale key '{locale}'")
+    return errors
+
+
+def validate_localized_text(provider: "CacheProvider") -> List[str]:
+    """
+    Check every localizable slot of a provider against the LocalizedText
+    contract; returns human-readable violations (empty when clean).
+
+    Enforced at load time because the UI resolves these mappings itself:
+    a slot missing its "default" degrades to whatever key the fallback
+    chain lands on, differently per locale, and a typo'd locale key is
+    text that simply never appears for anyone.
+    """
+    errors: List[str] = []
+    prefix = f"'{provider.name}'"
+    errors.extend(
+        _localized_violations(provider.display_name, f"{prefix} display_name")
+    )
+    errors.extend(_localized_violations(provider.description, f"{prefix} description"))
+    for index, link in enumerate(provider.links):
+        errors.extend(
+            _localized_violations(link.label, f"{prefix} link #{index} label")
+        )
+    for field in provider.external_fields:
+        where = f"{prefix} external field '{field.name}'"
+        errors.extend(_localized_violations(field.label, f"{where} label"))
+        errors.extend(_localized_violations(field.description, f"{where} description"))
+    for field in provider.managed_fields:
+        where = f"{prefix} managed field '{field.name}'"
+        errors.extend(_localized_violations(field.label, f"{where} label"))
+        errors.extend(_localized_violations(field.description, f"{where} description"))
+    for key, backend in provider.l2_backends.items():
+        where = f"{prefix} l2 backend '{key}'"
+        errors.extend(
+            _localized_violations(backend.display_name, f"{where} display_name")
+        )
+        errors.extend(
+            _localized_violations(backend.description, f"{where} description")
+        )
+        errors.extend(
+            _localized_violations(
+                backend.adapter_flag_label, f"{where} adapter_flag_label"
+            )
+        )
+        for field in backend.fields:
+            errors.extend(
+                _localized_violations(
+                    field.label, f"{where} field '{field.name}' label"
+                )
             )
     return errors
 

--- a/gpustack/server/cache_provider_catalog.py
+++ b/gpustack/server/cache_provider_catalog.py
@@ -8,6 +8,7 @@ from gpustack.schemas.cache_providers import (
     CacheProvider,
     render_injection as _render_injection,
     validate_injection_templates,
+    validate_localized_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -40,11 +41,13 @@ def load_cache_providers(reload: bool = False) -> List[CacheProvider]:
                     # not the catalog: the others still serve.
                     logger.error(f"Skipping malformed cache provider {name}: {e}")
                     continue
-                # A provider violating the injection placeholder contract
-                # is excluded outright: its failure modes are silent at
-                # runtime (literal placeholders corrupting connector
-                # config, secrets riding into instance snapshots).
+                # A provider violating the injection placeholder or the
+                # localized-text contract is excluded outright: both fail
+                # silently at runtime (literal placeholders corrupting
+                # connector config, secrets riding into instance
+                # snapshots, text that renders for no locale).
                 violations = validate_injection_templates(provider)
+                violations += validate_localized_text(provider)
                 if violations:
                     logger.error(
                         f"Skipping cache provider {provider.name}: "

--- a/tests/server/test_cache_provider_catalog.py
+++ b/tests/server/test_cache_provider_catalog.py
@@ -8,8 +8,11 @@ from gpustack.schemas.cache_providers import (
     CacheProviderL2Backend,
     CacheProviderL2Field,
     CacheProviderVersionConfig,
+    localized_default,
+    localized_values,
     render_l2_adapter,
     validate_injection_templates,
+    validate_localized_text,
 )
 from gpustack.schemas.cache_services import CacheServiceModeEnum
 from gpustack.server import cache_provider_catalog
@@ -629,7 +632,7 @@ def test_meshfusion_provider_is_a_branded_lmcache_clone():
     assert xdfs.icon == "/static/catalog_icons/xsky.png"
     assert xdfs.adapter_flag_optional is True
     assert xdfs.adapter_flag_default is False
-    assert xdfs.adapter_flag_label == "Enable L2 Adapter Flag"
+    assert localized_default(xdfs.adapter_flag_label) == "Enable L2 Adapter Flag"
     assert xdfs.adapter_type == "nixl_store_dynamic"
     assert xdfs.adapter_backend == "XDFS_KV"
     assert xdfs.adapter_params == {
@@ -692,12 +695,15 @@ def test_render_l2_adapter_stringifies_nested_backend_params():
 
 
 def test_provider_brand_links():
+    def labels(provider):
+        return {localized_default(link.label) for link in provider.links}
+
     lmcache = get_cache_provider("LMCache")
-    assert {link.label for link in lmcache.links} == {"Documentation", "GitHub"}
+    assert labels(lmcache) == {"Documentation", "GitHub"}
     assert all(link.url.startswith("https://") for link in lmcache.links)
 
     mooncake = get_cache_provider("Mooncake")
-    assert {link.label for link in mooncake.links} == {"Documentation", "GitHub"}
+    assert labels(mooncake) == {"Documentation", "GitHub"}
 
     meshfusion = get_cache_provider("XSKY MeshFusion")
     assert meshfusion.links, "partner card needs at least one brand link"
@@ -1051,3 +1057,129 @@ def test_injection_contract_flags_violations():
     # "mode" is not present in every locality bucket, so it is
     # unresolvable on the remote path and must be flagged.
     assert "placeholder 'mode'" in joined
+
+
+def test_bare_string_and_locale_mapping_are_both_accepted():
+    """A declaration written before the catalog had locales stays valid:
+    a bare string is the text in every locale, so translating a slot is
+    additive rather than a rewrite."""
+    provider = CacheProvider(
+        name="localized",
+        display_name="Localized",
+        description={"default": "A cache", "zh-CN": "一个缓存"},
+        links=[{"label": {"default": "Docs", "zh-CN": "文档"}, "url": "https://x"}],
+        managed_fields=[
+            {"name": "size", "label": {"default": "Size", "ja-JP": "サイズ"}}
+        ],
+    )
+    assert validate_localized_text(provider) == []
+    assert localized_default(provider.display_name) == "Localized"
+    assert localized_default(provider.description) == "A cache"
+    assert localized_values(provider.display_name) == ["Localized"]
+    assert sorted(localized_values(provider.description)) == ["A cache", "一个缓存"]
+
+
+def test_localized_slot_without_a_default_is_a_violation():
+    """Every locale mapping needs the fallback entry: without it a locale
+    the declaration skips has no text to render, so the slot reads as
+    untranslated instead of as the author's canonical wording."""
+    provider = CacheProvider(
+        name="no-default",
+        display_name={"zh-CN": "只有中文"},
+        description={},
+        l2_backends={
+            "b": CacheProviderL2Backend(
+                description={"zh-CN": "只有中文"},
+                fields=[CacheProviderL2Field(name="x", label={"zh-CN": "只有中文"})],
+            )
+        },
+    )
+    joined = "\n".join(validate_localized_text(provider))
+    assert "display_name has no 'default' entry" in joined
+    assert "description is an empty locale mapping" in joined
+    assert "l2 backend 'b' description has no 'default' entry" in joined
+    assert "l2 backend 'b' field 'x' label has no 'default' entry" in joined
+
+
+def test_invalid_locale_key_is_a_violation():
+    """A key that no locale resolves to is text that renders for nobody;
+    it is caught at load time rather than silently never appearing.
+
+    Rejection costs the whole provider, so the check admits every real tag
+    shape: a script or region suffix, and the three-letter primary subtags
+    of ISO 639-2/3 alongside 639-1's two."""
+    provider = CacheProvider(
+        name="bad-locale",
+        external_fields=[
+            {
+                "name": "protocol",
+                "label": {
+                    "default": "Protocol",
+                    "ZH_cn": "协议",
+                    "zh-Hant": "協議",
+                    "yue": "協議",
+                    "fil-PH": "Protocol",
+                },
+            }
+        ],
+    )
+    joined = "\n".join(validate_localized_text(provider))
+    assert "invalid locale key 'ZH_cn'" in joined
+    for valid in ("zh-Hant", "yue", "fil-PH"):
+        assert valid not in joined
+
+
+def test_localized_violation_costs_only_its_own_provider(monkeypatch):
+    """The localized-text contract is enforced with the same blast radius
+    as the injection contract: the offending provider drops out, the rest
+    of the catalog still serves."""
+    asset = (
+        "- name: Broken\n"
+        '  default_image: "repo/cache:{{version}}"\n'
+        "  description:\n"
+        "    zh-CN: 没有默认文案\n"
+        "  versions:\n"
+        '    "v1.0": {}\n'
+        "- name: Good\n"
+        '  default_image: "repo/cache:{{version}}"\n'
+        "  description:\n"
+        "    default: A cache\n"
+        "    zh-CN: 一个缓存\n"
+        "  versions:\n"
+        '    "v1.0": {}\n'
+    )
+
+    class _Asset:
+        def is_file(self):
+            return True
+
+        def read_text(self, encoding=None):
+            return asset
+
+    try:
+        monkeypatch.setattr(cache_provider_catalog, "files", lambda _package: _Asset())
+        monkeypatch.setattr(_Asset, "joinpath", lambda self, _name: self, raising=False)
+        providers = load_cache_providers(reload=True)
+        assert [provider.name for provider in providers] == ["Good"]
+    finally:
+        monkeypatch.undo()
+        load_cache_providers(reload=True)
+
+
+def test_every_form_field_declares_a_label():
+    """The UI humanizes a missing label from the field name, which is an
+    English identifier: a field without a label is a slot that stays
+    English in every other locale."""
+    missing = []
+    for provider in load_cache_providers(reload=True):
+        for field in provider.external_fields:
+            if field.label is None:
+                missing.append(f"{provider.name} external field '{field.name}'")
+        for field in provider.managed_fields:
+            if field.label is None:
+                missing.append(f"{provider.name} managed field '{field.name}'")
+        for key, backend in provider.l2_backends.items():
+            for field in backend.fields:
+                if field.label is None:
+                    missing.append(f"{provider.name} l2 '{key}' field '{field.name}'")
+    assert not missing, "fields missing a label: " + ", ".join(missing)


### PR DESCRIPTION
A provider declaration is the one place a partner ships user-facing copy, and the UI serves five locales — a catalog string written in one of them is wrong in the other four. Every display slot (display_name, description, label, adapter_flag_label, link label) now takes either a bare string or a mapping keyed by locale, so the translation travels with the declaration a partner hands over and translating a slot is additive: every existing bare string stays valid and means the text in every locale.

Identity is deliberately not localizable. Field names, options values, catalog keys and adapter parameters reach the engine verbatim whatever locale the catalog is read in, so a translated catalog renders byte-identical connector config. Options values are the engine's own enum and appear in its documentation under those names; what each one means belongs in the field description, which is localizable.

The mapping is served as declared and resolved in the UI, the only place that knows the locale the user picked — a request carries no reliable signal of it. Catalog search matches every translation, not just the fallback, since the term a user types is in the locale they are reading in. Load time rejects a mapping with no "default" entry or a key no locale resolves to, with the same blast radius as the injection contract: the offending provider drops out, the rest of the catalog still serves.

All three catalog entries are translated into Chinese whole: card description and documentation link, and every one of the 26 form fields with its label and help text. Half a translated form reads worse than none, so a field without a label is now a test failure — the UI would humanize the field name, which is an English identifier. What stays bare is what reads the same in every locale: brand names (GitHub, Redis / Valkey, S3) and the object store's own credential names.