### PR TITLE
feat(k8s): let a cluster register without the CPU worker DaemonSet

### DIFF
--- a/charts/gpustack-chart/README.md
+++ b/charts/gpustack-chart/README.md
@@ -135,7 +135,8 @@ If you need to customize Higress parameters, refer to the [Higress documentation
 | higressPlugins.image.repository          | gpustack/higress-plugins          | Image repo with namespace; see note below                                 |
 | higressPlugins.image.tag                 | "0.2.3.post5"                     | Higress plugins image tag; CI overrides from uv.lock at package time      |
 | higressPlugins.image.pullPolicy          | IfNotPresent                      | Higress plugins image pull policy                                         |
-| worker.gpuVendors                        | [nvidia]                          | List of GPU vendors; `[]` disables worker DaemonSet                       |
+| worker.gpuVendors                        | [nvidia]                          | List of GPU vendors; `[]` renders the CPU worker DaemonSet only           |
+| worker.cpuEnabled                        | true                              | Render the CPU worker DaemonSet; `false` requires a GPU vendor            |
 | worker.nodeSelector                      | {}                                | Base worker nodeSelector; replaces `global.nodeSelector` when non-empty   |
 | worker.port                              | 10150                             | Worker service port                                                       |
 | worker.metricsPort                       | 10151                             | Worker metrics port                                                       |
@@ -150,7 +151,7 @@ To customize parameters, use `--set key=value` or `-f your-values.yaml` during i
 
 ### Multi-vendor Worker Deployment
 
-When `worker.gpuVendors` lists one or more vendors, the chart renders a per-vendor DaemonSet (`<release>-worker-<vendor>`) for each, alongside the always-present CPU DaemonSet (`<release>-worker`). Each vendor DS gets the per-vendor driver mounts, `runtimeClassName`, and an automatic PCI-presence nodeSelector label (e.g. `feature.node.kubernetes.io/pci-10de.present: "true"` for NVIDIA) based on the vendor's PCI ID. Whenever at least one GPU vendor is listed, all worker pods additionally get a required `podAntiAffinity` (topologyKey=hostname, namespaceSelector={}) so two workers can't share a node — protects the `hostNetwork: true` ports from collision across namespaces.
+When `worker.gpuVendors` lists one or more vendors, the chart renders a per-vendor DaemonSet (`<release>-worker-<vendor>`) for each, alongside the CPU DaemonSet (`<release>-worker`) unless `worker.cpuEnabled` is false. Each vendor DS gets the per-vendor driver mounts, `runtimeClassName`, and an automatic PCI-presence nodeSelector label (e.g. `feature.node.kubernetes.io/pci-10de.present: "true"` for NVIDIA) based on the vendor's PCI ID. Whenever at least one GPU vendor is listed, all worker pods additionally get a required `podAntiAffinity` (topologyKey=hostname, namespaceSelector={}) so two workers can't share a node — protects the `hostNetwork: true` ports from collision across namespaces.
 
 > **Prerequisite:** The PCI-presence labels are advertised by [Node Feature Discovery (NFD)](https://kubernetes-sigs.github.io/node-feature-discovery/). NFD must be installed in the cluster for worker pods to schedule onto GPU nodes. Without NFD, no nodes will carry the required labels and all worker pods will remain Pending.
 
@@ -161,6 +162,15 @@ worker:
   gpuVendors:
     - nvidia
     - amd
+```
+
+The CPU DaemonSet covers the nodes no GPU runtime claims, via the nodeSelector `feature.gpustack.ai/acceleratable: "false"`. Set `worker.cpuEnabled: false` to leave those nodes alone — typically when the control plane shares the cluster with its GPU nodes and must not gain workers. `worker.gpuVendors` must then name at least one vendor; otherwise the release would render no worker DaemonSet at all and the install is refused. The vendor DaemonSets keep their `-<vendor>` suffix either way, so switching the CPU one off never promotes one of them onto the unsuffixed `<release>-worker` name.
+
+```yaml
+worker:
+  cpuEnabled: false
+  gpuVendors:
+    - nvidia
 ```
 
 ### NodeSelector Scoping

--- a/charts/gpustack-chart/templates/_helper.tpl
+++ b/charts/gpustack-chart/templates/_helper.tpl
@@ -35,13 +35,38 @@ entries. Returns a JSON-encoded list so callers can `fromJsonArray` it.
 {{- end -}}
 
 {{/*
-True when the chart should render in multi-vendor mode (CPU DS + at least one
-GPU vendor DS, meaning 2+ DaemonSets total). Controls anti-affinity, component
-labels, and service selector.
+Whether the CPU worker DaemonSet is part of this release, as "true" or "".
+
+Read through this rather than off `.Values.worker.cpuEnabled` directly — the
+DaemonSet, the mode flag below and the guard in validate.yaml all do — for two
+reasons. They have to agree: a mode flag reading "labelled" while the DaemonSet
+renders the legacy name leaves the worker Service selecting labels no pod
+carries. And `nil` has to read as this chart's default (true) rather than as
+false, which plain truthiness would give: Helm drops a key set to null, so
+`worker: {cpuEnabled: }` in a partial values file would otherwise delete the CPU
+workers from a cluster that never asked for that. Compared as a lowercased
+string, so `--set-string worker.cpuEnabled=false` and a quoted `"False"` in a
+values file turn them off as an unquoted `false` does, rather than being
+non-empty strings that silently read as "on".
+*/}}
+{{- define "gpustack.workerCPUEnabled" -}}
+{{- if ne (lower (toString .Values.worker.cpuEnabled)) "false" -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+True when the chart should render in multi-vendor mode: component + runtime
+labels on every worker pod, a hostname anti-affinity between them, and a worker
+Service that selects on the component label.
+
+That is every case except the one where a single DaemonSet carries the
+unsuffixed legacy name `<release>-worker` — CPU only, which is what a Service
+selecting `app: <release>-worker` matches. At least one GPU vendor means a
+suffixed DaemonSet exists, and so does turning the CPU one off, which leaves
+nothing but suffixed names however few vendors are selected.
 */}}
 {{- define "gpustack.multiVendorMode" -}}
 {{- $vendors := include "gpustack.workerVendors" . | fromJsonArray -}}
-{{- if gt (len $vendors) 0 -}}true{{- end -}}
+{{- if or (gt (len $vendors) 0) (not (include "gpustack.workerCPUEnabled" .)) -}}true{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/gpustack-chart/templates/validate.yaml
+++ b/charts/gpustack-chart/templates/validate.yaml
@@ -13,6 +13,24 @@ separate change, not here: two such guards currently sit dead at the top of
 {{- end }}
 
 {{/*
+A worker install with no DaemonSet to render. The CPU DaemonSet is the one that
+covers the nodes no GPU runtime claims, so switching it off without naming a
+vendor asks for a worker release that installs, reports success, and adds no
+worker to the cluster at all.
+
+Counted over the *sorted* vendors, which is the list worker-daemonset.yaml
+iterates: it renders nothing for a name outside the canonical set, so a typo
+would otherwise satisfy a guard reading the raw list and land in exactly the
+state this rejects. A name it drops while the CPU DaemonSet is on still installs
+today — that is a separate guard, and this file is not where one of those goes.
+*/}}
+{{- if and .Values.worker.enabled (not (include "gpustack.workerCPUEnabled" .)) }}
+{{- if not (include "gpustack.sortedVendors" . | fromJsonArray) }}
+{{- fail (printf "worker.cpuEnabled is false and worker.gpuVendors names no supported GPU vendor: the release would render no worker DaemonSet at all. Name at least one of %s in worker.gpuVendors, or leave the CPU DaemonSet enabled." (include "gpustack.canonicalVendorOrder" . | fromJsonArray | join ", ")) }}
+{{- end }}
+{{- end }}
+
+{{/*
 Credentials with nothing to write them into. `create: false` means a sibling
 release owns the Secret, so these would be silently dropped — and the pods would
 go on using whatever credentials that sibling put there, which is not what

--- a/charts/gpustack-chart/templates/worker-daemonset.yaml
+++ b/charts/gpustack-chart/templates/worker-daemonset.yaml
@@ -13,10 +13,19 @@ Build the list of DaemonSets to render. Each entry carries:
 */}}
 {{- $workers := list }}
 
-{{- /* CPU DaemonSet — always rendered first, owns the legacy name. */}}
+{{- /*
+CPU DaemonSet — rendered first, and the only one that takes the unsuffixed
+legacy name. Switched off for a cluster whose CPU nodes carry the control plane
+(or anything else that must not gain a worker); the vendor DaemonSets below keep
+their `-<vendor>` suffix either way, so turning it off never promotes one of
+them onto this name — a rename that would make a vendor DaemonSet adopt the CPU
+one's pods and reschedule a whole runtime for a nodeSelector change.
+*/}}
+{{- if include "gpustack.workerCPUEnabled" . }}
 {{- $cpuLabel := dict "feature.gpustack.ai/acceleratable" "false" }}
 {{- $cpuSel := mergeOverwrite (deepCopy $base) $cpuLabel }}
 {{- $workers = append $workers (dict "name" "cpu" "dsName" $dsBasename "runtime" "" "nodeSelector" $cpuSel) }}
+{{- end }}
 
 {{- /* GPU vendor DaemonSets — all get suffixed names. */}}
 {{- range $vendor := $vendors }}
@@ -30,7 +39,12 @@ Build the list of DaemonSets to render. Each entry carries:
   {{- $workers = append $workers (dict "name" $vendor "dsName" (printf "%s-%s" $dsBasename $vendor) "runtime" $vendor "nodeSelector" $merged) }}
 {{- end }}
 
-{{- $multiVendor := gt (len $workers) 1 }}
+{{- /*
+Shared with worker-service.yaml, which selects on the labels this flag renders:
+computing it here from `len $workers` instead would disagree with that Service
+the moment the CPU DaemonSet is off and a single vendor is on.
+*/}}
+{{- $multiVendor := include "gpustack.multiVendorMode" . }}
 
 {{- range $idx, $w := $workers }}
 {{- if $idx }}

--- a/charts/gpustack-chart/values.yaml
+++ b/charts/gpustack-chart/values.yaml
@@ -281,17 +281,15 @@ worker:
   #   cambricon - Cambricon MLU; mounts /usr/bin/cnmon and /usr/local/neuware
   #   thead     - T-Head PPU; mounts /usr/local/PPU_SDK
   #
-  # A CPU worker DaemonSet (`<release>-worker`) is always rendered and uses
-  # the nodeSelector `feature.gpustack.ai/acceleratable: "false"` to schedule
-  # onto non-acceleratable (CPU-only) nodes. It has no vendor-specific volume
-  # mounts or runtimeClassName.
+  # A CPU worker DaemonSet (`<release>-worker`) is rendered alongside these
+  # unless `cpuEnabled` below is false; see that key for what it covers.
   #
   # Rendering modes:
   #   - [] (empty): only the CPU DaemonSet `<release>-worker` is rendered
   #     (single mode — no vendor labels, no anti-affinity).
-  #   - 1+ entries: CPU DaemonSet `<release>-worker` plus one DaemonSet per
-  #     GPU vendor named `<release>-worker-<vendor>` (multi-vendor mode).
-  #     All worker pods get a required podAntiAffinity
+  #   - 1+ entries: the CPU DaemonSet `<release>-worker` (when enabled) plus one
+  #     DaemonSet per GPU vendor named `<release>-worker-<vendor>` (multi-vendor
+  #     mode). All worker pods get a required podAntiAffinity
   #     (topologyKey=hostname, namespaceSelector={}) so two GPUStack worker
   #     pods cannot share a node even across namespaces — protects the
   #     `hostNetwork: true` ports from collision.
@@ -303,6 +301,19 @@ worker:
   # schedule onto GPU nodes.
   gpuVendors:
     - nvidia
+  # Render the CPU worker DaemonSet (`<release>-worker`), which uses the
+  # nodeSelector `feature.gpustack.ai/acceleratable: "false"` to schedule onto
+  # non-acceleratable (CPU-only) nodes and carries no vendor-specific volume
+  # mounts or runtimeClassName.
+  #
+  # Set false for a cluster whose CPU-only nodes must not gain workers — the
+  # usual case being a control plane sharing the cluster with its GPU nodes.
+  # `gpuVendors` must then name at least one vendor, otherwise the release would
+  # render no worker DaemonSet at all and the install is refused.
+  #
+  # The GPU DaemonSets keep their `-<vendor>` suffix either way: turning this
+  # off never promotes one of them onto the unsuffixed name.
+  cpuEnabled: true
   # Base nodeSelector for ALL worker DaemonSets. When non-empty, REPLACES
   # `global.nodeSelector` entirely (no merging with global). Leave empty
   # to fall back to `global.nodeSelector`. Each DaemonSet additionally

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -136,7 +136,7 @@ Open the address in a browser and log in with username `admin` and the password 
 
 ### Enabling Worker DaemonSets
 
-Worker DaemonSets are disabled by default (`worker.enabled=false`). When enabled, the chart always renders a CPU worker DaemonSet (`<release>-worker`), and one DaemonSet per GPU vendor listed in `worker.gpuVendors` (named `<release>-worker-<vendor>`).
+Worker DaemonSets are disabled by default (`worker.enabled=false`). When enabled, the chart renders a CPU worker DaemonSet (`<release>-worker`), and one DaemonSet per GPU vendor listed in `worker.gpuVendors` (named `<release>-worker-<vendor>`).
 
 ```bash
 helm install gpustack oci://registry-1.docker.io/gpustack/gpustack-chart \
@@ -152,6 +152,18 @@ Supported `worker.gpuVendors` values: `nvidia`, `mthreads`, `amd`, `ascend`, `hy
     Each GPU DaemonSet receives an automatic PCI-presence `nodeSelector` label (e.g. `feature.node.kubernetes.io/pci-10de.present: "true"` for NVIDIA), advertised by Node Feature Discovery. **NFD must be installed** in the cluster, otherwise no nodes carry the required labels and all worker pods stay `Pending`.
 
 Whenever at least one GPU vendor is listed (i.e. `worker.gpuVendors` is non-empty), every worker pod additionally gets a required `podAntiAffinity` (topologyKey=hostname) so two workers cannot share a node — this protects the `hostNetwork: true` ports from collision.
+
+The CPU worker DaemonSet covers the nodes no GPU vendor claims, through the `nodeSelector` `feature.gpustack.ai/acceleratable: "false"`. Set `worker.cpuEnabled=false` to leave those nodes alone — typically when the control plane shares the cluster with the GPU nodes and must not gain workers:
+
+```bash
+helm install gpustack oci://registry-1.docker.io/gpustack/gpustack-chart \
+  --namespace gpustack-system --create-namespace \
+  --set worker.enabled=true \
+  --set worker.cpuEnabled=false \
+  --set 'worker.gpuVendors={nvidia}'
+```
+
+`worker.gpuVendors` must then name at least one supported vendor; otherwise the release would render no worker DaemonSet at all and the install is refused. The GPU DaemonSets keep their `-<vendor>` suffix either way, so turning the CPU one off never renames one of them to `<release>-worker`.
 
 Alternatively, add GPU clusters and worker nodes through the UI on the **Clusters** and **Workers** pages after installation.
 
@@ -252,7 +264,8 @@ The most commonly used parameters are listed below. For the complete and authori
 | `gateway.ingressClassname`             | `higress`                | Higress IngressClass name; enables in-cluster gateway mode when found.     |
 | `higress-core.enabled`                 | `true`                   | Deploy the bundled Higress gateway; disable if already installed.          |
 | `worker.enabled`                       | `false`                  | Render worker DaemonSets.                                                 |
-| `worker.gpuVendors`                    | `[nvidia]`               | GPU vendors; one DaemonSet per vendor plus a CPU DaemonSet.                |
+| `worker.gpuVendors`                    | `[nvidia]`               | GPU vendors; one DaemonSet per vendor plus the CPU DaemonSet.              |
+| `worker.cpuEnabled`                    | `true`                   | Render the CPU worker DaemonSet; `false` requires a GPU vendor.            |
 | `worker.nodeSelector`                  | `{}`                     | Base worker nodeSelector; replaces `global.nodeSelector` when non-empty.   |
 | `worker.port`                          | `10150`                  | Worker service port.                                                      |
 | `worker.metricsPort`                   | `10151`                  | Worker metrics port.                                                      |

--- a/gpustack/k8s/manifest_template.py
+++ b/gpustack/k8s/manifest_template.py
@@ -60,6 +60,15 @@ class TemplateConfig(ClusterRegistrationTokenPublic):
     cluster_owner_namespace: Optional[str] = None
     cluster_owner_principal_identifier: Optional[str] = None
     runtimes: Optional[List[ManufacturerEnum]] = None
+    # Whether the CPU worker DaemonSet is part of this deployment. It covers the
+    # nodes no GPU runtime claims, so a cluster whose CPU-only nodes carry the
+    # control plane — the case this switch exists for — turns it off and gets
+    # workers on its GPU nodes alone. Something then has to name a supported
+    # vendor, or there would be nothing left to deploy — ``runtimes`` here or
+    # ``worker.gpuVendors`` in the cluster's ``helmValues``, which is why
+    # ``build_chart_values`` refuses this on the merged values rather than on
+    # this field.
+    cpu_worker_enabled: bool = True
     k8s_options: Optional[K8sOptions] = None
     # Cluster-level default container registry (mirrors
     # ``clusters.system_default_container_registry``). Drives the operator

--- a/gpustack/k8s/values.py
+++ b/gpustack/k8s/values.py
@@ -188,6 +188,8 @@ def build_chart_values(config: TemplateConfig) -> Dict[str, Any]:
         )
     k8s_options = config.k8s_options
 
+    gpu_vendors = _gpu_vendors(config)
+
     configured_node_selector = (
         k8s_options.node_selector if k8s_options else None
     ) or {}
@@ -209,7 +211,11 @@ def build_chart_values(config: TemplateConfig) -> Dict[str, Any]:
         "worker": {
             "enabled": True,
             "serverURL": config.server_url,
-            "gpuVendors": _gpu_vendors(config),
+            "gpuVendors": gpu_vendors,
+            # Written even when true, which is what it almost always is: the
+            # chart's own default already agrees, but a values file that states
+            # it is what makes a downloaded manifest say which deployment it is.
+            "cpuEnabled": config.cpu_worker_enabled,
             "port": config.worker_port,
             "metricsPort": config.worker_metrics_port,
             "extraVolumeMounts": extra_mounts,
@@ -292,7 +298,61 @@ def build_chart_values(config: TemplateConfig) -> Dict[str, Any]:
                 "imageRegistry"
             ] = image_registry
 
-    return _merge_helm_values(values, k8s_options.helm_values if k8s_options else None)
+    merged = _merge_helm_values(
+        values, k8s_options.helm_values if k8s_options else None
+    )
+    _refuse_a_workerless_release(merged)
+    return merged
+
+
+# The vendors the chart renders a DaemonSet for. It normalizes the list itself
+# and drops anything outside this set, so a name it does not know is not a
+# worker — see `gpustack.canonicalVendorOrder` in the chart's `_helper.tpl`,
+# which `tests/k8s/test_chart_values.py` checks this against rather than
+# trusting the two copies to stay in step.
+CANONICAL_GPU_VENDORS = frozenset(
+    runtime.value for runtime in ManufacturerEnum if runtime != ManufacturerEnum.UNKNOWN
+)
+
+
+def _cpu_worker_enabled(values: Dict[str, Any]) -> bool:
+    """Whether these values render the CPU worker DaemonSet.
+
+    Mirrors `gpustack.workerCPUEnabled` in the chart, which is the authority:
+    absent reads as the chart's default (on), and only a `false` — in any case,
+    quoted or not — turns it off. Reading it any other way would have this
+    refuse a release the chart installs, or pass one it refuses.
+    """
+    worker = values.get("worker")
+    if not isinstance(worker, dict) or "cpuEnabled" not in worker:
+        return True
+    return str(worker["cpuEnabled"]).lower() != "false"
+
+
+def _refuse_a_workerless_release(values: Dict[str, Any]) -> None:
+    """Stop a manifest that would install a release with no worker in it.
+
+    Read off the *effective* values, after the cluster's own `helmValues` have
+    been merged, because that overlay reaches both halves of this: it can
+    disable the CPU worker on a request that selected no runtime, and it can
+    supply the vendors a request left out. Checking the request instead would
+    hand over the first and refuse the second.
+
+    The chart refuses this too. Doing it here as well is about where the
+    failure lands: on the request that asked for it, rather than in the
+    in-cluster Job's logs minutes after the manifest was handed over.
+    """
+    if _cpu_worker_enabled(values):
+        return
+    vendors = (values.get("worker") or {}).get("gpuVendors") or []
+    if isinstance(vendors, list) and any(v in CANONICAL_GPU_VENDORS for v in vendors):
+        return
+    raise ValueError(
+        "the CPU worker DaemonSet is disabled and no supported GPU runtime is "
+        "selected, which would deploy no worker at all. Select at least one "
+        "GPU runtime, or leave the CPU worker enabled. Both are also reachable "
+        "from helmValues, as worker.gpuVendors and worker.cpuEnabled."
+    )
 
 
 def _deep_merge(base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:

--- a/gpustack/routes/clusters.py
+++ b/gpustack/routes/clusters.py
@@ -988,8 +988,19 @@ async def get_cluster_manifests(
         description=(
             "GPU vendor runtimes to include in the manifest. Repeat the "
             "parameter for multiple vendors (e.g. ?runtime=nvidia&runtime=ascend). "
-            "The CPU worker DaemonSet is always rendered regardless of this "
-            "parameter."
+            "The CPU worker DaemonSet is rendered alongside them unless "
+            "`disable_cpu_worker` turns it off."
+        ),
+    ),
+    disable_cpu_worker: bool = Query(
+        False,
+        description=(
+            "Leave the CPU worker DaemonSet out of the manifest. It covers the "
+            "nodes no GPU runtime claims, so this is what keeps workers off the "
+            "CPU-only nodes of a cluster that also hosts the control plane. A "
+            "supported GPU vendor must then be selected, by `runtime` here or "
+            "by `worker.gpuVendors` in the cluster's `helmValues`; a manifest "
+            "that would deploy no worker at all is refused."
         ),
     ),
 ):
@@ -1031,6 +1042,7 @@ async def get_cluster_manifests(
         "registration": get_registration_from_cluster(request, cluster),
         "cluster_owner_principal_identifier": principal_namespace_identifier(principal),
         "runtimes": runtime,
+        "cpu_worker_enabled": not disable_cpu_worker,
         "k8s_options": k8s_options,
         "system_default_container_registry": cluster.system_default_container_registry
         or cfg.system_default_container_registry,
@@ -1054,11 +1066,13 @@ async def get_cluster_manifests(
     try:
         yaml_content = render_bootstrap(config)
     except ValueError as e:
-        # The cluster is configured in a way the chart cannot express — an image
-        # pinned by digest, or carrying no tag. Its own message names which, and
-        # the fix is to edit the cluster, so this is the caller's error and not a
-        # server fault. Raised here rather than deeper because this is where a
-        # cluster record becomes a request.
+        # Either the cluster is configured in a way the chart cannot express —
+        # an image pinned by digest, or carrying no tag — or this request asks
+        # for a manifest that deploys nothing, by disabling the CPU worker
+        # without selecting a runtime. Its own message names which, and the fix
+        # is the caller's either way, so this is not a server fault. Raised here
+        # rather than deeper because this is where a cluster record becomes a
+        # request.
         raise InvalidException(message=str(e))
     return Response(
         content=yaml_content,

--- a/tests/charts/test_chart_render.py
+++ b/tests/charts/test_chart_render.py
@@ -195,6 +195,107 @@ class TestServerAndWorker:
         }
 
 
+class TestCPUWorkerDisabled:
+    """`worker.cpuEnabled=false` — no workers on the nodes no runtime claims.
+
+    The case it exists for is a control plane sharing the cluster with its GPU
+    nodes: the CPU DaemonSet would otherwise cover exactly the nodes that must
+    not gain a worker.
+    """
+
+    ARGS = (
+        "--set",
+        "worker.enabled=true",
+        "--set",
+        "worker.cpuEnabled=false",
+        "--set",
+        "worker.gpuVendors={nvidia}",
+    )
+
+    def test_renders_the_vendor_daemonsets_and_not_the_cpu_one(self):
+        docs = render(*self.ARGS)
+        daemonsets = names(docs, "DaemonSet")
+        assert "gpustack-worker-nvidia" in daemonsets
+        # Suffixed even as the only worker DaemonSet. Promoting it onto the
+        # unsuffixed name would make it adopt the CPU DaemonSet's pods on an
+        # upgrade and reschedule the whole runtime for a nodeSelector change.
+        assert "gpustack-worker" not in daemonsets
+
+    def test_the_worker_service_still_selects_the_daemonset_it_has(self):
+        # The Service picks its selector from the same mode flag the DaemonSet
+        # labels do. Deriving that flag from the DaemonSet count instead would
+        # leave this single-vendor case labelled `app: gpustack-worker` and
+        # selected by `component: worker`, i.e. a Service with no endpoints.
+        docs = render(*self.ARGS)
+        service = next(
+            d
+            for d in docs
+            if d["kind"] == "Service" and d["metadata"]["name"] == "worker"
+        )
+        daemonset = next(
+            d
+            for d in docs
+            if d["kind"] == "DaemonSet"
+            and d["metadata"]["name"] == "gpustack-worker-nvidia"
+        )
+        labels = daemonset["spec"]["template"]["metadata"]["labels"]
+        assert service["spec"]["selector"].items() <= labels.items()
+
+    def test_refuses_a_release_with_no_worker_left_to_deploy(self):
+        error = render_error(
+            "--set",
+            "worker.enabled=true",
+            "--set",
+            "worker.cpuEnabled=false",
+            "--set",
+            "worker.gpuVendors=null",
+        )
+        assert "no worker DaemonSet at all" in error
+
+    def test_refuses_a_vendor_the_daemonsets_would_not_render(self):
+        # The DaemonSet template iterates the *canonical* vendors and renders
+        # nothing for a name outside them, so a guard counting the raw list
+        # would pass a typo straight into the state it exists to reject.
+        error = render_error(
+            "--set",
+            "worker.enabled=true",
+            "--set",
+            "worker.cpuEnabled=false",
+            "--set",
+            "worker.gpuVendors={bogus}",
+        )
+        assert "no supported GPU vendor" in error
+        # The names it would have accepted, so the typo is fixable from the
+        # message alone.
+        assert "nvidia" in error
+
+    def test_an_unset_value_keeps_the_cpu_daemonset(self):
+        # Helm drops a key set to null, and plain truthiness would read that
+        # `nil` as false — deleting the CPU workers from a cluster that only
+        # meant to leave the key out.
+        docs = render("--set", "worker.enabled=true", "--set", "worker.cpuEnabled=null")
+        assert "gpustack-worker" in names(docs, "DaemonSet")
+
+    @pytest.mark.parametrize("written", ["false", "False", "FALSE"])
+    def test_a_string_false_turns_it_off_like_a_bool(self, written):
+        # `--set-string` (and a values file quoting the value) would otherwise
+        # be a non-empty string, i.e. read as "on" — the opposite of what it
+        # says. YAML reads an unquoted `False` as the bool, so only the quoted
+        # spellings reach the template with their case intact.
+        docs = render(
+            "--set",
+            "worker.enabled=true",
+            "--set-string",
+            f"worker.cpuEnabled={written}",
+        )
+        assert "gpustack-worker" not in names(docs, "DaemonSet")
+
+    def test_a_server_only_release_is_unaffected(self):
+        # The guard is about workers; a control plane that renders none of them
+        # must not be refused for switching this off.
+        render("--set", "worker.cpuEnabled=false")
+
+
 class TestWorkerOnly:
     def test_deploys_no_server_side_components(self):
         docs = render(*WORKER_ONLY, *SERVER_AND_TOKEN)

--- a/tests/k8s/test_chart_values.py
+++ b/tests/k8s/test_chart_values.py
@@ -23,6 +23,7 @@ import yaml
 from gpustack.k8s.chart import chart_available
 from gpustack.k8s.manifest_template import TemplateConfig
 from gpustack.k8s.values import (
+    CANONICAL_GPU_VENDORS,
     applied_revision,
     build_chart_values,
     split_image_reference,
@@ -173,6 +174,108 @@ class TestGpuVendors:
         assert match, "the chart no longer declares a canonical vendor order"
         canonical = json.loads(match.group(1))
         assert canonical == sorted(canonical)
+
+    def test_python_knows_the_same_vendors_the_chart_renders(self):
+        # `CANONICAL_GPU_VENDORS` decides whether a manifest would deploy any
+        # worker at all, and it is only right while it names what the chart
+        # renders a DaemonSet for. A vendor added on one side alone makes the
+        # server refuse a release the chart installs, or hand over an empty one.
+        helper = (pathlib.Path(CHART) / "templates" / "_helper.tpl").read_text()
+        match = re.search(
+            r'define "gpustack\.canonicalVendorOrder".*?(\[[^]]*\])', helper, re.S
+        )
+        assert match, "the chart no longer declares a canonical vendor order"
+        assert set(json.loads(match.group(1))) == CANONICAL_GPU_VENDORS
+
+
+class TestCPUWorker:
+    """`cpu_worker_enabled` — whether the manifest covers the nodes no GPU
+    runtime claims. Off is for a cluster whose CPU-only nodes carry the control
+    plane and must not gain a worker."""
+
+    def test_enabled_by_default(self):
+        assert build_chart_values(config())["worker"]["cpuEnabled"] is True
+
+    def test_disabling_it_leaves_the_vendor_daemonsets_suffixed(self):
+        # The name is the whole point: were the single remaining DaemonSet
+        # promoted to `gpustack-worker`, it would adopt the CPU DaemonSet's pods
+        # on the upgrade that disables this and reschedule the runtime.
+        values = build_chart_values(
+            config(runtimes=[ManufacturerEnum.NVIDIA], cpu_worker_enabled=False)
+        )
+        assert values["worker"]["cpuEnabled"] is False
+        # DaemonSets only: the worker ServiceAccount and RBAC carry the
+        # unsuffixed name too, and they are not per-runtime.
+        daemonsets = {
+            doc["metadata"]["name"]
+            for doc in render(values)
+            if doc["kind"] == "DaemonSet"
+        }
+        assert "gpustack-worker-nvidia" in daemonsets
+        assert "gpustack-worker" not in daemonsets
+
+    def test_refuses_a_manifest_that_would_deploy_no_worker(self):
+        # The chart refuses it too, but there the failure lands in the
+        # in-cluster Job's logs instead of in this response.
+        with pytest.raises(ValueError, match="no worker at all"):
+            build_chart_values(config(cpu_worker_enabled=False))
+
+    def test_the_no_gpu_sentinel_is_not_a_selected_runtime(self):
+        # `_gpu_vendors` drops it, so a request carrying only the sentinel
+        # selects nothing — the case the guard has to catch on a non-empty list.
+        with pytest.raises(ValueError, match="no worker at all"):
+            build_chart_values(
+                config(runtimes=[ManufacturerEnum.UNKNOWN], cpu_worker_enabled=False)
+            )
+
+    def test_an_overlay_can_supply_the_runtime_the_request_left_out(self):
+        # `helmValues` reaches `worker.gpuVendors`, so the release this asks for
+        # has a worker in it. Checking the request instead of the merged values
+        # would refuse a manifest the chart installs happily.
+        values = build_chart_values(
+            config(
+                cpu_worker_enabled=False,
+                k8s_options=K8sOptions(
+                    helm_values={"worker": {"gpuVendors": ["nvidia"]}}
+                ),
+            )
+        )
+        assert values["worker"]["gpuVendors"] == ["nvidia"]
+        daemonsets = {
+            doc["metadata"]["name"]
+            for doc in render(values)
+            if doc["kind"] == "DaemonSet"
+        }
+        assert "gpustack-worker-nvidia" in daemonsets
+        assert "gpustack-worker" not in daemonsets
+
+    @pytest.mark.parametrize("written", [False, "false", "False"])
+    def test_an_overlay_can_be_what_empties_the_release(self, written):
+        # The mirror image: the request kept the CPU worker, the overlay took it
+        # away, and nothing selected a runtime. Read off the request this passes
+        # and fails in the cluster instead. Any spelling of false, as in the
+        # chart.
+        with pytest.raises(ValueError, match="no worker at all"):
+            build_chart_values(
+                config(
+                    k8s_options=K8sOptions(
+                        helm_values={"worker": {"cpuEnabled": written}}
+                    )
+                )
+            )
+
+    def test_an_overlay_vendor_the_chart_would_drop_is_not_a_worker(self):
+        # The chart renders a DaemonSet only for a vendor it knows, so a name
+        # outside that set leaves the release as empty as no name at all.
+        with pytest.raises(ValueError, match="no worker at all"):
+            build_chart_values(
+                config(
+                    cpu_worker_enabled=False,
+                    k8s_options=K8sOptions(
+                        helm_values={"worker": {"gpuVendors": ["bogus"]}}
+                    ),
+                )
+            )
 
 
 class TestWorkerOnlyValues:

--- a/tests/routes/test_cluster_manifests_cpu_worker.py
+++ b/tests/routes/test_cluster_manifests_cpu_worker.py
@@ -1,0 +1,144 @@
+"""The manifest endpoint's CPU-worker switch, driven through the handler.
+
+What the chart tests and the values tests cannot see is this layer's own
+mistake: a query parameter that reaches the render as its own opposite, or a
+refusal that leaves the caller holding a 500 instead of the message naming what
+to change. Both are one line in ``get_cluster_manifests`` and neither shows up
+in a render.
+
+The handler is called directly with the collaborators it loads by id mocked
+out — no database and no HTTP client. ``render_bootstrap`` is left real, since
+the values it produces are the thing being asserted; that needs the packaged
+chart, hence the skip.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gpustack.api.exceptions import InvalidException
+from gpustack.api.tenant import TenantContext
+from gpustack.k8s.chart import chart_available
+from gpustack.routes import clusters as clusters_route
+from gpustack.schemas.clusters import ClusterProvider, ClusterRegistrationTokenPublic
+from gpustack.schemas.principals import PrincipalType
+from gpustack_runtime.detector import ManufacturerEnum
+
+pytestmark = pytest.mark.skipif(
+    not chart_available(),
+    reason="the packaged chart is unavailable; run `make deps`",
+)
+
+OWNER_PRINCIPAL = 7
+
+
+def _admin_ctx() -> TenantContext:
+    user = MagicMock()
+    user.kind = PrincipalType.USER
+    return TenantContext(
+        user=user,
+        is_platform_admin=True,
+        current_principal_id=None,
+        org_role=None,
+    )
+
+
+@pytest.fixture
+def cluster(monkeypatch):
+    """A Kubernetes cluster the handler can render a manifest for.
+
+    ``get_registration_from_cluster`` is stubbed rather than fed a worker
+    config: resolving the image goes through the server-wide config, which is
+    not what these assert, and an untagged image would be refused for a reason
+    that has nothing to do with the CPU worker.
+    """
+    record = SimpleNamespace(
+        id=1,
+        name="k8s",
+        deleted_at=None,
+        owner_principal_id=OWNER_PRINCIPAL,
+        provider=ClusterProvider.Kubernetes,
+        k8s_options=None,
+        worker_config=None,
+        system_default_container_registry=None,
+    )
+    principal = SimpleNamespace(id=OWNER_PRINCIPAL, kind=PrincipalType.USER, name="u")
+
+    monkeypatch.setattr(
+        clusters_route.Cluster, "one_by_id", AsyncMock(return_value=record)
+    )
+    monkeypatch.setattr(
+        clusters_route.Principal, "one_by_id", AsyncMock(return_value=principal)
+    )
+    monkeypatch.setattr(
+        clusters_route,
+        "get_registration_from_cluster",
+        lambda request, cluster: ClusterRegistrationTokenPublic(
+            token="tok",
+            server_url="http://gpustack.example.com:30080",
+            image="docker.io/gpustack/gpustack:dev",
+            env={},
+            args=[],
+        ),
+    )
+    monkeypatch.setattr(
+        clusters_route,
+        "get_global_config",
+        lambda: SimpleNamespace(
+            namespace="gpustack-system",
+            operator_image=None,
+            system_default_container_registry=None,
+        ),
+    )
+    return record
+
+
+async def _manifest(runtime=None, disable_cpu_worker=False) -> str:
+    # Both passed explicitly: calling the handler as a function skips FastAPI's
+    # parameter resolution, so an omitted argument arrives as the `Query(...)`
+    # marker itself rather than as its default — and a truthy one at that.
+    response = await clusters_route.get_cluster_manifests(
+        request=MagicMock(),
+        session=MagicMock(),
+        ctx=_admin_ctx(),
+        id=1,
+        runtime=runtime,
+        disable_cpu_worker=disable_cpu_worker,
+    )
+    return response.body.decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_the_switch_reaches_the_values_it_renders(cluster):
+    # The whole point of the parameter, and the one thing a sign flip here
+    # would not change anywhere else: the chart values the cluster is handed.
+    manifest = await _manifest(
+        runtime=[ManufacturerEnum.NVIDIA], disable_cpu_worker=True
+    )
+    assert "cpuEnabled: false" in manifest
+
+
+@pytest.mark.asyncio
+async def test_the_cpu_worker_is_on_when_nothing_asks_otherwise(cluster):
+    manifest = await _manifest(runtime=[ManufacturerEnum.NVIDIA])
+    assert "cpuEnabled: true" in manifest
+
+
+@pytest.mark.asyncio
+async def test_disabling_it_without_a_runtime_is_the_callers_error(cluster):
+    # A manifest that deploys nothing is refused where the request can still be
+    # corrected. Raised as a ValueError deeper down, so what this pins is the
+    # translation: an InvalidException (4xx) rather than a 500 or a manifest.
+    with pytest.raises(InvalidException) as refused:
+        await _manifest(disable_cpu_worker=True)
+    assert "no worker at all" in str(refused.value.message)
+
+
+@pytest.mark.asyncio
+async def test_the_no_gpu_sentinel_does_not_count_as_a_runtime(cluster):
+    # `unknown` is what a cluster with no detected GPU carries. It renders no
+    # DaemonSet, so accepting it here would hand over the empty release the
+    # check above exists to refuse.
+    with pytest.raises(InvalidException):
+        await _manifest(runtime=[ManufacturerEnum.UNKNOWN], disable_cpu_worker=True)


### PR DESCRIPTION
Refer to issue:
- #5974

A control plane that shares its Kubernetes cluster with the GPU nodes gets a worker on every CPU-only node it runs on, because the CPU DaemonSet covers exactly the nodes no GPU runtime claims. That is not what registering the cluster asked for, and there was no way to say so: the DaemonSet was rendered unconditionally. `worker.cpuEnabled` turns it off in the chart, and the manifest endpoint asks for that with `?disable_cpu_worker=true`.

The vendor DaemonSets keep their `-<vendor>` suffix when it is off. Promoting the remaining one onto the unsuffixed `<release>-worker` would be the tidier name and a silent reschedule of a whole runtime: the upgrade that disables the CPU DaemonSet would hand its pods to a DaemonSet with a different nodeSelector. For the same reason the DaemonSet template stops deriving multi-vendor mode from how many DaemonSets it is rendering and reads the flag the worker Service selects on — the two disagree the moment the CPU DaemonSet is off and one vendor is on, which is a Service with no endpoints.

Selecting no GPU runtime with the CPU DaemonSet off asks for a release with no worker in it, and is refused on both sides. The values builder raises, so the request that asked for it gets the error rather than the in-cluster Job's logs minutes later; the chart guards it too, since `helmValues` reaches `worker.gpuVendors` and `worker.cpuEnabled` directly. Neither is server-owned: the guard is what the server-owned list would otherwise have to be for.