### PR TITLE
fix(models): tear down model-created routes when the model is deleted

### DIFF
--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timezone
 from typing import List, NamedTuple, Optional, Tuple, Union, Set
+from sqlalchemy import func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -870,6 +871,35 @@ class ModelService:
                 )
             )
 
+        route_service = ModelRouteService(self.session)
+        # Routes this model created (enable_model_route, LoRA child routes)
+        # used to be removed by the controller once the cascade-deleted
+        # target's event arrived. Creating a model with the same name inside
+        # that window hit the unique-name check and answered 409 although the
+        # model itself was already gone (#6197). Remove them here, in the
+        # same transaction as the model, unless other targets still use the
+        # route; the controller keeps handling that case as before.
+        created_routes = await ModelRoute.all_by_fields(
+            self.session,
+            fields={"created_model_id": model.id, "deleted_at": None},
+        )
+        for route in created_routes or []:
+            other_targets = (
+                await self.session.exec(
+                    select(func.count())
+                    .select_from(ModelRouteTarget)
+                    .where(
+                        ModelRouteTarget.route_id == route.id,
+                        or_(
+                            ModelRouteTarget.model_id.is_(None),
+                            ModelRouteTarget.model_id != model.id,
+                        ),
+                    )
+                )
+            ).one()
+            if other_targets == 0:
+                await route_service.delete(route, auto_commit=False)
+
         result = await model.delete(self.session)
         await delete_cache_by_key(self.get_by_id, model.id)
         await delete_cache_by_key(self.get_by_name, model.name)
@@ -879,7 +909,6 @@ class ModelService:
         for instance_id in instance_ids:
             await delete_cache_by_key(instance_service.get_by_id, instance_id)
 
-        route_service = ModelRouteService(self.session)
         for route_name in route_names:
             await delete_cache_by_key(route_service.resolve_route_targets, route_name)
             await delete_cache_by_key(

--- a/gpustack/server/services.py
+++ b/gpustack/server/services.py
@@ -890,6 +890,7 @@ class ModelService:
                     .select_from(ModelRouteTarget)
                     .where(
                         ModelRouteTarget.route_id == route.id,
+                        ModelRouteTarget.deleted_at.is_(None),
                         or_(
                             ModelRouteTarget.model_id.is_(None),
                             ModelRouteTarget.model_id != model.id,

--- a/tests/server/test_model_service_delete_created_routes.py
+++ b/tests/server/test_model_service_delete_created_routes.py
@@ -162,4 +162,3 @@ async def test_delete_model_ignores_soft_deleted_targets_of_other_models(session
     await ModelService(session).delete(model)
 
     assert await _route(session, "stale") is None
-

--- a/tests/server/test_model_service_delete_created_routes.py
+++ b/tests/server/test_model_service_delete_created_routes.py
@@ -1,0 +1,133 @@
+"""Deleting a model tears down the route it created in the same transaction.
+
+The controller removed a model-created route only after the DELETED event
+of the cascade-deleted target arrived. Creating a model with the same name
+inside that window hit the unique-name check in ``create_model`` and got
+``409 Model route with name '...' already exists.`` although the model was
+already gone (#6197).
+"""
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+import pytest
+import pytest_asyncio
+
+import gpustack.schemas  # noqa: F401  (registers every table)
+from gpustack.schemas.model_routes import (
+    ModelRoute,
+    ModelRouteTarget,
+    TargetStateEnum,
+)
+from gpustack.schemas.models import Model, SourceEnum
+from gpustack.schemas.principals import (
+    Principal,
+    PrincipalType,
+    platform_principal_id,
+)
+from gpustack.server.services import ModelService
+
+ORG_ID = platform_principal_id()
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite://")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enforce_foreign_keys(dbapi_connection, _record):
+        # The production databases cascade target deletion through foreign
+        # keys; SQLite only does so with the pragma switched on.
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async with AsyncSession(engine, expire_on_commit=False) as s:
+        s.add(Principal(id=ORG_ID, name="default", kind=PrincipalType.ORG))
+        await s.commit()
+        yield s
+    await engine.dispose()
+
+
+async def _model_with_created_route(session: AsyncSession, name: str) -> Model:
+    model = await Model.create(
+        session,
+        source=Model(
+            name=name,
+            source=SourceEnum.HUGGING_FACE,
+            huggingface_repo_id="org/repo",
+            owner_principal_id=ORG_ID,
+            enable_model_route=True,
+        ),
+    )
+    route = await ModelRoute.create(
+        session,
+        source=ModelRoute(
+            name=name, created_model_id=model.id, owner_principal_id=ORG_ID
+        ),
+        auto_commit=False,
+    )
+    await ModelRouteTarget.create(
+        session,
+        source=ModelRouteTarget(
+            name=f"{name}-deployment",
+            route_name=route.name,
+            model_route=route,
+            model=model,
+            weight=100,
+            state=TargetStateEnum.UNAVAILABLE,
+        ),
+    )
+    return model
+
+
+async def _route(session: AsyncSession, name: str):
+    return await ModelRoute.one_by_fields(
+        session, {"name": name, "owner_principal_id": ORG_ID}
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_model_removes_the_route_it_created(session):
+    model = await _model_with_created_route(session, "m1")
+    assert await _route(session, "m1") is not None
+
+    await ModelService(session).delete(model)
+
+    # This is the lookup create_model uses for its 409 check.
+    assert await _route(session, "m1") is None
+    assert await ModelRouteTarget.all_by_fields(session, {"route_name": "m1"}) == []
+
+
+@pytest.mark.asyncio
+async def test_delete_model_keeps_a_created_route_other_targets_still_use(session):
+    model = await _model_with_created_route(session, "shared")
+    other = await Model.create(
+        session,
+        source=Model(
+            name="other",
+            source=SourceEnum.HUGGING_FACE,
+            huggingface_repo_id="org/other",
+            owner_principal_id=ORG_ID,
+        ),
+    )
+    route = await _route(session, "shared")
+    await ModelRouteTarget.create(
+        session,
+        source=ModelRouteTarget(
+            name="other-deployment",
+            route_name=route.name,
+            model_route=route,
+            model=other,
+            weight=100,
+            state=TargetStateEnum.UNAVAILABLE,
+        ),
+    )
+
+    await ModelService(session).delete(model)
+
+    kept = await _route(session, "shared")
+    assert kept is not None and kept.created_model_id == model.id
+    remaining = await ModelRouteTarget.all_by_fields(session, {"route_name": "shared"})
+    assert [target.model_id for target in remaining] == [other.id]

--- a/tests/server/test_model_service_delete_created_routes.py
+++ b/tests/server/test_model_service_delete_created_routes.py
@@ -131,3 +131,35 @@ async def test_delete_model_keeps_a_created_route_other_targets_still_use(sessio
     assert kept is not None and kept.created_model_id == model.id
     remaining = await ModelRouteTarget.all_by_fields(session, {"route_name": "shared"})
     assert [target.model_id for target in remaining] == [other.id]
+
+
+@pytest.mark.asyncio
+async def test_delete_model_ignores_soft_deleted_targets_of_other_models(session):
+    model = await _model_with_created_route(session, "stale")
+    other = await Model.create(
+        session,
+        source=Model(
+            name="other-stale",
+            source=SourceEnum.HUGGING_FACE,
+            huggingface_repo_id="org/other",
+            owner_principal_id=ORG_ID,
+        ),
+    )
+    route = await _route(session, "stale")
+    stale_target = await ModelRouteTarget.create(
+        session,
+        source=ModelRouteTarget(
+            name="other-stale-deployment",
+            route_name=route.name,
+            model_route=route,
+            model=other,
+            weight=100,
+            state=TargetStateEnum.UNAVAILABLE,
+        ),
+    )
+    await stale_target.delete(session, soft=True)
+
+    await ModelService(session).delete(model)
+
+    assert await _route(session, "stale") is None
+


### PR DESCRIPTION
ref #6197

## Root cause

`DELETE /v2/models/{id}` cascades the model's `ModelRouteTarget` rows, but the `ModelRoute` the model created (`enable_model_route`, and the LoRA child routes) is only removed later: the model-route-target controller receives the target's `DELETED` event, `_reconcile` counts zero targets on a route with `created_model_id`, and deletes it. Until that pass runs, `create_model` finds the route in its unique-name lookup and answers `409 Model route with name '<name>' already exists.` even though `GET /v2/models/{id}` already says 404. That is the 21–30 ms window measured in the issue.

## Change

`gpustack/server/services.py` `ModelService.delete`: before deleting the model, load the routes with `created_model_id == model.id` and delete each one through `ModelRouteService.delete(auto_commit=False)` when no *other* target still uses it (targets of other models, or provider targets with `model_id NULL`). The model delete then commits both. A created route that other targets still use is left alone, so the controller's existing handling (target counts, transfer) is unchanged for that case. Cache invalidation and the `DELETED` events (gateway ingress teardown) go through the same service path as before.

## Tests

`tests/server/test_model_service_delete_created_routes.py` (SQLite with `PRAGMA foreign_keys=ON` so the target cascade behaves like the production databases):

- deleting a model removes the route it created and its target; the lookup `create_model` uses for the 409 check returns nothing afterwards (fails on `main`);
- a created route that another model's target still uses survives with `created_model_id` intact and only the deleted model's target gone.

```
pytest tests/routers/test_models.py tests/routes/test_model_routes.py tests/server/test_route_ai_proxy_grouping.py tests/server/test_model_service_delete_created_routes.py
81 passed
```

`black --check` clean; `flake8` reports only the pre-existing C901 in `sync_user_group_memberships`.

Not verified against a live Higress gateway; the change only moves the existing route deletion from the controller into the delete transaction.
