### PR TITLE
fix(worker): avoid duplicate distributed startup restarts

### DIFF
--- a/gpustack/worker/serve_manager.py
+++ b/gpustack/worker/serve_manager.py
@@ -461,6 +461,24 @@ class ServeManager:
 
             is_main_worker = model_instance.worker_id == self._worker_id
 
+            # INITIALIZE_LATER deliberately keeps subordinate workers idle until
+            # the main worker has finished its model-file initialization.  The
+            # event handler applies the same gate before creating the subordinate
+            # workload.  Do not let the periodic reconciler mistake that expected
+            # absence for a crashed inference server in the meantime.
+            if (
+                not is_main_worker
+                and model_instance.distributed_servers.mode
+                == DistributedServerCoordinateModeEnum.INITIALIZE_LATER
+                and model_instance.state
+                not in [
+                    ModelInstanceStateEnum.STARTING,
+                    ModelInstanceStateEnum.RUNNING,
+                    ModelInstanceStateEnum.ERROR,
+                ]
+            ):
+                continue
+
             # Skip if the workload is still launching.
             # Use deployment metadata name for subordinate workers (e.g., "model-f0")
             # since their workload name differs from the model instance name.
@@ -1063,20 +1081,35 @@ class ServeManager:
         if event.type == EventType.UPDATED:
             # Caching matched ERROR instances for restart handling.
             if mi.state == ModelInstanceStateEnum.ERROR:
-                model = self._get_model(mi)
-                if model.restart_on_error:
-                    self._error_model_instances[mi.id] = mi
-                    logger.trace(
-                        f"UPDATED event: cached error model instance {mi.name} for restart."
-                    )
+                # The main worker owns the model-instance state machine.  A
+                # subordinate observes the same global ERROR event, but must not
+                # independently advance it to SCHEDULED or multiple workers race
+                # to restart the same distributed deployment.
+                if is_main_worker:
+                    model = self._get_model(mi)
+                    if model.restart_on_error:
+                        self._error_model_instances[mi.id] = mi
+                        logger.trace(
+                            f"UPDATED event: cached error model instance {mi.name} for restart."
+                        )
                 return
 
             # Restart if scheduled and this is the assigned worker.
             if is_main_worker and mi.state == ModelInstanceStateEnum.SCHEDULED:
-                self._restart_model_instance(mi)
-                logger.trace(
-                    f"UPDATED event: restarted scheduled model instance {mi.name}."
-                )
+                # A burst of equivalent SCHEDULED events can arrive before the
+                # INITIALIZING update written by _start_model_instance is seen.
+                # Do not tear down the provisioning process started by the first
+                # event; its result (or ERROR state) remains authoritative.
+                if self._is_provisioning(mi):
+                    logger.trace(
+                        f"UPDATED event: model instance {mi.name} is already "
+                        "provisioning; skipped duplicate scheduled restart."
+                    )
+                else:
+                    self._restart_model_instance(mi)
+                    logger.trace(
+                        f"UPDATED event: restarted scheduled model instance {mi.name}."
+                    )
 
             # Start on subordinate worker if not started yet, or restart if failed.
             if not is_main_worker:
@@ -1858,6 +1891,10 @@ class ServeManager:
         current_time = datetime.now(timezone.utc)
         delay = min(10 * (2 ** (backoff_count - 1)), 300) if backoff_count > 0 else 0
         if backoff_count > 0 and last_restart_time:
+            if last_restart_time.tzinfo is None:
+                # API/database timestamps without an explicit offset are UTC.
+                # Normalize before subtracting from the aware current_time.
+                last_restart_time = last_restart_time.replace(tzinfo=timezone.utc)
             elapsed_time = (current_time - last_restart_time).total_seconds()
             if elapsed_time < delay:
                 logger.trace(

--- a/tests/worker/test_serve_manager.py
+++ b/tests/worker/test_serve_manager.py
@@ -143,6 +143,30 @@ def test_restart_error_model_instance_uses_transient_backoff_count():
     )
 
 
+def test_restart_error_model_instance_accepts_naive_database_timestamp():
+    manager, _ = _build_serve_manager()
+    model_instance = new_model_instance(
+        1,
+        "restarted-instance",
+        1,
+        worker_id=1,
+        state=ModelInstanceStateEnum.ERROR,
+    )
+    model_instance.last_restart_time = datetime.now(timezone.utc).replace(
+        microsecond=0, tzinfo=None
+    )
+    manager._restart_backoff_counts[model_instance.id] = 1
+
+    with (
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch.object(manager, "_update_model_instance") as update_model_instance,
+        patch("gpustack.worker.serve_manager.logger"),
+    ):
+        manager._restart_error_model_instance(model_instance)
+
+    update_model_instance.assert_not_called()
+
+
 def test_restart_model_instance_preserves_transient_backoff_count():
     manager, _ = _build_serve_manager()
     model_instance = new_model_instance(
@@ -445,6 +469,86 @@ def test_updated_event_error_does_not_crash_watch():
     ):
         # Must not raise.
         manager._handle_model_instance_event(Event(type=EventType.UPDATED, data=mi))
+
+
+def test_scheduled_update_does_not_restart_while_provisioning():
+    manager, _ = _build_serve_manager(worker_id=1)
+    mi = new_model_instance(
+        5,
+        "distributed-instance",
+        1,
+        worker_id=1,
+        state=ModelInstanceStateEnum.SCHEDULED,
+    )
+    mi.source = SourceEnum.HUGGING_FACE
+    mi.huggingface_repo_id = "Qwen/Qwen3-0.6B"
+
+    with (
+        patch.object(manager, "_is_provisioning", return_value=True),
+        patch.object(manager, "_restart_model_instance") as restart_model_instance,
+    ):
+        manager._dispatch_model_instance_event(Event(type=EventType.UPDATED, data=mi))
+
+    restart_model_instance.assert_not_called()
+
+
+def test_subordinate_does_not_schedule_global_error_restart():
+    manager, _ = _build_serve_manager(worker_id=2)
+    mi = new_model_instance(
+        5, "distributed-instance", 1, worker_id=1, state=ModelInstanceStateEnum.ERROR
+    )
+    mi.source = SourceEnum.HUGGING_FACE
+    mi.huggingface_repo_id = "Qwen/Qwen3-0.6B"
+    mi.distributed_servers = DistributedServers(
+        mode=DistributedServerCoordinateModeEnum.INITIALIZE_LATER,
+        subordinate_workers=[
+            ModelInstanceSubordinateWorker(
+                worker_id=2,
+                worker_name="worker-2",
+                worker_ip="10.0.0.2",
+                state=ModelInstanceStateEnum.ERROR,
+            )
+        ],
+    )
+
+    with patch.object(manager, "_get_model") as get_model:
+        manager._dispatch_model_instance_event(Event(type=EventType.UPDATED, data=mi))
+
+    get_model.assert_not_called()
+    assert mi.id not in manager._error_model_instances
+
+
+def test_initialize_later_subordinate_wait_is_not_treated_as_failure():
+    manager, clientset = _build_serve_manager(worker_id=2)
+    mi = new_model_instance(
+        5,
+        "distributed-instance",
+        1,
+        worker_id=1,
+        state=ModelInstanceStateEnum.INITIALIZING,
+    )
+    mi.distributed_servers = DistributedServers(
+        mode=DistributedServerCoordinateModeEnum.INITIALIZE_LATER,
+        subordinate_workers=[
+            ModelInstanceSubordinateWorker(
+                worker_id=2,
+                worker_name="worker-2",
+                worker_ip="10.0.0.2",
+                state=ModelInstanceStateEnum.PENDING,
+            )
+        ],
+    )
+    clientset.model_instances.list.return_value = SimpleNamespace(items=[mi])
+
+    with (
+        patch.object(manager, "_is_provisioning", return_value=False),
+        patch("gpustack.worker.serve_manager.get_workload") as get_workload,
+        patch.object(manager, "_update_model_instance") as update_model_instance,
+    ):
+        manager.sync_model_instances_state()
+
+    get_workload.assert_not_called()
+    update_model_instance.assert_not_called()
 
 
 def test_persist_container_logs_reconnects_and_dedupes(tmp_path: Path):


### PR DESCRIPTION
## Summary

- make the assigned main worker the sole owner of global model-instance restart scheduling
- ignore duplicate `SCHEDULED` updates while the main worker is already provisioning
- keep `INITIALIZE_LATER` subordinate workers out of workload-failure reconciliation until the main worker is ready
- normalize naive database restart timestamps to UTC before calculating restart backoff

## Problem

On a distributed deployment using `INITIALIZE_LATER`, the subordinate worker is intentionally idle while the main worker prepares the model. The periodic state reconciler currently interprets the missing subordinate workload as a failure and updates the distributed instance.

Every worker also caches the resulting global `ERROR` state for automatic restart. Multiple workers can therefore advance the same instance back to `SCHEDULED`, while repeated `SCHEDULED` events on the main worker unconditionally tear down and recreate a deployment that may already be provisioning. This produces several short-lived workload starts before one survives.

The restart timer can additionally fail with `can't subtract offset-naive and offset-aware datetimes` when `last_restart_time` is returned without timezone information, preventing the intended backoff from serializing recovery.

## Reproduction

1. Configure a model for distributed inference across at least two workers with `distributed_servers.mode=initialize_later` and `restart_on_error=true`.
2. Start the model with no existing workloads on either worker.
3. Let the worker state reconciliation run while the subordinate is waiting for the main worker.
4. Observe the subordinate report the intentionally absent workload as failed, more than one worker schedule a global restart, and the main workload be stopped and recreated during startup.

Expected behavior: the subordinate wait is not treated as a crash, and a scheduled restart is owned and executed once by the main worker.

## Tests

- `uv run pytest -q tests/worker/test_serve_manager.py` (36 passed)
- `uv run pytest -q tests/worker` (555 passed)
- `uv run black --check --config pyproject.toml gpustack/worker/serve_manager.py tests/worker/test_serve_manager.py`

This change does not alter vLLM's internal port selection or the separate ZMQ port-collision behavior tracked in #6019.
