### PR TITLE
chore(review): add automated review configuration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,75 @@
+# Copilot Code Review — GPUStack
+
+GPUStack is an open-source GPU cluster manager for running AI models. The
+single Python distribution provides server, worker, and CLI runtimes. The
+server exposes FastAPI APIs, manages SQLModel/SQLAlchemy data, schedules work,
+and coordinates controllers. Workers discover and manage local resources and
+run inference backends. Higress fronts inference traffic as the AI gateway.
+
+Read `CLAUDE.md` and `AGENTS.md` before reviewing. They are the source of
+truth for repository conventions. Keep review feedback specific and actionable,
+and cite the file and line. Report correctness, security, data-loss, and
+regression risks; do not report stylistic preferences already enforced by
+formatters and linters.
+
+## Review priorities
+
+- Treat every new or changed route as security-sensitive. Check its deliberate
+  tier in `gpustack/routes/routes.py`: authenticated user, tenant-scoped user,
+  platform administrator, or worker/cluster system principal. Flag missing or
+  overly broad authentication and authorization dependencies.
+- Treat every tenant-reachable query as security-sensitive. List queries must
+  use `tenant_list_conditions`; single-resource access must use
+  `assert_resource_visible` or an equivalent established ownership guard from
+  `gpustack/api/tenant.py`. Never allow a missing ownership predicate to expose
+  another organization’s data.
+- Do not allow API keys, access tokens, passwords, SAML assertions, cloud
+  credentials, or other secrets to be logged, returned, serialized into errors,
+  or included in tests and documentation.
+- A behavior change or bug fix needs a focused test under the matching `tests/`
+  package. Async tests require `@pytest.mark.asyncio`; tests must not use a real
+  database, network, or GPU.
+
+## Repository conventions
+
+- Python is formatted with Black (88 columns) and checked by Flake8. Preserve
+  existing quote style; do not suggest unrelated formatting changes.
+- Prefer simple, explicit code. Flag speculative abstractions, mutable shared
+  state without synchronization, swallowed exceptions, and error paths that
+  leave persisted or external state inconsistent.
+- Public functions require type hints. Use `Optional` and `List` from `typing`
+  where applicable. Comments explain behavior and rationale, never revision
+  history.
+- Generated clients in `gpustack/client/generated_*.py` come from
+  `gpustack/codegen/` and must not be hand-edited. Review the templates or
+  generator and require `make generate` as a reminder when they change; do not
+  claim generated output is present or absent.
+- Docs in `docs/` are English-only. A new documentation page must be added to
+  `mkdocs.yml` navigation. `README.md` is canonical; meaningful changes there
+  require noting that Chinese and Japanese translations need updating.
+- Commit-message and PR-title conventions are not source-code defects. Do not
+  post them as inline review findings.
+
+## Database migrations
+
+- Released migration revisions are immutable. Unreleased schema changes belong
+  in the current release bundle unless ordering requires a standalone revision.
+- Changes must support PostgreSQL, openGauss, MySQL, and OceanBase. Review for
+  dialect assumptions, especially PostgreSQL enums/JSON functions and MySQL
+  differences. `dialect.name` distinguishes only PostgreSQL and MySQL; use the
+  existing migration utilities for openGauss-specific detection.
+- Migrations must be re-runnable with `table_exists` and `column_exists` guards
+  where appropriate, and must provide a real downgrade or explain why reversal
+  is impossible. Ownership and permission migrations require special scrutiny.
+
+## Out of scope
+
+- `gpustack/client/generated_*.py` (generated; review its templates instead).
+- Python bytecode and cache directories such as `__pycache__/`.
+
+## Known non-findings
+
+- Do not ask to reformat code solely for quote normalization: Black is
+  configured to preserve existing quote style.
+- Do not request network, database, or GPU integration tests: project tests
+  intentionally mock those boundaries.

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,44 @@
+# This workflow runs AI code review on pull requests by calling the reusable workflow in
+# gpustack/.github. Trigger gating and the concurrency group are owned by that reusable
+# workflow now, so this file only owns the "on:" triggers (required because GitHub has no
+# way to invoke a workflow_call workflow without a concrete event trigger living here),
+# the "permissions:" grant (GITHUB_TOKEN cannot be granted more than this declares), and
+# this repository's review configuration: the secrets mapping and the LLM inputs below
+# (endpoint/model/thinking/reasoning-effort from org variables).
+#
+# Aligned with upstream:
+# https://github.com/alibaba/open-code-review/blob/main/examples/github_actions/ocr-review.yml
+
+name: Code Review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  # Use pull_request_target instead of pull_request so that secrets are
+  # available even for PRs from forks. This is safe because the reusable
+  # workflow only reads the diff and does not execute any code from the PR.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    uses: gpustack/.github/.github/workflows/code-review.yml@main
+    with:
+      # This repository's review backing: the org-level LLM endpoint/model
+      # (OCR appends /chat/completions to the base URL), thinking mode, and
+      # reasoning effort.
+      llm-url: "${{ vars.CI_GPUSTACK_CODEREVIEW_LLM_URL }}"
+      llm-model: "${{ vars.CI_GPUSTACK_CODEREVIEW_LLM_MODEL }}"
+      llm-thinking: "${{ vars.CI_GPUSTACK_CODEREVIEW_LLM_THINKING }}"
+      llm-reasoning-effort: "${{ vars.CI_GPUSTACK_CODEREVIEW_LLM_REASONING_EFFORT }}"
+      llm-temperature: "${{ vars.CI_GPUSTACK_CODEREVIEW_LLM_TEMPERATURE }}"
+      llm-top-p: "${{ vars.CI_GPUSTACK_CODEREVIEW_LLM_TOP_P }}"
+      llm-thinking-clear: "${{ vars.CI_GPUSTACK_CODEREVIEW_LLM_THINKING_CLEAR }}"
+    secrets:
+      llm-auth-token: ${{ secrets.CI_GPUSTACK_CODEREVIEW_LLM_AUTH_TOKEN }}
+      app-id: ${{ secrets.CI_GPUSTACK_CODEREVIEW_APP_ID }}
+      app-private-key: ${{ secrets.CI_GPUSTACK_CODEREVIEW_APP_PRIVATE_KEY }}

--- a/.opencodereview/rule.json
+++ b/.opencodereview/rule.json
@@ -47,6 +47,11 @@
       "rule": "Scheduling code. Flag candidate selection or scoring that violates requested resource constraints, worker availability, model compatibility, cluster/pool affinity, or multi-tenant visibility. Scheduling decisions must be deterministic for equivalent inputs and must not mutate shared state during evaluation. Flag resource arithmetic that can overcommit GPU, VRAM, RAM, or ports, and failure paths that strand reservations. Test changes with representative candidates and edge cases."
     },
     {
+      "path": "gpustack/policies/**/*.py",
+      "merge_system_rule": true,
+      "rule": "Scheduling policies: worker filters, candidate selectors, and scorers. Flag logic that violates requested resource constraints, worker availability, model compatibility, cluster or pool affinity, or multi-tenant visibility. Policy evaluation must be deterministic for equivalent inputs and must not mutate shared state. Flag resource arithmetic that can overcommit GPU, VRAM, RAM, or ports, and failure paths that strand reservations. Test changes with representative candidates and edge cases."
+    },
+    {
       "path": "gpustack/worker/**/*.py",
       "merge_system_rule": true,
       "rule": "Worker runtime, inference backends, benchmarks, and local resource management. Flag shell-command or container arguments built from untrusted values without safe argument handling; command, process, port, temporary-file, or GPU allocation leaks; and backend lifecycle operations that cannot safely retry or clean up after a partial failure. Do not log backend credentials or user prompts. Keep hardware and process interaction mocked at the client boundary in tests."
@@ -65,6 +70,16 @@
       "path": "charts/gpustack-chart/**",
       "merge_system_rule": true,
       "rule": "GPUStack Helm chart. Flag templates that make configuration, resource, security, or lifecycle behavior diverge from charts/gpustack-chart/values.yaml and the server or worker runtime they configure. Ensure Secret values are never emitted into ConfigMaps, logs, or unsafe command arguments; generated Secrets must remain stable across upgrades where required. Flag invalid resource names, selectors, service ports, probes, volume mounts, RBAC, or server/worker topology. Chart.yaml dependency pins must remain compatible with their consumers: the gpustack-operator dependency pin tracks gpustack/__init__.py as enforced by tests/charts/test_operator_version_pin.py. Do not review vendored dependencies in charts/gpustack-chart/charts/; they are excluded."
+    },
+    {
+      "path": "README.md",
+      "merge_system_rule": true,
+      "rule": "The canonical repository README. Flag a meaningful change without a corresponding note that README_CN.md and README_JP.md require translation updates. Flag credentials or other secrets in examples, and documentation that contradicts the CLI, configuration, or shipped behavior."
+    },
+    {
+      "path": "mkdocs.yml",
+      "merge_system_rule": true,
+      "rule": "MkDocs configuration. A new page under docs/ must be registered in the nav tree or it will not be published. Flag navigation entries that point to a missing page or conflict with the documentation structure."
     }
   ]
 }

--- a/.opencodereview/rule.json
+++ b/.opencodereview/rule.json
@@ -1,0 +1,70 @@
+{
+  "include": [
+    "gpustack/**/*.py",
+    "charts/gpustack-chart/**",
+    "README.md",
+    "mkdocs.yml"
+  ],
+  "exclude": [
+    "gpustack/client/generated_*.py",
+    "charts/gpustack-chart/charts/**",
+    "static/**",
+    "docker-compose/**",
+    "docs/**",
+    "tests/**",
+    "hack/**",
+    "**/__pycache__/**"
+  ],
+  "rules": [
+    {
+      "path": "gpustack/routes/**/*.py",
+      "merge_system_rule": true,
+      "rule": "FastAPI route handlers. Treat every changed route as security-sensitive. Flag an endpoint without its deliberate authorization tier as wired in gpustack/routes/routes.py: authenticated user, tenant-scoped user, platform administrator, or worker/cluster system principal. For any tenant-reachable list query, require tenant_list_conditions from gpustack/api/tenant.py; for a single row, require assert_resource_visible or an established equivalent before returning or mutating it. Deny by default when ownership is unclear. Flag credentials, API keys, tokens, SAML assertions, or cloud secrets that can reach logs, responses, exceptions, or telemetry. A behavior change or bug fix requires a focused test under tests/routes/."
+    },
+    {
+      "path": "gpustack/api/**/*.py",
+      "merge_system_rule": true,
+      "rule": "Authentication, authorization, tenancy, and API primitives. Flag an authorization bypass, confused principal type, tenant-context loss across a call boundary, or error response that distinguishes absent resources from resources the caller is not allowed to see. Never log, serialize, or return secrets. Keep changes compatible with the route dependency tiers in gpustack/routes/routes.py. A behavior change or bug fix needs a focused test under tests/api/."
+    },
+    {
+      "path": "gpustack/schemas/**/*.py",
+      "merge_system_rule": true,
+      "rule": "SQLModel tables and API schemas. Flag incompatible changes to persisted fields, defaults, serialization aliases, or ownership fields unless accompanied by a safe migration. Flag a model made tenant-reachable without the ownership data and query guards needed for isolation. Separate request input from persisted and response models where exposing a field could leak a secret or permit privilege escalation."
+    },
+    {
+      "path": "gpustack/migrations/**/*.py",
+      "merge_system_rule": true,
+      "rule": "Alembic migrations must support PostgreSQL, openGauss, MySQL, and OceanBase. Flag a change to a released revision; an unguarded migration that cannot safely rerun where table_exists or column_exists applies; PostgreSQL-only enum or JSON behavior without compatible handling; and a missing downgrade unless the irreversible reason is documented. dialect.name only distinguishes PostgreSQL and MySQL, so use the existing migration helpers for openGauss-specific behavior. Treat ownership and permission changes as data-isolation risks."
+    },
+    {
+      "path": "gpustack/server/**/*.py",
+      "merge_system_rule": true,
+      "rule": "Server controllers, services, collectors, and event processing. Flag controller or background-loop work that is not idempotent, retries without bounded backoff or cancellation, leaks sessions/tasks/subprocesses, or leaves model, worker, cluster, cache, or GPU-instance state inconsistent after failure. Flag unbounded fan-out and per-object database or network calls in reconciliation hot paths. Preserve tenant isolation when controllers load resources outside request context. A behavior change or bug fix requires a focused test under tests/server/ or tests/controller/."
+    },
+    {
+      "path": "gpustack/scheduler/**/*.py",
+      "merge_system_rule": true,
+      "rule": "Scheduling code. Flag candidate selection or scoring that violates requested resource constraints, worker availability, model compatibility, cluster/pool affinity, or multi-tenant visibility. Scheduling decisions must be deterministic for equivalent inputs and must not mutate shared state during evaluation. Flag resource arithmetic that can overcommit GPU, VRAM, RAM, or ports, and failure paths that strand reservations. Test changes with representative candidates and edge cases."
+    },
+    {
+      "path": "gpustack/worker/**/*.py",
+      "merge_system_rule": true,
+      "rule": "Worker runtime, inference backends, benchmarks, and local resource management. Flag shell-command or container arguments built from untrusted values without safe argument handling; command, process, port, temporary-file, or GPU allocation leaks; and backend lifecycle operations that cannot safely retry or clean up after a partial failure. Do not log backend credentials or user prompts. Keep hardware and process interaction mocked at the client boundary in tests."
+    },
+    {
+      "path": "gpustack/gateway/**/*.py",
+      "merge_system_rule": true,
+      "rule": "Higress gateway integration and external authorization. Flag any request path that bypasses authentication, tenant isolation, model-route access checks, or rate/metering attribution. Treat headers, URLs, upstream responses, and plugin configuration as untrusted. Prevent request smuggling, unsafe header forwarding, SSRF-style upstream selection, and logging of authorization material."
+    },
+    {
+      "path": "gpustack/codegen/**/*.py",
+      "merge_system_rule": true,
+      "rule": "Client-code generator and templates. Generated clients under gpustack/client/generated_*.py must never be hand-edited. Review template and generator changes for correct API paths, serialization, authentication, error propagation, and backward compatibility. Require make generate as a reminder; generated output is excluded, so never claim it is present or absent."
+    },
+    {
+      "path": "charts/gpustack-chart/**",
+      "merge_system_rule": true,
+      "rule": "GPUStack Helm chart. Flag templates that make configuration, resource, security, or lifecycle behavior diverge from charts/gpustack-chart/values.yaml and the server or worker runtime they configure. Ensure Secret values are never emitted into ConfigMaps, logs, or unsafe command arguments; generated Secrets must remain stable across upgrades where required. Flag invalid resource names, selectors, service ports, probes, volume mounts, RBAC, or server/worker topology. Chart.yaml dependency pins must remain compatible with their consumers: the gpustack-operator dependency pin tracks gpustack/__init__.py as enforced by tests/charts/test_operator_version_pin.py. Do not review vendored dependencies in charts/gpustack-chart/charts/; they are excluded."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add repository-specific Copilot review guidance for tenancy, migrations, generated clients, and security-sensitive code.
- Add the reusable automated code-review workflow.
- Add OpenCodeReview rules for Python services and the Helm chart, with configured exclusions.

## Verification

- Origin CI will run the repository test suite and required checks.
- Independently reviewed the frozen diff; no actionable findings.