### PR TITLE
feat(gateway): make the TLS protocol version bounds configurable

### DIFF
--- a/charts/gpustack-chart/templates/_helper.tpl
+++ b/charts/gpustack-chart/templates/_helper.tpl
@@ -252,6 +252,75 @@ tls:
 {{- end -}}
 
 
+{{/*
+Normalize one TLS protocol version onto Higress' spelling, or fail the render.
+
+Refusing the install is the point. Higress fails *open* on a version string it
+cannot parse: the Ingress applies, the listener keeps its TLS 1.0 default, and
+the only trace is a line in the higress-controller log. A `TLSv1.4` or a
+`TLSv1_2` that rendered fine would leave the floor exactly where it was while
+looking like it had been raised.
+
+Underscores and case are normalized rather than rejected -- `TLSv1_2` is Envoy's
+own spelling and the likeliest thing to reach for. Mirrors
+`_normalized_tls_protocol_version` in gpustack/gateway/utils.py, which does the
+same for the environment variables the non-in-cluster modes use.
+
+Args: dict with `input` (the configured value) and `field` (its values path,
+used in the error message).
+*/}}
+{{- define "normalized_tls_protocol_version" -}}
+{{- $candidate := .input | toString | replace "_" "." | lower -}}
+{{- $match := "" -}}
+{{- range $supported := list "TLSv1.0" "TLSv1.1" "TLSv1.2" "TLSv1.3" -}}
+{{- if eq $candidate (lower $supported) -}}{{- $match = $supported -}}{{- end -}}
+{{- end -}}
+{{- if not $match -}}
+{{/* `.input | toString` before %q: %q on a bool or int renders as %!q(bool=false)
+or an escape sequence, which tells the operator nothing about what they typed. */}}
+{{- fail (printf "%s: %q is not a TLS version Higress accepts. Valid values are TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3 -- anything else is ignored by Higress, which keeps accepting TLS 1.0." .field (.input | toString)) -}}
+{{- end -}}
+{{- $match -}}
+{{- end -}}
+
+{{/*
+TLS protocol version bounds for this Ingress' listener, as Higress' annotations.
+
+Only rendered here. The Ingress this chart creates is the anchor GPUStack reads
+when it generates an Ingress per LLM route, so setting the bounds once here puts
+them on the whole gateway -- there is no second place to keep in step.
+*/}}
+{{- define "ingress_tls_protocol_annotations" -}}
+{{- $tls := .Values.server.ingress.tls -}}
+{{- $min := "" -}}
+{{- $max := "" -}}
+{{/* An explicit nil/empty test rather than `with`, which also treats `false`
+and `0` as unset. Those are not TLS versions, but letting them skip validation
+would render no annotation at all and leave the listener on TLS 1.0 -- the
+silent failure this block exists to prevent. Anything not null and not empty
+goes to the validator, which names it in the error. */}}
+{{- $rawMin := $tls.minProtocolVersion -}}
+{{- if and (not (kindIs "invalid" $rawMin)) (ne (toString $rawMin) "") -}}
+{{- $min = include "normalized_tls_protocol_version" (dict "input" $rawMin "field" "server.ingress.tls.minProtocolVersion") -}}
+{{- end -}}
+{{- $rawMax := $tls.maxProtocolVersion -}}
+{{- if and (not (kindIs "invalid" $rawMax)) (ne (toString $rawMax) "") -}}
+{{- $max = include "normalized_tls_protocol_version" (dict "input" $rawMax "field" "server.ingress.tls.maxProtocolVersion") -}}
+{{- end -}}
+{{/* Lexical order matches version order across these four, all same length and
+differing only in the last digit, so this needs no index lookup. */}}
+{{- if and $min $max (gt $min $max) -}}
+{{- fail (printf "server.ingress.tls.minProtocolVersion (%s) is higher than server.ingress.tls.maxProtocolVersion (%s); no TLS version would be accepted." $min $max) -}}
+{{- end -}}
+{{- with $min }}
+higress.io/tls-min-protocol-version: "{{ . }}"
+{{- end }}
+{{- with $max }}
+higress.io/tls-max-protocol-version: "{{ . }}"
+{{- end }}
+{{- end -}}
+
+
 {{- define "image_pull_secrets" -}}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/gpustack-chart/templates/server-service.yaml
+++ b/charts/gpustack-chart/templates/server-service.yaml
@@ -60,6 +60,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "chart_labels" . | indent 4 }}
+  {{- with (include "ingress_tls_protocol_annotations" . | trim) }}
+  annotations:
+    {{- nindent 4 . }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.gateway.ingressClassname }}
   rules:

--- a/charts/gpustack-chart/values.yaml
+++ b/charts/gpustack-chart/values.yaml
@@ -114,6 +114,22 @@ server:
       #   -----BEGIN PRIVATE KEY-----
       #   MIIE...
       #   -----END PRIVATE KEY-----
+      # Lowest and highest TLS protocol version this Ingress' listener accepts.
+      # One of TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
+      #
+      # This Ingress is the anchor: GPUStack copies these bounds onto every
+      # Ingress it generates for an LLM route, so they land on the whole
+      # gateway, not just the entrypoint. Empty leaves Higress on its own
+      # default, which accepts TLS 1.0 and 1.1 -- what a security scan flags,
+      # and what existing releases already run, so raising the floor is opt-in.
+      #
+      # Changing these on an existing release takes effect on this Ingress
+      # immediately, and on already-generated LLM-route Ingresses at their next
+      # reconcile. Restart the server to propagate at once -- it replays every
+      # route on startup. Left to you rather than rolled automatically, since a
+      # control-plane restart costs more than this setting is usually worth.
+      minProtocolVersion: null
+      maxProtocolVersion: null
 
   # if you have an existing database, set externalDatabaseURL to its connection string
   # e.g. postgresql://user:password@hostname:port/dbname

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -81,6 +81,17 @@ The **Applies to** column indicates where the environment variable should be set
 | `GPUSTACK_GATEWAY_AUTH_RECONCILE_INTERVAL_SECONDS` | How often the server recomputes, from the database, the API keys the gateway authenticates locally. Deletions that bypass the ORM emit no event, so on a public route this is the worst-case time such a key keeps working. | `30`      | Server     |
 | `GPUSTACK_GATEWAY_AUTH_ALLOW_CUSTOM_KEYS`          | Whether a custom API key (one whose secret the user supplied) may be authenticated at the gateway. Off, it keeps working but asks the server on every request. On, the key is published into the gateway's configuration indexed by an unsalted fast hash of the secret itself — identical across deployments, so a weak secret falls to a precomputed table. `custom` imposes no entropy requirement, so turn this off where users choose their own keys — it is re-read on every reconcile, so it withdraws custom keys published while it was on, not just new ones. | `true`    | Server     |
 | `GPUSTACK_GATEWAY_AUTH_MAX_CR_BYTES`               | Byte budget for the key tables and public-route rules the server writes into the gateway's auth plugin. Sized under etcd's ~1.5 MiB object limit; keys past it authenticate via the server on every request.                | `1100000` | Server     |
+| `GPUSTACK_GATEWAY_TLS_MIN_PROTOCOL_VERSION`        | Lowest TLS protocol version the gateway's HTTPS listeners accept. One of `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`; anything else is refused at startup. Empty leaves Higress on its default, which accepts TLS 1.0 and 1.1. Ignored in `incluster` mode — see below. | (empty)   | Server     |
+| `GPUSTACK_GATEWAY_TLS_MAX_PROTOCOL_VERSION`        | Highest version those listeners accept. Same values and same scope; rarely needed.                                                                                                                                         | (empty)   | Server     |
+
+The TLS protocol version configuration is written onto the ingress named by
+`GPUSTACK_GATEWAY_MIRROR_INGRESS_NAME`, and every ingress GPUStack generates for
+an LLM route copies the bounds from it.
+In `incluster` mode that ingress belongs to the helm chart, so set
+`server.ingress.tls.minProtocolVersion` / `maxProtocolVersion` there instead —
+the variables are ignored, and setting one logs a warning. A change applies to
+that ingress immediately and to existing LLM routes at their next reconcile;
+restart the server to propagate at once.
 
 Settings that end up **inside** a gateway plugin's configuration are set in the
 config file under `gateway_plugin` rather than here, so that each mechanism has

--- a/gpustack/envs/__init__.py
+++ b/gpustack/envs/__init__.py
@@ -328,6 +328,23 @@ GATEWAY_MIRROR_INGRESS_NAME = os.getenv(
     "GPUSTACK_GATEWAY_MIRROR_INGRESS_NAME", "gpustack"
 )
 
+# TLS protocol version floor and ceiling for the gateway's HTTPS listeners,
+# stamped onto every Ingress gpustack manages (the mirror Ingress and every
+# generated LLM route). Both empty by default, which leaves Higress on its own
+# defaults -- a minimum of TLS 1.0, which is what a security scan flags, but
+# also what existing deployments already run, so raising it stays opt-in.
+#
+# Accepted spellings are Higress' own: TLSv1.0 / TLSv1.1 / TLSv1.2 / TLSv1.3.
+# Anything else is rejected at startup rather than passed through, because
+# Higress fails *open* on a value it cannot parse -- see
+# ``gateway_tls_annotations``.
+GATEWAY_TLS_MIN_PROTOCOL_VERSION = os.getenv(
+    "GPUSTACK_GATEWAY_TLS_MIN_PROTOCOL_VERSION", ""
+).strip()
+GATEWAY_TLS_MAX_PROTOCOL_VERSION = os.getenv(
+    "GPUSTACK_GATEWAY_TLS_MAX_PROTOCOL_VERSION", ""
+).strip()
+
 # Heuristics for partial-stream usage estimation.
 # Used by metrics_collector when a gateway report arrives with completed=false
 # (client disconnect, upstream cancel) and token fields are blank or partial.

--- a/gpustack/gateway/__init__.py
+++ b/gpustack/gateway/__init__.py
@@ -46,6 +46,7 @@ from gpustack.gateway.utils import (
     router_header_key,
     gpustack_original_path_header,
     gpustack_fallback_path_header,
+    gateway_tls_annotations,
 )
 from gpustack.gateway.ext_auth import (
     ext_auth_init_spec_diff,
@@ -252,6 +253,7 @@ async def ensure_ingress_resources(cfg: Config, api_client: k8s_client.ApiClient
             annotations={
                 "higress.io/destination": f"{registry.get_service_name_with_port()}",
                 "higress.io/ignore-path-case": "false",
+                **gateway_tls_annotations(),
             },
             labels=managed_labels,
         ),
@@ -819,6 +821,51 @@ def initialize_gateway(cfg: Config, timeout: int = 60, interval: int = 5):
         GatewayModeEnum.incluster,
     ]:
         validate_ai_statistics_plugin_content_types(cfg=cfg)
+        if cfg.gateway_mode == GatewayModeEnum.incluster:
+            # In-cluster the anchor Ingress belongs to the helm chart, so this
+            # server never writes the annotations and the generated routes
+            # mirror whatever the chart set. Honoring the variables here would
+            # fight the chart for ownership; ignoring them quietly would leave a
+            # floor that was asked for and never applied. Not validated either,
+            # for the same reason they are not used -- refusing to start over a
+            # value this mode has no use for helps nobody. The chart validates
+            # its own keys as it renders them.
+            ignored = {
+                name: value
+                for name, value in (
+                    (
+                        "GPUSTACK_GATEWAY_TLS_MIN_PROTOCOL_VERSION",
+                        envs.GATEWAY_TLS_MIN_PROTOCOL_VERSION,
+                    ),
+                    (
+                        "GPUSTACK_GATEWAY_TLS_MAX_PROTOCOL_VERSION",
+                        envs.GATEWAY_TLS_MAX_PROTOCOL_VERSION,
+                    ),
+                )
+                if value
+            }
+            if ignored:
+                logger.warning(
+                    "Ignoring %s: in-cluster mode takes the gateway's TLS "
+                    "protocol bounds from the %s ingress, which the helm chart "
+                    "owns. Set server.ingress.tls.minProtocolVersion / "
+                    "maxProtocolVersion in the chart instead.",
+                    ", ".join(f"{k}={v}" for k, v in sorted(ignored.items())),
+                    envs.GATEWAY_MIRROR_INGRESS_NAME,
+                )
+        else:
+            # Raises here, before a single Ingress is written, on a TLS version
+            # Higress would reject -- which it would do by keeping its own TLS
+            # 1.0 floor and logging one line in a container nobody is watching.
+            # Logged when set for the same reason: an enforced floor should be
+            # visible in the server's own log, not only inferable from a
+            # handshake failure.
+            tls_annotations = gateway_tls_annotations()
+            if tls_annotations:
+                logger.info(
+                    "Gateway ingresses will be annotated with %s",
+                    ", ".join(f"{k}={v}" for k, v in sorted(tls_annotations.items())),
+                )
         plugin_list: List[Tuple[str, WasmPluginSpec]] = [
             ext_auth_plugin(cfg=cfg),
             ai_statistics_plugin(cfg=cfg),

--- a/gpustack/gateway/utils.py
+++ b/gpustack/gateway/utils.py
@@ -61,6 +61,7 @@ from gpustack.schemas.clusters import Cluster
 from gpustack.utils.network import is_ipaddress
 from kubernetes_asyncio import client as k8s_client
 from kubernetes_asyncio.client import ApiException, V1IngressTLS
+from gpustack import envs
 from gpustack.envs import GATEWAY_MIRROR_INGRESS_NAME
 from gpustack.api.exceptions import NotFoundException
 from gpustack.websocket_proxy.message import ServerInfo, RegisteredClientInfo
@@ -686,6 +687,83 @@ async def ensure_mcp_bridge(
             )
 
 
+# Higress' spelling of the TLS version enum on an Ingress: dots, not the
+# underscores Envoy uses in the config these end up in. A value Higress cannot
+# parse fails *open* -- the Ingress still applies, the listener keeps Higress'
+# default floor of TLS 1.0, and the only trace is one line in the
+# higress-controller log -- so the value is checked here rather than passed
+# through and trusted.
+tls_min_protocol_version_annotation = "higress.io/tls-min-protocol-version"
+tls_max_protocol_version_annotation = "higress.io/tls-max-protocol-version"
+tls_protocol_version_annotations = (
+    tls_min_protocol_version_annotation,
+    tls_max_protocol_version_annotation,
+)
+# Weakest first, so a position in this tuple is also the comparison that
+# rejects an inverted min/max pair.
+supported_tls_protocol_versions = ("TLSv1.0", "TLSv1.1", "TLSv1.2", "TLSv1.3")
+
+
+def _normalized_tls_protocol_version(env_name: str, value: str) -> Optional[str]:
+    """Map a configured TLS version onto Higress' spelling, or raise.
+
+    Underscores are accepted because ``TLSv1_2`` is Envoy's own spelling and so
+    the likeliest thing to reach for; it is normalized rather than rejected.
+    """
+    if not value:
+        return None
+    candidate = value.strip().replace("_", ".").lower()
+    for supported in supported_tls_protocol_versions:
+        if candidate == supported.lower():
+            return supported
+    raise ValueError(
+        f"Invalid {env_name}: {value!r}. Valid values are "
+        f"{', '.join(supported_tls_protocol_versions)}."
+    )
+
+
+def gateway_tls_annotations() -> Dict[str, str]:
+    """TLS version bounds for the anchor Ingress, from the environment.
+
+    Only the anchor is configured this way. Every generated LLM-route Ingress
+    copies its bounds off the anchor instead
+    (:func:`mirror_from_anchor_ingress`), the same way it already copies the
+    hostname and the TLS secret -- so there is one place the bounds are set and
+    no way for the routes to drift from the entrypoint they share a listener
+    with.
+
+    Empty unless configured, leaving each deployment on whatever Higress
+    defaults to -- the behaviour deployments already have. Raises ValueError on
+    an unusable configuration, which callers let propagate: a floor that was
+    meant to be enforced and silently is not is worse than a startup failure.
+    """
+    minimum = _normalized_tls_protocol_version(
+        "GPUSTACK_GATEWAY_TLS_MIN_PROTOCOL_VERSION",
+        envs.GATEWAY_TLS_MIN_PROTOCOL_VERSION,
+    )
+    maximum = _normalized_tls_protocol_version(
+        "GPUSTACK_GATEWAY_TLS_MAX_PROTOCOL_VERSION",
+        envs.GATEWAY_TLS_MAX_PROTOCOL_VERSION,
+    )
+    if (
+        minimum is not None
+        and maximum is not None
+        and supported_tls_protocol_versions.index(minimum)
+        > supported_tls_protocol_versions.index(maximum)
+    ):
+        raise ValueError(
+            f"GPUSTACK_GATEWAY_TLS_MIN_PROTOCOL_VERSION ({minimum}) is higher "
+            f"than GPUSTACK_GATEWAY_TLS_MAX_PROTOCOL_VERSION ({maximum}); no "
+            "TLS version would be accepted."
+        )
+    annotations: Dict[str, str] = {}
+    if minimum is not None:
+        annotations[tls_min_protocol_version_annotation] = minimum
+    if maximum is not None:
+        annotations[tls_max_protocol_version_annotation] = maximum
+    return annotations
+
+
 def generate_model_ingress(
     ingress_name: str,
     namespace: str,
@@ -697,6 +775,7 @@ def generate_model_ingress(
     included_proxy_route: Optional[bool] = False,
     extra_annotations: Optional[Dict[str, str]] = None,
     ingress_class_name: str = "higress",
+    tls_protocol_annotations: Optional[Dict[str, str]] = None,
 ) -> k8s_client.V1Ingress:
     retry_policies = "error,timeout,http_503,http_502,non_idempotent"
     matcher_op = "exact"
@@ -707,6 +786,10 @@ def generate_model_ingress(
         "higress.io/proxy-next-upstream-tries": '2',
         "higress.io/proxy-next-upstream": retry_policies,
         **higress_http_header_matcher(matcher_op, "x-higress-llm-model", route_name),
+        # Copied off the anchor Ingress, not read from the environment: these
+        # routes share a TLS listener with it, so a bound set on one and not the
+        # other is a bound Higress may or may not end up applying.
+        **(tls_protocol_annotations or {}),
     }
     if extra_annotations is not None:
         annotations.update(extra_annotations)
@@ -767,9 +850,21 @@ def higress_metadata_equal(
         existing_metadata.annotations = {}
     if expected_metadata.annotations is None:
         expected_metadata.annotations = {}
-    for key in set(
+    compared_keys = set(
         k for k in expected_metadata.annotations if k.startswith("higress.io")
-    ):
+    )
+    # Compared even where the expected set has dropped them, so clearing the
+    # bounds takes the annotations back off the live object. Without this the
+    # object is judged equal, no write happens, and a floor stays in force after
+    # it was turned off -- the one direction that matters for a security
+    # setting.
+    #
+    # This only decides *whether* to rewrite. What a rewrite then keeps is the
+    # caller's business, and callers differ: ensure_model_ingress drops every
+    # higress.io annotation it did not expect, so nothing hand-added survives a
+    # rewrite there whatever triggered it.
+    compared_keys.update(tls_protocol_version_annotations)
+    for key in compared_keys:
         if existing_metadata.annotations.get(key) != expected_metadata.annotations.get(
             key
         ):
@@ -964,11 +1059,12 @@ async def ensure_model_ingress(
             logger.error(f"Failed to get ingress {ingress_name}: {e}")
             return
         existing_ingress = None
-    hostname, tls = await mirror_hostname_tls_from_ingress(
+    anchor = await mirror_from_anchor_ingress(
         network_v1_client=networking_api,
         gateway_namespace=namespace,
         target_ingress_name=GATEWAY_MIRROR_INGRESS_NAME,
     )
+    hostname, tls = anchor.hostname, anchor.tls
     expected_ingress = generate_model_ingress(
         ingress_name=ingress_name,
         route_name=route_name,
@@ -980,6 +1076,7 @@ async def ensure_model_ingress(
         included_proxy_route=included_proxy_route,
         extra_annotations=extra_annotations,
         ingress_class_name=ingress_class_name,
+        tls_protocol_annotations=anchor.tls_protocol_annotations,
     )
 
     if existing_ingress is None:
@@ -1180,21 +1277,38 @@ async def ensure_model_mcp_bridge(
     return desired_registry
 
 
-async def mirror_hostname_tls_from_ingress(
+@dataclass
+class AnchorIngressSettings:
+    """What a generated LLM-route Ingress copies off the anchor Ingress.
+
+    The anchor is the entrypoint Ingress named by
+    ``GPUSTACK_GATEWAY_MIRROR_INGRESS_NAME`` -- written by this server outside
+    in-cluster mode, by the helm chart within it. Everything here describes the
+    TLS listener the generated routes end up sharing with it, which is why it is
+    mirrored rather than configured twice.
+    """
+
+    hostname: Optional[str] = None
+    tls: Optional[List[V1IngressTLS]] = None
+    tls_protocol_annotations: Dict[str, str] = dataclass_field(default_factory=dict)
+
+
+async def mirror_from_anchor_ingress(
     network_v1_client: k8s_client.NetworkingV1Api,
     gateway_namespace: str,
     target_ingress_name: str,
-) -> Tuple[Optional[str], Optional[List[V1IngressTLS]]]:
+) -> AnchorIngressSettings:
     """
-    Mirror TLS settings from an existing ingress to be used in the gateway.
+    Read the listener settings a generated ingress has to match from the anchor.
 
     Parameters:
-        api_client (k8s_client.ApiClient): The Kubernetes API client.
+        network_v1_client (k8s_client.NetworkingV1Api): The Kubernetes networking API client.
         gateway_namespace (str): The namespace where the gateway ingress resides.
-        target_ingress_name (str): The name of the ingress to mirror TLS settings from.
+        target_ingress_name (str): The name of the anchor ingress to mirror from.
 
     Returns:
-        Tuple[Optional[str], Optional[List[V1IngressTLS]]]: A tuple containing the hostname and ingress TLS settings.
+        AnchorIngressSettings: hostname, TLS secret and TLS protocol bounds.
+        Empty when the anchor does not exist.
     """
     try:
         ingress: k8s_client.V1Ingress = await network_v1_client.read_namespaced_ingress(
@@ -1205,17 +1319,34 @@ async def mirror_hostname_tls_from_ingress(
             logger.warning(
                 f"Target ingress {target_ingress_name} not found in namespace {gateway_namespace} for TLS mirroring."
             )
-            return None, None
+            return AnchorIngressSettings()
         else:
             raise
 
-    tls = getattr(ingress.spec, 'tls', None)
+    # ``metadata`` and ``spec`` are both optional on V1Ingress. Anything the API
+    # server hands back has them, so this is not a case anyone should hit -- but
+    # reading through them unguarded means one malformed object raises inside
+    # every model-route reconcile instead of mirroring nothing, and the anchor is
+    # read on each one.
+    metadata = getattr(ingress, 'metadata', None)
+    spec = getattr(ingress, 'spec', None)
+    tls = getattr(spec, 'tls', None)
     hostname = None
-    for rule in ingress.spec.rules or []:
+    for rule in getattr(spec, 'rules', None) or []:
         if rule.host:
             hostname = rule.host
             break
-    return hostname, tls
+    anchor_annotations = getattr(metadata, 'annotations', None) or {}
+    tls_protocol_annotations = {
+        key: anchor_annotations[key]
+        for key in tls_protocol_version_annotations
+        if anchor_annotations.get(key)
+    }
+    return AnchorIngressSettings(
+        hostname=hostname,
+        tls=tls,
+        tls_protocol_annotations=tls_protocol_annotations,
+    )
 
 
 def get_expected_match_list(

--- a/tests/charts/test_chart_render.py
+++ b/tests/charts/test_chart_render.py
@@ -462,3 +462,100 @@ class TestGuards:
             assert "gpustack.ai/pool" not in selectors.get(
                 name, {}
             ), f"{name} covers the nodes it serves and must not be confined"
+
+
+class TestGatewayTLSVersions:
+    """The chart's Ingress is the anchor the whole gateway's TLS floor comes from.
+
+    GPUStack copies the bounds off it onto every Ingress it generates for an LLM
+    route, so this one annotation is the only place they are set. The server is
+    deliberately *not* told through its environment: two owners for one anchor is
+    how the chart and the server end up disagreeing about it.
+    """
+
+    def ingress_annotations(self, docs: list[dict]) -> dict[str, str]:
+        for doc in docs:
+            if doc["kind"] == "Ingress" and doc["metadata"]["name"] == "gpustack":
+                return doc["metadata"].get("annotations") or {}
+        pytest.fail("Ingress/gpustack not rendered")
+
+    def test_unset_by_default(self):
+        # Existing releases keep Higress' defaults: stamping a floor on upgrade
+        # would drop clients they still serve.
+        assert self.ingress_annotations(render()) == {}
+
+    def test_both_bounds_land_on_the_anchor(self):
+        docs = render(
+            "--set",
+            "server.ingress.tls.minProtocolVersion=TLSv1.2",
+            "--set",
+            "server.ingress.tls.maxProtocolVersion=TLSv1.3",
+        )
+        assert self.ingress_annotations(docs) == {
+            "higress.io/tls-min-protocol-version": "TLSv1.2",
+            "higress.io/tls-max-protocol-version": "TLSv1.3",
+        }
+
+    def test_a_floor_alone_leaves_the_ceiling_to_higress(self):
+        docs = render("--set", "server.ingress.tls.minProtocolVersion=TLSv1.2")
+        assert self.ingress_annotations(docs) == {
+            "higress.io/tls-min-protocol-version": "TLSv1.2"
+        }
+
+    def test_the_server_is_not_told_through_its_environment(self):
+        # In-cluster the server reads the anchor, not its own environment. An env
+        # var here would be a second owner for the same setting.
+        docs = render("--set", "server.ingress.tls.minProtocolVersion=TLSv1.2")
+        env = container_env(docs, "StatefulSet", "gpustack-server")
+        assert not [name for name in env if "TLS_MIN" in name or "TLS_MAX" in name]
+
+    def test_a_release_predating_these_keys_renders_unchanged(self):
+        # A values file that sets only cert/key, as every existing release has.
+        # The new keys must be absent rather than empty-valued: `higress.io/
+        # tls-min-protocol-version: ""` is a value Higress rejects, and it
+        # rejects it by keeping TLS 1.0.
+        docs = render(
+            "--set",
+            "server.ingress.hostname=gpustack.example.com",
+            "--set",
+            "server.ingress.tls.cert=dGVzdA==",
+            "--set",
+            "server.ingress.tls.key=dGVzdA==",
+        )
+        assert self.ingress_annotations(docs) == {}
+
+    def test_the_envoy_spelling_is_normalized(self):
+        # TLSv1_2 is Envoy's spelling and the likeliest thing to reach for.
+        # Higress rejects it, so the chart translates rather than passes it on.
+        docs = render("--set", "server.ingress.tls.minProtocolVersion=tlsv1_2")
+        assert self.ingress_annotations(docs) == {
+            "higress.io/tls-min-protocol-version": "TLSv1.2"
+        }
+
+    def test_an_unusable_version_is_refused(self):
+        # Refusing the install is the point: Higress ignores a value it cannot
+        # parse and keeps accepting TLS 1.0, so a render that succeeded here
+        # would look like a raised floor and be none.
+        error = render_error("--set", "server.ingress.tls.minProtocolVersion=TLSv1.4")
+        assert "is not a TLS version Higress accepts" in error
+
+    def test_an_inverted_range_is_refused(self):
+        error = render_error(
+            "--set",
+            "server.ingress.tls.minProtocolVersion=TLSv1.3",
+            "--set",
+            "server.ingress.tls.maxProtocolVersion=TLSv1.2",
+        )
+        assert "no TLS version would be accepted" in error
+
+    def test_falsey_scalars_are_validated_not_skipped(self):
+        # `with` treats false and 0 as unset. Neither is a TLS version, but
+        # skipping them would render no annotation and leave TLS 1.0 in place --
+        # the silent failure this validation exists to prevent.
+        for value in ("false", "0"):
+            error = render_error(
+                "--set", f"server.ingress.tls.minProtocolVersion={value}"
+            )
+            assert "is not a TLS version Higress accepts" in error
+            # The operator has to recognize what they typed in the message.
+            assert f'"{value}"' in error

--- a/tests/gateway/test_gateway_utils.py
+++ b/tests/gateway/test_gateway_utils.py
@@ -4,8 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
+from kubernetes_asyncio import client as k8s_client
 from kubernetes_asyncio.client import ApiException
 
+from gpustack import envs
 from gpustack.api.exceptions import NotFoundException
 from gpustack.gateway.utils import (
     RoutePrefix,
@@ -13,10 +15,13 @@ from gpustack.gateway.utils import (
     diff_proxies,
     diff_registries,
     ensure_model_ingress,
+    gateway_tls_annotations,
     generate_model_ingress,
     generic_proxy_router_diff_spec,
     get_instance_id_from_header,
+    higress_metadata_equal,
     lora_registry_name_suffix,
+    mirror_from_anchor_ingress,
     model_instance_registry,
     model_instances_registry_list,
     provider_proxy_plugin_spec,
@@ -776,3 +781,186 @@ async def test_ensure_model_ingress_with_destinations_still_creates():
         body.metadata.annotations["higress.io/destination"]
         == "100% svc.gpustack.svc.cluster.local:80"
     )
+
+
+# --- Gateway TLS protocol version bounds -----------------------------------
+#
+# The failure these guard is silent: Higress refuses an annotation value it
+# cannot parse by keeping its own TLS 1.0 floor, logging one line in a container
+# nobody watches, and applying the Ingress anyway. So a wrong spelling here does
+# not break a deployment loudly -- it leaves a security scan's finding in place
+# while the operator believes it is fixed.
+
+
+@pytest.fixture
+def tls_versions(monkeypatch):
+    """Set the two TLS environment variables as the server reads them."""
+
+    def _set(minimum: str = "", maximum: str = ""):
+        monkeypatch.setattr(envs, "GATEWAY_TLS_MIN_PROTOCOL_VERSION", minimum)
+        monkeypatch.setattr(envs, "GATEWAY_TLS_MAX_PROTOCOL_VERSION", maximum)
+
+    return _set
+
+
+def test_tls_annotations_are_absent_by_default(tls_versions):
+    # Unset must stay unset: stamping a floor on upgrade would drop clients an
+    # existing deployment still serves.
+    tls_versions()
+    assert gateway_tls_annotations() == {}
+
+
+def test_tls_annotations_use_higress_spelling(tls_versions):
+    tls_versions(minimum="TLSv1.2", maximum="TLSv1.3")
+    assert gateway_tls_annotations() == {
+        "higress.io/tls-min-protocol-version": "TLSv1.2",
+        "higress.io/tls-max-protocol-version": "TLSv1.3",
+    }
+
+
+def test_tls_annotations_normalize_the_envoy_spelling(tls_versions):
+    # TLSv1_2 is Envoy's own spelling and the likeliest thing to reach for, but
+    # Higress rejects it. Normalized rather than passed through and ignored.
+    tls_versions(minimum="tlsv1_2")
+    assert gateway_tls_annotations() == {
+        "higress.io/tls-min-protocol-version": "TLSv1.2"
+    }
+
+
+@pytest.mark.parametrize("value", ["1.2", "TLS1.2", "TLSv1.4", "yes"])
+def test_tls_annotations_reject_an_unusable_version(tls_versions, value):
+    tls_versions(minimum=value)
+    with pytest.raises(ValueError, match="Valid values are"):
+        gateway_tls_annotations()
+
+
+def test_tls_annotations_reject_an_inverted_range(tls_versions):
+    tls_versions(minimum="TLSv1.3", maximum="TLSv1.2")
+    with pytest.raises(ValueError, match="no TLS version would be accepted"):
+        gateway_tls_annotations()
+
+
+def test_model_ingress_carries_the_mirrored_bounds(tls_versions):
+    # Mirrored off the anchor, never read from the environment here: in-cluster
+    # the anchor belongs to the helm chart and this server's environment has
+    # nothing to say about it.
+    tls_versions(minimum="TLSv1.3")
+    ingress = generate_model_ingress(
+        ingress_name="ai-route-route-42.internal",
+        namespace="default",
+        route_name="my-route",
+        destinations="100% svc.default.svc.cluster.local:80",
+        tls_protocol_annotations={"higress.io/tls-min-protocol-version": "TLSv1.2"},
+    )
+    assert (
+        ingress.metadata.annotations["higress.io/tls-min-protocol-version"] == "TLSv1.2"
+    )
+    assert "higress.io/tls-max-protocol-version" not in ingress.metadata.annotations
+
+
+def test_model_ingress_without_an_anchor_bound_carries_none(tls_versions):
+    tls_versions(minimum="TLSv1.2")
+    ingress = generate_model_ingress(
+        ingress_name="ai-route-route-42.internal",
+        namespace="default",
+        route_name="my-route",
+        destinations="100% svc.default.svc.cluster.local:80",
+    )
+    assert not [
+        k for k in ingress.metadata.annotations if "tls-m" in k
+    ], "the environment must not reach a generated route directly"
+
+
+@pytest.mark.asyncio
+async def test_anchor_mirroring_reads_hostname_tls_and_bounds():
+    anchor = k8s_client.V1Ingress(
+        metadata=k8s_client.V1ObjectMeta(
+            annotations={
+                "higress.io/tls-min-protocol-version": "TLSv1.2",
+                "higress.io/destination": "svc:80",
+            }
+        ),
+        spec=k8s_client.V1IngressSpec(
+            rules=[k8s_client.V1IngressRule(host="gpustack.example.com")],
+            tls=[
+                k8s_client.V1IngressTLS(
+                    hosts=["gpustack.example.com"], secret_name="tls-x"
+                )
+            ],
+        ),
+    )
+    api = MagicMock()
+    api.read_namespaced_ingress = AsyncMock(return_value=anchor)
+
+    settings = await mirror_from_anchor_ingress(
+        network_v1_client=api,
+        gateway_namespace="higress-system",
+        target_ingress_name="gpustack",
+    )
+
+    assert settings.hostname == "gpustack.example.com"
+    assert settings.tls[0].secret_name == "tls-x"
+    # Only the TLS bounds are mirrored; the anchor's own routing annotations
+    # would send every generated route to the control plane.
+    assert settings.tls_protocol_annotations == {
+        "higress.io/tls-min-protocol-version": "TLSv1.2"
+    }
+
+
+@pytest.mark.asyncio
+async def test_an_anchor_without_metadata_or_spec_mirrors_nothing():
+    # Both are optional on V1Ingress. Nothing the API server returns looks like
+    # this, but the anchor is re-read on every model-route reconcile, so raising
+    # here would take the whole loop down rather than mirror nothing.
+    api = MagicMock()
+    api.read_namespaced_ingress = AsyncMock(return_value=k8s_client.V1Ingress())
+
+    settings = await mirror_from_anchor_ingress(
+        network_v1_client=api,
+        gateway_namespace="higress-system",
+        target_ingress_name="gpustack",
+    )
+
+    assert settings.hostname is None
+    assert settings.tls is None
+    assert settings.tls_protocol_annotations == {}
+
+
+@pytest.mark.asyncio
+async def test_a_missing_anchor_mirrors_nothing():
+    api = MagicMock()
+    api.read_namespaced_ingress = AsyncMock(
+        side_effect=ApiException(status=404, reason="Not Found")
+    )
+
+    settings = await mirror_from_anchor_ingress(
+        network_v1_client=api,
+        gateway_namespace="higress-system",
+        target_ingress_name="gpustack",
+    )
+
+    assert settings.hostname is None
+    assert settings.tls is None
+    assert settings.tls_protocol_annotations == {}
+
+
+def test_clearing_the_tls_bound_makes_a_live_ingress_unequal():
+    # Dropping a bound from the expected set has to read as a difference. If it
+    # did not, the object would be judged equal, never rewritten, and the floor
+    # would stay in force after it was turned off.
+    existing = k8s_client.V1ObjectMeta(
+        annotations={
+            "higress.io/destination": "svc:80",
+            "higress.io/tls-min-protocol-version": "TLSv1.2",
+        }
+    )
+    expected = k8s_client.V1ObjectMeta(annotations={"higress.io/destination": "svc:80"})
+    assert not higress_metadata_equal(existing, expected)
+    # Other higress.io annotations stay compared one-way, so an unmanaged one
+    # does not on its own provoke a rewrite. Whether it survives a rewrite
+    # provoked by something else is the caller's call, not this function's.
+    existing.annotations = {
+        "higress.io/destination": "svc:80",
+        "higress.io/ignore-path-case": "true",
+    }
+    assert higress_metadata_equal(existing, expected)


### PR DESCRIPTION
Refer to issue:
- #6182 

A security scan flagged TLS 1.0/1.1 on the Higress gateway, which defaults its listeners to a TLSv1_0 floor with no way to raise it from GPUStack.

Set the bounds on the anchor ingress -- the entrypoint named by GPUSTACK_GATEWAY_MIRROR_INGRESS_NAME -- and let every generated LLM-route ingress mirror them off it, alongside the hostname and TLS secret it already mirrors. One place to set them, and a route cannot drift from the listener it shares with the entrypoint.

Which side owns the anchor decides where they are set: embedded and external gateways take GPUSTACK_GATEWAY_TLS_MIN/MAX_PROTOCOL_VERSION, in-cluster ones take server.ingress.tls.minProtocolVersion/maxProtocolVersion from the chart. Setting the variables in-cluster logs a warning naming the chart keys instead of honoring them: the server never writes that ingress, so the value would otherwise do nothing at all.

Values are validated at startup rather than passed through. Higress fails *open* on a version string it cannot parse -- the ingress applies, the listener keeps TLS 1.0, and the only trace is one line in the controller log -- so a typo would leave the scan finding in place while looking fixed. Envoy's TLSv1_2 spelling is normalized to Higress' TLSv1.2 rather than rejected. higress_metadata_equal compares the two TLS keys both ways, so clearing them takes the annotation back off instead of leaving a floor nobody asked for.

Both bounds default to empty, leaving existing deployments on Higress' defaults.