### PR TITLE
fix(images): resolve the image list-images reports at runtime

### DIFF
--- a/gpustack/cmd/images.py
+++ b/gpustack/cmd/images.py
@@ -1,6 +1,6 @@
 import argparse
 
-from gpustack import __version__, __benchmark_runner_version__, __operator_version__
+from gpustack import __benchmark_runner_version__, __operator_version__
 from gpustack_higress_plugins import __version__ as __higress_plugins_version__
 
 from gpustack_runtime.cmds import (
@@ -11,7 +11,9 @@ from gpustack_runtime.cmds import (
     append_images,
 )
 
+from gpustack.config.config import get_image_name
 from gpustack.extension import iter_plugin_classes, Plugin
+from gpustack.utils.envs import get_gpustack_env
 
 # The higress version should be sync with HIGRESS_VERSION in pack/Dockerfile.
 higress_version = "2.1.9"
@@ -27,9 +29,9 @@ csi_snapshotter_version = "v8.6.0"
 csi_livenessprobe_version = "v2.19.0"
 csi_node_driver_registrar_version = "v2.17.0"
 
-# Append images used by GPUStack here.
+# Append images used by GPUStack here. The GPUStack image itself is appended
+# from _append_self_image() instead, since it cannot be resolved at import time.
 append_images(
-    f"gpustack/gpustack:{'dev' if __version__.removeprefix('v') == '0.0.0' else __version__}",
     f"gpustack/benchmark-runner:{__benchmark_runner_version__}",
     f"gpustack/higress-plugins:{__higress_plugins_version__}",
     f"gpustack/mirrored-higress-higress:{higress_version}",
@@ -49,6 +51,27 @@ append_images(
 )
 
 
+def _append_self_image():
+    # Resolved through get_image_name(), the helper that also names the image
+    # workers pull: repository from GPUSTACK_IMAGE_REPO -- where the
+    # --image-repo default comes from, and the only seam this command has,
+    # running as its own process with no server config to read -- and version
+    # from resolve_version_info(). Deferred until the images subcommand is
+    # wired because plugins are loaded by then: a repackaged distribution
+    # reports its own version and ships its own repository, and the baked-in
+    # __version__ names an image that was never published for it.
+    #
+    # An image name override stays out: it is a full reference that may carry
+    # its own registry, while save-images / copy-images prefix every listed
+    # name with --source, which would build docker.io/quay.io/gpustack/...
+    append_images(
+        get_image_name(
+            image_name_override=None,
+            image_repo=get_gpustack_env("IMAGE_REPO") or "gpustack/gpustack",
+        )
+    )
+
+
 def _append_plugin_images():
     # Deferred until the images subcommand is wired so a misbehaving plugin
     # can't crash unrelated CLI entry points (start, --help, version).
@@ -64,6 +87,7 @@ def _append_plugin_images():
 
 
 def setup_images_cmd(subparsers: argparse._SubParsersAction):
+    _append_self_image()
     _append_plugin_images()
     ListImagesSubCommand.register(subparsers)
     SaveImagesSubCommand.register(subparsers)

--- a/tests/config/test_self_image.py
+++ b/tests/config/test_self_image.py
@@ -1,0 +1,73 @@
+"""The GPUStack image ``list-images`` reports for this build.
+
+It has to name an image that was actually published: whatever a worker would
+pull, i.e. the repository from ``--image-repo`` at the version
+``resolve_version_info()`` reports, which a plugin may override.
+"""
+
+import gpustack.cmd.images as images
+import gpustack.extension as extension
+
+
+class _Plugin(extension.Plugin):
+    @classmethod
+    def get_version_info(cls):
+        return "v2.2.3-repack1", "repackcommit"
+
+
+def _self_image(monkeypatch, **env):
+    for key in ("GPUSTACK_IMAGE_REPO", "GPUSTACK_IMAGE_NAME_OVERRIDE"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    appended = []
+    monkeypatch.setattr(images, "append_images", lambda *imgs: appended.extend(imgs))
+    images._append_self_image()
+    assert len(appended) == 1
+    return appended[0]
+
+
+def _with_plugin(monkeypatch):
+    monkeypatch.setattr(
+        extension, "iter_plugin_classes", lambda: iter([("test", _Plugin)])
+    )
+
+
+def test_defaults_to_core_repo_and_version(monkeypatch):
+    monkeypatch.setattr(extension, "iter_plugin_classes", lambda: iter([]))
+    monkeypatch.setattr("gpustack.__version__", "v2.2.3")
+
+    assert _self_image(monkeypatch) == "gpustack/gpustack:v2.2.3"
+
+
+def test_unreleased_version_maps_to_dev_tag(monkeypatch):
+    monkeypatch.setattr(extension, "iter_plugin_classes", lambda: iter([]))
+    monkeypatch.setattr("gpustack.__version__", "v0.0.0")
+
+    assert _self_image(monkeypatch) == "gpustack/gpustack:dev"
+
+
+def test_takes_version_from_plugin(monkeypatch):
+    # A repackaged distribution ships its own repository and version; core's
+    # baked-in __version__ names an image that was never published for it.
+    _with_plugin(monkeypatch)
+    monkeypatch.setattr("gpustack.__version__", "v2.2-dev")
+
+    image = _self_image(monkeypatch, GPUSTACK_IMAGE_REPO="example/gpustack")
+
+    assert image == "example/gpustack:v2.2.3-repack1"
+
+
+def test_ignores_an_image_name_override(monkeypatch):
+    # An override is a full reference that may carry its own registry, which
+    # save-images / copy-images would prefix with --source a second time.
+    _with_plugin(monkeypatch)
+
+    image = _self_image(
+        monkeypatch,
+        GPUSTACK_IMAGE_REPO="example/gpustack",
+        GPUSTACK_IMAGE_NAME_OVERRIDE="registry.example.com/mine/gpustack:custom",
+    )
+
+    assert image == "example/gpustack:v2.2.3-repack1"


### PR DESCRIPTION
The GPUStack image was appended at module import from the baked-in __version__, so a distribution that repackages GPUStack under its own repository and version reported an image that was never published for it, which save-images / copy-images then cannot pull for an air-gapped install.

Append it when the images subcommand is wired instead, through get_image_name(): repository from --image-repo, version from resolve_version_info(). That is exactly the reference workers pull, and a plugin can override both.