### PR TITLE
fix(http_proxy): keep round-robin position across requests

### DIFF
--- a/gpustack/http_proxy/strategies.py
+++ b/gpustack/http_proxy/strategies.py
@@ -18,18 +18,20 @@ class LoadBalancingStrategy(ABC):
 class RoundRobinStrategy(LoadBalancingStrategy):
     def __init__(self):
         self._iterators: Dict[int, itertools.cycle] = {}
-        self._instance_lists: Dict[int, List[ModelInstance]] = {}
+        self._instance_ids: Dict[int, List[int]] = {}
 
     async def select_instance(self, instances: List[ModelInstance]) -> ModelInstance:
         if len(instances) == 0:
             raise Exception("No instances available")
         model_id = instances[0].model_id
+        instance_ids = sorted(instance.id for instance in instances)
         if (
             model_id not in self._iterators
-            or self._instance_lists[model_id] != instances
+            or self._instance_ids[model_id] != instance_ids
         ):
             logger.debug(f"Creating new iterator for model {model_id}")
-            self._iterators[model_id] = itertools.cycle(instances)
-            self._instance_lists[model_id] = instances
+            self._iterators[model_id] = itertools.cycle(instance_ids)
+            self._instance_ids[model_id] = instance_ids
 
-        return next(self._iterators[model_id])
+        next_id = next(self._iterators[model_id])
+        return next(instance for instance in instances if instance.id == next_id)

--- a/gpustack/http_proxy/strategies.py
+++ b/gpustack/http_proxy/strategies.py
@@ -34,4 +34,5 @@ class RoundRobinStrategy(LoadBalancingStrategy):
             self._instance_ids[model_id] = instance_ids
 
         next_id = next(self._iterators[model_id])
-        return next(instance for instance in instances if instance.id == next_id)
+        instances_by_id = {instance.id: instance for instance in instances}
+        return instances_by_id[next_id]

--- a/tests/http_proxy/test_strategies.py
+++ b/tests/http_proxy/test_strategies.py
@@ -1,0 +1,70 @@
+import pytest
+
+from gpustack.http_proxy.strategies import RoundRobinStrategy
+from gpustack.schemas.models import ModelInstance
+
+
+def make_instances(ids, model_id=10, restart_count=0):
+    return [
+        ModelInstance(
+            id=i,
+            model_id=model_id,
+            worker_ip=f"10.0.0.{i}",
+            port=8000,
+            restart_count=restart_count,
+        )
+        for i in ids
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cycles_when_each_call_passes_fresh_objects():
+    strategy = RoundRobinStrategy()
+    selected = []
+    for call in range(6):
+        inst = await strategy.select_instance(make_instances([1, 2, 3], restart_count=call))
+        selected.append(inst.id)
+    assert selected == [1, 2, 3, 1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_returns_object_from_current_list():
+    strategy = RoundRobinStrategy()
+    instances = make_instances([1, 2])
+    first = await strategy.select_instance(instances)
+    assert first is instances[0]
+    instances = make_instances([1, 2])
+    second = await strategy.select_instance(instances)
+    assert second is instances[1]
+
+
+@pytest.mark.asyncio
+async def test_resets_when_membership_changes():
+    strategy = RoundRobinStrategy()
+    assert (await strategy.select_instance(make_instances([1, 2]))).id == 1
+    assert (await strategy.select_instance(make_instances([1, 2, 3]))).id == 1
+    assert (await strategy.select_instance(make_instances([1, 2, 3]))).id == 2
+    assert (await strategy.select_instance(make_instances([2, 3]))).id == 2
+
+
+@pytest.mark.asyncio
+async def test_models_are_tracked_separately():
+    strategy = RoundRobinStrategy()
+    assert (await strategy.select_instance(make_instances([1, 2], model_id=10))).id == 1
+    assert (await strategy.select_instance(make_instances([7, 8], model_id=20))).id == 7
+    assert (await strategy.select_instance(make_instances([1, 2], model_id=10))).id == 2
+    assert (await strategy.select_instance(make_instances([7, 8], model_id=20))).id == 8
+
+
+@pytest.mark.asyncio
+async def test_single_instance():
+    strategy = RoundRobinStrategy()
+    for _ in range(3):
+        assert (await strategy.select_instance(make_instances([1]))).id == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_list_raises():
+    strategy = RoundRobinStrategy()
+    with pytest.raises(Exception, match="No instances available"):
+        await strategy.select_instance([])

--- a/tests/http_proxy/test_strategies.py
+++ b/tests/http_proxy/test_strategies.py
@@ -22,7 +22,9 @@ async def test_cycles_when_each_call_passes_fresh_objects():
     strategy = RoundRobinStrategy()
     selected = []
     for call in range(6):
-        inst = await strategy.select_instance(make_instances([1, 2, 3], restart_count=call))
+        inst = await strategy.select_instance(
+            make_instances([1, 2, 3], restart_count=call)
+        )
         selected.append(inst.id)
     assert selected == [1, 2, 3, 1, 2, 3]
 


### PR DESCRIPTION
`RoundRobinStrategy.select_instance` decides whether to rebuild its `itertools.cycle` by comparing the `ModelInstance` objects from the previous call with the ones passed now. Every request fetches fresh objects from the database, and any field that changed in between (heartbeat data, restart counters, state) makes the lists compare unequal, so the cycle is recreated and starts from the first instance again.

On a two-replica reranker deployment (GPUStack v2.2.3) this showed up as very uneven splits under bursty load: 37 requests went 27/10, another batch 21/16. Over long periods it evens out, which is probably why it went unnoticed.

This change tracks the sorted instance ids instead, rebuilds the cycle only when the membership changes, and returns the instance object from the current list so callers never get a stale object.

Same approach as #5879, which was closed without being merged; tests added under `tests/http_proxy`. With the old code two of the six tests fail (`test_cycles_when_each_call_passes_fresh_objects`, `test_returns_object_from_current_list`).
